### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ sudo make install  # installation puts .h files in /usr/local/include and librar
 sudo ldconfig      # just in case... it doesn't hurt :)
 ```
 
-* Get the code (alternatively you can download it using a zipped version or a different URL pattern):
+* Get the code (alternatively you can download it using a zipped version or a different URL pattern, e.g `git clone git@github.com:telefonicaid/fiware-orion.git`):
 
 ```
 sudo yum install git
 git clone https://github.com/telefonicaid/fiware-orion
+```
 
 * Build the source:
 


### PR DESCRIPTION
former link shows:
###### 

[root@localhost mongo-cxx-driver-v2.2]# git clone git@github.com:telefonicaid/fiware-orion.git
Cloning into 'fiware-orion'...
Warning: Permanently added the RSA host key for IP address '192.30.252.131' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
###### 

so I changed the link in order to allow downloading the repo
