### PR TITLE
FIX explicit default service path in code

### DIFF
--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -224,14 +224,6 @@ static int httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, co
   else
     LM_T(LmtHttpUnsupportedHeader, ("'unsupported' HTTP header: '%s', value '%s'", ckey, value));
 
-  /* If servicePath was not provided, then use the default value */
-  if (!headerP->servicePathReceived)
-  {
-    headerP->servicePath         = DEFAULT_SERVICE_PATH;
-    headerP->servicePathReceived = true;
-  }
-
-
   if ((strcasecmp(key.c_str(), "connection") == 0) && (headerP->connection != "") && (headerP->connection != "close"))
     LM_T(LmtRest, ("connection '%s' - currently not supported, sorry ...", headerP->connection.c_str()));
 
@@ -722,6 +714,8 @@ static int connectionTreat
     }
     LM_T(LmtUriParams, ("notifyFormat: '%s'", ciP->uriParam[URI_PARAM_NOTIFY_FORMAT].c_str()));
 
+    /* In the case an actual Fiware-ServicePath is found, the default will be overwritten */
+    ciP->httpHeaders.servicePath = DEFAULT_SERVICE_PATH;
     MHD_get_connection_values(connection, MHD_HEADER_KIND, httpHeaderGet, &ciP->httpHeaders);
 
     char tenant[128];

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -225,7 +225,7 @@ static int httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, co
     LM_T(LmtHttpUnsupportedHeader, ("'unsupported' HTTP header: '%s', value '%s'", ckey, value));
 
   /* If servicePath was not provided, then use the default value */
-  if (headerP->servicePathReceived = false)
+  if (!headerP->servicePathReceived)
   {
     headerP->servicePath         = DEFAULT_SERVICE_PATH;
     headerP->servicePathReceived = true;

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -224,6 +224,13 @@ static int httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, co
   else
     LM_T(LmtHttpUnsupportedHeader, ("'unsupported' HTTP header: '%s', value '%s'", ckey, value));
 
+  /* If servicePath was not provided, then use the default value */
+  if (headerP->servicePathReceived = false)
+  {
+    headerP->servicePath         = DEFAULT_SERVICE_PATH;
+    headerP->servicePathReceived = true;
+  }
+
 
   if ((strcasecmp(key.c_str(), "connection") == 0) && (headerP->connection != "") && (headerP->connection != "close"))
     LM_T(LmtRest, ("connection '%s' - currently not supported, sorry ...", headerP->connection.c_str()));

--- a/src/lib/rest/rest.h
+++ b/src/lib/rest/rest.h
@@ -30,7 +30,8 @@
 
 #include "rest/RestService.h"
 
-#define  MAX_LEN_IP   64
+#define  MAX_LEN_IP            64
+#define  DEFAULT_SERVICE_PATH  "/"
 
 /* ****************************************************************************
 *


### PR DESCRIPTION
This PR doesn't merge in release/0.18.1 as in the IoTP version Fiware-ServicePath is always use, so this hardening is not needed.