### PR TITLE
One more sleep needed for valgrind functional test

### DIFF
--- a/test/functionalTest/cases/subscription_sequence_ontimeinterval_expiration.test
+++ b/test/functionalTest/cases/subscription_sequence_ontimeinterval_expiration.test
@@ -55,6 +55,15 @@ echo "1: ++++++++++++++++++++"
 # to avoid a race condition in the order of notifications
 sleep 0.5s
 
+#
+# We need more sleep if running under valgrind :-)
+#
+if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
+then
+  sleep 2
+fi
+
+
 #Subscribe for 5 seconds
 url="/v1/subscribeContext"
 payload='<?xml version="1.0"?>


### PR DESCRIPTION
### Description

Found another functional test in need of more sleep under valgrind.
Jenkins will probably show us some more.

Made a mistake renaming the branch.
Should be called bug/harness_tests_failing_under_valgrind2.
