### PR TITLE
sending stderr output from cat command to /dev/null

### DIFF
--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -212,7 +212,7 @@ function brokerStop
   fi
 
   if [ "$VALGRIND" == "" ]; then
-    kill $(cat $pidFile) 2> /dev/null
+    kill $(cat $pidFile 2> /dev/null) 2> /dev/null
     if [ -f /tmp/orion_${port}.pid ]
     then
       rm -f /tmp/orion_${port}.pid 2> /dev/null


### PR DESCRIPTION
Description
I took a look at this 'old' issue and the problem is easier than it seems.

Look at this example:

```
kz@krasno:manual> export pidFile=/tmp/123
kz@krasno:manual> kill $(cat $pidFile) 2> /dev/null
cat: /tmp/123: No such file or directory
kz@krasno:manual> kill $(cat $pidFile 2> /dev/null) 2> /dev/null
```

The second redirection to /dev/null isn't for what's inside the parenthesis.
We needed another redirection inside the parenthesis, that's all

This PR solved the bug Issue #400 
