### PR TITLE
ROLLBACK semaphore initialization to fix "empty server responses" in CentOS

### DIFF
--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -529,8 +529,7 @@ int main(int argC, char* argV[])
   statisticsTime = startTime;
 
   /* Initialize the semaphore used by mongoBackend */
-  if (semInit() != 0)
-    LM_X(1, ("Error initializing semaphore: %s\n", strerror(errno)));
+  semInit();
 
   int r;
   if ((r = restStart()) != 0)

--- a/src/lib/common/sem.cpp
+++ b/src/lib/common/sem.cpp
@@ -47,7 +47,11 @@ int semInit(void) {
   // sem_init: 
   //   parameter #1: 0 - the semaphore is to be shared between threads,
   //   parameter #2: 1 - initially the semaphore is free
-  return sem_init(&sem, 0, 1);
+  if (sem_init(&sem, 0, 1) == -1) 
+  {
+    LM_RE(1, ("Error initializing semaphore: %s\n", strerror(errno)));
+  }  
+  return 0;
 }
 
 /* ****************************************************************************


### PR DESCRIPTION
This changed was originally introduced in development branch in November 6th from PR #62 to PR #64 merges, corresponding to commits https://github.com/telefonicaid/fiware-orion/commit/be37371 and 89b5253
