### PR TITLE
Hardening/117 post subscribe context conv op

### DIFF
--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -112,6 +112,7 @@
 #include "serviceRoutines/postNotifyContext.h"
 #include "serviceRoutines/postNotifyContextAvailability.h"
 
+#include "serviceRoutines/postSubscribeContextConvOp.h"
 #include "serviceRoutines/getContextEntitiesByEntityId.h"
 #include "serviceRoutines/postContextEntitiesByEntityId.h"
 #include "serviceRoutines/getContextEntityAttributes.h"
@@ -712,7 +713,7 @@ PaArgument paArgs[] =
   { "GET",    CETAA, CETAA_COMPS_V0,       "",              getNgsi10ContextEntityTypesAttribute      }, \
   { "*",      CETAA, CETAA_COMPS_V0,       "",              badVerbGetOnly                            }, \
                                                                                                          \
-  { "POST",   SC,    SC_COMPS_V0,          SC_POST_WORD,    postSubscribeContext                      }, \
+  { "POST",   SC,    SC_COMPS_V0,          SC_POST_WORD,    postSubscribeContextConvOp                }, \
   { "*",      SC,    SC_COMPS_V0,          "",              badVerbPostOnly                           }, \
                                                                                                          \
   { "PUT",    SCS,   SCS_COMPS_V0,         SCS_PUT_WORD,    putSubscriptionConvOp                     }, \
@@ -754,7 +755,7 @@ PaArgument paArgs[] =
   { "GET",    CETAA, CETAA_COMPS_V1,         "",              getNgsi10ContextEntityTypesAttribute      }, \
   { "*",      CETAA, CETAA_COMPS_V1,         "",              badVerbGetOnly                            }, \
                                                                                                            \
-  { "POST",   SC,    SC_COMPS_V1,            SC_POST_WORD,    postSubscribeContext                      }, \
+  { "POST",   SC,    SC_COMPS_V1,            SC_POST_WORD,    postSubscribeContextConvOp                }, \
   { "*",      SC,    SC_COMPS_V1,            "",              badVerbPostOnly                           }, \
                                                                                                            \
   { "PUT",    SCS,   SCS_COMPS_V1,           SCS_PUT_WORD,    putSubscriptionConvOp                     }, \

--- a/src/lib/ngsi10/SubscribeContextRequest.cpp
+++ b/src/lib/ngsi10/SubscribeContextRequest.cpp
@@ -147,16 +147,8 @@ void SubscribeContextRequest::release(void)
 *
 * SubscribeContextRequest::fill - 
 */
-void SubscribeContextRequest::fill(const std::string& entityType, EntityTypeInfo typeInfo)
+void SubscribeContextRequest::fill(EntityTypeInfo typeInfo)
 {
-  if (entityType != "")
-  {
-    for (unsigned int ix = 0; ix < entityIdVector.size(); ++ix)
-    {
-      entityIdVector[ix]->type = entityType;
-    }
-  }
-
   if ((typeInfo == EntityTypeEmpty) || (typeInfo == EntityTypeNotEmpty))
   {
     Scope* scopeP = new Scope(SCOPE_FILTER_EXISTENCE, SCOPE_VALUE_ENTITY_TYPE);

--- a/src/lib/ngsi10/SubscribeContextRequest.cpp
+++ b/src/lib/ngsi10/SubscribeContextRequest.cpp
@@ -28,6 +28,7 @@
 #include "common/tag.h"
 #include "ngsi/Request.h"
 #include "ngsi/StatusCode.h"
+#include "rest/EntityTypeInfo.h"
 #include "ngsi10/SubscribeContextResponse.h"
 #include "ngsi10/SubscribeContextRequest.h"
 
@@ -138,4 +139,30 @@ void SubscribeContextRequest::release(void)
   attributeList.release();
   restriction.release();
   notifyConditionVector.release();
+}
+
+
+
+/* ****************************************************************************
+*
+* SubscribeContextRequest::fill - 
+*/
+void SubscribeContextRequest::fill(const std::string& entityType, EntityTypeInfo typeInfo)
+{
+  if (entityType != "")
+  {
+    for (unsigned int ix = 0; ix < entityIdVector.size(); ++ix)
+    {
+      entityIdVector[ix]->type = entityType;
+    }
+  }
+
+  if ((typeInfo == EntityTypeEmpty) || (typeInfo == EntityTypeNotEmpty))
+  {
+    Scope* scopeP = new Scope(SCOPE_FILTER_EXISTENCE, SCOPE_VALUE_ENTITY_TYPE);
+
+    scopeP->oper  = (typeInfo == EntityTypeEmpty)? SCOPE_OPERATOR_NOT : "";
+      
+    restriction.scopeVector.push_back(scopeP);
+  }
 }

--- a/src/lib/ngsi10/SubscribeContextRequest.h
+++ b/src/lib/ngsi10/SubscribeContextRequest.h
@@ -62,7 +62,7 @@ typedef struct SubscribeContextRequest
   void         present(const std::string& indent);
   void         release(void);
 
-  void         fill(const std::string& entityType, EntityTypeInfo typeInfo);
+  void         fill(EntityTypeInfo typeInfo);
 } SubscribeContextRequest;
 
 #endif

--- a/src/lib/ngsi10/SubscribeContextRequest.h
+++ b/src/lib/ngsi10/SubscribeContextRequest.h
@@ -35,6 +35,7 @@
 #include "ngsi/Reference.h"
 #include "ngsi/Restriction.h"
 #include "ngsi/Throttling.h"
+#include "rest/EntityTypeInfo.h"
 
 
 
@@ -60,6 +61,8 @@ typedef struct SubscribeContextRequest
   std::string  check(RequestType requestType, Format format, const std::string& indent, const std::string& predetectedError, int counter);
   void         present(const std::string& indent);
   void         release(void);
+
+  void         fill(const std::string& entityType, EntityTypeInfo typeInfo);
 } SubscribeContextRequest;
 
 #endif

--- a/src/lib/serviceRoutines/CMakeLists.txt
+++ b/src/lib/serviceRoutines/CMakeLists.txt
@@ -95,6 +95,7 @@ getContextEntitiesByEntityIdAndType.cpp
 postContextEntitiesByEntityIdAndType.cpp
 getEntityByIdAttributeByNameWithTypeAndId.cpp
 postEntityByIdAttributeByNameWithTypeAndId.cpp
+postSubscribeContextConvOp.cpp
 )
 
 SET (HEADERS
@@ -158,6 +159,7 @@ getContextEntitiesByEntityIdAndType.h
 postContextEntitiesByEntityIdAndType.h
 getEntityByIdAttributeByNameWithTypeAndId.h
 postEntityByIdAttributeByNameWithTypeAndId.h
+postSubscribeContextConvOp.h
 )
 
 

--- a/src/lib/serviceRoutines/deleteIndividualContextEntityAttributeWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/deleteIndividualContextEntityAttributeWithTypeAndId.cpp
@@ -123,6 +123,7 @@ std::string deleteIndividualContextEntityAttributeWithTypeAndId
 
   // 06. Cleanup and return result
   answer = response.render(ciP->outFormat, "", false, false);
+  parseDataP->upcr.res.release();
 
   return answer;
 }

--- a/src/lib/serviceRoutines/getEntityByIdAttributeByNameWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getEntityByIdAttributeByNameWithTypeAndId.cpp
@@ -116,5 +116,6 @@ std::string getEntityByIdAttributeByNameWithTypeAndId
 
 
   // 05. Cleanup and return result
+  parseDataP->dcar.res.release();
   return answer;
 }

--- a/src/lib/serviceRoutines/postIndividualContextEntityAttributeWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/postIndividualContextEntityAttributeWithTypeAndId.cpp
@@ -113,6 +113,7 @@ std::string postIndividualContextEntityAttributeWithTypeAndId
 
     // 05. Translate UpdateContextResponse to StatusCode
     response.fill(parseDataP->upcrs.res);
+    parseDataP->upcr.res.release();
   }
 
 
@@ -120,5 +121,6 @@ std::string postIndividualContextEntityAttributeWithTypeAndId
   answer = response.render(ciP->outFormat, "", false, false);
   parseDataP->upcar.res.release();
   parseDataP->upcrs.res.release();
+
   return answer;
 }

--- a/src/lib/serviceRoutines/postSubscribeContext.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContext.cpp
@@ -36,6 +36,15 @@
 /* ****************************************************************************
 *
 * postSubscribeContext - 
+*
+* POST /v1/subscribeContext
+* POST /ngsi10/subscribeContext
+*
+* Payload In:  SubscribeContextRequest
+* Payload Out: SubscribeContextResponse
+*
+* URI parameters
+*   - notifyFormat=XXX    (handled by mongoBackend)
 */
 std::string postSubscribeContext
 (
@@ -49,7 +58,7 @@ std::string postSubscribeContext
   std::string               answer;
 
   //
-  // FIXME P6: for the moment, we are assuming that notification will be sent in the same format as the one
+  // FIXME P6: at the moment, we are assuming that notification are sent in the same format as the one
   // used to do the subscription, so we are passing ciP->inFormat. This is just an heuristic, the client could want
   // for example to use XML in the subscription message but wants notifications in JSON. We need a more
   // flexible approach, to be implemented
@@ -57,7 +66,7 @@ std::string postSubscribeContext
 
   //
   // FIXME P0: Only *one* service path is allowed for subscriptions.
-  //           Personally (kz) I kind ot like that. If you want additional service-path, just add another subscription!
+  //           Personally (kz) I kind of like that. If you want additional service-paths, just add another subscription!
   //           However, we need to at least state that HERE is where we limit the number of service paths to *one*.
   //
   if (ciP->servicePathV.size() > 1)

--- a/src/lib/serviceRoutines/postSubscribeContextConvOp.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContextConvOp.cpp
@@ -1,0 +1,91 @@
+/*
+*
+* Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Ken Zangelin
+*/
+#include <string>
+#include <vector>
+
+#include "logMsg/logMsg.h"
+
+#include "ngsi/ParseData.h"
+#include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
+#include "rest/EntityTypeInfo.h"
+#include "serviceRoutines/postSubscribeContext.h"
+#include "serviceRoutines/postSubscribeContextConvOp.h"
+
+
+
+/* ****************************************************************************
+*
+* postSubscribeContextConvOp - 
+*
+* POST /v1/contextSubscriptions
+* POST /ngsi10/contextSubscriptions
+*
+* Payload In:  SubscribeContextRequest
+* Payload Out: SubscribeContextResponse
+*
+* URI parameters
+*   - entity::type=TYPE    (entity-types in payload are overwritten with this entity::type)
+*   - !exist=entity::type
+*   - exist=entity::type
+*   - notifyFormat=XXX     (handled by std-op postSubscribeContext)
+*/
+std::string postSubscribeContextConvOp
+(
+  ConnectionInfo*            ciP,
+  int                        components,
+  std::vector<std::string>&  compV,
+  ParseData*                 parseDataP
+)
+{
+  std::string               answer;
+  std::string               entityType     = ciP->uriParam[URI_PARAM_ENTITY_TYPE];
+  EntityTypeInfo            typeInfo       = EntityTypeEmptyOrNotEmpty;
+
+
+  // 01. Take care of URI params
+  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  {
+    typeInfo = EntityTypeEmpty;
+  }
+  else if (ciP->uriParam[URI_PARAM_EXIST] == URI_PARAM_ENTITY_TYPE)
+  {
+    typeInfo = EntityTypeNotEmpty;
+  }
+
+
+  // 02. Fill in SubscribeContextRequest (actually, modify it)
+  parseDataP->scr.res.fill(entityType, typeInfo);
+
+
+  // 03. Call standard operation
+  answer = postSubscribeContext(ciP, components, compV, parseDataP);
+
+
+  // 04. Cleanup and return result
+  parseDataP->scr.res.release();
+
+  return answer;
+}

--- a/src/lib/serviceRoutines/postSubscribeContextConvOp.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContextConvOp.cpp
@@ -47,10 +47,10 @@
 * Payload Out: SubscribeContextResponse
 *
 * URI parameters
-*   - entity::type=TYPE    (entity-types in payload are overwritten with this entity::type)
 *   - !exist=entity::type
 *   - exist=entity::type
 *   - notifyFormat=XXX     (handled by std-op postSubscribeContext)
+*   x entity::type=TYPE    (NOT TREATED)
 */
 std::string postSubscribeContextConvOp
 (
@@ -60,9 +60,8 @@ std::string postSubscribeContextConvOp
   ParseData*                 parseDataP
 )
 {
-  std::string               answer;
-  std::string               entityType     = ciP->uriParam[URI_PARAM_ENTITY_TYPE];
-  EntityTypeInfo            typeInfo       = EntityTypeEmptyOrNotEmpty;
+  std::string     answer;
+  EntityTypeInfo  typeInfo       = EntityTypeEmptyOrNotEmpty;
 
 
   // 01. Take care of URI params
@@ -77,7 +76,7 @@ std::string postSubscribeContextConvOp
 
 
   // 02. Fill in SubscribeContextRequest (actually, modify it)
-  parseDataP->scr.res.fill(entityType, typeInfo);
+  parseDataP->scr.res.fill(typeInfo);
 
 
   // 03. Call standard operation

--- a/src/lib/serviceRoutines/postSubscribeContextConvOp.h
+++ b/src/lib/serviceRoutines/postSubscribeContextConvOp.h
@@ -1,0 +1,49 @@
+#ifndef SRC_LIB_SERVICEROUTINES_POSTSUBSCRIBECONTEXTCONVOP_H_
+#define SRC_LIB_SERVICEROUTINES_POSTSUBSCRIBECONTEXTCONVOP_H_
+
+/*
+*
+* Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Ken Zangelin
+*/
+#include <string>
+#include <vector>
+
+
+#include "rest/ConnectionInfo.h"
+#include "ngsi/ParseData.h"
+
+
+
+/* ****************************************************************************
+*
+* postSubscribeContextConvOp - 
+*/
+extern std::string postSubscribeContextConvOp
+(
+  ConnectionInfo*            ciP,
+  int                        components,
+  std::vector<std::string>&  compV,
+  ParseData*                 parseDataP
+);
+
+#endif  // SRC_LIB_SERVICEROUTINES_POSTSUBSCRIBECONTEXTCONVOP_H_

--- a/src/lib/serviceRoutines/putAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/putAllEntitiesWithTypeAndId.cpp
@@ -125,6 +125,7 @@ extern std::string putAllEntitiesWithTypeAndId
 
   // 06. Cleanup and return result
   answer = response.render(ciP, IndividualContextEntity, "");
+  parseDataP->upcr.res.release();
   response.release();
 
   return answer;

--- a/src/lib/serviceRoutines/putIndividualContextEntityAttributeWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/putIndividualContextEntityAttributeWithTypeAndId.cpp
@@ -114,5 +114,7 @@ std::string putIndividualContextEntityAttributeWithTypeAndId
   answer = response.render(ciP->outFormat, "", false, false);
   parseDataP->upcar.res.release();
   parseDataP->upcrs.res.release();
+  parseDataP->upcr.res.release();
+
   return answer;
 }

--- a/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextConvOp.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextConvOp.test
@@ -31,7 +31,7 @@ accumulatorStart
 --SHELL--
 
 #
-# 01. Subscribe to E1/T1:ONCHANGE (POST /v1/contextSubscriptions?entity::type=T1), with T2 in payload
+# 01. Subscribe to E1/T1:ONCHANGE (POST /v1/contextSubscriptions)
 # 02. Create E1/T2
 # 03. Dump accumulator to see NOTHING
 # 04. Create E1/T1
@@ -53,13 +53,13 @@ accumulatorStart
 # 18. Dump accumulator to see one notification of 'E2/T1' only
 #
 
-echo "01. Subscribe to E1/T1:ONCHANGE (POST /v1/contextSubscriptions?entity::type=T1), with T2 in payload"
-echo "==================================================================================================="
+echo "01. Subscribe to E1/T1:ONCHANGE (POST /v1/contextSubscriptions)"
+echo "==============================================================="
 payload='{
   "entities": [
     {
       "id":   "E1",
-      "type": "T2"
+      "type": "T1"
     }
   ],
   "reference": "http://localhost:'$LISTENER_PORT'/notify",
@@ -74,7 +74,7 @@ payload='{
     }
   ]
 }'
-orionCurl --url /v1/contextSubscriptions?entity::type=T1 --payload "$payload" --json
+orionCurl --url /v1/contextSubscriptions --payload "$payload" --json
 echo
 echo
 
@@ -140,8 +140,8 @@ echo
 
 
 --REGEXPECT--
-01. Subscribe to E1/T1:ONCHANGE (POST /v1/contextSubscriptions?entity::type=T1), with T2 in payload
-===================================================================================================
+01. Subscribe to E1/T1:ONCHANGE (POST /v1/contextSubscriptions)
+===============================================================
 HTTP/1.1 200 OK
 Content-Length: 134
 Content-Type: application/json

--- a/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextConvOp.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextConvOp.test
@@ -261,5 +261,4 @@ Content-Type: application/json
 --TEARDOWN--
 brokerStop CB
 accumulatorStop
-#dbDrop CB
-
+dbDrop CB

--- a/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextConvOp.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextConvOp.test
@@ -1,0 +1,265 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+ConvOp postSubscribeContextConvOp: POST /v1/contextSubscriptions
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0
+accumulatorStart
+
+--SHELL--
+
+#
+# 01. Subscribe to E1/T1:ONCHANGE (POST /v1/contextSubscriptions?entity::type=T1), with T2 in payload
+# 02. Create E1/T2
+# 03. Dump accumulator to see NOTHING
+# 04. Create E1/T1
+# 05. Dump accumulator to see E1/T1
+#
+# FIXME: Once NGSI10 Subscriptions implement Restrictions 'exist=entity::type' and '!exist=entity::type'
+# 06. Subscribe to E2/<empty>:ONCHANGE (POST /v1/contextSubscriptions?!exist=entity::type)
+# 07. Create E2/<empty>
+# 08. Create E2/T1
+# 09. Dump accumulator to see 'E2/<empty>' only
+# 10. Reset accumulator
+# 11. Subscribe to E2/<non-empty>
+# 12. Dump accumulator to see 'E2/T1' only
+# 13. Reset accumulator
+# 14. Subscribe to E2/<non-empty>:ONCHANGE (POST /v1/contextSubscriptions?exist=entity::type)
+# 15. Dump accumulator to see 'E2/T1' only
+# 16. Reset accumulator
+# 17. Update E2/T1
+# 18. Dump accumulator to see one notification of 'E2/T1' only
+#
+
+echo "01. Subscribe to E1/T1:ONCHANGE (POST /v1/contextSubscriptions?entity::type=T1), with T2 in payload"
+echo "==================================================================================================="
+payload='{
+  "entities": [
+    {
+      "id":   "E1",
+      "type": "T2"
+    }
+  ],
+  "reference": "http://localhost:'$LISTENER_PORT'/notify",
+  "duration": "P5Y",
+  "throttling": "P5Y",
+  "notifyConditions": [
+    {
+      "type": "ONCHANGE",
+      "condValues": [
+        "A1"
+      ]
+    }
+  ]
+}'
+orionCurl --url /v1/contextSubscriptions?entity::type=T1 --payload "$payload" --json
+echo
+echo
+
+
+echo "02. Create E1/T2"
+echo "================"
+payload='{
+  "contextElements": [
+    {
+      "id":   "E1",
+      "type": "T2",
+      "attributes" : [
+        {
+          "name" : "A1",
+          "type" : "a",
+          "value" : "E1/T2/A1"
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --url /v1/updateContext --payload "$payload" --json
+echo
+echo
+
+
+echo "03. Dump accumulator to see NOTHING"
+echo "==================================="
+curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+echo
+echo
+
+
+echo "04. Create E1/T1"
+echo "================"
+payload='{
+  "contextElements": [
+    {
+      "id":   "E1",
+      "type": "T1",
+      "attributes" : [
+        {
+          "name" : "A1",
+          "type" : "a",
+          "value" : "E1/T1/A1"
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --url /v1/updateContext --payload "$payload" --json
+echo
+echo
+
+
+echo "05. Dump accumulator to see E1/T1"
+echo "================================="
+curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+echo
+echo
+
+
+--REGEXPECT--
+01. Subscribe to E1/T1:ONCHANGE (POST /v1/contextSubscriptions?entity::type=T1), with T2 in payload
+===================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 134
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "subscribeResponse": {
+        "duration": "P5Y", 
+        "subscriptionId": "REGEX([0-9a-f]{24})", 
+        "throttling": "P5Y"
+    }
+}
+
+
+02. Create E1/T2
+================
+HTTP/1.1 200 OK
+Content-Length: 378
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "a", 
+                        "value": ""
+                    }
+                ], 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "T2"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+03. Dump accumulator to see NOTHING
+===================================
+
+
+04. Create E1/T1
+================
+HTTP/1.1 200 OK
+Content-Length: 378
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1", 
+                        "type": "a", 
+                        "value": ""
+                    }
+                ], 
+                "id": "E1", 
+                "isPattern": "false", 
+                "type": "T1"
+            }, 
+            "statusCode": {
+                "code": "200", 
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+05. Dump accumulator to see E1/T1
+=================================
+POST http://localhost:REGEX(\d+)/notify
+Content-Length: 465
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Host: localhost:REGEX(\d+)
+Accept: application/xml, application/json
+Content-Type: application/json
+
+{
+  "subscriptionId" : "REGEX([0-9a-f]{24})",
+  "originator" : "localhost",
+  "contextResponses" : [
+    {
+      "contextElement" : {
+        "type" : "T1",
+        "isPattern" : "false",
+        "id" : "E1",
+        "attributes" : [
+          {
+            "name" : "A1",
+            "type" : "a",
+            "value" : "E1/T1/A1"
+          }
+        ]
+      },
+      "statusCode" : {
+        "code" : "200",
+        "reasonPhrase" : "OK"
+      }
+    }
+  ]
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+#dbDrop CB
+


### PR DESCRIPTION
POST /v1/contextSubscriptions now has its very own service routine, supporting a few URI parameters.

Point of discussion: if URI param 'entity::type=XXX' is used, then the all entity types in the entity-vector are overwritten with this 'XXX' ...

As I said, let's discuss how we want this to work.
