### PR TITLE
Bug/746 valid service path for updates

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,3 +6,4 @@
 - Fix: Service-Path supported for registrations and discoveries (Issue #719)
 - Fix: Service-Path supported for forwarding of registrations between Config Manager and Context Broker (Issue #719)
 - Fix: Service-Path supported for forwarding to Context Providers (Issue #719)
+- Fix: Hash sign (#) in service-path, or multiple service-paths not valid for updateContext requests (Issue #746)

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -73,7 +73,7 @@ std::string postUpdateContext
   if (ciP->servicePathV.size() > 1)
   {
     upcr.errorCode.fill(SccBadRequest, "more than one service path in context update request");
-    LM_W(("Bad Input (more than one service path for a notification)"));
+    LM_W(("Bad Input (more than one service path for an update request)"));
     answer = upcr.render(ciP, UpdateContext, "");
     return answer;
   }

--- a/test/functionalTest/cases/746_valid_service_path_for_updates/invalid_service_paths.test
+++ b/test/functionalTest/cases/746_valid_service_path_for_updates/invalid_service_paths.test
@@ -1,0 +1,118 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Invalid service-paths for /v1/updateContext
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0
+
+--SHELL--
+
+#
+# 01. Update/APPEND E1/A1, servicePath /#
+# 02. Update/APPEND E1/A1, servicePath /a,/b
+#
+
+echo "01. Update/APPEND E1/A1, servicePath /#"
+echo "======================================="
+payload='{
+  "contextElements": [
+    {
+      "type": "T",
+      "id":   "E1",
+      "attributes": [
+        {
+          "name": "A1",
+          "type": "string",
+          "value": "1"
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --url /v1/updateContext --payload "$payload" --json --servicePath /#
+echo
+echo
+
+
+echo "02. Update/APPEND E1/A1, servicePath /a,/b"
+echo "=========================================="
+payload='{
+  "contextElements": [
+    {
+      "type": "T",
+      "id":   "E1",
+      "attributes": [
+        {
+          "name": "A1",
+          "type": "string",
+          "value": "1"
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --url /v1/updateContext --payload "$payload" --json --servicePath /a,/b
+echo
+echo
+
+
+--REGEXPECT--
+01. Update/APPEND E1/A1, servicePath /#
+=======================================
+HTTP/1.1 200 OK
+Content-Length: 130
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errorCode": {
+        "code": "400",
+        "details": "Bad Character in Service-Path",
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+02. Update/APPEND E1/A1, servicePath /a,/b
+==========================================
+HTTP/1.1 200 OK
+Content-Length: 153
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errorCode": {
+        "code": "400",
+        "details": "more than one service path in context update request",
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+--TEARDOWN---
+brokerStop CB
+dbDrop CB

--- a/unittests_that_fail_sporadically.txt
+++ b/unittests_that_fail_sporadically.txt
@@ -1,6 +1,6 @@
 mongoOntimeintervalOperations.mongoGetContextElementResponses_ok     (x2)
 mongoOntimeintervalOperations.mongoUpdateCsubNewNotification_dbfail  (x4)
-mongoRegisterContext_update.updateCase1                              (x1)
+mongoRegisterContext_update.updateCase1                              (x2)
 mongoUnsubscribeContext.MongoDbFindOneFail                           (x3)
 mongoUnsubscribeContext.MongoDbRemoveFail                            (x3)
 mongoUnsubscribeContextAvailability.MongoDbFindOneFail               (x2)


### PR DESCRIPTION
Calling the 'servicePathCheck' for incoming update requests, to not accept service paths with the '#' character and also not multiple service paths.
