### PR TITLE
Hardening/117 post individual context entity

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,4 @@
 - Fix: Correct rendering of response to convop "POST /v1/contextEntities/{entityId::id}/attributes/{attributeName} (Issue #772)
-- Fix:  All convenience operations to use the service routines of standard operations (Issue #117)
+- Fix: All convenience operations to use the service routines of standard operations (Issue #117)
+- Fix: Made 'POST /v1/contextEntities/{entityId::id}' and 'POST /v1/contextEntities' accept entity::id and entity::type in payload,
+       as long as they coincide with the entityId::id and entityId::type in the payload.

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 - Fix: Correct rendering of response to convop "POST /v1/contextEntities/{entityId::id}/attributes/{attributeName} (Issue #772)
 - Fix: All convenience operations to use the service routines of standard operations (Issue #117)
-- Fix: Made 'POST /v1/contextEntities/{entityId::id}' and 'POST /v1/contextEntities' accept entity::id and entity::type in payload,
-       as long as they coincide with the entityId::id and entityId::type in the payload.
+- Fix: Made 'POST /v1/contextEntities/{entityId::id}' and 'POST /v1/contextEntities' accept entity::id and entity::type
+       in both payload and URL, as long as the values coincide.
+- Fix: A few more of the 'responses without entityId::type filled in' found and fixed (Issue #585)

--- a/src/lib/convenience/AppendContextElementRequest.h
+++ b/src/lib/convenience/AppendContextElementRequest.h
@@ -42,10 +42,11 @@
 * AppendContextElementRequest - 
 *
 * NOTE
-* The field 'entity' is:
-*   o MANDATORY for "POST /v1/contextEntities"
-*   o FORBIDDEN for "POST /v1/contextEntities/{entityId::id}"
-*   o FORBIDDEN for "POST /v1/contextEntities/type/{entityId::type}/id/{entityId::id}"
+* The field 'entity' is MANDATORY for "POST /v1/contextEntities".
+* For other requests, data in the URL (path and parameters) must coincide
+* with the data in the payload.
+* If not, an error is raised.
+*
 */
 typedef struct AppendContextElementRequest
 {

--- a/src/lib/convenience/AppendContextElementResponse.cpp
+++ b/src/lib/convenience/AppendContextElementResponse.cpp
@@ -32,6 +32,8 @@
 #include "common/tag.h"
 #include "convenience/ContextAttributeResponseVector.h"
 #include "ngsi/StatusCode.h"
+#include "ngsi/ContextElementResponse.h"
+#include "ngsi10/UpdateContextResponse.h"
 #include "convenience/AppendContextElementResponse.h"
 #include "rest/ConnectionInfo.h"
 
@@ -69,7 +71,7 @@ std::string AppendContextElementResponse::render(ConnectionInfo* ciP, RequestTyp
       out += entity.render(ciP->outFormat, indent + "  ", true);
     }
 
-    out += contextResponseVector.render(ciP, requestType, indent + "  ");
+    out += contextAttributeResponseVector.render(ciP, requestType, indent + "  ");
   }
 
   out += endTag(indent, tag, ciP->outFormat);
@@ -98,7 +100,7 @@ std::string AppendContextElementResponse::check
   {
     errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = contextResponseVector.check(ciP, requestType, indent, "", counter)) != "OK")
+  else if ((res = contextAttributeResponseVector.check(ciP, requestType, indent, "", counter)) != "OK")
   {
     errorCode.fill(SccBadRequest, res);
   }
@@ -120,6 +122,71 @@ void AppendContextElementResponse::release(void)
 {
   LM_T(LmtRelease, ("Releasing AppendContextElementResponse"));
 
-  contextResponseVector.release();
+  contextAttributeResponseVector.release();
   errorCode.release();
+}
+
+
+
+/* ****************************************************************************
+*
+* AppendContextElementResponse::fill - 
+*
+* NOTE
+* This method is used in the service routine of 'POST /v1/contextEntities/{entityId::id} et al.
+* Only ONE response in the vector contextElementResponseVector of UpdateContextResponse is possible.
+* FIXME P7: Is this true? Only ONE response?
+*/
+void AppendContextElementResponse::fill(UpdateContextResponse* ucrsP)
+{
+  ContextElementResponse* cerP = ucrsP->contextElementResponseVector[0];
+
+  if (ucrsP->contextElementResponseVector.size() != 0)
+  {
+    contextAttributeResponseVector.fill(&cerP->contextElement.contextAttributeVector, cerP->statusCode);
+  }
+
+  entity.fill(&cerP->contextElement.entityId);
+  errorCode.fill(ucrsP->errorCode);
+
+  //
+  // Special treatment if only one contextElementResponse that is NOT FOUND and if
+  // AppendContextElementResponse::errorCode is not 404 already
+  //
+  // Also if NO contextElementResponse is present
+  //
+  // These 'fixes' are mainly to maintain backward compatibility
+  //
+  if ((errorCode.code != SccContextElementNotFound) &&
+      (contextAttributeResponseVector.size() == 1) &&
+      (contextAttributeResponseVector[0]->statusCode.code == SccContextElementNotFound)
+     )
+  {
+    errorCode.fill(SccContextElementNotFound);
+  }
+  else if ((errorCode.code != SccContextElementNotFound) && (contextAttributeResponseVector.size() == 0))
+  {
+    errorCode.fill(SccContextElementNotFound);
+  }
+  else if (contextAttributeResponseVector.size() == 1)
+  {
+    //
+    // Now, if any error inside ContextAttributeResponse, move it to the outside, but only if we have ONLY ONE contextAttributeResponse
+    // and only if there is no error already in the 'external' errorCode.
+    //
+    if (((errorCode.code == SccNone) || (errorCode.code == SccOk)) && 
+        ((contextAttributeResponseVector[0]->statusCode.code != SccNone) && (contextAttributeResponseVector[0]->statusCode.code != SccOk)))
+    {
+      errorCode.fill(contextAttributeResponseVector[0]->statusCode);
+    }
+  }
+
+  // Now, if the external error code is 404 and 'details' is empty - add the name of the incoming entity::id as details
+  if ((errorCode.code == SccContextElementNotFound) && (errorCode.details == ""))
+  {
+    if (ucrsP->contextElementResponseVector.size() == 1)
+    {
+      errorCode.details = ucrsP->contextElementResponseVector[0]->contextElement.entityId.id;
+    }
+  }
 }

--- a/src/lib/convenience/AppendContextElementResponse.cpp
+++ b/src/lib/convenience/AppendContextElementResponse.cpp
@@ -135,7 +135,6 @@ void AppendContextElementResponse::release(void)
 * NOTE
 * This method is used in the service routine of 'POST /v1/contextEntities/{entityId::id} et al.
 * Only ONE response in the vector contextElementResponseVector of UpdateContextResponse is possible.
-* FIXME P7: Is this true? Only ONE response?
 */
 void AppendContextElementResponse::fill(UpdateContextResponse* ucrsP)
 {

--- a/src/lib/convenience/AppendContextElementResponse.h
+++ b/src/lib/convenience/AppendContextElementResponse.h
@@ -38,6 +38,14 @@
 
 /* ****************************************************************************
 *
+* Forward declaration
+*/
+struct UpdateContextResponse;
+
+
+
+/* ****************************************************************************
+*
 * AppendContextElementResponse - 
 *
 * FIXME P5: AppendContextElementResponse and UpdateContextElementResponse are
@@ -58,9 +66,9 @@
 */
 typedef struct AppendContextElementResponse
 {
-  EntityId                         entity;                  // See NOTE in type header above
-  ContextAttributeResponseVector   contextResponseVector;   // Optional, but mandatory if success
-  StatusCode                       errorCode;               // Optional, but mandatory if failure
+  EntityId                         entity;                          // See NOTE in type header above
+  ContextAttributeResponseVector   contextAttributeResponseVector;  // Optional, but mandatory if success
+  StatusCode                       errorCode;                       // Optional, but mandatory if failure
 
   AppendContextElementResponse();
 
@@ -72,6 +80,7 @@ typedef struct AppendContextElementResponse
                      std::string      indent,
                      std::string      predetectedError,
                      int              counter);
+  void         fill(UpdateContextResponse* ucrsP);
 } AppendContextElementResponse;
 
 #endif  // SRC_LIB_CONVENIENCE_APPENDCONTEXTELEMENTRESPONSE_H_

--- a/src/lib/convenienceMap/mapPostIndividualContextEntity.cpp
+++ b/src/lib/convenienceMap/mapPostIndividualContextEntity.cpp
@@ -84,7 +84,7 @@ HttpStatusCode mapPostIndividualContextEntity
   }
   car->statusCode.fill(&contextElementResponse->statusCode);
 
-  response->contextResponseVector.push_back(car);
+  response->contextAttributeResponseVector.push_back(car);
   response->errorCode.fill(&ucResponse.contextElementResponseVector.get(0)->statusCode);
 
   ucRequest.release();

--- a/src/lib/convenienceMap/mapPostIndividualContextEntityAttributes.cpp
+++ b/src/lib/convenienceMap/mapPostIndividualContextEntityAttributes.cpp
@@ -81,7 +81,7 @@ HttpStatusCode mapPostIndividualContextEntityAttributes
   }
   car->statusCode.fill(&ucContextElementResponse->statusCode);
 
-  response->contextResponseVector.push_back(car);
+  response->contextAttributeResponseVector.push_back(car);
   response->errorCode.fill(&ucResponse.contextElementResponseVector.get(0)->statusCode);
 
   return ms;

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -32,6 +32,7 @@
 #include "common/globals.h"
 #include "common/tag.h"
 #include "convenience/UpdateContextElementRequest.h"
+#include "convenience/AppendContextElementRequest.h"
 #include "ngsi/ContextElement.h"
 #include "ngsi10/UpdateContextRequest.h"
 #include "ngsi10/UpdateContextResponse.h"
@@ -146,4 +147,24 @@ void UpdateContextRequest::fill
   contextElementVector.push_back(ceP);
 
   updateActionType.set("UPDATE");  // Coming from an UpdateContextElementRequest (PUT), must be UPDATE
+}
+
+
+
+/* ****************************************************************************
+*
+* UpdateContextRequest::fill - 
+*/
+void UpdateContextRequest::fill(const AppendContextElementRequest* acerP)
+{
+  ContextElement* ceP = new ContextElement();
+
+  ceP->entityId.fill(&acerP->entity);
+
+  ceP->attributeDomainName.fill(acerP->attributeDomainName);
+  ceP->contextAttributeVector.fill((ContextAttributeVector*) &acerP->contextAttributeVector);
+  ceP->domainMetadataVector.fill((MetadataVector*) &acerP->domainMetadataVector);
+
+  contextElementVector.push_back(ceP);
+  updateActionType.set("APPEND");  // Coming from an AppendContextElementRequest (POST), must be APPEND
 }

--- a/src/lib/ngsi10/UpdateContextRequest.h
+++ b/src/lib/ngsi10/UpdateContextRequest.h
@@ -39,6 +39,7 @@
 * Forward declarations
 */
 struct UpdateContextElementRequest;
+struct AppendContextElementRequest;
 
 
 
@@ -57,6 +58,7 @@ typedef struct UpdateContextRequest
   void         release(void);
   void         present(const std::string& indent);
   void         fill(const UpdateContextElementRequest* ucerP, const std::string& entityId, const std::string& entityType);
+  void         fill(const AppendContextElementRequest* acerP);
 } UpdateContextRequest;
 
 #endif

--- a/src/lib/serviceRoutines/postIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/postIndividualContextEntity.cpp
@@ -124,7 +124,7 @@ std::string postIndividualContextEntity
   // 01.03. entityId::isPattern
   if (reqP->entity.isPattern == "true")
   {
-    std::string error = "entityId::isPattern in contextUpdate convenience operation";
+    std::string error = "entityId::isPattern set to true in contextUpdate convenience operation";
 
     LM_W(("Bad Input (%s)", error.c_str()));
     response.errorCode.fill(SccBadRequest, error);

--- a/src/lib/serviceRoutines/postIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/postIndividualContextEntity.cpp
@@ -28,10 +28,12 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "convenience/AppendContextElementRequest.h"
 #include "convenience/AppendContextElementResponse.h"
-#include "convenienceMap/mapPostIndividualContextEntity.h"
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
+#include "serviceRoutines/postUpdateContext.h"
 #include "serviceRoutines/postIndividualContextEntity.h"
 
 
@@ -40,15 +42,38 @@
 *
 * postIndividualContextEntity -
 *
-* NOTE
-* This function is used for two requests:
-* o POST /v1/contextEntities  and
-* o POST /v1/contextEntities/{entityId::id}
+* Corresponding Standard Operation: UpdateContext/APPEND
 *
-* In the latter case, the payload (AppendContextElementRequest) cannot contain any
+* NOTE
+*   This function is used for two different URLs:
+*     o /v1/contextEntities
+*     o /v1/contextEntities/{entityId::id}
+*
+* In the longer URL (with entityId::id), the payload (AppendContextElementRequest) cannot contain any
 * entityId data (id, type, isPattern).
 * In the first case, the entityId data of the payload is mandatory.
 * entityId::type can be empty, as always, but entityId::id MUST be filled in.
+*
+* POST /v1/contextEntities
+* POST /ngsi10/contextEntities
+* POST /v1/contextEntities/{entityId::id}
+* POST /ngsi10/contextEntities/{entityId::id}
+*
+* Payload In:  AppendContextElementRequest
+* Payload Out: AppendContextElementResponse
+*
+* URI parameters:
+*   - attributesFormat=object
+*   - entity::type=TYPE
+*   - note that '!exist=entity::type' and 'exist=entity::type' are not supported by convenience operations
+*     that use the standard operation UpdateContext as there is no restriction within UpdateContext.
+*
+* 00. Take care of URI params
+* 01. Check that total input in consistent and correct
+* 02. Fill in UpdateContextRequest from AppendContextElementRequest + URL-data + URI params
+* 03. Call postUpdateContext standard service routine
+* 04. Translate UpdateContextResponse to AppendContextElementResponse
+* 05. Cleanup and return result
 */
 std::string postIndividualContextEntity
 (
@@ -58,44 +83,87 @@ std::string postIndividualContextEntity
   ParseData*                 parseDataP
 )
 {
+  AppendContextElementRequest*  reqP                  = &parseDataP->acer.res;
+  AppendContextElementResponse  response;
+  std::string                   entityIdFromPayload   = reqP->entity.id;
+  std::string                   entityIdFromURL       = (compV.size() == 3)? compV[2] : "";
   std::string                   entityId;
+  std::string                   entityTypeFromPayload = reqP->entity.type;
+  std::string                   entityTypeFromURL     = ciP->uriParam[URI_PARAM_ENTITY_TYPE];
   std::string                   entityType;
   std::string                   answer;
-  AppendContextElementRequest*  reqP       = &parseDataP->acer.res;
-  AppendContextElementResponse  response;
 
-  response.entity = reqP->entity;
 
-  if (compV.size() == 3)  // /v1/contextEntities/{entityId}
+  //
+  // 01. Check that total input in consistent and correct
+  //
+
+  // 01.01. entityId::id
+  if ((entityIdFromPayload != "") && (entityIdFromURL != "") && (entityIdFromPayload != entityIdFromURL))
   {
-    entityId   = compV[2];
-    entityType = "";
+    std::string error = "entityId::id differs in URL and payload";
 
-    if ((reqP->entity.id != "") || (reqP->entity.type != "") || (reqP->entity.isPattern != ""))
-    {
-      LM_W(("Bad Input (unknown field)"));
-      response.errorCode.fill(SccBadRequest, "invalid payload: unknown fields");
-      return response.render(ciP, IndividualContextEntity, "");
-    }
-  }
-  else if (compV.size() == 2)  // /v1/contextEntities
+    LM_W(("Bad Input (%s)", error.c_str()));
+    response.errorCode.fill(SccBadRequest, error);
+    return response.render(ciP, IndividualContextEntity, "");
+  }  
+  entityId = (entityIdFromPayload != "")? entityIdFromPayload : entityIdFromURL;
+
+  // 01.02. entityId::type
+  if ((entityTypeFromPayload != "") && (entityTypeFromURL != "") && (entityTypeFromPayload != entityTypeFromURL))
   {
-    entityId   = reqP->entity.id;
-    entityType = reqP->entity.type;
+    std::string error = "entityId::type differs in URL and payload";
 
-    if ((entityId == "") && (entityType == ""))
-    {
-      LM_W(("Bad Input (mandatory entityId::id missing)"));
-      response.errorCode.fill(SccBadRequest, "invalid payload: mandatory entityId::id missing");
-      return response.render(ciP, IndividualContextEntity, "");
-    }
+    LM_W(("Bad Input (%s)", error.c_str()));
+    response.errorCode.fill(SccBadRequest, error);
+    return response.render(ciP, IndividualContextEntity, "");
+  }
+  entityType = (entityTypeFromPayload != "")? entityTypeFromPayload :entityTypeFromURL;
+
+
+  // 01.03. entityId::isPattern
+  if (reqP->entity.isPattern == "true")
+  {
+    std::string error = "entityId::isPattern in contextUpdate convenience operation";
+
+    LM_W(("Bad Input (%s)", error.c_str()));
+    response.errorCode.fill(SccBadRequest, error);
+    return response.render(ciP, IndividualContextEntity, "");
   }
 
-  ciP->httpStatusCode = mapPostIndividualContextEntity(entityId, entityType, &parseDataP->acer.res, &response, ciP);
+  // 01.04. Entity::id must be present, somewhere ...
+  if (entityId == "")
+  {
+    std::string error = "invalid request: mandatory entityId::id missing";
 
+    LM_W(("Bad Input (%s)", error.c_str()));
+    response.errorCode.fill(SccBadRequest, error);
+    return response.render(ciP, IndividualContextEntity, "");
+  }
+
+  // Now, forward Entity to response
   response.entity.fill(entityId, entityType, "false");
+
+  // Also, add entity::id and entity::type to the payload. The UpdateContextRequest::fill method needs this
+  reqP->entity.id   = entityId;
+  reqP->entity.type = entityType;
+
+
+  //
+  // 02. Fill in UpdateContextRequest from AppendContextElementRequest + URL-data + URI params
+  //
+  parseDataP->upcr.res.fill(&parseDataP->acer.res);
+
+
+  // 03. Call postUpdateContext standard service routine
+  answer = postUpdateContext(ciP, components, compV, parseDataP);
+
+
+  // 04. Translate UpdateContextResponse to AppendContextElementResponse
+  response.fill(&parseDataP->upcrs.res);
+
+  // 05. Cleanup and return result
   answer = response.render(ciP, IndividualContextEntity, "");
   response.release();
-
   return answer;
 }

--- a/test/functionalTest/cases/117_convop_using_standard_ops/postIndividualContextEntity_v1_contextEntities.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/postIndividualContextEntity_v1_contextEntities.test
@@ -1,0 +1,450 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+ConvOp postIndividualContextEntity: POST /v1/contextEntities
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. POST /v1/contextEntities
+# 02. Query the entity 'E1' that was just created
+# 03. Query the entity 'E1' with URI-param attributesFormat=object
+# 04. POST /v1/contextEntities?entity::type=E (id='E2', type='F' in payload) and see it fail
+# 05. POST /v1/contextEntities?entity::type=E (isPattern='true' in payload) and see it fail
+# 06. POST /v1/contextEntities?entity::type=E (id='E2', type='E' in payload) and see it work
+# 07. Query the entity 'E2' that was just created
+# 08. Change attribute 'A' of the entity 'E2'
+# 09. Query the entity 'E2' that was just modified
+#
+
+
+echo "01. POST /v1/contextEntities"
+echo "============================"
+payload='{
+    "id": "E1",
+    "type": "E",
+    "isPattern": "false",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "10"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities --payload "${payload}" --json
+echo
+echo
+
+
+echo "02. Query the entity 'E1' that was just created"
+echo "==============================================="
+payload='{
+  "entities": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E1"
+    }
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "${payload}" --json
+echo
+echo
+
+
+echo "03. Query the entity 'E1' with URI-param attributesFormat=object"
+echo "================================================================"
+payload='{
+  "entities": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E1"
+    }
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "${payload}" --json --urlParams attributesFormat=object
+echo
+echo
+
+
+echo "04. POST /v1/contextEntities?entity::type=E (id='E2', type='F' in payload) and see it fail"
+echo "=========================================================================================="
+payload='{
+    "id": "E2",
+    "type": "F",
+    "isPattern": "false",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "10"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities?entity::type=E --payload "${payload}" --json
+echo
+echo
+
+
+echo "05. POST /v1/contextEntities?entity::type=E (isPattern='true' in payload) and see it fail"
+echo "========================================================================================="
+payload='{
+    "id": "E2",
+    "type": "E",
+    "isPattern": "true",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "10"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities?entity::type=E --payload "${payload}" --json
+echo
+echo
+
+
+echo "06. POST /v1/contextEntities?entity::type=E (id='E2', type='E' in payload) and see it work"
+echo "=========================================================================================="
+payload='{
+    "id": "E2",
+    "type": "E",
+    "isPattern": "false",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "10"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities?entity::type=E --payload "${payload}" --json
+echo
+echo
+
+
+echo "07. Query the entity 'E2' that was just created"
+echo "==============================================="
+payload='{
+  "entities": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E2"
+    }
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "${payload}" --json
+echo
+echo
+
+
+
+echo "08. Change attribute 'A' of the entity 'E2'"
+echo "==========================================="
+payload='{
+    "id": "E2",
+    "type": "E",
+    "isPattern": "false",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "200"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities?entity::type=E --payload "${payload}" --json
+echo
+echo
+
+
+echo "09. Query the entity 'E2' that was just modified"
+echo "================================================"
+payload='{
+  "entities": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E2"
+    }
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "${payload}" --json
+echo
+echo
+
+
+--REGEXPECT--
+01. POST /v1/contextEntities
+============================
+HTTP/1.1 200 OK
+Content-Length: 311
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "A1", 
+                    "type": "AT", 
+                    "value": ""
+                }
+            ], 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ], 
+    "id": "E1", 
+    "isPattern": "false", 
+    "type": "E"
+}
+
+
+02. Query the entity 'E1' that was just created
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 380
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "AT", 
+                        "value": "10"
+                    }
+                ], 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "E"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+03. Query the entity 'E1' with URI-param attributesFormat=object
+================================================================
+HTTP/1.1 200 OK
+Content-Length: 360
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": {
+                    "A1": {
+                        "type": "AT", 
+                        "value": "10"
+                    }
+                }, 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "E"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+04. POST /v1/contextEntities?entity::type=E (id='E2', type='F' in payload) and see it fail
+==========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 142
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errorCode": {
+        "code": "400", 
+        "details": "entityId::type differs in URL and payload", 
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+05. POST /v1/contextEntities?entity::type=E (isPattern='true' in payload) and see it fail
+=========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 159
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errorCode": {
+        "code": "400", 
+        "details": "entityId::isPattern in contextUpdate convenience operation", 
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+06. POST /v1/contextEntities?entity::type=E (id='E2', type='E' in payload) and see it work
+==========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 311
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "A1", 
+                    "type": "AT", 
+                    "value": ""
+                }
+            ], 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ], 
+    "id": "E2", 
+    "isPattern": "false", 
+    "type": "E"
+}
+
+
+07. Query the entity 'E2' that was just created
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 380
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "AT", 
+                        "value": "10"
+                    }
+                ], 
+                "id": "E2", 
+                "isPattern": "false", 
+                "type": "E"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+08. Change attribute 'A' of the entity 'E2'
+===========================================
+HTTP/1.1 200 OK
+Content-Length: 311
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "A1", 
+                    "type": "AT", 
+                    "value": ""
+                }
+            ], 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ], 
+    "id": "E2", 
+    "isPattern": "false", 
+    "type": "E"
+}
+
+
+09. Query the entity 'E2' that was just modified
+================================================
+HTTP/1.1 200 OK
+Content-Length: 381
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "AT", 
+                        "value": "200"
+                    }
+                ], 
+                "id": "E2", 
+                "isPattern": "false", 
+                "type": "E"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/117_convop_using_standard_ops/postIndividualContextEntity_v1_contextEntities.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/postIndividualContextEntity_v1_contextEntities.test
@@ -312,14 +312,14 @@ Date: REGEX(.*)
 05. POST /v1/contextEntities?entity::type=E (isPattern='true' in payload) and see it fail
 =========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 159
+Content-Length: 171
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "errorCode": {
         "code": "400", 
-        "details": "entityId::isPattern in contextUpdate convenience operation", 
+        "details": "entityId::isPattern set to true in contextUpdate convenience operation", 
         "reasonPhrase": "Bad Request"
     }
 }

--- a/test/functionalTest/cases/117_convop_using_standard_ops/postIndividualContextEntity_v1_contextEntities_EID.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/postIndividualContextEntity_v1_contextEntities_EID.test
@@ -1,0 +1,486 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+ConvOp postIndividualContextEntity: POST /v1/contextEntities/{entityId::id}
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. POST /v1/contextEntities/E1
+# 02. Query the entity 'E1' that was just created
+# 03. Query the entity 'E1' with URI-param attributesFormat=object
+# 04. POST /v1/contextEntities/E2?entity::type=E (id='E2', type='F' in payload) and see it fail
+# 05. POST /v1/contextEntities/E2?entity::type=E (id='E3', type='E' in payload) and see it fail
+# 06. POST /v1/contextEntities/E2?entity::type=E (isPattern='true' in payload) and see it fail
+# 07. POST /v1/contextEntities/E2?entity::type=E (id='E2', type='E' in payload) and see it work
+# 08. Query the entity 'E2' that was just created
+# 09. Change attribute 'A' of the entity 'E2'
+# 10. Query the entity 'E2' that was just modified
+#
+
+
+echo "01. POST /v1/contextEntities/E1"
+echo "==============================="
+payload='{
+    "id": "E1",
+    "type": "E",
+    "isPattern": "false",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "10"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities/E1 --payload "${payload}" --json
+echo
+echo
+
+
+echo "02. Query the entity 'E1' that was just created"
+echo "==============================================="
+payload='{
+  "entities": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E1"
+    }
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "${payload}" --json
+echo
+echo
+
+
+echo "03. Query the entity 'E1' with URI-param attributesFormat=object"
+echo "================================================================"
+payload='{
+  "entities": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E1"
+    }
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "${payload}" --json --urlParams attributesFormat=object
+echo
+echo
+
+
+echo "04. POST /v1/contextEntities/E2?entity::type=E (id='E2', type='F' in payload) and see it fail"
+echo "============================================================================================="
+payload='{
+    "id": "E2",
+    "type": "F",
+    "isPattern": "false",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "10"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities/E2?entity::type=E --payload "${payload}" --json
+echo
+echo
+
+
+echo "05. POST /v1/contextEntities/E2?entity::type=E (id='E3', type='E' in payload) and see it fail"
+echo "============================================================================================="
+payload='{
+    "id": "E3",
+    "type": "E",
+    "isPattern": "false",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "10"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities/E2?entity::type=E --payload "${payload}" --json
+echo
+echo
+
+
+echo "06. POST /v1/contextEntities/E2?entity::type=E (isPattern='true' in payload) and see it fail"
+echo "============================================================================================"
+payload='{
+    "id": "E2",
+    "type": "E",
+    "isPattern": "true",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "10"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities/E2?entity::type=E --payload "${payload}" --json
+echo
+echo
+
+
+echo "07. POST /v1/contextEntities/E2?entity::type=E (id='E2', type='E' in payload) and see it work"
+echo "============================================================================================="
+payload='{
+    "id": "E2",
+    "type": "E",
+    "isPattern": "false",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "10"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities/E2?entity::type=E --payload "${payload}" --json
+echo
+echo
+
+
+echo "08. Query the entity 'E2' that was just created"
+echo "==============================================="
+payload='{
+  "entities": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E2"
+    }
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "${payload}" --json
+echo
+echo
+
+
+
+echo "09. Change attribute 'A' of the entity 'E2'"
+echo "==========================================="
+payload='{
+    "id": "E2",
+    "type": "E",
+    "isPattern": "false",
+    "attributes": [
+        {
+            "name": "A1",
+            "type": "AT",
+            "value": "200"
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities/E2?entity::type=E --payload "${payload}" --json
+echo
+echo
+
+
+echo "10. Query the entity 'E2' that was just modified"
+echo "================================================"
+payload='{
+  "entities": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E2"
+    }
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "${payload}" --json
+echo
+echo
+
+
+--REGEXPECT--
+01. POST /v1/contextEntities/E1
+===============================
+HTTP/1.1 200 OK
+Content-Length: 311
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "A1", 
+                    "type": "AT", 
+                    "value": ""
+                }
+            ], 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ], 
+    "id": "E1", 
+    "isPattern": "false", 
+    "type": "E"
+}
+
+
+02. Query the entity 'E1' that was just created
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 380
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "AT", 
+                        "value": "10"
+                    }
+                ], 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "E"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+03. Query the entity 'E1' with URI-param attributesFormat=object
+================================================================
+HTTP/1.1 200 OK
+Content-Length: 360
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": {
+                    "A1": {
+                        "type": "AT", 
+                        "value": "10"
+                    }
+                }, 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "E"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+04. POST /v1/contextEntities/E2?entity::type=E (id='E2', type='F' in payload) and see it fail
+=============================================================================================
+HTTP/1.1 200 OK
+Content-Length: 142
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errorCode": {
+        "code": "400", 
+        "details": "entityId::type differs in URL and payload", 
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+05. POST /v1/contextEntities/E2?entity::type=E (id='E3', type='E' in payload) and see it fail
+=============================================================================================
+HTTP/1.1 200 OK
+Content-Length: 140
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errorCode": {
+        "code": "400", 
+        "details": "entityId::id differs in URL and payload", 
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+06. POST /v1/contextEntities/E2?entity::type=E (isPattern='true' in payload) and see it fail
+============================================================================================
+HTTP/1.1 200 OK
+Content-Length: 159
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errorCode": {
+        "code": "400", 
+        "details": "entityId::isPattern in contextUpdate convenience operation", 
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+07. POST /v1/contextEntities/E2?entity::type=E (id='E2', type='E' in payload) and see it work
+=============================================================================================
+HTTP/1.1 200 OK
+Content-Length: 311
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "A1", 
+                    "type": "AT", 
+                    "value": ""
+                }
+            ], 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ], 
+    "id": "E2", 
+    "isPattern": "false", 
+    "type": "E"
+}
+
+
+08. Query the entity 'E2' that was just created
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 380
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "AT", 
+                        "value": "10"
+                    }
+                ], 
+                "id": "E2", 
+                "isPattern": "false", 
+                "type": "E"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+09. Change attribute 'A' of the entity 'E2'
+===========================================
+HTTP/1.1 200 OK
+Content-Length: 311
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "A1", 
+                    "type": "AT", 
+                    "value": ""
+                }
+            ], 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ], 
+    "id": "E2", 
+    "isPattern": "false", 
+    "type": "E"
+}
+
+
+10. Query the entity 'E2' that was just modified
+================================================
+HTTP/1.1 200 OK
+Content-Length: 381
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "AT", 
+                        "value": "200"
+                    }
+                ], 
+                "id": "E2", 
+                "isPattern": "false", 
+                "type": "E"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/117_convop_using_standard_ops/postIndividualContextEntity_v1_contextEntities_EID.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/postIndividualContextEntity_v1_contextEntities_EID.test
@@ -348,14 +348,14 @@ Date: REGEX(.*)
 06. POST /v1/contextEntities/E2?entity::type=E (isPattern='true' in payload) and see it fail
 ============================================================================================
 HTTP/1.1 200 OK
-Content-Length: 159
+Content-Length: 171
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "errorCode": {
         "code": "400", 
-        "details": "entityId::isPattern in contextUpdate convenience operation", 
+        "details": "entityId::isPattern set to true in contextUpdate convenience operation",
         "reasonPhrase": "Bad Request"
     }
 }

--- a/test/functionalTest/cases/559_new_url_paths/ngsi10.test
+++ b/test/functionalTest/cases/559_new_url_paths/ngsi10.test
@@ -721,13 +721,13 @@ Date: REGEX(.*)
 6.3. POST /ngsi10/contextEntities/EID
 ===================================
 HTTP/1.1 200 OK
-Content-Length: 556
+Content-Length: 557
 Content-Type: application/xml
 Date: REGEX(.*)
 
 <?xml version="1.0"?>
 <appendContextElementResponse>
-  <entityId type="" isPattern="false">
+  <entityId type="T" isPattern="false">
     <id>EID</id>
   </entityId>
   <contextResponseList>

--- a/test/functionalTest/cases/559_new_url_paths/v1.test
+++ b/test/functionalTest/cases/559_new_url_paths/v1.test
@@ -721,13 +721,13 @@ Date: REGEX(.*)
 6.3. POST /v1/contextEntities/EID
 ===================================
 HTTP/1.1 200 OK
-Content-Length: 556
+Content-Length: 557
 Content-Type: application/xml
 Date: REGEX(.*)
 
 <?xml version="1.0"?>
 <appendContextElementResponse>
-  <entityId type="" isPattern="false">
+  <entityId type="T" isPattern="false">
     <id>EID</id>
   </entityId>
   <contextResponseList>

--- a/test/functionalTest/cases/613_POST_v1_contextEntities/v1_contextEntities_without_entity.test
+++ b/test/functionalTest/cases/613_POST_v1_contextEntities/v1_contextEntities_without_entity.test
@@ -31,9 +31,9 @@ brokerStart CB
 
 #
 # 01. POST /v1/contextEntities without entityId in JSON payload and see it fail
-# 02. POST /v1/contextEntities/EID with entityId:id=EID in JSON payload and see it fail
+# 02. POST /v1/contextEntities/EID with entityId:id=EID2 in JSON payload and see it fail
 # 03. POST /v1/contextEntities without entityId in XML payload and see it fail
-# 04. POST /v1/contextEntities/EID with entityId:id=EID in XML payload and see it fail
+# 04. POST /v1/contextEntities/EID with entityId:id=EID2 in XML payload and see it fail
 
 # 05. POST /v1/contextEntities with entityId:id=EID in JSON payload OK
 # 06. POST /v1/contextEntities/EID without entityId in JSON payload OK
@@ -63,10 +63,10 @@ echo
 echo
 
 
-echo "02. POST /v1/contextEntities/EID with entityId:id=EID in JSON payload and see it fail"
-echo "====================================================================================="
+echo "02. POST /v1/contextEntities/EID with entityId:id=EID2 in JSON payload and see it fail"
+echo "======================================================================================"
 payload='{
-    "id": "EID",
+    "id": "EID2",
     "type": "ET",
     "isPattern": "false",
     "attributes": [
@@ -99,12 +99,12 @@ echo
 echo
 
 
-echo "04. POST /v1/contextEntities/EID with entityId:id=EID in XML payload and see it fail"
-echo "===================================================================================="
+echo "04. POST /v1/contextEntities/EID with entityId:id=EID2 in XML payload and see it fail"
+echo "====================================================================================="
 payload='<?xml version="1.0"?>
 <appendContextElementRequest>
   <entityId type="ET" isPattern="false">
-    <id>EID</id>
+    <id>EID2</id>
   </entityId>
   <contextAttributeList>
     <contextAttribute>
@@ -273,23 +273,23 @@ Date: REGEX(.*)
 {
     "errorCode": {
         "code": "400", 
-        "details": "invalid payload: mandatory entityId::id missing", 
+        "details": "invalid request: mandatory entityId::id missing", 
         "reasonPhrase": "Bad Request"
     }
 }
 
 
-02. POST /v1/contextEntities/EID with entityId:id=EID in JSON payload and see it fail
-=====================================================================================
+02. POST /v1/contextEntities/EID with entityId:id=EID2 in JSON payload and see it fail
+======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 132
+Content-Length: 140
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "errorCode": {
         "code": "400", 
-        "details": "invalid payload: unknown fields", 
+        "details": "entityId::id differs in URL and payload", 
         "reasonPhrase": "Bad Request"
     }
 }
@@ -307,15 +307,15 @@ Date: REGEX(.*)
   <errorCode>
     <code>400</code>
     <reasonPhrase>Bad Request</reasonPhrase>
-    <details>invalid payload: mandatory entityId::id missing</details>
+    <details>invalid request: mandatory entityId::id missing</details>
   </errorCode>
 </appendContextElementResponse>
 
 
-04. POST /v1/contextEntities/EID with entityId:id=EID in XML payload and see it fail
-====================================================================================
+04. POST /v1/contextEntities/EID with entityId:id=EID2 in XML payload and see it fail
+=====================================================================================
 HTTP/1.1 200 OK
-Content-Length: 213
+Content-Length: 221
 Content-Type: application/xml
 Date: REGEX(.*)
 
@@ -324,7 +324,7 @@ Date: REGEX(.*)
   <errorCode>
     <code>400</code>
     <reasonPhrase>Bad Request</reasonPhrase>
-    <details>invalid payload: unknown fields</details>
+    <details>entityId::id differs in URL and payload</details>
   </errorCode>
 </appendContextElementResponse>
 
@@ -361,7 +361,7 @@ Date: REGEX(.*)
 06. POST /v1/contextEntities/EID without entityId in JSON payload OK
 ====================================================================
 HTTP/1.1 200 OK
-Content-Length: 312
+Content-Length: 314
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -383,7 +383,7 @@ Date: REGEX(.*)
     ], 
     "id": "EID", 
     "isPattern": "false", 
-    "type": ""
+    "type": "ET"
 }
 
 
@@ -420,13 +420,13 @@ Date: REGEX(.*)
 08. POST /v1/contextEntities/EID without entityId in XML payload OK
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 556
+Content-Length: 558
 Content-Type: application/xml
 Date: REGEX(.*)
 
 <?xml version="1.0"?>
 <appendContextElementResponse>
-  <entityId type="" isPattern="false">
+  <entityId type="ET" isPattern="false">
     <id>EID</id>
   </entityId>
   <contextResponseList>

--- a/test/unittests/convenience/AppendContextElementResponse_test.cpp
+++ b/test/unittests/convenience/AppendContextElementResponse_test.cpp
@@ -119,9 +119,9 @@ TEST(AppendContextElementResponse, check_xml)
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
-  // 2. bad contextResponseVector
+  // 2. bad contextAttributeResponseVector
   car.contextAttributeVector.push_back(&ca);
-  acer.contextResponseVector.push_back(&car);
+  acer.contextAttributeResponseVector.push_back(&car);
   out = acer.check(&ci, IndividualContextEntity, "", "", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
@@ -158,9 +158,9 @@ TEST(AppendContextElementResponse, check_json)
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
-  // 2. bad contextResponseVector
+  // 2. bad contextAttributeResponseVector
   car.contextAttributeVector.push_back(&ca);
-  acer.contextResponseVector.push_back(&car);
+  acer.contextAttributeResponseVector.push_back(&car);
   out = acer.check(&ci, IndividualContextEntity, "", "", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
@@ -188,12 +188,12 @@ TEST(AppendContextElementResponse, release)
   utInit();
 
   carP->contextAttributeVector.push_back(caP);
-  acer.contextResponseVector.push_back(carP);
+  acer.contextAttributeResponseVector.push_back(carP);
 
   EXPECT_EQ(1, carP->contextAttributeVector.size());
-  EXPECT_EQ(1, acer.contextResponseVector.size());
+  EXPECT_EQ(1, acer.contextAttributeResponseVector.size());
   acer.release();
-  EXPECT_EQ(0, acer.contextResponseVector.size());
+  EXPECT_EQ(0, acer.contextAttributeResponseVector.size());
 
   utExit();
 }

--- a/unittests_that_fail_sporadically.txt
+++ b/unittests_that_fail_sporadically.txt
@@ -1,6 +1,6 @@
 mongoOntimeintervalOperations.mongoGetContextElementResponses_ok     (x3)
 mongoOntimeintervalOperations.mongoUpdateCsubNewNotification_dbfail  (x5)
-mongoRegisterContext_update.updateCase1                              (x2)
+mongoRegisterContext_update.updateCase1                              (x3)
 mongoUnsubscribeContext.MongoDbFindOneFail                           (x4)
 mongoUnsubscribeContext.MongoDbRemoveFail                            (x4)
 mongoUnsubscribeContextAvailability.MongoDbFindOneFail               (x3)


### PR DESCRIPTION
Made two convops use standard op 'UpdateContextRequest' instead of convMap:
* POST /v1/contextEntities
* POST /v1/contextEntities/{entityId::id}

Changed the name of *AppendContextElementResponse::contextResponseVector* to *AppendContextElementResponse::contextAttributeResponseVector*.
