### PR TITLE
FIX fedora build problem with namespaces (?)

### DIFF
--- a/src/lib/mongoBackend/MongoCommonRegister.cpp
+++ b/src/lib/mongoBackend/MongoCommonRegister.cpp
@@ -35,6 +35,9 @@
 
 #include "mongoBackend/MongoGlobal.h"
 
+using std::string;
+using std::map;
+using std::auto_ptr;
 
 /*****************************************************************************
 *

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -34,6 +34,10 @@
 #include "common/sem.h"
 #include "mongoBackend/MongoGlobal.h"
 
+using std::string;
+using std::map;
+using std::auto_ptr;
+
 /* ****************************************************************************
  * Forward declarations
  */

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -45,7 +45,7 @@
 #include "ngsiNotify/Notifier.h"
 
 using namespace mongo;
-
+using std::auto_ptr;
 
 
 /* ****************************************************************************

--- a/src/lib/mongoBackend/mongoDiscoverContextAvailability.cpp
+++ b/src/lib/mongoBackend/mongoDiscoverContextAvailability.cpp
@@ -37,6 +37,7 @@
 #include "mongo/client/dbclient.h"
 
 using namespace mongo;
+using std::auto_ptr;
 
 /* ****************************************************************************
 *


### PR DESCRIPTION
For some reason the mongoBackend module won't compile under Fedora 20 unless I place these _using_ statements. If they don't hurt anyone...
