### PR TITLE
hardening/moving setNotifier

### DIFF
--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -568,6 +568,9 @@ static void mongoInit(const char* dbHost, std::string dbName, const char* user, 
   setSubscribeContextAvailabilityCollectionName(dbName + ".casubs");
   setAssociationsCollectionName(dbName + ".associations");
 
+  /* Set notifier object (singleton) */
+  setNotifier(new Notifier());
+
   /* Launch threads corresponding to ONTIMEINTERVAL subscriptions in the database (unless ngsi9 only mode) */
   if (!ngsi9Only)
     recoverOntimeIntervalThreads();

--- a/src/lib/common/globals.cpp
+++ b/src/lib/common/globals.cpp
@@ -62,9 +62,6 @@ void orionInit(OrionExitFunction exitFunction, const char* version)
   /* Set timer object (singleton) */
   setTimer(new Timer());
 
-  /* Set notifier object (singleton) */
-  setNotifier(new Notifier());
-
   /* Set start time */
   startTime      = getCurrentTime();
   statisticsTime = startTime;


### PR DESCRIPTION
Moving initialization  "setNotifier(new Notifier())"  from orionInit to mongoInit.
 If it is in a common library, compilation of iotAgent fails.
