### PR TITLE
Fix missing entry in changes next release (release/iotplatform)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Add: support for MongoDB replica sets (using the new -rplSet CLI parameter) (Issue #493)
 - Fix: each send is now considered a separate transaction (Issue #478)
+- Fix: lseek after each write in log file in order to work with logrotate truncate (Issue #411)


### PR DESCRIPTION
Missing entry for PR #513 

In this case, I'm ussing cherry picking instead of "dual merge of same branch", to make thinks easier.

(Typo in the name of the name, referring to 514 instead of 513)
