### PR TITLE
Bug/703 mime types in forwarding requests

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+Fix:  Forwarded requests always in XML (Issue #703)

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -136,9 +136,15 @@ std::string postUpdateContext
 
 
     //
-    // 3. Render an XML-string of the request we want to forward
+    // 3. Render a string of the request we want to forward, forced to XML
+    //    FIXME P8: The format of this string (XML or JSON) should depend on the
+    //              format of the incoming message, but right now we force it to XML.
     //
-    std::string payloadIn = ucrP->render(ciP, UpdateContext, "");
+    ConnectionInfo ci;
+
+    ci.outFormat = XML;
+
+    std::string payloadIn = ucrP->render(&ci, UpdateContext, "");
 
     LM_T(LmtCtxProviders, ("payloadIn:\n%s", payloadIn.c_str()));
 

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -138,7 +138,7 @@ std::string postUpdateContext
     //
     // 3. Render a string of the request we want to forward, forced to XML
     //    FIXME P8: The format of this string (XML or JSON) should depend on the
-    //              format of the incoming message, but right now we force it to XML.
+    //              CB-CPr content type negotiation, but right now we force it to XML.
     //
     ConnectionInfo ci;
 


### PR DESCRIPTION
### Description

Forced the rendering of forwarded messages to be in XML.
Fixes issue #703 