### PR TITLE
Removed 'Connection: close' as it is different in jenkins

### DIFF
--- a/test/functionalTest/cases/000_bad_requests/pagination_error_in_uri_params.test
+++ b/test/functionalTest/cases/000_bad_requests/pagination_error_in_uri_params.test
@@ -61,7 +61,6 @@ echo
 --REGEXPECT--
 +++++ 1. bad characters in URI param 'limit'
 HTTP/1.1 400 Bad Request
-Connection: close
 Content-Length: 165
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -76,7 +75,6 @@ Date: REGEX(.*)
 
 +++++ 2. bad characters in URI param 'offset'
 HTTP/1.1 400 Bad Request
-Connection: close
 Content-Length: 166
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -91,7 +89,6 @@ Date: REGEX(.*)
 
 +++++ 3. URI param 'limit' == 0
 HTTP/1.1 400 Bad Request
-Connection: close
 Content-Length: 173
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -106,7 +103,6 @@ Date: REGEX(.*)
 
 +++++ 4. URI param 'details' == 'Yes'
 HTTP/1.1 400 Bad Request
-Connection: close
 Content-Length: 196
 Content-Type: application/xml
 Date: REGEX(.*)

--- a/test/functionalTest/cases/000_content_related_headers/accept_fail.test
+++ b/test/functionalTest/cases/000_content_related_headers/accept_fail.test
@@ -247,7 +247,6 @@ Date: REGEX(.*)
 </queryContextResponse>
 5: ++++++++++++++++++++
 HTTP/1.1 406 Not Acceptable
-Connection: close
 Content-Length: 220
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -260,7 +259,6 @@ Date: REGEX(.*)
 </orionError>
 6: ++++++++++++++++++++
 HTTP/1.1 406 Not Acceptable
-Connection: close
 Content-Length: 243
 Content-Type: application/xml
 Date: REGEX(.*)

--- a/test/functionalTest/cases/000_content_related_headers/in_out_formats.test
+++ b/test/functionalTest/cases/000_content_related_headers/in_out_formats.test
@@ -175,7 +175,6 @@ Date: REGEX(.*)
 
 1.1: Unrecognized Content-Type, Accepts ONLY JSON: 415, response in JSON
 HTTP/1.1 415 Unsupported Media Type
-Connection: close
 Content-Length: 151
 Content-Type: application/json
 Date: REGEX(.*)
@@ -191,7 +190,6 @@ Date: REGEX(.*)
 
 1.2: Unrecognized Content-Type, Accepts ONLY XML: 415, response in XML
 HTTP/1.1 415 Unsupported Media Type
-Connection: close
 Content-Length: 160
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -206,7 +204,6 @@ Date: REGEX(.*)
 
 1.3: Unrecognized Content-Type, Accepts BOTH JSON and XML: 415, response in XML
 HTTP/1.1 415 Unsupported Media Type
-Connection: close
 Content-Length: 160
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -221,7 +218,6 @@ Date: REGEX(.*)
 
 1.4: Unrecognized Content-Type, Accepts text/plain: 415, response in XML
 HTTP/1.1 415 Unsupported Media Type
-Connection: close
 Content-Length: 160
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -236,7 +232,6 @@ Date: REGEX(.*)
 
 1.5: Unrecognized Content-Type, Accepts NOTHING: 415, response in XML
 HTTP/1.1 415 Unsupported Media Type
-Connection: close
 Content-Length: 160
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -343,7 +338,6 @@ Date: REGEX(.*)
 
 2.4: Content-Type OK, Accepts text/plain: 406, Response in XML
 HTTP/1.1 406 Not Acceptable
-Connection: close
 Content-Length: 208
 Content-Type: application/xml
 Date: REGEX(.*)

--- a/test/functionalTest/cases/000_content_related_headers/missing_content_type_header.test
+++ b/test/functionalTest/cases/000_content_related_headers/missing_content_type_header.test
@@ -87,7 +87,6 @@ orionCurl --url "$url" --payload "$payload" --in "application/json; charset=UTF-
 --REGEXPECT--
 1: ++++++++++++++++++++
 HTTP/1.1 415 Unsupported Media Type
-Connection: close
 Content-Length: 201
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -100,7 +99,6 @@ Date: REGEX(.*)
 </orionError>
 2: ++++++++++++++++++++
 HTTP/1.1 415 Unsupported Media Type
-Connection: close
 Content-Length: 180
 Content-Type: application/xml
 Date: REGEX(.*)

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/uri_params_bad_notify_format.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/uri_params_bad_notify_format.test
@@ -62,7 +62,6 @@ echo
 Trying to ask for HTML as Notification Format
 =============================================
 HTTP/1.1 400 Bad Request
-Connection: close
 Content-Length: 174
 Content-Type: application/xml
 Date: REGEX(.*)

--- a/test/functionalTest/cases/392_service_path_update_and_query/service_path_http_header.test
+++ b/test/functionalTest/cases/392_service_path_update_and_query/service_path_http_header.test
@@ -85,7 +85,6 @@ Date: REGEX(.*)
 
 +++++ 1. Path-Component more than 50 chars
 HTTP/1.1 200 OK
-Connection: close
 Content-Length: 149
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -99,7 +98,6 @@ Date: REGEX(.*)
 
 +++++ 2. Too many levels in path
 HTTP/1.1 200 OK
-Connection: close
 Content-Length: 145
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -113,7 +111,6 @@ Date: REGEX(.*)
 
 +++++ 3: bad char in component
 HTTP/1.1 200 OK
-Connection: close
 Content-Length: 167
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -127,7 +124,6 @@ Date: REGEX(.*)
 
 +++++ 4: service path must start with a '/'
 HTTP/1.1 200 OK
-Connection: close
 Content-Length: 183
 Content-Type: application/xml
 Date: REGEX(.*)
@@ -166,7 +162,6 @@ Date: REGEX(.*)
 
 +++++ 7: eleven service paths
 HTTP/1.1 200 OK
-Connection: close
 Content-Length: 177
 Content-Type: application/xml
 Date: REGEX(.*)

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -643,9 +643,11 @@ function orionCurl()
   fi
   
   #
-  # Remove "Connection: Keep-Alive" header and print headers out
+  # Remove "Connection: Keep-Alive" and "Connection: close" headers and print headers out
   #
-  sed '/Connection: Keep-Alive/d' /tmp/httpHeaders.out
+  sed '/Connection: Keep-Alive/d' /tmp/httpHeaders.out  > /tmp/httpHeaders2.out
+  sed '/Connection: close/d'      /tmp/httpHeaders2.out > /tmp/httpHeaders.out
+  sed '/Connection: Close/d'      /tmp/httpHeaders.out  
   
   #
   # Print and beautify response body, if any  (and if option --noPayloadCheck hasn't been set)


### PR DESCRIPTION
### Description

The "Connection:close" HTTP header is seen in jenkins, but not in all centos machines.
To avoid problems now and in the future, these headers are simply removed.

NOTE:
This is ONLY for the functional test suite.
