### PR TITLE
FIX git push command

### DIFF
--- a/scripts/build/release.sh
+++ b/scripts/build/release.sh
@@ -182,6 +182,7 @@ then
        # REL procedures
        #git tag $NEW_VERSION-FIWARE-$FIWARE_VERSION
        #git push --tags origin release/$NEW_VERSION
+       git push origin release/$NEW_VERSION
 
        # Build release only when step to a non-dev release. Note that, taking into account
        # how the "make rpm" target works, it has to be done after commit has been done


### PR DESCRIPTION
Fix in a previous PR. I though that `--tag` means "only push the tags" not "push the tags in addition to the branch, as usual".

Thus, the "git push" command shouldn't be commented out compeltely but adjusted.

@dmoranj @alvarolmedo 