### PR TITLE
Fixed a memory leak for payload parse errors

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,5 +6,5 @@
 - Fix: StatusCode is now correctly rendered in JSON when sent as a standalone message (partially fixes issue #225)
 - Fix: Fixed a bug about incoming buffer pollution.
 - Fix: Some unknown incoming URLs were not responded to. Now they are. (Bug #277)
-- Fix: Now the operations GET, POST and PUT work properly with convenience operations 
-over valueID's.
+- Fix: Now the operations GET, POST and PUT work properly with convenience operations over valueID's.
+- Fix: JSON/XML Payload parsing that ended in parse error had a bug resulting in a possible memory leak.

--- a/src/lib/jsonParse/jsonRequest.cpp
+++ b/src/lib/jsonParse/jsonRequest.cpp
@@ -146,6 +146,9 @@ std::string jsonTreat(const char* content, ConnectionInfo* ciP, ParseData* parse
     LM_RE(errorReply, ("Sorry, no request treating object found for RequestType %d (%s)", request, requestType(request)));
   }
 
+  if (reqPP != NULL)
+    *reqPP = reqP;
+
   LM_T(LmtParse, ("Treating '%s' request", reqP->keyword.c_str()));
 
   reqP->init(parseDataP);
@@ -165,9 +168,6 @@ std::string jsonTreat(const char* content, ConnectionInfo* ciP, ParseData* parse
 
   res = reqP->check(parseDataP, ciP);
   reqP->present(parseDataP);
-
-  if (reqPP != NULL)
-    *reqPP = reqP;
 
   return res;
 }

--- a/src/lib/xmlParse/xmlRequest.cpp
+++ b/src/lib/xmlParse/xmlRequest.cpp
@@ -211,6 +211,9 @@ std::string xmlTreat(const char* content, ConnectionInfo* ciP, ParseData* parseD
   }
 
 
+  if (reqPP != NULL)
+    *reqPP = reqP;
+
   //
   // Checking that the payload matches the URL
   //
@@ -248,18 +251,6 @@ std::string xmlTreat(const char* content, ConnectionInfo* ciP, ParseData* parseD
      LM_E(("check(%s): %s", reqP->keyword.c_str(), check.c_str()));
 
   reqP->present(parseDataP);
-
-  // -----------------------------
-  //
-  // Can't release here ...
-  // reqP->release(parseDataP);
-  //
-  // pass request pointer to father that will know when the free can be executed.
-  //
-  if (reqPP != NULL)
-  {
-    *reqPP = reqP;
-  }
 
   return check;
 }


### PR DESCRIPTION
### Description

The pointer to the result of the parse was copied as output after the function returns a 'parse error'.
So, in case of parse error, the caller cannot cleanup the allocated data during the parse.
The fix is more than simple - just copy the pointer before 'return parse-error'
