### PR TITLE
No more responses with 'random' reasonPhrase

### DIFF
--- a/src/lib/convenience/AppendContextElementRequest.cpp
+++ b/src/lib/convenience/AppendContextElementRequest.cpp
@@ -74,8 +74,7 @@ std::string AppendContextElementRequest::render(RequestType requestType, Format 
 -
 *   else if ((res = attributeDomainName.check(AppendContextElement, format, indent, predetectedError, counter)) != "OK")
 *   {
-*     response.errorCode.code         = SccBadRequest;
-*     response.errorCode.reasonPhrase = res;
+*     response.errorCode.fill(SccBadRequest, res):
 *   }
 *
 */
@@ -86,18 +85,15 @@ std::string AppendContextElementRequest::check(RequestType requestType, Format f
 
    if (predetectedError != "")
    {
-     response.errorCode.code         = SccBadRequest;
-     response.errorCode.reasonPhrase = predetectedError;
+     response.errorCode.fill(SccBadRequest, predetectedError);
    }
    else if ((res = contextAttributeVector.check(AppendContextElement, format, indent, predetectedError, counter)) != "OK")
    {
-     response.errorCode.code         = SccBadRequest;
-     response.errorCode.reasonPhrase = res;
+     response.errorCode.fill(SccBadRequest, res);
    }
    else if ((res = domainMetadataVector.check(AppendContextElement, format, indent, predetectedError, counter)) != "OK")
    {
-     response.errorCode.code         = SccBadRequest;
-     response.errorCode.reasonPhrase = res;
+     response.errorCode.fill(SccBadRequest, res);
    }
    else
      return "OK";

--- a/src/lib/convenience/ContextAttributeResponse.cpp
+++ b/src/lib/convenience/ContextAttributeResponse.cpp
@@ -65,14 +65,12 @@ std::string ContextAttributeResponse::check(RequestType requestType, Format form
 
    if (predetectedError != "")
    {
-     statusCode.code         = SccBadRequest;
-     statusCode.reasonPhrase = predetectedError;
+     statusCode.fill(SccBadRequest, predetectedError);
    }
    else if ((res = contextAttributeVector.check(requestType, format, indent, predetectedError, counter)) != "OK")
    {
      LM_E(("contextAttributeVector::check flags an error: '%s'", res.c_str()));
-     statusCode.code         = SccBadRequest;
-     statusCode.reasonPhrase = res;
+     statusCode.fill(SccBadRequest, res);
 
      //
      // If this ContextAttributeResponse is part of an IndividualContextEntity, the complete rendered 
@@ -82,7 +80,7 @@ std::string ContextAttributeResponse::check(RequestType requestType, Format form
        return res;
    }
    else 
-      return "OK";
+     return "OK";
 
    return render(requestType, format, indent);
 }

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -91,16 +91,14 @@ std::string RegisterProviderRequest::check(RequestType requestType, Format forma
 
    if (predetectedError != "")
    {
-      response.errorCode.code         = SccBadRequest;
-      response.errorCode.reasonPhrase = predetectedError;
+     response.errorCode.fill(SccBadRequest, predetectedError);
    }
    else if (((res = metadataVector.check(requestType, format, indent, "", counter))  != "OK") ||
             ((res = duration.check(requestType, format, indent, "", 0))              != "OK") ||
             ((res = providingApplication.check(requestType, format, indent, "", 0))  != "OK") ||
             ((res = registrationId.check(requestType, format, indent, "", 0))        != "OK"))
    {
-      response.errorCode.code = SccBadRequest;
-      response.errorCode.reasonPhrase = res;
+     response.errorCode.fill(SccBadRequest, res);
    }
    else
       return "OK";

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -82,18 +82,15 @@ std::string UpdateContextAttributeRequest::check(RequestType requestType, Format
 
   if (predetectedError != "")
   {
-    response.code         = SccBadRequest;
-    response.reasonPhrase = predetectedError;
+    response.fill(SccBadRequest, predetectedError);
   }
   else if (contextValue == "")
   {
-    response.code         = SccBadRequest;
-    response.reasonPhrase = "empty context value";
+    response.fill(SccBadRequest, "empty context value");
   }
   else if ((res = metadataVector.check(requestType, format, indent, predetectedError, counter)) != "OK")
   {
-    response.code         = SccBadRequest;
-    response.reasonPhrase = res;
+    response.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/convenience/UpdateContextElementRequest.cpp
+++ b/src/lib/convenience/UpdateContextElementRequest.cpp
@@ -64,8 +64,7 @@ std::string UpdateContextElementRequest::render(RequestType requestType, Format 
 -
 *   else if ((res = attributeDomainName.check(AppendContextElement, format, indent, predetectedError, counter)) != "OK")
 *   {
-*     response.errorCode.code         = SccBadRequest;
-*     response.errorCode.reasonPhrase = res;
+*     response.errorCode.fill(SccBadRequest, res);
 *   }
 *
 */
@@ -76,13 +75,11 @@ std::string UpdateContextElementRequest::check(RequestType requestType, Format f
 
    if (predetectedError != "")
    {
-     response.errorCode.code         = SccBadRequest;
-     response.errorCode.reasonPhrase = predetectedError;
+     response.errorCode.fill(SccBadRequest, predetectedError);
    }
    else if ((res = contextAttributeVector.check(UpdateContextElement, format, indent, predetectedError, counter)) != "OK")
    {
-     response.errorCode.code         = SccBadRequest;
-     response.errorCode.reasonPhrase = res;
+     response.errorCode.fill(SccBadRequest, res);
    }
    else
      return "OK";

--- a/src/lib/jsonParse/jsonNotifyContextRequest.cpp
+++ b/src/lib/jsonParse/jsonNotifyContextRequest.cpp
@@ -213,7 +213,7 @@ static std::string statusCodeCode(std::string path, std::string value, ParseData
 static std::string statusCodeReasonPhrase(std::string path, std::string value, ParseData* parseDataP)
 {
   LM_T(LmtParse, ("Got a statusCode reasonPhrase: '%s'", value.c_str()));
-  parseDataP->ncr.cerP->statusCode.reasonPhrase = value;
+  parseDataP->ncr.cerP->statusCode.reasonPhrase = value; // OK - parsing step reading reasonPhrase
   return "OK";
 }
 

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -69,15 +69,13 @@ std::string NotifyContextRequest::check(RequestType requestType, Format format, 
    
   if (predetectedError != "")
   {
-    response.responseCode.code         = SccBadRequest;
-    response.responseCode.reasonPhrase = predetectedError;
+    response.responseCode.fill(SccBadRequest, predetectedError);
   }
   else if (((res = subscriptionId.check(QueryContext, format, indent, predetectedError, 0))               != "OK") ||
            ((res = originator.check(QueryContext, format, indent, predetectedError, 0))                   != "OK") ||
            ((res = contextElementResponseVector.check(QueryContext, format, indent, predetectedError, 0)) != "OK"))
   {
-    response.responseCode.code         = SccBadRequest;
-    response.responseCode.reasonPhrase = res;
+    response.responseCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi10/QueryContextRequest.cpp
+++ b/src/lib/ngsi10/QueryContextRequest.cpp
@@ -81,15 +81,13 @@ std::string QueryContextRequest::check(RequestType requestType, Format format, s
 
   if (predetectedError != "")
   {
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = predetectedError;
+    response.errorCode.fill(SccBadRequest, predetectedError);
   }
   else if (((res = entityIdVector.check(QueryContext, format, indent, predetectedError, 0))         != "OK") ||
            ((res = attributeList.check(QueryContext, format, indent, predetectedError, 0))          != "OK") ||
            ((res = restriction.check(QueryContext, format, indent, predetectedError, restrictions)) != "OK"))
   {
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = res;
+    response.errorCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi10/UpdateContextSubscriptionRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextSubscriptionRequest.cpp
@@ -88,9 +88,8 @@ std::string UpdateContextSubscriptionRequest::check(RequestType requestType, For
 
   if (predetectedError != "")
   {
-    response.subscribeError.subscriptionId         = subscriptionId;
-    response.subscribeError.errorCode.code         = SccBadRequest;
-    response.subscribeError.errorCode.reasonPhrase = predetectedError;
+    response.subscribeError.subscriptionId = subscriptionId;
+    response.subscribeError.errorCode.fill(SccBadRequest, predetectedError);
   }
   else if (((res = duration.check(UpdateContextSubscription, format, indent, predetectedError, counter))              != "OK") ||
            ((res = restriction.check(UpdateContextSubscription, format, indent, predetectedError, restrictions))      != "OK") ||
@@ -98,9 +97,8 @@ std::string UpdateContextSubscriptionRequest::check(RequestType requestType, For
            ((res = notifyConditionVector.check(UpdateContextSubscription, format, indent, predetectedError, counter)) != "OK") ||
            ((res = throttling.check(UpdateContextSubscription, format, indent, predetectedError, counter))            != "OK"))
   {
-    response.subscribeError.subscriptionId         = subscriptionId;
-    response.subscribeError.errorCode.code         = SccBadRequest;
-    response.subscribeError.errorCode.reasonPhrase = res;
+    response.subscribeError.subscriptionId = subscriptionId;
+    response.subscribeError.errorCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi9/DiscoverContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/DiscoverContextAvailabilityRequest.cpp
@@ -70,20 +70,17 @@ std::string DiscoverContextAvailabilityRequest::check(RequestType requestType, F
 
   if (predetectedError != "")
   {
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = predetectedError;
+    response.errorCode.fill(SccBadRequest, predetectedError);
   }
   else if (entityIdVector.size() == 0)
   {
-     response.errorCode.code         = SccContextElementNotFound;
-     response.errorCode.reasonPhrase = "No context element found";
+    response.errorCode.fill(SccContextElementNotFound);
   }
   else if (((res = entityIdVector.check(DiscoverContextAvailability, format, indent, predetectedError, restrictions))                      != "OK") ||
            ((res = attributeList.check(DiscoverContextAvailability, format, indent, predetectedError, restrictions))                       != "OK") ||
            ((restrictions != 0) && ((res = restriction.check(DiscoverContextAvailability, format, indent, predetectedError, restrictions)) != "OK")))
   {
-     response.errorCode.code         = SccBadRequest;
-     response.errorCode.reasonPhrase = res;
+    response.errorCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi9/DiscoverContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/DiscoverContextAvailabilityResponse.cpp
@@ -61,10 +61,7 @@ DiscoverContextAvailabilityResponse::~DiscoverContextAvailabilityResponse()
 */
 DiscoverContextAvailabilityResponse::DiscoverContextAvailabilityResponse(StatusCode& _errorCode)
 {
-  errorCode.code         = _errorCode.code;
-  errorCode.reasonPhrase = _errorCode.reasonPhrase;
-  errorCode.details      = _errorCode.details;
-
+  errorCode.fill(&_errorCode);
   errorCode.tagSet("errorCode");
 }
 

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
@@ -78,14 +78,12 @@ std::string NotifyContextAvailabilityRequest::check(RequestType requestType, For
 
   if (predetectedError != "")
   {
-    response.responseCode.code         = SccBadRequest;
-    response.responseCode.reasonPhrase = predetectedError;
+    response.responseCode.fill(SccBadRequest, predetectedError);
   }
   else if (((res = subscriptionId.check(QueryContext, format, indent, predetectedError, 0))                    != "OK") ||
            ((res = contextRegistrationResponseVector.check(QueryContext, format, indent, predetectedError, 0)) != "OK"))
   {
-    response.responseCode.code         = SccBadRequest;
-    response.responseCode.reasonPhrase = res;
+    response.responseCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi9/RegisterContextRequest.cpp
+++ b/src/lib/ngsi9/RegisterContextRequest.cpp
@@ -77,22 +77,19 @@ std::string RegisterContextRequest::check(RequestType requestType, Format format
   if (predetectedError != "")
   {
     LM_E(("predetectedError not empty"));
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = predetectedError;
+    response.errorCode.fill(SccBadRequest, predetectedError);
   }
   else if (contextRegistrationVector.size() == 0)
   {
     LM_E(("contextRegistrationVector.size() == 0"));
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = "Empty Context Registration List";
+    response.errorCode.fill(SccBadRequest, "Empty Context Registration List");
   }
   else if (((res = contextRegistrationVector.check(RegisterContext, format, indent, predetectedError, counter)) != "OK") ||
            ((res = duration.check(RegisterContext, format, indent, predetectedError, counter))                  != "OK") ||
            ((res = registrationId.check(RegisterContext, format, indent, predetectedError, counter))            != "OK"))
   {
     LM_E(("Some check method failed: %s", res.c_str()));
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = res;
+    response.errorCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi9/RegisterContextResponse.cpp
+++ b/src/lib/ngsi9/RegisterContextResponse.cpp
@@ -132,14 +132,12 @@ std::string RegisterContextResponse::check(RequestType requestType, Format forma
 
   if (predetectedError != "")
   {
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = predetectedError;
+    response.errorCode.fill(SccBadRequest, predetectedError);
   }
   else if (((res = duration.check(RegisterResponse, format, indent, predetectedError, counter))       != "OK") ||
            ((res = registrationId.check(RegisterResponse, format, indent, predetectedError, counter)) != "OK"))
   {
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = res;
+    response.errorCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
@@ -87,8 +87,7 @@ std::string SubscribeContextAvailabilityRequest::check(RequestType requestType, 
 
   if (predetectedError != "")
   {
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = predetectedError;
+    response.errorCode.fill(SccBadRequest, predetectedError);
   }
   else if (((res = entityIdVector.check(SubscribeContextAvailability, format, indent, predetectedError, counter))   != "OK") ||
            ((res = attributeList.check(SubscribeContextAvailability, format, indent, predetectedError, counter))    != "OK") ||
@@ -96,9 +95,7 @@ std::string SubscribeContextAvailabilityRequest::check(RequestType requestType, 
            ((res = duration.check(SubscribeContextAvailability, format, indent, predetectedError, counter))         != "OK") ||
            ((res = restriction.check(SubscribeContextAvailability, format, indent, predetectedError, restrictions)) != "OK"))
   {
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = httpStatusCodeString(SccBadRequest);
-    response.errorCode.details      = res;
+    response.errorCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi9/UnsubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/UnsubscribeContextAvailabilityRequest.cpp
@@ -64,13 +64,11 @@ std::string UnsubscribeContextAvailabilityRequest::check(RequestType requestType
 
   if (predetectedError != "")
   {
-    response.statusCode.code         = SccBadRequest;
-    response.statusCode.reasonPhrase = predetectedError;
+    response.statusCode.fill(SccBadRequest, predetectedError);
   }
   else if ((res = subscriptionId.check(UnsubscribeContextAvailability, format, indent, predetectedError, counter)) != "OK")
   {
-    response.statusCode.code         = SccBadRequest;
-    response.statusCode.reasonPhrase = res;
+    response.statusCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
@@ -105,8 +105,7 @@ std::string UpdateContextAvailabilitySubscriptionRequest::check(RequestType requ
 
   if (predetectedError != "")
   {
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = predetectedError;
+    response.errorCode.fill(SccBadRequest, predetectedError);
   }
   else if (((res = entityIdVector.check(UpdateContextAvailabilitySubscription, format, indent, predetectedError, counter))      != "OK") ||
            ((res = attributeList.check(UpdateContextAvailabilitySubscription, format, indent, predetectedError, counter))       != "OK") ||
@@ -114,8 +113,7 @@ std::string UpdateContextAvailabilitySubscriptionRequest::check(RequestType requ
            ((res = restriction.check(UpdateContextAvailabilitySubscription, format, indent, predetectedError, counter))         != "OK") ||
            ((res = subscriptionId.check(UpdateContextAvailabilitySubscription, format, indent, predetectedError, counter))      != "OK"))
   {
-    response.errorCode.code         = SccBadRequest;
-    response.errorCode.reasonPhrase = res;
+    response.errorCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.cpp
@@ -50,10 +50,7 @@ UpdateContextAvailabilitySubscriptionResponse::UpdateContextAvailabilitySubscrip
 */
 UpdateContextAvailabilitySubscriptionResponse::UpdateContextAvailabilitySubscriptionResponse(StatusCode& _errorCode)
 {
-  errorCode.code         = _errorCode.code;
-  errorCode.reasonPhrase = _errorCode.reasonPhrase;
-  errorCode.details      = _errorCode.details;
-
+  errorCode.fill(&_errorCode);
   errorCode.tagSet("errorCode");
 }
 
@@ -106,14 +103,12 @@ std::string UpdateContextAvailabilitySubscriptionResponse::check(RequestType req
 
   if (predetectedError != "")
   {
-    errorCode.code         = SccBadRequest;
-    errorCode.reasonPhrase = predetectedError;
+    errorCode.fill(SccBadRequest, predetectedError);
   }
   else if (((res = subscriptionId.check(UpdateContextAvailabilitySubscription, format, indent, predetectedError, counter)) != "OK") ||
            ((res = duration.check(UpdateContextAvailabilitySubscription, format, indent, predetectedError, counter))       != "OK"))
   {
-    errorCode.code         = SccBadRequest;
-    errorCode.reasonPhrase = res;
+    errorCode.fill(SccBadRequest, res);
   }
   else
     return "OK";

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -29,6 +29,7 @@
 
 #include "common/string.h"
 #include "common/wsStrip.h"
+#include "common/globals.h"
 #include "rest/RestService.h"
 #include "rest/rest.h"
 #include "rest/restReply.h"
@@ -542,11 +543,11 @@ void restInit(RestService* _restServiceV, IpVersion _ipVersion, const char* _bin
      strncpy(bindIPv6, bindIPv6, MAX_LEN_IP - 1);
 
 
-  // Starting REST intrerface
+  // Starting REST interface
   int r;
   if ((r = restStart(_ipVersion)) != 0)
   {
     fprintf(stderr, "restStart: error %d\n", r);
-    LM_X(1, ("restStart: error %d", r));
+    orionExitFunction(1, "restStart: error");
   }
 }

--- a/src/lib/xmlParse/xmlNotifyContextRequest.cpp
+++ b/src/lib/xmlParse/xmlNotifyContextRequest.cpp
@@ -306,7 +306,7 @@ static int statusCodeCode(xml_node<>* node, ParseData* parseDataP)
 static int statusCodeReasonPhrase(xml_node<>* node, ParseData* parseDataP)
 {
   LM_T(LmtParse, ("Got a statusCode reasonPhrase: '%s'", node->value()));
-  parseDataP->ncr.cerP->statusCode.reasonPhrase = node->value();
+  parseDataP->ncr.cerP->statusCode.reasonPhrase = node->value(); // OK - parsing step
   return 0;
 }
 

--- a/src/lib/xmlParse/xmlRegisterContextResponse.cpp
+++ b/src/lib/xmlParse/xmlRegisterContextResponse.cpp
@@ -86,7 +86,7 @@ static int errorCodeCode(xml_node<>* node, ParseData* reqData)
 static int errorCodeReasonPhrase(xml_node<>* node, ParseData* reqData)
 {
   LM_T(LmtParse, ("Got an errorCode reason phrase: '%s'", node->value()));
-  reqData->rcrs.res.errorCode.reasonPhrase = node->value();
+  reqData->rcrs.res.errorCode.reasonPhrase = node->value(); // OK - parsing step
   return 0;
 }
 

--- a/test/testharness/jsonParse/empty_payloads.test
+++ b/test/testharness/jsonParse/empty_payloads.test
@@ -72,14 +72,15 @@ echo "13: ++++++++++++++++++++"
 
 --REGEXPECT--
 HTTP/1.1 200 OK
-Content-Length: 150
+Content-Length: 181
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "errorCode": {
         "code": "400",
-        "reasonPhrase": "Empty Context Registration List"
+        "details": "Empty Context Registration List",
+        "reasonPhrase": "Bad Request"
     },
     "registrationId": "000000000000000000000000"
 }
@@ -111,14 +112,15 @@ Date: REGEX(.*)
 }
 3: ++++++++++++++++++++
 HTTP/1.1 200 OK
-Content-Length: 130
+Content-Length: 161
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "errorCode": {
         "code": "400",
-        "reasonPhrase": "No entities"
+        "details": "No entities",
+        "reasonPhrase": "Bad Request"
     },
     "subscriptionId": "000000000000000000000000"
 }
@@ -137,14 +139,15 @@ Date: REGEX(.*)
 }
 5: ++++++++++++++++++++
 HTTP/1.1 200 OK
-Content-Length: 81
+Content-Length: 112
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "errorCode": {
         "code": "400",
-        "reasonPhrase": "No entities"
+        "details": "No entities",
+        "reasonPhrase": "Bad Request"
     }
 }
 6: ++++++++++++++++++++

--- a/test/testharness/update_sequence_empty_value_in_context_value_json.test
+++ b/test/testharness/update_sequence_empty_value_in_context_value_json.test
@@ -1,0 +1,85 @@
+# Copyright 2014 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# fermin at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Create and query compound values (standard op and JSON creation)
+--SHELL-INIT--
+source harnessFunctions.sh
+
+dbInit CB
+brokerStart CB
+
+--SHELL--
+echo "1: +++++++++ create vector compound +++++++++++"
+(curl localhost:${BROKER_PORT}/NGSI10/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+{
+    "contextElements": [
+        {
+            "type": "T",
+            "isPattern": "false",
+            "id": "EVector",
+            "attributes": [
+            {
+                "name": "att",
+                "type": "compound",
+                "value": [
+                   "",
+                   {
+                      "x": [ "x1", "x2" ],
+                      "y": "3"
+                   },
+                   [ "z1", "z2" ]
+                ]
+            }
+            ]
+        }
+    ],
+    "updateAction": "APPEND"
+}
+EOF
+--REGEXPECT--
+1: +++++++++ create vector compound +++++++++++
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "compound",
+                        "value": ""
+                    }
+                ],
+                "id": "EVector",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+--TEARDOWN--
+source harnessFunctions.sh
+brokerStop CB

--- a/test/testharness/xmlParse/xmlParsePostNotifyContextAvailability.test
+++ b/test/testharness/xmlParse/xmlParsePostNotifyContextAvailability.test
@@ -137,7 +137,7 @@ Date: REGEX(.*)
 </notifyContextAvailabilityResponse>
 2: ***********************************
 HTTP/1.1 200 OK
-Content-Length: 193
+Content-Length: 228
 Content-Type: application/xml
 Date: REGEX(.*)
 
@@ -145,7 +145,8 @@ Date: REGEX(.*)
 <notifyContextAvailabilityResponse>
   <responseCode>
     <code>400</code>
-    <reasonPhrase>bad length (24 chars expected)</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>bad length (24 chars expected)</details>
   </responseCode>
 </notifyContextAvailabilityResponse>
 3: ***********************************

--- a/test/unittests/ngsi9/DiscoverContextAvailabilityRequest_test.cpp
+++ b/test/unittests/ngsi9/DiscoverContextAvailabilityRequest_test.cpp
@@ -899,9 +899,9 @@ TEST(DiscoverContextAvailabilityRequest, parseError_json)
 
 /* ****************************************************************************
 *
-* emptyAttributeName - 
+* emptyAttributeName_json - 
 */
-TEST(DiscoverContextAvailabilityRequest, emptyAttributeName)
+TEST(DiscoverContextAvailabilityRequest, emptyAttributeName_json)
 {
   ParseData       reqData;
   const char*     inFile  = "ngsi9.discoverContextAvailabilityRequest.emptyAttributeName.invalid.json";

--- a/test/unittests/testData/ngsi10.appendContextElementResponse.missingAttributeName.invalid.xml
+++ b/test/unittests/testData/ngsi10.appendContextElementResponse.missingAttributeName.invalid.xml
@@ -1,6 +1,7 @@
 <appendContextElementResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>missing attribute name</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing attribute name</details>
   </errorCode>
 </appendContextElementResponse>

--- a/test/unittests/testData/ngsi10.appendContextElementResponse.missingAttributeName.valid.json
+++ b/test/unittests/testData/ngsi10.appendContextElementResponse.missingAttributeName.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "missing attribute name"
+    "reasonPhrase" : "Bad Request",
+    "details" : "missing attribute name"
   }
 }

--- a/test/unittests/testData/ngsi10.appendContextElementResponse.missingMetadataName.invalid.xml
+++ b/test/unittests/testData/ngsi10.appendContextElementResponse.missingMetadataName.invalid.xml
@@ -1,6 +1,7 @@
 <appendContextElementResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>missing metadata name</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing metadata name</details>
   </errorCode>
 </appendContextElementResponse>

--- a/test/unittests/testData/ngsi10.appendContextElementResponse.missingMetadataName.valid.json
+++ b/test/unittests/testData/ngsi10.appendContextElementResponse.missingMetadataName.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "missing metadata name"
+    "reasonPhrase" : "Bad Request",
+    "details" : "missing metadata name"
   }
 }

--- a/test/unittests/testData/ngsi10.appendContextElementResponse.predetectedError.valid.json
+++ b/test/unittests/testData/ngsi10.appendContextElementResponse.predetectedError.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "Error is predetected"
+    "reasonPhrase" : "Bad Request",
+    "details" : "Error is predetected"
   }
 }

--- a/test/unittests/testData/ngsi10.appendContextElementResponse.predetectedError.valid.xml
+++ b/test/unittests/testData/ngsi10.appendContextElementResponse.predetectedError.valid.xml
@@ -1,6 +1,7 @@
 <appendContextElementResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Error is predetected</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Error is predetected</details>
   </errorCode>
 </appendContextElementResponse>

--- a/test/unittests/testData/ngsi10.contextAttributeResponse.check1.valid.json
+++ b/test/unittests/testData/ngsi10.contextAttributeResponse.check1.valid.json
@@ -8,6 +8,7 @@
   ],
   "statusCode" : {
     "code" : "400",
-    "reasonPhrase" : "PRE ERROR"
+    "reasonPhrase" : "Bad Request",
+    "details" : "PRE ERROR"
   }
 }

--- a/test/unittests/testData/ngsi10.contextAttributeResponse.check1.valid.xml
+++ b/test/unittests/testData/ngsi10.contextAttributeResponse.check1.valid.xml
@@ -8,6 +8,7 @@
   </contextAttributeList>
   <statusCode>
     <code>400</code>
-    <reasonPhrase>PRE ERROR</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>PRE ERROR</details>
   </statusCode>
 </contextAttributeResponse>

--- a/test/unittests/testData/ngsi10.contextAttributeResponse.check2.valid.json
+++ b/test/unittests/testData/ngsi10.contextAttributeResponse.check2.valid.json
@@ -13,6 +13,7 @@
   ],
   "statusCode" : {
     "code" : "400",
-    "reasonPhrase" : "missing attribute name"
+    "reasonPhrase" : "Bad Request",
+    "details" : "missing attribute name"
   }
 }

--- a/test/unittests/testData/ngsi10.contextAttributeResponse.check2.valid.xml
+++ b/test/unittests/testData/ngsi10.contextAttributeResponse.check2.valid.xml
@@ -13,6 +13,7 @@
   </contextAttributeList>
   <statusCode>
     <code>400</code>
-    <reasonPhrase>missing attribute name</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing attribute name</details>
   </statusCode>
 </contextAttributeResponse>

--- a/test/unittests/testData/ngsi10.contextAttributeResponse.check3.valid.json
+++ b/test/unittests/testData/ngsi10.contextAttributeResponse.check3.valid.json
@@ -8,7 +8,7 @@
   ],
   "statusCode" : {
     "code" : "400",
-    "reasonPhrase" : "PRE Error",
-    "details" : "OK"
+    "reasonPhrase" : "Bad Request",
+    "details" : "PRE Error"
   }
 }

--- a/test/unittests/testData/ngsi10.contextAttributeResponse.check3.valid.xml
+++ b/test/unittests/testData/ngsi10.contextAttributeResponse.check3.valid.xml
@@ -8,6 +8,7 @@
   </contextAttributeList>
   <statusCode>
     <code>400</code>
-    <reasonPhrase>PRE Error</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>PRE Error</details>
   </statusCode>
 </contextAttributeResponse>

--- a/test/unittests/testData/ngsi10.contextAttributeResponse.check4.valid.json
+++ b/test/unittests/testData/ngsi10.contextAttributeResponse.check4.valid.json
@@ -13,7 +13,7 @@
   ],
   "statusCode" : {
     "code" : "400",
-    "reasonPhrase" : "missing attribute name",
-    "details" : "OK"
+    "reasonPhrase" : "Bad Request",
+    "details" : "missing attribute name"
   }
 }

--- a/test/unittests/testData/ngsi10.contextAttributeResponse.check4.valid.xml
+++ b/test/unittests/testData/ngsi10.contextAttributeResponse.check4.valid.xml
@@ -13,6 +13,7 @@
   </contextAttributeList>
   <statusCode>
     <code>400</code>
-    <reasonPhrase>missing attribute name</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing attribute name</details>
   </statusCode>
 </contextAttributeResponse>

--- a/test/unittests/testData/ngsi10.notifyContextResponse.badIsPattern.valid.json
+++ b/test/unittests/testData/ngsi10.notifyContextResponse.badIsPattern.valid.json
@@ -1,6 +1,7 @@
 {
   "responseCode" : {
     "code" : "400",
-    "reasonPhrase" : "invalid isPattern (boolean) value for entity: 'phalse'"
+    "reasonPhrase" : "Bad Request",
+    "details" : "invalid isPattern (boolean) value for entity: 'phalse'"
   }
 }

--- a/test/unittests/testData/ngsi10.notifyContextResponse.entityIdAttribute.valid.xml
+++ b/test/unittests/testData/ngsi10.notifyContextResponse.entityIdAttribute.valid.xml
@@ -1,6 +1,7 @@
 <notifyContextResponse>
   <responseCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </responseCode>
 </notifyContextResponse>

--- a/test/unittests/testData/ngsi10.notifyContextResponse.isPatternError.valid.xml
+++ b/test/unittests/testData/ngsi10.notifyContextResponse.isPatternError.valid.xml
@@ -1,6 +1,7 @@
 <notifyContextResponse>
   <responseCode>
     <code>400</code>
-    <reasonPhrase>invalid isPattern (boolean) value for entity: 'phalse'</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>invalid isPattern (boolean) value for entity: 'phalse'</details>
   </responseCode>
 </notifyContextResponse>

--- a/test/unittests/testData/ngsi10.notifyContextResponse.predetectedError.valid.xml
+++ b/test/unittests/testData/ngsi10.notifyContextResponse.predetectedError.valid.xml
@@ -1,6 +1,7 @@
 <notifyContextResponse>
   <responseCode>
     <code>400</code>
-    <reasonPhrase>predetected error</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>predetected error</details>
   </responseCode>
 </notifyContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.attributeUnknown.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.attributeUnknown.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.badIsPattern.valid.json
+++ b/test/unittests/testData/ngsi10.queryContextResponse.badIsPattern.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "invalid isPattern (boolean) value for entity: 'fralse'"
+    "reasonPhrase" : "Bad Request",
+    "details" : "invalid isPattern (boolean) value for entity: 'fralse'"
   }
 }

--- a/test/unittests/testData/ngsi10.queryContextResponse.circleInvertedBadValue.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.circleInvertedBadValue.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>bad string for circle/inverted: 'not at all'</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>bad string for circle/inverted: 'not at all'</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.circleZeroRadius.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.circleZeroRadius.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Radius zero for a circle area</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Radius zero for a circle area</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.emptyAttribute.valid.json
+++ b/test/unittests/testData/ngsi10.queryContextResponse.emptyAttribute.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "Empty attribute name"
+    "reasonPhrase" : "Bad Request",
+    "details" : "Empty attribute name"
   }
 }

--- a/test/unittests/testData/ngsi10.queryContextResponse.emptyAttributeExpression.valid.json
+++ b/test/unittests/testData/ngsi10.queryContextResponse.emptyAttributeExpression.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "Empty attribute expression"
+    "reasonPhrase" : "Bad Request",
+    "details" : "Empty attribute expression"
   }
 }

--- a/test/unittests/testData/ngsi10.queryContextResponse.emptyEntityIdId.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.emptyEntityIdId.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>empty entityId:id</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>empty entityId:id</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.emptyEntityList.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.emptyEntityList.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>No entities</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>No entities</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.emptyScopeType.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.emptyScopeType.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty type in restriction scope</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty type in restriction scope</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.emptyScopeValue.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.emptyScopeValue.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty value in restriction scope</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty value in restriction scope</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.entityIdIdAsAttribute.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.entityIdIdAsAttribute.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.isPattern.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.isPattern.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>invalid isPattern (boolean) value for entity: 'fralse'</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>invalid isPattern (boolean) value for entity: 'fralse'</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.noEntityList.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.noEntityList.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>No entities</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>No entities</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.noScopeType.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.noScopeType.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty type in restriction scope</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty type in restriction scope</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.noScopeValue.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.noScopeValue.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty value in restriction scope</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty value in restriction scope</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.polygonInvertedBadValue.valid.json
+++ b/test/unittests/testData/ngsi10.queryContextResponse.polygonInvertedBadValue.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "bad string for polygon/inverted: 'zero'"
+    "reasonPhrase" : "Bad Request",
+    "details" : "bad string for polygon/inverted: 'zero'"
   }
 }

--- a/test/unittests/testData/ngsi10.queryContextResponse.polygonInvertedBadValue.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.polygonInvertedBadValue.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>bad string for polygon/inverted: 'cero'</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>bad string for polygon/inverted: 'cero'</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.polygonNoVertices.valid.json
+++ b/test/unittests/testData/ngsi10.queryContextResponse.polygonNoVertices.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "too few vertices for a polygon"
+    "reasonPhrase" : "Bad Request",
+    "details" : "too few vertices for a polygon"
   }
 }

--- a/test/unittests/testData/ngsi10.queryContextResponse.polygonNoVertices.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.polygonNoVertices.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>too few vertices for a polygon</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>too few vertices for a polygon</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.polygonOneVertex.valid.json
+++ b/test/unittests/testData/ngsi10.queryContextResponse.polygonOneVertex.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "too few vertices for a polygon"
+    "reasonPhrase" : "Bad Request",
+    "details" : "too few vertices for a polygon"
   }
 }

--- a/test/unittests/testData/ngsi10.queryContextResponse.polygonOneVertex.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.polygonOneVertex.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>too few vertices for a polygon</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>too few vertices for a polygon</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.queryContextResponse.polygonTwoVertices.valid.json
+++ b/test/unittests/testData/ngsi10.queryContextResponse.polygonTwoVertices.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "too few vertices for a polygon"
+    "reasonPhrase" : "Bad Request",
+    "details" : "too few vertices for a polygon"
   }
 }

--- a/test/unittests/testData/ngsi10.queryContextResponse.polygonTwoVertices.valid.xml
+++ b/test/unittests/testData/ngsi10.queryContextResponse.polygonTwoVertices.valid.xml
@@ -1,6 +1,7 @@
 <queryContextResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>too few vertices for a polygon</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>too few vertices for a polygon</details>
   </errorCode>
 </queryContextResponse>

--- a/test/unittests/testData/ngsi10.updateContextAttributeRequest.check1.invalid.json
+++ b/test/unittests/testData/ngsi10.updateContextAttributeRequest.check1.invalid.json
@@ -1,4 +1,5 @@
 "statusCode" : {
   "code" : "400",
-  "reasonPhrase" : "PRE Error"
+  "reasonPhrase" : "Bad Request",
+  "details" : "PRE Error"
 }

--- a/test/unittests/testData/ngsi10.updateContextAttributeRequest.check1.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextAttributeRequest.check1.valid.xml
@@ -1,4 +1,5 @@
 <statusCode>
   <code>400</code>
-  <reasonPhrase>PRE Error</reasonPhrase>
+  <reasonPhrase>Bad Request</reasonPhrase>
+  <details>PRE Error</details>
 </statusCode>

--- a/test/unittests/testData/ngsi10.updateContextAttributeRequest.check2.invalid.json
+++ b/test/unittests/testData/ngsi10.updateContextAttributeRequest.check2.invalid.json
@@ -1,4 +1,5 @@
 "statusCode" : {
   "code" : "400",
-  "reasonPhrase" : "empty context value"
+  "reasonPhrase" : "Bad Request",
+  "details" : "empty context value"
 }

--- a/test/unittests/testData/ngsi10.updateContextAttributeRequest.check2.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextAttributeRequest.check2.valid.xml
@@ -1,4 +1,5 @@
 <statusCode>
   <code>400</code>
-  <reasonPhrase>empty context value</reasonPhrase>
+  <reasonPhrase>Bad Request</reasonPhrase>
+  <details>empty context value</details>
 </statusCode>

--- a/test/unittests/testData/ngsi10.updateContextAttributeRequest.check3.invalid.json
+++ b/test/unittests/testData/ngsi10.updateContextAttributeRequest.check3.invalid.json
@@ -1,4 +1,5 @@
 "statusCode" : {
   "code" : "400",
-  "reasonPhrase" : "missing metadata name"
+  "reasonPhrase" : "Bad Request",
+  "details" : "missing metadata name"
 }

--- a/test/unittests/testData/ngsi10.updateContextAttributeRequest.check3.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextAttributeRequest.check3.valid.xml
@@ -1,4 +1,5 @@
 <statusCode>
   <code>400</code>
-  <reasonPhrase>missing metadata name</reasonPhrase>
+  <reasonPhrase>Bad Request</reasonPhrase>
+  <details>missing metadata name</details>
 </statusCode>

--- a/test/unittests/testData/ngsi10.updateContextElementRequest.check1.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextElementRequest.check1.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "PRE Error"
+    "reasonPhrase" : "Bad Request",
+    "details" : "PRE Error"
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextElementRequest.check1.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextElementRequest.check1.valid.xml
@@ -1,6 +1,7 @@
 <updateContextElementResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>PRE Error</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>PRE Error</details>
   </errorCode>
 </updateContextElementResponse>

--- a/test/unittests/testData/ngsi10.updateContextElementRequest.check2.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextElementRequest.check2.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "missing attribute name"
+    "reasonPhrase" : "Bad Request",
+    "details" : "missing attribute name"
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextElementRequest.check2.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextElementRequest.check2.valid.xml
@@ -1,6 +1,7 @@
 <updateContextElementResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>missing attribute name</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing attribute name</details>
   </errorCode>
 </updateContextElementResponse>

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionRequest.badLength.expected1.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionRequest.badLength.expected1.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e2",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "bad length (24 chars expected)"
+      "reasonPhrase" : "Bad Request",
+      "details" : "bad length (24 chars expected)"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionRequest.badLength.expected3.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionRequest.badLength.expected3.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e2",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "FORCED ERROR"
+      "reasonPhrase" : "Bad Request",
+      "details" : "FORCED ERROR"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionRequest.badLength.expected4.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionRequest.badLength.expected4.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e2",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "syntax error in duration string"
+      "reasonPhrase" : "Bad Request",
+      "details" : "syntax error in duration string"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.badDuration.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.badDuration.valid.xml
@@ -3,7 +3,8 @@
     <subscriptionId>12345</subscriptionId>
     <errorCode>
       <code>400</code>
-      <reasonPhrase>syntax error in duration string</reasonPhrase>
+      <reasonPhrase>Bad Request</reasonPhrase>
+      <details>syntax error in duration string</details>
     </errorCode>
   </subscribeError>
 </updateContextSubscriptionResponse>

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.circleInvertedBadValue.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.circleInvertedBadValue.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e21",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "bad string for circle/inverted: 'zero'"
+      "reasonPhrase" : "Bad Request",
+      "details" : "bad string for circle/inverted: 'zero'"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.circleInvertedBadValue.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.circleInvertedBadValue.valid.xml
@@ -3,7 +3,8 @@
     <subscriptionId>111222333444555666777888</subscriptionId>
     <errorCode>
       <code>400</code>
-      <reasonPhrase>bad string for circle/inverted: '2'</reasonPhrase>
+      <reasonPhrase>Bad Request</reasonPhrase>
+      <details>bad string for circle/inverted: '2'</details>
     </errorCode>
   </subscribeError>
 </updateContextSubscriptionResponse>

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.circleZeroRadius.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.circleZeroRadius.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e21",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "Radius zero for a circle area"
+      "reasonPhrase" : "Bad Request",
+      "details" : "Radius zero for a circle area"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.circleZeroRadius.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.circleZeroRadius.valid.xml
@@ -3,7 +3,8 @@
     <subscriptionId>111222333444555666777888</subscriptionId>
     <errorCode>
       <code>400</code>
-      <reasonPhrase>Radius zero for a circle area</reasonPhrase>
+      <reasonPhrase>Bad Request</reasonPhrase>
+      <details>Radius zero for a circle area</details>
     </errorCode>
   </subscribeError>
 </updateContextSubscriptionResponse>

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.forcedError.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.forcedError.valid.xml
@@ -3,7 +3,8 @@
     <subscriptionId>12345</subscriptionId>
     <errorCode>
       <code>400</code>
-      <reasonPhrase>FORCED ERROR</reasonPhrase>
+      <reasonPhrase>Bad Request</reasonPhrase>
+      <details>FORCED ERROR</details>
     </errorCode>
   </subscribeError>
 </updateContextSubscriptionResponse>

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.invalidDuration.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.invalidDuration.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e2b",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "syntax error in duration string"
+      "reasonPhrase" : "Bad Request",
+      "details" : "syntax error in duration string"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonInvertedBadValue.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonInvertedBadValue.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e21",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "bad string for polygon/inverted: 'zero'"
+      "reasonPhrase" : "Bad Request",
+      "details" : "bad string for polygon/inverted: 'zero'"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonInvertedBadValue.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonInvertedBadValue.valid.xml
@@ -3,7 +3,8 @@
     <subscriptionId>111222333444555666777888</subscriptionId>
     <errorCode>
       <code>400</code>
-      <reasonPhrase>bad string for polygon/inverted: 'not false'</reasonPhrase>
+      <reasonPhrase>Bad Request</reasonPhrase>
+      <details>bad string for polygon/inverted: 'not false'</details>
     </errorCode>
   </subscribeError>
 </updateContextSubscriptionResponse>

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonNoVertices.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonNoVertices.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e21",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "too few vertices for a polygon"
+      "reasonPhrase" : "Bad Request",
+      "details" : "too few vertices for a polygon"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonNoVertices.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonNoVertices.valid.xml
@@ -3,7 +3,8 @@
     <subscriptionId>111222333444555666777888</subscriptionId>
     <errorCode>
       <code>400</code>
-      <reasonPhrase>too few vertices for a polygon</reasonPhrase>
+      <reasonPhrase>Bad Request</reasonPhrase>
+      <details>too few vertices for a polygon</details>
     </errorCode>
   </subscribeError>
 </updateContextSubscriptionResponse>

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonOneVertex.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonOneVertex.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e21",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "too few vertices for a polygon"
+      "reasonPhrase" : "Bad Request",
+      "details" : "too few vertices for a polygon"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonOneVertex.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonOneVertex.valid.xml
@@ -3,7 +3,8 @@
     <subscriptionId>111222333444555666777888</subscriptionId>
     <errorCode>
       <code>400</code>
-      <reasonPhrase>too few vertices for a polygon</reasonPhrase>
+      <reasonPhrase>Bad Request</reasonPhrase>
+      <details>too few vertices for a polygon</details>
     </errorCode>
   </subscribeError>
 </updateContextSubscriptionResponse>

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonTwoVertices.valid.json
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonTwoVertices.valid.json
@@ -3,7 +3,8 @@
     "subscriptionId" : "9212ce4b0c214479be429e21",
     "errorCode" : {
       "code" : "400",
-      "reasonPhrase" : "too few vertices for a polygon"
+      "reasonPhrase" : "Bad Request",
+      "details" : "too few vertices for a polygon"
     }
   }
 }

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonTwoVertices.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.polygonTwoVertices.valid.xml
@@ -3,7 +3,8 @@
     <subscriptionId>111222333444555666777888</subscriptionId>
     <errorCode>
       <code>400</code>
-      <reasonPhrase>too few vertices for a polygon</reasonPhrase>
+      <reasonPhrase>Bad Request</reasonPhrase>
+      <details>too few vertices for a polygon</details>
     </errorCode>
   </subscribeError>
 </updateContextSubscriptionResponse>

--- a/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.subscriptionIdLengthInvalid.valid.xml
+++ b/test/unittests/testData/ngsi10.updateContextSubscriptionResponse.subscriptionIdLengthInvalid.valid.xml
@@ -3,7 +3,8 @@
     <subscriptionId>12345</subscriptionId>
     <errorCode>
       <code>400</code>
-      <reasonPhrase>bad length (24 chars expected)</reasonPhrase>
+      <reasonPhrase>Bad Request</reasonPhrase>
+      <details>bad length (24 chars expected)</details>
     </errorCode>
   </subscribeError>
 </updateContextSubscriptionResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityRequest.isPatternValueResponse.valid.json
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityRequest.isPatternValueResponse.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "invalid isPattern (boolean) value for entity: 'falseX'"
+    "reasonPhrase" : "Bad Request",
+    "details" : "invalid isPattern (boolean) value for entity: 'falseX'"
   }
 }

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityRequestResponse.isPattern.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityRequestResponse.isPattern.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>invalid isPattern (boolean) value for entity: 'falseX'</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>invalid isPattern (boolean) value for entity: 'falseX'</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.EntityIdIsPattern.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.EntityIdIsPattern.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>invalid isPattern (boolean) value for entity: 'fahlse'</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>invalid isPattern (boolean) value for entity: 'fahlse'</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyAttributeName.valid.json
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyAttributeName.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "empty attribute name"
+    "reasonPhrase" : "Bad Request",
+    "details" : "empty attribute name"
   }
 }

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyEntityIdId.valid.json
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyEntityIdId.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "empty entityId:id"
+    "reasonPhrase" : "Bad Request",
+    "details" : "empty entityId:id"
   }
 }

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyEntityIdId.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyEntityIdId.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>empty entityId:id</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>empty entityId:id</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyScopeType.valid.json
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyScopeType.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "Empty type in restriction scope"
+    "reasonPhrase" : "Bad Request",
+    "details" : "Empty type in restriction scope"
   }
 }

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyScopeType.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyScopeType.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty type in restriction scope</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty type in restriction scope</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyScopeValue.valid.json
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyScopeValue.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "Empty value in restriction scope"
+    "reasonPhrase" : "Bad Request",
+    "details" : "Empty value in restriction scope"
   }
 }

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyScopeValue.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.emptyScopeValue.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty value in restriction scope</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty value in restriction scope</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.entityIdIdAsAttribute.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.entityIdIdAsAttribute.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noEntityIdId.valid.json
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noEntityIdId.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "empty entityId:id"
+    "reasonPhrase" : "Bad Request",
+    "details" : "empty entityId:id"
   }
 }

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noEntityIdId.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noEntityIdId.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>empty entityId:id</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>empty entityId:id</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noScopeType.valid.json
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noScopeType.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "Empty type in restriction scope"
+    "reasonPhrase" : "Bad Request",
+    "details" : "Empty type in restriction scope"
   }
 }

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noScopeType.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noScopeType.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty type in restriction scope</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty type in restriction scope</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noScopeValue.valid.json
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noScopeValue.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "Empty value in restriction scope"
+    "reasonPhrase" : "Bad Request",
+    "details" : "Empty value in restriction scope"
   }
 }

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noScopeValue.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.noScopeValue.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty value in restriction scope</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty value in restriction scope</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.overrideEntityIdIsPattern.valid.json
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.overrideEntityIdIsPattern.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "invalid isPattern (boolean) value for entity: 'falseH'"
+    "reasonPhrase" : "Bad Request",
+    "details" : "invalid isPattern (boolean) value for entity: 'falseH'"
   }
 }

--- a/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.unsupportedAttributeForEntityId.valid.xml
+++ b/test/unittests/testData/ngsi9.discoverContextAvailabilityResponse.unsupportedAttributeForEntityId.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.notifyContextAvailabilityResponse.invalidEntityAttribute.valid.xml
+++ b/test/unittests/testData/ngsi9.notifyContextAvailabilityResponse.invalidEntityAttribute.valid.xml
@@ -1,6 +1,7 @@
 <notifyContextAvailabilityResponse>
   <responseCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </responseCode>
 </notifyContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.notifyContextAvailabilityResponse.invalidSubscriptionId.valid.xml
+++ b/test/unittests/testData/ngsi9.notifyContextAvailabilityResponse.invalidSubscriptionId.valid.xml
@@ -1,6 +1,7 @@
 <notifyContextAvailabilityResponse>
   <responseCode>
     <code>400</code>
-    <reasonPhrase>bad length (24 chars expected)</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>bad length (24 chars expected)</details>
   </responseCode>
 </notifyContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.notifyContextAvailabilityResponse.predetectedError.valid.xml
+++ b/test/unittests/testData/ngsi9.notifyContextAvailabilityResponse.predetectedError.valid.xml
@@ -1,6 +1,7 @@
 <notifyContextAvailabilityResponse>
   <responseCode>
     <code>400</code>
-    <reasonPhrase>predetected error</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>predetected error</details>
   </responseCode>
 </notifyContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.badContextRegistrationAttributeIsDomain.valid.json
+++ b/test/unittests/testData/ngsi9.registerContextResponse.badContextRegistrationAttributeIsDomain.valid.json
@@ -3,6 +3,7 @@
   "registrationId" : "000000000000000000000000",
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "missing isDomain value for registration attribute"
+    "reasonPhrase" : "Bad Request",
+    "details" : "missing isDomain value for registration attribute"
   }
 }

--- a/test/unittests/testData/ngsi9.registerContextResponse.constructors2.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.constructors2.valid.xml
@@ -2,6 +2,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>bad length (24 chars expected)</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>bad length (24 chars expected)</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.constructors3.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.constructors3.valid.xml
@@ -2,6 +2,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Forced Error</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Forced Error</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.constructors4.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.constructors4.valid.xml
@@ -2,6 +2,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>syntax error in duration string</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>syntax error in duration string</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.contextRegistrationAttributeIsDomain.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.contextRegistrationAttributeIsDomain.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>invalid isDomain (boolean) value for registration attribute: 'fallsehh'</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>invalid isDomain (boolean) value for registration attribute: 'fallsehh'</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.duration.invalid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.duration.invalid.xml
@@ -2,6 +2,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>syntax error in duration string</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>syntax error in duration string</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.emptyContextMetadataName.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.emptyContextMetadataName.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>missing metadata name</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing metadata name</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.emptyContextMetadataValue.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.emptyContextMetadataValue.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>missing metadata value</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing metadata value</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.emptyContextRegistration.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.emptyContextRegistration.valid.xml
@@ -2,6 +2,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty Context Registration List</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty Context Registration List</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.emptyContextRegistrationAttributeIsDomain.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.emptyContextRegistrationAttributeIsDomain.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>missing isDomain value for registration attribute</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing isDomain value for registration attribute</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.emptyContextRegistrationAttributeName.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.emptyContextRegistrationAttributeName.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>missing name for registration attribute</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing name for registration attribute</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.emptyEntityIdList.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.emptyEntityIdList.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty entityIdVector</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty entityIdVector</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.emptyProvidingApplication.valid.json
+++ b/test/unittests/testData/ngsi9.registerContextResponse.emptyProvidingApplication.valid.json
@@ -3,6 +3,7 @@
   "registrationId" : "000000000000000000000000",
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "no providing application"
+    "reasonPhrase" : "Bad Request",
+    "details" : "no providing application"
   }
 }

--- a/test/unittests/testData/ngsi9.registerContextResponse.emptyProvidingApplication.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.emptyProvidingApplication.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>no providing application</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>no providing application</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.emptyRegistrationMetadataValue.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.emptyRegistrationMetadataValue.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>missing metadata value</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing metadata value</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.entityIdAttribute.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.entityIdAttribute.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.entityIdWithEmptyId.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.entityIdWithEmptyId.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>empty entityId:id</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>empty entityId:id</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.entityIdWithIsPatternTrue.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.entityIdWithIsPatternTrue.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>'isPattern' set to true for a registration</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>'isPattern' set to true for a registration</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.entityIdWithNoId.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.entityIdWithNoId.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>empty entityId:id</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>empty entityId:id</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.invalidSourceEntityId.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.invalidSourceEntityId.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.invalidTargetEntityId.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.invalidTargetEntityId.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.isPattern.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.isPattern.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>invalid isPattern (boolean) value for entity: 'not false'</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>invalid isPattern (boolean) value for entity: 'not false'</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.noContextRegistration.valid.json
+++ b/test/unittests/testData/ngsi9.registerContextResponse.noContextRegistration.valid.json
@@ -2,6 +2,7 @@
   "registrationId" : "000000000000000000000000",
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "Empty Context Registration List"
+    "reasonPhrase" : "Bad Request",
+    "details" : "Empty Context Registration List"
   }
 }

--- a/test/unittests/testData/ngsi9.registerContextResponse.noContextRegistration.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.noContextRegistration.valid.xml
@@ -2,6 +2,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Empty Context Registration List</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Empty Context Registration List</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.noProvidingApplication.valid.json
+++ b/test/unittests/testData/ngsi9.registerContextResponse.noProvidingApplication.valid.json
@@ -3,6 +3,7 @@
   "registrationId" : "000000000000000000000000",
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "no providing application"
+    "reasonPhrase" : "Bad Request",
+    "details" : "no providing application"
   }
 }

--- a/test/unittests/testData/ngsi9.registerContextResponse.noProvidingApplication.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.noProvidingApplication.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>no providing application</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>no providing application</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerContextResponse.twoEntityIdLists.valid.xml
+++ b/test/unittests/testData/ngsi9.registerContextResponse.twoEntityIdLists.valid.xml
@@ -3,6 +3,7 @@
   <registrationId>000000000000000000000000</registrationId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>Got an entityIdList when one was present already</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Got an entityIdList when one was present already</details>
   </errorCode>
 </registerContextResponse>

--- a/test/unittests/testData/ngsi9.registerProviderRequest.noMetdataName.valid.json
+++ b/test/unittests/testData/ngsi9.registerProviderRequest.noMetdataName.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "missing metadata name"
+    "reasonPhrase" : "Bad Request",
+    "details" : "missing metadata name"
   }
 }

--- a/test/unittests/testData/ngsi9.registerProviderRequest.noMetdataName.valid.xml
+++ b/test/unittests/testData/ngsi9.registerProviderRequest.noMetdataName.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>missing metadata name</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>missing metadata name</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.registerProviderRequest.predetectedError.valid.json
+++ b/test/unittests/testData/ngsi9.registerProviderRequest.predetectedError.valid.json
@@ -1,6 +1,7 @@
 {
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "forced predetectedError"
+    "reasonPhrase" : "Bad Request",
+    "details" : "forced predetectedError"
   }
 }

--- a/test/unittests/testData/ngsi9.registerProviderRequest.predetectedError.valid.xml
+++ b/test/unittests/testData/ngsi9.registerProviderRequest.predetectedError.valid.xml
@@ -1,6 +1,7 @@
 <discoverContextAvailabilityResponse>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>forced predetectedError</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>forced predetectedError</details>
   </errorCode>
 </discoverContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.unsubscribeContextAvailabilityResponse.badSubscriptionId.valid.json
+++ b/test/unittests/testData/ngsi9.unsubscribeContextAvailabilityResponse.badSubscriptionId.valid.json
@@ -2,6 +2,7 @@
   "subscriptionId" : "12345",
   "statusCode" : {
     "code" : "400",
-    "reasonPhrase" : "bad length (24 chars expected)"
+    "reasonPhrase" : "Bad Request",
+    "details" : "bad length (24 chars expected)"
   }
 }

--- a/test/unittests/testData/ngsi9.unsubscribeContextAvailabilityResponse.forcedError.valid.xml
+++ b/test/unittests/testData/ngsi9.unsubscribeContextAvailabilityResponse.forcedError.valid.xml
@@ -2,6 +2,7 @@
   <subscriptionId>000000000000000000000000</subscriptionId>
   <statusCode>
     <code>400</code>
-    <reasonPhrase>Forced Error</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>Forced Error</details>
   </statusCode>
 </unsubscribeContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.unsubscribeContextAvailabilityResponse.invalidSubscriptionId.valid.xml
+++ b/test/unittests/testData/ngsi9.unsubscribeContextAvailabilityResponse.invalidSubscriptionId.valid.xml
@@ -2,6 +2,7 @@
   <subscriptionId>1</subscriptionId>
   <statusCode>
     <code>400</code>
-    <reasonPhrase>bad length (24 chars expected)</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>bad length (24 chars expected)</details>
   </statusCode>
 </unsubscribeContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.unsubscribeContextAvailabilityResponse.invalidSubscriptionId2.valid.xml
+++ b/test/unittests/testData/ngsi9.unsubscribeContextAvailabilityResponse.invalidSubscriptionId2.valid.xml
@@ -2,6 +2,7 @@
   <subscriptionId>12345</subscriptionId>
   <statusCode>
     <code>400</code>
-    <reasonPhrase>bad length (24 chars expected)</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>bad length (24 chars expected)</details>
   </statusCode>
 </unsubscribeContextAvailabilityResponse>

--- a/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionRequest.expected2.valid.json
+++ b/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionRequest.expected2.valid.json
@@ -2,6 +2,7 @@
   "subscriptionId" : "012345678901234567890123",
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "predetected error"
+    "reasonPhrase" : "Bad Request",
+    "details" : "predetected error"
   }
 }

--- a/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionRequest.expected3.valid.json
+++ b/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionRequest.expected3.valid.json
@@ -2,6 +2,7 @@
   "subscriptionId" : "012345678901234567890123",
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "syntax error in duration string"
+    "reasonPhrase" : "Bad Request",
+    "details" : "syntax error in duration string"
   }
 }

--- a/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionResponse.entityIdAttribute.valid.xml
+++ b/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionResponse.entityIdAttribute.valid.xml
@@ -2,6 +2,7 @@
   <subscriptionId>012345678901234567890123</subscriptionId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>unsupported attribute for EntityId</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>unsupported attribute for EntityId</details>
   </errorCode>
 </updateContextAvailabilitySubscriptionResponse>

--- a/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionResponse.invalidIsPattern.valid.json
+++ b/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionResponse.invalidIsPattern.valid.json
@@ -2,6 +2,7 @@
   "subscriptionId" : "012345678901234567890123",
   "errorCode" : {
     "code" : "400",
-    "reasonPhrase" : "invalid isPattern (boolean) value for entity: '2'"
+    "reasonPhrase" : "Bad Request",
+    "details" : "invalid isPattern (boolean) value for entity: '2'"
   }
 }

--- a/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionResponse.response3.ok.xml
+++ b/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionResponse.response3.ok.xml
@@ -2,6 +2,7 @@
   <subscriptionId>012345678901234567890123</subscriptionId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>syntax error in duration string</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>syntax error in duration string</details>
   </errorCode>
 </updateContextAvailabilitySubscriptionResponse>

--- a/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionResponse.response4.ok.xml
+++ b/test/unittests/testData/ngsi9.updateContextAvailabilitySubscriptionResponse.response4.ok.xml
@@ -2,6 +2,7 @@
   <subscriptionId>012345678901234567890123</subscriptionId>
   <errorCode>
     <code>400</code>
-    <reasonPhrase>predetected error</reasonPhrase>
+    <reasonPhrase>Bad Request</reasonPhrase>
+    <details>predetected error</details>
   </errorCode>
 </updateContextAvailabilitySubscriptionResponse>


### PR DESCRIPTION
### Description

Removed all responses where 'reasonPhrase' is composed 'freely'.
Now all responses have a reasonPhrase taken from the HTTP status code.
### NOTE

NOT TO BE MERGED until the release 0.11.0 is accepted.
Also, a line in CHANGES_NEXT_RELEASE is missing.
