### PR TITLE
Bug/699 context provider responses without payload

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 Fix:  Fixed the bug about recovering ONTIMEINTERVAL subscriptions (Issue #693)
 Fix:  Fixed the crash in queryContext with a double geoscope (Issue #690)
+Fix:  Protect the broker against payload-less responses to forwarded requests (Issue #699)

--- a/src/lib/jsonParse/jsonRequest.cpp
+++ b/src/lib/jsonParse/jsonRequest.cpp
@@ -171,6 +171,13 @@ std::string jsonTreat
   std::string   res   = "OK";
   JsonRequest*  reqP  = jsonRequestGet(request, ciP->method);
 
+
+  //
+  // If the payload is empty, the XML parsing library does an assert
+  // and the broker dies. I don't know about the JSON library, but just in case ...
+  // 
+  // 'OK' is returned as there is no error to send a request without payload.
+  //
   if ((content == NULL) || (*content == 0))
   {
     return "OK";

--- a/src/lib/jsonParse/jsonRequest.cpp
+++ b/src/lib/jsonParse/jsonRequest.cpp
@@ -171,6 +171,11 @@ std::string jsonTreat
   std::string   res   = "OK";
   JsonRequest*  reqP  = jsonRequestGet(request, ciP->method);
 
+  if ((content == NULL) || (*content == 0))
+  {
+    return "OK";
+  }
+
   LM_T(LmtParse, ("Treating a JSON request: '%s'", content));
 
   ciP->parseDataP = parseDataP;

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -346,7 +346,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
       continue;
     }
 
-    if ((ciP->payload != NULL) && (ciP->payloadSize != 0) && (serviceV[ix].verb != "*"))
+    if ((ciP->payload != NULL) && (ciP->payloadSize != 0) && (ciP->payload[0] != 0) && (serviceV[ix].verb != "*"))
     {
       std::string response;
 

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -178,10 +178,12 @@ std::string postQueryContext
   {
     QueryContextResponse qcrs;
 
-    // FIXME P1: What StatusCode should be used here?
-    qcrs.errorCode.fill(SccReceiverInternalError, "invalid context provider response");
+    //
+    // This is really an internal error in the Context Provider
+    // It is not in the orion broker though, so 404 is returned
+    //
+    qcrs.errorCode.fill(SccContextElementNotFound, "invalid context provider response");
 
-    // FIXME P1: What 'error concept' should be used here?
     LM_W(("Other Error (context provider response to QueryContext is empty)"));
     answer = qcrs.render(ciP, QueryContext, "");
     return answer;

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -153,6 +153,7 @@ std::string postQueryContext
                        false,
                        true);
 
+
   if ((out == "error") || (out == ""))
   {
     QueryContextResponse qcrs;
@@ -172,6 +173,19 @@ std::string postQueryContext
   std::string  errorMsg;
 
   cleanPayload = xmlPayloadClean(out.c_str(), "<queryContextResponse>");
+
+  if ((cleanPayload == NULL) || (cleanPayload[0] == 0))
+  {
+    QueryContextResponse qcrs;
+
+    // FIXME P1: What StatusCode should be used here?
+    qcrs.errorCode.fill(SccReceiverInternalError, "invalid context provider response");
+
+    // FIXME P1: What 'error concept' should be used here?
+    LM_W(("Other Error (context provider response to QueryContext is empty)"));
+    answer = qcrs.render(ciP, QueryContext, "");
+    return answer;
+  }
 
   s = xmlTreat(cleanPayload, ciP, &parseData, RtQueryContextResponse, "queryContextResponse", NULL, &errorMsg);
   if (s != "OK")

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -188,6 +188,19 @@ std::string postUpdateContext
 
     cleanPayload = xmlPayloadClean(out.c_str(), "<updateContextResponse>");
 
+    if ((cleanPayload == NULL) || (cleanPayload[0] == 0))
+    {
+      UpdateContextResponse ucrs;
+
+      // FIXME P1: What StatusCode should be used here?
+      ucrs.errorCode.fill(SccReceiverInternalError, "invalid context provider response");
+
+      // FIXME P1: What 'error concept' should be used here?
+      LM_W(("Other Error (context provider response to UpdateContext is empty)"));
+      answer = ucrs.render(ciP, UpdateContext, "");
+      return answer;
+    }
+
     s = xmlTreat(cleanPayload, ciP, &parseData, RtUpdateContextResponse, "updateContextResponse", NULL, &errorMsg);
     provUpcrsP = &parseData.upcrs.res;
     if (s != "OK")

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -192,10 +192,12 @@ std::string postUpdateContext
     {
       UpdateContextResponse ucrs;
 
-      // FIXME P1: What StatusCode should be used here?
-      ucrs.errorCode.fill(SccReceiverInternalError, "invalid context provider response");
+      //
+      // This is really an internal error in the Context Provider
+      // It is not in the orion broker though, so 404 is returned
+      //
+      ucrs.errorCode.fill(SccContextElementNotFound, "invalid context provider response");
 
-      // FIXME P1: What 'error concept' should be used here?
       LM_W(("Other Error (context provider response to UpdateContext is empty)"));
       answer = ucrs.render(ciP, UpdateContext, "");
       return answer;

--- a/src/lib/xmlParse/xmlRequest.cpp
+++ b/src/lib/xmlParse/xmlRequest.cpp
@@ -208,6 +208,13 @@ std::string xmlTreat
   xml_document<>  doc;
   char*           xmlPayload = (char*) content;
 
+  //
+  // If the payload is empty, the XML parsing library does an assert
+  // and the broker dies.
+  // Therefore, this check here is important, to avoid death.
+  // 
+  // 'OK' is returned as there is no error to send a request without payload.
+  //
   if ((content == NULL) || (*content == 0))
   {
     return "OK";

--- a/src/lib/xmlParse/xmlRequest.cpp
+++ b/src/lib/xmlParse/xmlRequest.cpp
@@ -208,6 +208,11 @@ std::string xmlTreat
   xml_document<>  doc;
   char*           xmlPayload = (char*) content;
 
+  if ((content == NULL) || (*content == 0))
+  {
+    return "OK";
+  }
+
   try
   {
     doc.parse<0>(xmlPayload);

--- a/test/unittests/jsonParse/jsonRequest_test.cpp
+++ b/test/unittests/jsonParse/jsonRequest_test.cpp
@@ -52,5 +52,8 @@ TEST(jsonRequest, jsonTreat)
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
 
+   out  = jsonTreat("", &ci, &parseData, InvalidRequest, "no_payload", NULL);
+   EXPECT_STREQ("OK", out.c_str());
+
    utExit();
 }

--- a/test/unittests/jsonParse/jsonRequest_test.cpp
+++ b/test/unittests/jsonParse/jsonRequest_test.cpp
@@ -48,11 +48,11 @@ TEST(jsonRequest, jsonTreat)
    utInit();
 
    ci.outFormat = JSON;
-   out  = jsonTreat("no payload", &ci, &parseData, InvalidRequest, "no_payload", NULL);
+   out  = jsonTreat("non-empty content", &ci, &parseData, InvalidRequest, "", NULL);
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
 
-   out  = jsonTreat("", &ci, &parseData, InvalidRequest, "no_payload", NULL);
+   out  = jsonTreat("", &ci, &parseData, InvalidRequest, "", NULL);
    EXPECT_STREQ("OK", out.c_str());
 
    utExit();

--- a/test/unittests/jsonParse/jsonRequest_test.cpp
+++ b/test/unittests/jsonParse/jsonRequest_test.cpp
@@ -48,7 +48,7 @@ TEST(jsonRequest, jsonTreat)
    utInit();
 
    ci.outFormat = JSON;
-   out  = jsonTreat("", &ci, &parseData, InvalidRequest, "no_payload", NULL);
+   out  = jsonTreat("no payload", &ci, &parseData, InvalidRequest, "no_payload", NULL);
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/xmlParse/xmlRequest_test.cpp
+++ b/test/unittests/xmlParse/xmlRequest_test.cpp
@@ -90,3 +90,24 @@ TEST(xmlRequest, parseError)
 
   utExit();
 }
+
+
+
+/* ****************************************************************************
+*
+* emptyPayload - 
+*/
+TEST(xmlRequest, emptyPayload)
+{
+  ConnectionInfo  ci("/ngsi/registerContext", "POST", "1.1");
+  ParseData       parseData;
+  const char*     payload = "";
+  std::string     out;
+
+  utInit();
+
+  out  = xmlTreat(payload, &ci, &parseData, RegisterContext, "registerContextRequest", NULL);
+  EXPECT_STREQ("OK", out.c_str());
+
+  utExit();
+}


### PR DESCRIPTION
### Description
Made the broker not crash when an empty string is input to the XML/JSON parsing routines.
"OK" is returned on empty payload. Not sure this is the best approach, as the function shouldn't
be called on empty payload and yet there is no real 'generic' error sending a request without payload ...  
Two short unit tests to test this out as it is **very** difficult to provoke this failure 'from the outside', using a functional test.