### PR TITLE
fixed a unittest bug - payload files are now closed after being read

### DIFF
--- a/test/unittests/testDataFromFile.cpp
+++ b/test/unittests/testDataFromFile.cpp
@@ -89,8 +89,10 @@ std::string testDataFromFile(char* buffer, int bufSize, const char* fileName)
      return std::string("open(") + path + "): " + strerror(errno);
 
   nb = read(fd, buffer, sBuf.st_size);
+  close(fd);
   if (nb == -1)
     return std::string("read(") + path + "): " + strerror(errno);
+
   if (nb != sBuf.st_size)
      return std::string("bad size read from ") + path;
   


### PR DESCRIPTION
### Description

Fixed a unit-test bug.
The heavily used function that opens and reads the payload files for unit tests (testDataFromFile) now closes the file after reading it.
