### PR TITLE
ADD file to disable prelink

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -15,3 +15,4 @@ o Fix: double-quotes in output payload have been escaped (Issue #456)
 o Fix: Added tests to make sure that latitude and longitude are within range
        (-90 <= latitude <=90)  and (-180 <= longitude <= 180) and properly stored in database (Issue #461)
 o Fix: RPM binary complied in release mode (previous versions used debug)
+o Add: file to disable prelinking automatically along with RPM

--- a/rpm/SOURCES/etc/prelink.conf.d/contextBroker.conf
+++ b/rpm/SOURCES/etc/prelink.conf.d/contextBroker.conf
@@ -1,0 +1,24 @@
+# Copyright 2014 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# fermin at tid dot es
+#
+# Orion Context Broker prelink file
+#
+# All files/directories listed in here will be exempt from prelinking
+-b /usr/bin/contextBroker


### PR DESCRIPTION
Manually tested:

```
[fermin@centollo fiware-orion]$ rpm -qlp rpm/RPMS/x86_64/contextBroker-0.14.0_next-dev.x86_64.rpm 
/etc/cron.d/cron-logrotate-contextBroker-size
/etc/init.d/contextBroker
/etc/logrotate.d/logrotate-contextBroker-daily
/etc/prelink.conf.d/contextBroker.conf
/etc/sysconfig/contextBroker
/etc/sysconfig/logrotate-contextBroker-size
/usr/bin/contextBroker
/usr/bin/proxyCoap
/usr/share/contextBroker/garbage-collector.py
/usr/share/contextBroker/latest-updates.py
/usr/share/doc/contextBroker/LICENSE
[fermin@centollo fiware-orion]$ sudo rpm -i rpm/RPMS/x86_64/contextBroker-0.14.0_next-dev.x86_64.rpm
...
[fermin@centollo fiware-orion]$ ls /etc/prelink.conf.d/ -l
total 8
-rw-r--r--. 1 root root 1014 jul 30 15:14 contextBroker.conf
-rw-r--r--. 1 root root  118 may  1 19:42 vmware-tools-prelink.conf
```
