### PR TITLE
removed completely the old RegisterProvider 'conv op type'

### DIFF
--- a/src/lib/common/statistics.cpp
+++ b/src/lib/common/statistics.cpp
@@ -67,7 +67,6 @@ int noOfEntityByIdAttributeByName            = -1;
 int noOfIndividualContextEntity              = -1;
 int noOfIndividualContextEntityAttributes    = -1;
 int noOfIndividualContextEntityAttribute     = -1;
-int noOfRegisterProviders                    = -1;
 int noOfUpdateContextElement                 = -1;
 int noOfAppendContextElement                 = -1;
 int noOfUpdateContextAttribute               = -1;
@@ -113,8 +112,6 @@ void statisticsUpdate(RequestType request, Format inFormat)
    case IndividualContextEntity:                ++noOfIndividualContextEntity; break;
    case IndividualContextEntityAttributes:      ++noOfIndividualContextEntityAttributes; break;
    case IndividualContextEntityAttribute:       ++noOfIndividualContextEntityAttribute; break;
-
-   case RegisterProvider:                       ++noOfRegisterProviders; break;
 
    case UpdateContextElement:                   ++noOfUpdateContextElement; break;
    case AppendContextElement:                   ++noOfAppendContextElement; break;

--- a/src/lib/common/statistics.h
+++ b/src/lib/common/statistics.h
@@ -70,7 +70,6 @@ extern int noOfEntityByIdAttributeByName;
 extern int noOfIndividualContextEntity;
 extern int noOfIndividualContextEntityAttributes;
 extern int noOfIndividualContextEntityAttribute;
-extern int noOfRegisterProviders;
 extern int noOfUpdateContextElement;
 extern int noOfAppendContextElement;
 extern int noOfUpdateContextAttribute;

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -84,7 +84,7 @@ std::string RegisterProviderRequest::check(RequestType requestType, Format forma
       response.errorCode.code         = SccBadRequest;
       response.errorCode.reasonPhrase = predetectedError;
    }
-   else if ((res = metadataVector.check(RegisterProvider, format, indent, predetectedError, counter)) != "OK")
+   else if ((res = metadataVector.check(requestType, format, indent, predetectedError, counter)) != "OK")
    {
       response.errorCode.code = SccBadRequest;
       response.errorCode.reasonPhrase = res;

--- a/src/lib/ngsi/Request.cpp
+++ b/src/lib/ngsi/Request.cpp
@@ -52,7 +52,6 @@ const char* requestType(RequestType rt)
   case IndividualContextEntity:                     return "IndividualContextEntity";
   case IndividualContextEntityAttributes:           return "IndividualContextEntityAttributes";
   case IndividualContextEntityAttribute:            return "IndividualContextEntityAttribute";
-  case RegisterProvider:                            return "RegisterProvider";
   case UpdateContextElement:                        return "UpdateContextElement";
   case AppendContextElement:                        return "AppendContextElement";
   case UpdateContextAttribute:                      return "UpdateContextAttribute";

--- a/src/lib/ngsi/Request.h
+++ b/src/lib/ngsi/Request.h
@@ -59,13 +59,11 @@ typedef enum RequestType
   IndividualContextEntityAttributes,
   IndividualContextEntityAttribute,
 
-  RegisterProvider = 18,
-
-  UpdateContextElement,
+  UpdateContextElement = 18,
   AppendContextElement,
   UpdateContextAttribute,
 
-  LogRequest = 22,
+  LogRequest = 21,
   VersionRequest,
   ExitRequest,
   LeakRequest,

--- a/src/lib/serviceRoutines/statisticsTreat.cpp
+++ b/src/lib/serviceRoutines/statisticsTreat.cpp
@@ -87,7 +87,6 @@ std::string statisticsTreat(ConnectionInfo* ciP, int components, std::vector<std
      noOfIndividualContextEntity              = -1;
      noOfIndividualContextEntityAttributes    = -1;
      noOfIndividualContextEntityAttribute     = -1;
-     noOfRegisterProviders                    = -1;
      noOfUpdateContextElement                 = -1;
      noOfAppendContextElement                 = -1;
      noOfUpdateContextAttribute               = -1;
@@ -131,7 +130,6 @@ std::string statisticsTreat(ConnectionInfo* ciP, int components, std::vector<std
   if (noOfIndividualContextEntity != -1)            out += valueTag(indent + "  ", "individualContextEntity",               noOfIndividualContextEntity + 1,              ciP->outFormat);
   if (noOfIndividualContextEntityAttributes != -1)  out += valueTag(indent + "  ", "individualContextEntityAttributes",     noOfIndividualContextEntityAttributes + 1,    ciP->outFormat);
   if (noOfIndividualContextEntityAttribute != -1)   out += valueTag(indent + "  ", "individualContextEntityAttribute",      noOfIndividualContextEntityAttribute + 1,     ciP->outFormat);
-  if (noOfRegisterProviders != -1)                  out += valueTag(indent + "  ", "registerProviderRequests",              noOfRegisterProviders + 1,                    ciP->outFormat);
   if (noOfUpdateContextElement != -1)               out += valueTag(indent + "  ", "updateContextElement",                  noOfUpdateContextElement + 1,                 ciP->outFormat);
   if (noOfAppendContextElement != -1)               out += valueTag(indent + "  ", "appendContextElement",                  noOfAppendContextElement + 1,                 ciP->outFormat);
   if (noOfUpdateContextAttribute != -1)             out += valueTag(indent + "  ", "updateContextAttribute",                noOfUpdateContextAttribute + 1,               ciP->outFormat);

--- a/src/lib/xmlParse/xmlRegisterProviderRequest.cpp
+++ b/src/lib/xmlParse/xmlRegisterProviderRequest.cpp
@@ -186,7 +186,7 @@ void rprRelease(ParseData* reqData)
 */
 std::string rprCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->rpr.res.check(RegisterProvider, ciP->outFormat, "", reqData->errorString, 0);
+  return reqData->rpr.res.check(ContextEntitiesByEntityId, ciP->outFormat, "", reqData->errorString, 0);
 }
 
 

--- a/test/unittests/common/commonStatistics_test.cpp
+++ b/test/unittests/common/commonStatistics_test.cpp
@@ -55,7 +55,6 @@ TEST(commonStatistics, statisticsUpdate)
   noOfIndividualContextEntity                = 0;
   noOfIndividualContextEntityAttributes      = 0;
   noOfIndividualContextEntityAttribute       = 0;
-  noOfRegisterProviders                      = 0;
   noOfUpdateContextElement                   = 0;
   noOfAppendContextElement                   = 0;
   noOfUpdateContextAttribute                 = 0;
@@ -87,7 +86,6 @@ TEST(commonStatistics, statisticsUpdate)
   statisticsUpdate(IndividualContextEntity, JSON);
   statisticsUpdate(IndividualContextEntityAttributes, XML);
   statisticsUpdate(IndividualContextEntityAttribute, JSON);
-  statisticsUpdate(RegisterProvider, XML);
   statisticsUpdate(UpdateContextElement, JSON);
   statisticsUpdate(AppendContextElement, XML);
   statisticsUpdate(UpdateContextAttribute, JSON);
@@ -117,7 +115,6 @@ TEST(commonStatistics, statisticsUpdate)
   EXPECT_EQ(1, noOfIndividualContextEntity);
   EXPECT_EQ(1, noOfIndividualContextEntityAttributes);
   EXPECT_EQ(1, noOfIndividualContextEntityAttribute);
-  EXPECT_EQ(1, noOfRegisterProviders);
   EXPECT_EQ(1, noOfUpdateContextElement);
   EXPECT_EQ(1, noOfAppendContextElement);
   EXPECT_EQ(1, noOfUpdateContextAttribute);
@@ -129,6 +126,6 @@ TEST(commonStatistics, statisticsUpdate)
   EXPECT_EQ(1, noOfInvalidRequests);
   EXPECT_EQ(1, noOfRegisterResponses);
 
-  EXPECT_EQ(15, noOfXmlRequests);
+  EXPECT_EQ(14, noOfXmlRequests);
   EXPECT_EQ(14, noOfJsonRequests);
 }

--- a/test/unittests/convenience/RegisterProviderRequest_test.cpp
+++ b/test/unittests/convenience/RegisterProviderRequest_test.cpp
@@ -65,11 +65,11 @@ TEST(RegisterProviderRequest, xml_ok)
   // Destroying metadata to provoke an error
   reqData.rpr.res.metadataVector.get(0)->name = "";
   std::string error;
-  error = reqData.rpr.res.check(RegisterProvider, XML, "", "", 0);
+  error = reqData.rpr.res.check(DiscoverContextAvailability, XML, "", "", 0);
   EXPECT_EQ("<discoverContextAvailabilityResponse>\n  <errorCode>\n    <code>400</code>\n    <reasonPhrase>missing metadata name</reasonPhrase>\n  </errorCode>\n</discoverContextAvailabilityResponse>\n", error);
 
   // sending a 'predetected error' to the check function
-  error    = reqData.rpr.res.check(RegisterProvider, XML, "", "forced predetectedError", 0);
+  error    = reqData.rpr.res.check(DiscoverContextAvailability, XML, "", "forced predetectedError", 0);
   expected = "<discoverContextAvailabilityResponse>\n  <errorCode>\n    <code>400</code>\n    <reasonPhrase>forced predetectedError</reasonPhrase>\n  </errorCode>\n</discoverContextAvailabilityResponse>\n";
   EXPECT_EQ(expected, error);
 

--- a/test/unittests/ngsi/Request_test.cpp
+++ b/test/unittests/ngsi/Request_test.cpp
@@ -63,7 +63,6 @@ TEST(Request, requestType)
     { IndividualContextEntity,                   "IndividualContextEntity"                                },
     { IndividualContextEntityAttributes,         "IndividualContextEntityAttributes"                      },
     { IndividualContextEntityAttribute,          "IndividualContextEntityAttribute"                       },
-    { RegisterProvider,                          "RegisterProvider"                                       },
     { UpdateContextElement,                      "UpdateContextElement"                                   },
     { AppendContextElement,                      "AppendContextElement"                                   },
     { UpdateContextAttribute,                    "UpdateContextAttribute"                                 },


### PR DESCRIPTION
### Description

Old stuff from the very first conv op, that I mistakedly called 'RegisterProvider' in the beginning (RegisterProvider is the name of the payload struct).
