### PR TITLE
FIX missing comment in unit test preamble

### DIFF
--- a/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
@@ -84,6 +84,7 @@
 * Test with associations
 *
 * - sourceAssociations
+* - sourceAssociationsFails
 * - targetAssoications
 *
 * Simulating fails in MongoDB connection:


### PR DESCRIPTION
PR #518 added a new unit test, but the preamble with the list of unit test in that file was not edited to include it. This PR fix that.

This is not going to be mirrored to release/iotplatform-v1 branch, as PR #518 is about a functionality only present in develop.
