### PR TITLE
FIX small bug in unit test and tuning lcov for unit test covergage

### DIFF
--- a/makefile
+++ b/makefile
@@ -335,6 +335,8 @@ coverage_unit_test: build_unit_test
 	lcov -r coverage/broker.info "test/unittests/*" -o coverage/broker.info	
 	lcov -r coverage/broker.info "src/lib/logMsg/*" -o coverage/broker.info
 	lcov -r coverage/broker.info "src/lib/parseArgs/*" -o coverage/broker.info
+	# app/ contains application itself, not libraries which make sense to measure unit_test coverage
+	lcov -r coverage/broker.info "src/app/*" -o coverage/broker.info
 	genhtml -o coverage coverage/broker.info
 
 coverage_functional_test: install_coverage

--- a/test/unittests/serviceRoutines/getContextEntityTypes_test.cpp
+++ b/test/unittests/serviceRoutines/getContextEntityTypes_test.cpp
@@ -66,6 +66,9 @@ TEST(getContextEntityTypes, nothingFound)
   ConnectionInfo ci("/ngsi9/contextEntityTypes/TYPE_123",  "GET", "1.1");
   std::string    expected = "<discoverContextAvailabilityResponse>\n  <errorCode>\n    <code>404</code>\n    <reasonPhrase>No context element registrations found</reasonPhrase>\n  </errorCode>\n</discoverContextAvailabilityResponse>\n";
 
+  // Cleaning database before starting the test, as it may cause a "false positive" otherwise (it happened in Jenkins)
+  setupDatabase();
+
   std::string    out;
 
   TimerMock* timerMock = new TimerMock();


### PR DESCRIPTION
This is supposed to solve the following bug detected by Jenkins:

```
/var/develenv/jenkins/jobs/orion-develop-unittest/workspace/test/unittests/serviceRoutines/getContextEntityTypes_test.cpp:78: Failure
Value of: out.c_str()
  Actual: "<discoverContextAvailabilityResponse>
  <contextRegistrationResponseList>
    <contextRegistrationResponse>
      <contextRegistration>
        <entityIdList>
          <entityId type="TYPE_123" isPattern="false">
            <id></id>
          </entityId>
        </entityIdList>
        <providingApplication>http://kz.tid.es/abc</providingApplication>
      </contextRegistration>
    </contextRegistrationResponse>
  </contextRegistrationResponseList>
</discoverContextAvailabilityResponse>
"
Expected: expected.c_str()
Which is: "<discoverContextAvailabilityResponse>
  <errorCode>
    <code>404</code>
    <reasonPhrase>No context element registrations found</reasonPhrase>
  </errorCode>
</discoverContextAvailabilityResponse>
"
```

@kzangeli , it would be a good idea to do a `setupDatabase()` to clean-up database before starting each unit test involving database. I would create an issue about it.

I have also taken the opportunity to do a small fix in makefile coverage target for unit tests.
