### PR TITLE
bug/511_lseek_before_writing_log_lines

### DIFF
--- a/src/lib/logMsg/logMsg.cpp
+++ b/src/lib/logMsg/logMsg.cpp
@@ -1913,6 +1913,8 @@ LmStatus lmFdRegister
 
       sz = strlen(startMsg);
 
+      lseek(fd, 0, SEEK_END);
+
       if (write(fd, startMsg, sz) != sz)
       {
         return LmsWrite;
@@ -2201,7 +2203,10 @@ LmStatus lmOut
     }
     else
     {
-      int nb = write(fds[i].fd, line, sz);
+      int nb;
+
+      lseek(fds[i].fd, 0, SEEK_END);
+      nb = write(fds[i].fd, line, sz);
 
       if (nb == -1)
       {


### PR DESCRIPTION
### Description

Performing an lseek before each write.
This extra system call is necessary as the broker isn't informed about the fact that logrotate empties the broker's log file every now and then.
If this lseek isn't done, the broker's log library will write far out from the end of the file is a newly emptied logfile and this causes the size of the file to look very big (as big as brefore emptying the file + the newly written but starting with a big 'file-hole') and monit will react upon this BIG log file and restart the broker.

This PR fixes issue #511.
