### PR TITLE
Fixed a problem with the PATH to a config file in a functest

### DIFF
--- a/test/functionalTest/cases/000_https_support/https.test
+++ b/test/functionalTest/cases/000_https_support/https.test
@@ -25,7 +25,7 @@ HTTPS simple test
 
 --SHELL-INIT--
 dbInit CB
-${PWD}/../../../scripts/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
+${SCRIPT_HOME}/../../scripts/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
 extraParams="-https -key /tmp/harnessTest.key -cert /tmp/harnessTest.pem"
 brokerStart CB 0-255 IPV4 "$extraParams"
 --SHELL--

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -36,7 +36,7 @@ then
 fi
 
 cd $dirname
-SCRIPT_HOME=$(pwd)
+export SCRIPT_HOME=$(pwd)
 cd - > /dev/null 2>&1
 
 


### PR DESCRIPTION
Using SCRIPT_HOME instead of PWD to find script httpsPrepare.sh in https.test.
Fixes issue #677 
