### PR TITLE
OrionError json start and end braces

### DIFF
--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -92,6 +92,16 @@ std::string OrionError::render(Format format, std::string indent)
   std::string out     = "";
   std::string tag     = "orionError";
 
+  //
+  // OrionError is NEVER part of any other payload, so the JSON start/end braces must be added here
+  //
+
+  if (format == JSON)
+  {
+    out     = "{\n";
+    indent += "  ";
+  }
+
   out += startTag(indent, tag, format);
   out += valueTag(indent + "  ", "code",          code,         format, true);
   out += valueTag(indent + "  ", "reasonPhrase",  reasonPhrase, format, details != "");
@@ -100,6 +110,9 @@ std::string OrionError::render(Format format, std::string indent)
     out += valueTag(indent + "  ", "details",       details,      format);
 
   out += endTag(indent, tag, format);
+
+  if (format == JSON)
+    out += "}\n";
 
   return out;
 }

--- a/test/testharness/jsonParse/empty_payloads.test
+++ b/test/testharness/jsonParse/empty_payloads.test
@@ -184,22 +184,28 @@ echo "13: ++++++++++++++++++++"
   }
 }
 10: ++++++++++++++++++++
-"orionError" : {
-  "code" : "400",
-  "reasonPhrase" : "bad ngsi9 request",
-  "details" : "ngsi9 service '/NGSI9/notSupportedRequest' not found"
+{
+  "orionError" : {
+    "code" : "400",
+    "reasonPhrase" : "bad ngsi9 request",
+    "details" : "ngsi9 service '/NGSI9/notSupportedRequest' not found"
+  }
 }
 11: ++++++++++++++++++++
-"orionError" : {
-  "code" : "400",
-  "reasonPhrase" : "bad ngsi10 request",
-  "details" : "ngsi10 service '/NGSI10/notSupportedRequest' not found"
+{
+  "orionError" : {
+    "code" : "400",
+    "reasonPhrase" : "bad ngsi10 request",
+    "details" : "ngsi10 service '/NGSI10/notSupportedRequest' not found"
+  }
 }
 12: ++++++++++++++++++++
-"orionError" : {
-  "code" : "400",
-  "reasonPhrase" : "bad request",
-  "details" : "service '/notSupportedRequest' not found"
+{
+  "orionError" : {
+    "code" : "400",
+    "reasonPhrase" : "bad request",
+    "details" : "service '/notSupportedRequest' not found"
+  }
 }
 13: ++++++++++++++++++++
 --TEARDOWN--

--- a/test/unittests/jsonParse/jsonRequest_test.cpp
+++ b/test/unittests/jsonParse/jsonRequest_test.cpp
@@ -45,8 +45,7 @@ TEST(jsonRequest, jsonTreat)
    ci.outFormat = JSON;
 
    std::string  out;
-   std::string  expected1 = "\"orionError\" : {\n  \"code\" : \"400\",\n  \"reasonPhrase\" : \"no request treating object found\",\n  \"details\" : \"Sorry, no request treating object found for RequestType 'InvalidRequest'\"\n}\n";
-   std::string  expected2 = "\"orionError\" : {\n  \"code\" : \"400\",\n  \"reasonPhrase\" : \"Sorry, not implemented\"\n}\n";
+   std::string  expected1 = "{\n  \"orionError\" : {\n    \"code\" : \"400\",\n    \"reasonPhrase\" : \"no request treating object found\",\n    \"details\" : \"Sorry, no request treating object found for RequestType 'InvalidRequest'\"\n  }\n}\n";
 
    out  = jsonTreat("", &ci, &parseData, InvalidRequest, "no_payload", NULL);
    EXPECT_EQ(expected1, out);

--- a/test/unittests/rest/OrionError_test.cpp
+++ b/test/unittests/rest/OrionError_test.cpp
@@ -45,10 +45,10 @@ TEST(OrionError, all)
   std::string   expected2     = "<orionError>\n  <code>400</code>\n  <reasonPhrase>Bad Request</reasonPhrase>\n  <details>no details</details>\n</orionError>\n";
   std::string   expected3     = "<orionError>\n  <code>400</code>\n  <reasonPhrase>Bad Request 2</reasonPhrase>\n  <details>no details 2</details>\n</orionError>\n";
   std::string   expected4     = "<orionError>\n  <code>200</code>\n  <reasonPhrase>Good Request</reasonPhrase>\n</orionError>\n";
-  std::string   expected1json = "\"orionError\" : {\n  \"code\" : \"200\",\n  \"reasonPhrase\" : \"Good Request\",\n  \"details\" : \"no details 3\"\n}\n";
-  std::string   expected2json = "\"orionError\" : {\n  \"code\" : \"400\",\n  \"reasonPhrase\" : \"Bad Request\",\n  \"details\" : \"no details\"\n}\n";
-  std::string   expected3json = "\"orionError\" : {\n  \"code\" : \"400\",\n  \"reasonPhrase\" : \"Bad Request 2\",\n  \"details\" : \"no details 2\"\n}\n";
-  std::string   expected4json = "\"orionError\" : {\n  \"code\" : \"200\",\n  \"reasonPhrase\" : \"Good Request\"\n}\n";
+  std::string   expected1json = "{\n  \"orionError\" : {\n    \"code\" : \"200\",\n    \"reasonPhrase\" : \"Good Request\",\n    \"details\" : \"no details 3\"\n  }\n}\n";
+  std::string   expected2json = "{\n  \"orionError\" : {\n    \"code\" : \"400\",\n    \"reasonPhrase\" : \"Bad Request\",\n    \"details\" : \"no details\"\n  }\n}\n";
+  std::string   expected3json = "{\n  \"orionError\" : {\n    \"code\" : \"400\",\n    \"reasonPhrase\" : \"Bad Request 2\",\n    \"details\" : \"no details 2\"\n  }\n}\n";
+  std::string   expected4json = "{\n  \"orionError\" : {\n    \"code\" : \"200\",\n    \"reasonPhrase\" : \"Good Request\"\n  }\n}\n";
 
   EXPECT_EQ(SccNone, e0.code);
   EXPECT_EQ("",      e0.reasonPhrase);


### PR DESCRIPTION
### Description

OrionError::render didn't render the start and end curly braces for JSON.
Now it does.
