### PR TITLE
Feature/716 entity found attribute not found

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - Fix: The option '-multiservice' was ignored and the broker ran always in multiservice mode. Now the option is taken taken into account (Issue #725)
 - Fix: Forwarded requests always in XML (Issue #703)
 - Fix: internal substitution of servicePath defaults ("/" for update-like operations, "/#" for query-like operations)
+- Fix: Temporal hack to allow for forwarding of 'attribute not found in entity found' (Issue #716)

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1148,6 +1148,8 @@ static void setResponseMetadata(ContextAttribute* caReq, ContextAttribute* caRes
 * Returns true if entity was actually modified, false otherwise (including fail cases)
 *
 */
+#define ATTRIBUTE_NOT_FOUND 1
+
 static bool processContextAttributeVector (ContextElement*                            ceP,
                                            std::string                                action,
                                            std::map<string, TriggeredSubscription*>&  subsToNotify,
@@ -1158,7 +1160,7 @@ static bool processContextAttributeVector (ContextElement*                      
                                            double&                                    coordLong,
                                            std::string                                tenant,
                                            const std::vector<std::string>&            servicePathV,
-                                           std::string*                               why)
+                                           int*                                       why)
 {
     EntityId*   eP         = &cerP->contextElement.entityId;
     std::string entityId   = cerP->contextElement.entityId.id;
@@ -1192,7 +1194,7 @@ static bool processContextAttributeVector (ContextElement*                      
                                       std::string("action: UPDATE") + 
                                       " - entity: [" + eP->toString() + "]" +
                                       " - offending attribute: " + targetAttr->toString());
-                *why = "Attribute Not Found";
+                *why = ATTRIBUTE_NOT_FOUND;
                 return false;
 
             }
@@ -1740,7 +1742,7 @@ void processContextElement(ContextElement*                      ceP,
             coordLat = loc.getField(ENT_LOCATION_COORDS).Array()[1].Double();
         }
 
-        std::string why;
+        int why = 0;
         if (!processContextAttributeVector(ceP, action, subsToNotify, attrs, cerP, locAttr, coordLat, coordLong, tenant, servicePathV, &why))
         {
             /* The entity wasn't actually modified, so we don't need to update it and we can continue with next one */
@@ -1763,7 +1765,7 @@ void processContextElement(ContextElement*                      ceP,
             //           The real fix will probably be a rewrite of this piece of code,
             //           implemented when fixing 'definitely' the issue #716
             //
-            if ((why != "Attribute Not Found") || (caller != "postUpdateContext"))
+            if ((why != ATTRIBUTE_NOT_FOUND) || (caller != "postUpdateContext"))
             {
               ++docs;
             }

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1763,7 +1763,7 @@ void processContextElement(ContextElement*                      ceP,
             //           The real fix will probably be a rewrite of this piece of code,
             //           implemented when fixing 'definitely' the issue #716
             //
-            if ((why != "Attribute Not Found") || (caller != "postContextUpdate"))
+            if ((why != "Attribute Not Found") || (caller != "postUpdateContext"))
             {
               ++docs;
             }
@@ -1917,7 +1917,7 @@ void processContextElement(ContextElement*                      ceP,
           {
             // Suitable CProvider has been found: creating response and returning
             std::string prApp = crrV[0]->contextRegistration.providingApplication.get();
-            LM_T(LmtCtxProviders, ("context provide found: %s", prApp.c_str()));
+            LM_T(LmtCtxProviders, ("context provider found: %s", prApp.c_str()));
             buildGeneralErrorResponse(ceP, NULL, responseP, SccFound, prApp, &ceP->contextAttributeVector);
           }
           else

--- a/src/lib/mongoBackend/MongoCommonUpdate.h
+++ b/src/lib/mongoBackend/MongoCommonUpdate.h
@@ -42,6 +42,7 @@ extern void processContextElement(ContextElement*                      ceP,
                                   const std::string&                   tenant,
                                   const std::vector<std::string>&      servicePath,
                                   std::map<std::string, std::string>&  uriParams,   // FIXME P7: we need this to implement "restriction-based" filters
-                                  const std::string&                   xauthToken);
+                                  const std::string&                   xauthToken,
+                                  const std::string&                   caller = "");
 
 #endif

--- a/src/lib/mongoBackend/mongoUpdateContext.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContext.cpp
@@ -51,7 +51,8 @@ HttpStatusCode mongoUpdateContext
   const std::string&                    tenant,
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
-  const std::string&                    xauthToken
+  const std::string&                    xauthToken,
+  const std::string&                    caller
 )
 {
     reqSemTake(__FUNCTION__, "ngsi10 update request");
@@ -72,7 +73,8 @@ HttpStatusCode mongoUpdateContext
                                   tenant,
                                   servicePathV,
                                   uriParams,
-                                  xauthToken);
+                                  xauthToken,
+                                  caller);
         }
 
         /* Note that although individual processContextElements() invocations return ConnectionError, this

--- a/src/lib/mongoBackend/mongoUpdateContext.h
+++ b/src/lib/mongoBackend/mongoUpdateContext.h
@@ -45,7 +45,8 @@ extern HttpStatusCode mongoUpdateContext
   const std::string&                    tenant,
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
-  const std::string&                    xauthToken
+  const std::string&                    xauthToken,
+  const std::string&                    caller = ""
 );
 
 #endif

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -64,7 +64,7 @@ std::string postUpdateContext
   UpdateContextResponse  upcr;
   std::string            answer;
 
-  ciP->httpStatusCode = mongoUpdateContext(&parseDataP->upcr.res, &upcr, ciP->tenant, ciP->servicePathV, ciP->uriParam, ciP->httpHeaders.xauthToken);
+  ciP->httpStatusCode = mongoUpdateContext(&parseDataP->upcr.res, &upcr, ciP->tenant, ciP->servicePathV, ciP->uriParam, ciP->httpHeaders.xauthToken, "postUpdateContext");
 
   //
   // Checking for SccFound in the ContextElementResponseVector
@@ -81,6 +81,23 @@ std::string postUpdateContext
     answer = upcr.render(ciP, UpdateContext, "");
     return answer;
   }
+
+  //
+  // If upcr.contextElementResponseVector contains TWO responses and one of them is a 'SccFound',
+  // then skip the one that isn't 'SccFound'.
+  //
+  // FIXME P6: Temporary hack for 'Entity found but Attribute not found':
+  //           See FIXME P6 'Temporary hack ...' 
+  //           in MongoCommonUpdate.cpp, function processContextElement
+  //
+  if (upcr.contextElementResponseVector.size() == 2)
+  {
+    if (upcr.contextElementResponseVector[1]->statusCode.code == SccFound)
+    {
+      upcr.contextElementResponseVector.erase(upcr.contextElementResponseVector.begin());
+    }
+  }
+
 
   for (unsigned int ix = 0; ix < upcr.contextElementResponseVector.size(); ++ix)
   {

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -83,20 +83,37 @@ std::string postUpdateContext
   }
 
   //
-  // If upcr.contextElementResponseVector contains TWO responses and one of them is a 'SccFound',
-  // then skip the one that isn't 'SccFound'.
+  // If upcr.contextElementResponseVector contains >= TWO responses and the second of them is a 'SccFound',
+  // then skip the first, the one that isn't 'SccFound'.
+  // Also, if the first of them is 472, then skip the second
   //
   // FIXME P6: Temporary hack for 'Entity found but Attribute not found':
   //           See FIXME P6 'Temporary hack ...' 
   //           in MongoCommonUpdate.cpp, function processContextElement
   //
-  if (upcr.contextElementResponseVector.size() == 2)
+
+  //
+  // 1. Remove Response 0 if Response 1 is SccFound AND Response 0 is NOT SccFound
+  //
+  if (upcr.contextElementResponseVector.size() >= 2)
   {
-    if (upcr.contextElementResponseVector[1]->statusCode.code == SccFound)
+    if ((upcr.contextElementResponseVector[1]->statusCode.code == SccFound) && (upcr.contextElementResponseVector[0]->statusCode.code != SccFound))
     {
-      upcr.contextElementResponseVector.erase(upcr.contextElementResponseVector.begin());
+      upcr.contextElementResponseVector.vec.erase(upcr.contextElementResponseVector.vec.begin());
     }
   }
+
+  //
+  // 2. Remove Response 1 if Response 0 is SccInvalidParameter
+  //
+  if (upcr.contextElementResponseVector.size() >= 2)
+  {
+    if (upcr.contextElementResponseVector[0]->statusCode.code == SccInvalidParameter)
+    {
+      upcr.contextElementResponseVector.vec.erase(upcr.contextElementResponseVector.vec.begin() + 1);
+    }
+  }
+
 
 
   for (unsigned int ix = 0; ix < upcr.contextElementResponseVector.size(); ++ix)

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -94,16 +94,6 @@ std::string postUpdateContext
 
 
   //
-  // Debug - show all responses and their types
-  //
-  LM_M(("KZ: ----------------------------------------------------------------"));
-  LM_M(("KZ: In: %d vector-items", parseDataP->upcr.res.contextElementVector.size()));
-  LM_M(("KZ: Out: %d vector-items", upcr.contextElementResponseVector.size()));
-  for (unsigned int ix = 0; ix < upcr.contextElementResponseVector.size(); ++ix)
-    LM_M(("KZ: Out[%d]: (%d) %s", ix, upcr.contextElementResponseVector[ix]->statusCode.code, upcr.contextElementResponseVector[ix]->statusCode.reasonPhrase.c_str()));
-  LM_M(("KZ: ----------------------------------------------------------------"));
-
-  //
   // Removing 'garbage' from the response vector (when just *one* incoming contextElement
   //
   
@@ -131,7 +121,6 @@ std::string postUpdateContext
           {
             // Remove the 472
             upcr.contextElementResponseVector.vec.erase(upcr.contextElementResponseVector.vec.begin() + ix);
-            LM_M(("KZ: Removing the 472 to keep the 302"));
           }
 
           // 472+404
@@ -139,7 +128,6 @@ std::string postUpdateContext
           {
             // Remove the 404
             upcr.contextElementResponseVector.vec.erase(upcr.contextElementResponseVector.vec.begin() + ix + 1);
-            LM_M(("KZ: Removing the 404 to keep the 472"));
           }
         }
       }

--- a/test/functionalTest/cases/716_forward_registered_attributes/forward_attribute.test
+++ b/test/functionalTest/cases/716_forward_registered_attributes/forward_attribute.test
@@ -1,0 +1,303 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Forward non-existing attribute in existing entity for update in context provider
+
+--SHELL-INIT--
+dbInit CB
+dbInit CP1
+brokerStart CB 0
+brokerStart CP1 0
+
+--SHELL--
+
+#
+# 01. Update/APPEND E1/A1 in CP1
+# 02. Update/APPEND E1/A2 in CB
+# 03. Register E1/A1 in CB for CP1
+# 04. Update/UPDATE E1/A1 in CB
+# 05. Query E1/A1 in CP1
+#
+
+echo "01. Update/APPEND E1/A1 in CP1"
+echo "=============================="
+payload='{
+  "contextElements": [
+    {
+      "type": "T",
+      "id":   "E1",
+      "attributes": [
+        {
+          "name": "A1",
+          "type": "string",
+          "value": "E1/A1 in CP1"
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --url /v1/updateContext --payload "${payload}" --json --port $CP1_PORT
+echo
+echo
+
+
+echo "02. Update/APPEND E1/A2 in CB"
+echo "============================="
+payload='{
+  "contextElements": [
+    {
+      "type": "T",
+      "id":   "E1",
+      "attributes": [
+        {
+          "name": "A2",
+          "type": "string",
+          "value": "E1/A2 in CB"
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --url /v1/updateContext --payload "${payload}" --json
+echo
+echo
+
+
+echo "03. Register E1/A1 in CB for CP1"
+echo "================================"
+payload='{
+  "contextRegistrations": [
+  {
+    "entities": [
+      {
+         "type": "T",
+         "isPattern": "false",
+         "id": "E1"
+      }
+    ],
+    "attributes": [
+      {
+        "name": "A1",
+        "type": "string",
+        "isDomain": "false"
+      }
+    ],
+    "providingApplication": "http://localhost:'${CP1_PORT}'/v1"
+    }
+ ],
+ "duration": "P1M"
+}'
+orionCurl --url /v1/registry/registerContext --payload "${payload}" --json
+echo
+echo
+
+
+echo "04. Update/UPDATE E1/A1 in CB"
+echo "============================="
+payload='{
+  "contextElements": [
+    {
+      "type": "T",
+      "id":   "E1",
+      "attributes": [
+        {
+          "name": "A1",
+          "type": "string",
+          "value": "E1/A1 via CB"
+        }
+      ]
+    }
+  ],
+  "updateAction": "UPDATE"
+}'
+orionCurl --url /v1/updateContext --payload "${payload}" --json
+echo
+echo
+
+
+echo "05. Query E1/A1 in CP1"
+echo "======================"
+payload='{
+  "entities": [
+    {
+      "type": "T",
+      "isPattern": "false",
+      "id": "E1"
+    }
+  ],
+  "attributes": [
+    "A1"
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "${payload}" --json --port $CP1_PORT
+echo
+echo
+
+
+
+
+--REGEXPECT--
+01. Update/APPEND E1/A1 in CP1
+==============================
+HTTP/1.1 200 OK
+Content-Length: 382
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "string", 
+                        "value": ""
+                    }
+                ], 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "T"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+02. Update/APPEND E1/A2 in CB
+=============================
+HTTP/1.1 200 OK
+Content-Length: 382
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A2", 
+                        "type": "string", 
+                        "value": ""
+                    }
+                ], 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "T"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+03. Register E1/A1 in CB for CP1
+================================
+HTTP/1.1 200 OK
+Content-Length: 74
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "duration": "P1M", 
+    "registrationId": "REGEX([0-9a-f]{24})"
+}
+
+
+04. Update/UPDATE E1/A1 in CB
+=============================
+HTTP/1.1 200 OK
+Content-Length: 454
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "string", 
+                        "value": ""
+                    }
+                ], 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "T"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "details": "Redirected to context provider localhost:REGEX(\d+)/v1", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+05. Query E1/A1 in CP1
+======================
+HTTP/1.1 200 OK
+Content-Length: 394
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "string", 
+                        "value": "E1/A1 via CB"
+                    }
+                ], 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "T"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+--TEARDOWN---
+brokerStop CB
+dbDrop CB
+dbDrop CP1


### PR DESCRIPTION
### Description
Just a 'hack' to make forward updates work (not queries, only updates) for non-found attributes in entities that exist in the broker.
The code is no good, but it enables this feature for the campus party in Brasil.
After this we need to *really* fix this problem.