### PR TITLE
FIX version number after steping to 0.14.1 in develop branch

### DIFF
--- a/test/functionalTest/cases/coap_version.test
+++ b/test/functionalTest/cases/coap_version.test
@@ -29,7 +29,7 @@ proxyCoap version
 contextBroker --version
 
 --REGEXPECT--
-0.14.0-next
+0.14.1-next
 Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
 Orion Context Broker is free software: you can redistribute it and/or
 modify it under the terms of the GNU Affero General Public License as

--- a/test/functionalTest/cases/version.test
+++ b/test/functionalTest/cases/version.test
@@ -29,7 +29,7 @@ broker version
 contextBroker --version
 
 --REGEXPECT--
-0.14.0-next
+0.14.1-next
 Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
 Orion Context Broker is free software: you can redistribute it and/or
 modify it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
This is a bug/\* branch that merges into develop as exception to the general rule of passing bug/\* and hardening/\* first by release/iotplatform-v1, given that it is related a bug in develop not exactly applicable to iotplatform-v1.
