### PR TITLE
REMOVE contextBroker-fiware virtual RPM stuff

### DIFF
--- a/makefile
+++ b/makefile
@@ -42,24 +42,14 @@ ifndef TOPDIR
 	RPM_TOPDIR=$(ORION_WS)/rpm
 endif
 
-# Version for the contextBroker-* packages (except contextBroker-fiware)
+# Version for the contextBroker-* packages 
 ifndef BROKER_VERSION
 	BROKER_VERSION:=$(shell grep "\#define ORION_VERSION" src/app/contextBroker/version.h | sed -e 's/^.* "//' -e 's/"//' | sed -e 's/-/_/g')
 endif
 
-# Release ID for the contextBroker-* packages (execept contextBroker-fiware)
+# Release ID for the contextBroker-* packages
 ifndef BROKER_RELEASE
 	BROKER_RELEASE=dev
-endif
-
-# Version for the contextBroker-fiware package
-ifndef FIWARE_VERSION
-	FIWARE_VERSION=3.1.1
-endif
-
-# Release ID for the contextBroker-fiware package
-ifndef FIWARE_RELEASE
-	FIWARE_RELEASE=dev
 endif
 
 ifndef BUILD_ARCH
@@ -214,8 +204,6 @@ rpm-ts:
 		--define '_topdir $(RPM_TOPDIR)' \
 		--define 'broker_version $(BROKER_VERSION)' \
 		--define 'broker_release $(BROKER_RELEASE)' \
-		--define 'fiware_version $(FIWARE_VERSION)' \
-		--define 'fiware_release $(FIWARE_RELEASE)' \
 		--define 'build_arch $(BUILD_ARCH)'
 
 rpm: 
@@ -225,8 +213,6 @@ rpm:
 		--define '_topdir $(RPM_TOPDIR)' \
 		--define 'broker_version $(BROKER_VERSION)' \
 		--define 'broker_release $(BROKER_RELEASE)' \
-		--define 'fiware_version $(FIWARE_VERSION)' \
-		--define 'fiware_release $(FIWARE_RELEASE)' \
 		--define 'build_arch $(BUILD_ARCH)'
 
 mock: 
@@ -236,14 +222,10 @@ mock:
 	rpmbuild -bs rpm/contextBroker.spec \
 		--define 'broker_version $(BROKER_VERSION)' \
 		--define 'broker_release $(BROKER_RELEASE)' \
-		--define 'fiware_version $(FIWARE_VERSION)' \
-		--define 'fiware_release $(FIWARE_RELEASE)' \
 		--define 'build_arch $(BUILD_ARCH)'
 	/usr/bin/mock -r $(MOCK_CONFIG)-$(BUILD_ARCH) ~/rpmbuild/SRPMS/contextBroker-$(BROKER_VERSION)-$(BROKER_RELEASE).src.rpm -v \
 		--define='broker_version $(BROKER_VERSION)' \
 		--define='broker_release $(BROKER_RELEASE)' \
-		--define='fiware_version $(BROKER_FIWARE_VERSION)' \
-		--define 'fiware_release $(FIWARE_RELEASE)' \
 		--define='build_arch $(BUILD_ARCH)'
 	mkdir -p packages
 	cp /var/lib/mock/$(MOCK_CONFIG)-$(BUILD_ARCH)/result/*.rpm packages

--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -142,24 +142,6 @@ Test suite for %{name}
 
 %files tests -f MANIFEST.broker-tests
 
-%package -n %{name}-fiware
-Requires: %{name} = %{broker_version}-%{broker_release}, %{name}-tests = %{broker_version}-%{broker_release}
-Summary: FI-WARE NGSI Broker - Telefónica I+D Implementation
-Version: %{fiware_version}
-Release: %{fiware_release}
-%description -n %{name}-fiware
-The Orion Context Broker is an implementation of the NGSI9 and NGSI10 interfaces. 
-Using these interfaces, clients can do several operations:
-* Register context producer applications, e.g. a temperature sensor within a room.
-* Update context information, e.g. send updates of temperature.
-* Being notified when changes on context information take place (e.g. the
-  temperature has changed) or with a given frecuency (e.g. get the temperature
-  each minute).
-* Query context information. The Orion Context Broker stores context information
-  updated from applications, so queries are resolved based on that information.
-
-%files -n %{name}-fiware
-
 %preun
 if [ "$1" == "0" ]; then
   /etc/init.d/%{name} stop
@@ -167,12 +149,6 @@ if [ "$1" == "0" ]; then
 fi
 
 %preun tests
-
-%preun -n %{name}-fiware
-if [ "$1" == "0" ]; then
-  /etc/init.d/%{name} stop
-  /sbin/chkconfig --del %{name}
-fi
 
 %postun 
 if [ "$1" == "0" ]; then
@@ -183,12 +159,6 @@ fi
 %postun tests
 if [ "$1" == "0" ]; then
   rm -rf  /usr/share/contextBroker/tests
-fi
-
-%postun -n %{name}-fiware
-if [ "$1" == "0" ]; then
-  rm -rf  /usr/share/contextBroker
-  /usr/sbin/userdel -f %{owner}
 fi
 
 %changelog

--- a/scripts/build/release.sh
+++ b/scripts/build/release.sh
@@ -31,7 +31,7 @@ progName=$0
 #
 function usage
 {
-  echo "$progName <NEW_VERSION> <BROKER_RELEASE> <FIWARE_VERSION> <FIWARE_RELEASE> <changelog-file>"
+  echo "$progName <NEW_VERSION> <BROKER_RELEASE> <changelog-file>"
   exit 1
 }
 
@@ -56,9 +56,7 @@ fi
 #
 export NEW_VERSION=$1
 export BROKER_RELEASE=$2
-export FIWARE_VERSION=$3
-export FIWARE_RELEASE=$4
-export CHANGELOG_FILE=$5
+export CHANGELOG_FILE=$3
 
 
 
@@ -66,7 +64,7 @@ export CHANGELOG_FILE=$5
 # correct date format
 #
 DATE=$(LANG=C date +"%a %b %d %Y")
-export dateLine="$DATE Fermin Galan <fermin@tid.es> ${NEW_VERSION}-${BROKER_RELEASE} (FIWARE-${FIWARE_VERSION}-${FIWARE_RELEASE})"
+export dateLine="$DATE Fermin Galan <fermin.galanmarquez@telefonica.com> ${NEW_VERSION}-${BROKER_RELEASE}"
 
 
 # Modify rpm/SPECS/contextBroker.spec only when step to a non-deve release
@@ -180,7 +178,7 @@ then
        git checkout -b release/$NEW_VERSION
        # FIXME: disabled so the releasing script doesn't automatically produce a tag, according to
        # REL procedures
-       #git tag $NEW_VERSION-FIWARE-$FIWARE_VERSION
+       #git tag $NEW_VERSION
        #git push --tags origin release/$NEW_VERSION
        git push origin release/$NEW_VERSION
 


### PR DESCRIPTION
Implements https://github.com/telefonicaid/fiware-orion/issues/779

I have tested this with `make rpm` and it seems to generate a correct contextBroker-0.19.0_next-dev.x86_64.rpm package. However, the "definitive test" will be done when we produce 0.20.0 using the release.sh script.