### PR TITLE
Hardening/valgrind only for debug compilations

### DIFF
--- a/makefile
+++ b/makefile
@@ -403,7 +403,7 @@ coverage_functional_test: install_coverage
 	lcov -r coverage/broker.info "src/lib/parseArgs/*" -o coverage/broker.info
 	genhtml -o coverage coverage/broker.info
 
-valgrind:
+valgrind: install_debug
 	@echo For detailed info: tail -f /tmp/valgrindTestSuiteLog
 	test/valgrind/valgrindTestSuite.sh
 

--- a/test/functionalTest/cases/000_ipv6_support/ipv4_ipv6_both.test
+++ b/test/functionalTest/cases/000_ipv6_support/ipv4_ipv6_both.test
@@ -125,11 +125,12 @@ orionCurl --url "$url" --payload "$payload" --host "[::1]" -g 2> /dev/null
 echo "6: ++++++++++++++++++++"
 #Get accumulated data
 valgrindSleep 2
-curl -g [::1]:${LISTENER2_PORT}/dump -s -S 2> /dev/null
+accumulator2Dump IPV6
 
 echo "7: ++++++++++++++++++++"
 #Get accumulated data
-curl 127.0.0.1:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
+
 
 --REGEXPECT--
 1: ++++++++++++++++++++

--- a/test/functionalTest/cases/000_ipv6_support/ipv4_ipv6_both.test
+++ b/test/functionalTest/cases/000_ipv6_support/ipv4_ipv6_both.test
@@ -124,6 +124,7 @@ orionCurl --url "$url" --payload "$payload" --host "[::1]" -g 2> /dev/null
 
 echo "6: ++++++++++++++++++++"
 #Get accumulated data
+valgrindSleep 2
 curl -g [::1]:${LISTENER2_PORT}/dump -s -S 2> /dev/null
 
 echo "7: ++++++++++++++++++++"

--- a/test/functionalTest/cases/000_ipv6_support/ipv4_ipv6_both.test
+++ b/test/functionalTest/cases/000_ipv6_support/ipv4_ipv6_both.test
@@ -124,7 +124,6 @@ orionCurl --url "$url" --payload "$payload" --host "[::1]" -g 2> /dev/null
 
 echo "6: ++++++++++++++++++++"
 #Get accumulated data
-valgrindSleep 2
 accumulator2Dump IPV6
 
 echo "7: ++++++++++++++++++++"

--- a/test/functionalTest/cases/000_ngsi10_compound_values/compound_subscription_json.test
+++ b/test/functionalTest/cases/000_ngsi10_compound_values/compound_subscription_json.test
@@ -120,7 +120,8 @@ payload='<?xml version="1.0"?>
 orionCurl --url "$url" --payload "$payload"
 
 #Get accumulated data
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
+
 
 --REGEXPECT--
 1: +++++++++ Prepare subscription +++++++++++

--- a/test/functionalTest/cases/000_ngsi10_compound_values/compound_subscription_xml.test
+++ b/test/functionalTest/cases/000_ngsi10_compound_values/compound_subscription_xml.test
@@ -119,7 +119,7 @@ echo "3: ++++++++++ Update the entity attribute with object value ++++++++++"
 EOF
 
 #Get accumulated data
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 
 --REGEXPECT--
 1: +++++++++ Prepare subscription +++++++++++

--- a/test/functionalTest/cases/000_ngsi10_convenience/subscriptions_onchange.test
+++ b/test/functionalTest/cases/000_ngsi10_convenience/subscriptions_onchange.test
@@ -271,7 +271,7 @@ orionCurl --url "$url" --payload "$payload"
 
 echo "10: ++++++++++++++++++++"
 #Get accumulated data
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_id_metadata.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_id_metadata.test
@@ -98,7 +98,8 @@ orionCurl --url "$url" --payload "$payload"
 
 echo
 echo "Accumulated data:"
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_empty.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_empty.test
@@ -114,10 +114,7 @@ echo "3: ++++++++++++++++++++"
 sleep 4
 
 # Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
+valgrindSleep 1
 
 url="/v1/unsubscribeContext"
 payload='<?xml version="1.0"?>
@@ -152,12 +149,7 @@ SUB_ID=$(echo "$_response" | grep subscriptionId | awk -F '>' '{print $2}' | awk
 echo "5: ++++++++++++++++++++"
 # Wait 5 seconds, so we receive two notifications
 sleep 5
-
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
+valgrindSleep 1
 
 url="/v1/unsubscribeContext"
 payload='<?xml version="1.0"?>
@@ -249,11 +241,8 @@ orionCurl --url "$url" --payload "$payload"
 
 echo "10: ++++++++++++++++++++"
 # Get accumulated data - if running under valgrind, sleep 2 secs, to make sure the onchange notifications have time to arrive 
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 2
-fi
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_onchange.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_onchange.test
@@ -292,7 +292,7 @@ echo
 
 echo "Accumulated data:"
 echo "================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 
 --REGEXPECT--

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_onchange_expiration.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_onchange_expiration.test
@@ -131,7 +131,8 @@ orionCurl --url "$url" --payload "$payload"
 
 echo "4: ++++++++++++++++++++"
 #Get accumulated data
-curl localhost:${LISTENER_PORT}/dump -s -S 
+accumulatorDump
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_ontimeinterval.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_ontimeinterval.test
@@ -82,12 +82,7 @@ SUB_ID=$(echo "$_response" | grep subscriptionId | awk -F '>' '{print $2}' | awk
 
 # Interval from 0 to 5: we receive three notifications (t=0, t=2, t=4)
 sleep 5
-
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
+valgrindSleep 1
 
 
 echo "2: ++++++++++++++++++++"
@@ -109,12 +104,7 @@ orionCurl --url "$url" --payload "$payload"
 
 # Interval from 5 to 14: we will receive three notifications (t=5, t=9, t=13)
 sleep 9
-
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
+valgrindSleep 1
 
 
 echo "3: ++++++++++++++++++++"
@@ -138,12 +128,7 @@ orionCurl --url "$url" --payload "$payload"
 
 # Interval from 14 to 35: we will receive three notifications (t=14, t=24, t=34)
 sleep 21
-
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
+valgrindSleep 1
 
 
 echo "4: ++++++++++++++++++++"
@@ -165,12 +150,8 @@ orionCurl --url "$url" --payload "$payload"
 
 # Interval from 35 to 40 seconds, so we will receive three notifications (t=35, t=37, t=39)
 sleep 5
+valgrindSleep 1
 
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
 
 echo "5: ++++++++++++++++++++"
 url=/v1/updateContextSubscription
@@ -191,12 +172,7 @@ orionCurl --url "$url" --payload "$payload"
 # into account both possibilities. However, this curious behaviour should be investigated.
 #
 sleep 26
-
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
+valgrindSleep 1
 
 echo "6: ++++++++++++++++++++"
 url=/v1/updateContextSubscription
@@ -213,15 +189,10 @@ echo
 
 # Interval 66 to 70: we will receive two notifications (t=67, t=69)
 sleep 4
-
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
-
+valgrindSleep 1
 echo Notification count from mongo:
 mongoCmd ${CB_DATABASE_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+
 
 echo "7: ++++++++++++++++++++"
 url=/v1/unsubscribeContext
@@ -233,7 +204,7 @@ orionCurl --url "$url" --payload "$payload"
 
 #Get accumulated data (only the first notification and the notification number and times)
 echo "8: ++++++++++++++++++++"
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null | head -n 32
+accumulatorDump | head -n 32
 
 NUMBER=$(curl localhost:${LISTENER_PORT}/number -s -S )
 echo "NUMBER: $NUMBER"

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_ontimeinterval_expiration.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_ontimeinterval_expiration.test
@@ -55,14 +55,7 @@ echo "1: ++++++++++++++++++++"
 
 # to avoid a race condition in the order of notifications
 sleep 0.5s
-
-#
-# We need more sleep if running under valgrind :-)
-#
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
+valgrindSleep 1
 
 
 #Subscribe for 5 seconds
@@ -95,13 +88,9 @@ echo "2: ++++++++++++++++++++"
 
 #Sleep 10 seconds. Only 3 subscriptions arrive (at time 0, 2 and 4) as subscription expires at time=5s
 sleep 10s
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
+valgrindSleep 2
+accumulatorDump
 
-curl localhost:${LISTENER_PORT}/dump -s -S 
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_ontimeinterval_expiration.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_ontimeinterval_expiration.test
@@ -55,10 +55,16 @@ echo "1: ++++++++++++++++++++"
 
 # to avoid a race condition in the order of notifications
 sleep 0.5s
-valgrindSleep 1
+valgrindSleep 2
 
 
-#Subscribe for 5 seconds
+#Subscribe for 5 seconds (7 if VALGRIND)
+sleepTime=PT5S
+if [ "$VALGRIND" == 1 ]
+then
+  sleepTime=PT7S
+fi
+
 url="/v1/subscribeContext"
 payload='<?xml version="1.0"?>
 <subscribeContextRequest>
@@ -71,7 +77,7 @@ payload='<?xml version="1.0"?>
         <attribute>temperature</attribute>
   </attributeList>
   <reference>http://127.0.0.1:'${LISTENER_PORT}'/notify</reference>
-  <duration>PT5S</duration>
+  <duration>'${sleepTime}'</duration>
   <notifyConditions>
         <notifyCondition>
           <type>ONTIMEINTERVAL</type>
@@ -88,7 +94,6 @@ echo "2: ++++++++++++++++++++"
 
 #Sleep 10 seconds. Only 3 subscriptions arrive (at time 0, 2 and 4) as subscription expires at time=5s
 sleep 10s
-valgrindSleep 2
 accumulatorDump
 
 
@@ -131,7 +136,7 @@ Date: REGEX(.*)
 <subscribeContextResponse>
   <subscribeResponse>
     <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
-    <duration>PT5S</duration>
+    <duration>REGEX((PT5S|PT7S))</duration>
   </subscribeResponse>
 </subscribeContextResponse>
 2: ++++++++++++++++++++

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_ontimeinterval_long_expiration.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_ontimeinterval_long_expiration.test
@@ -55,12 +55,8 @@ echo
 
 # to avoid race conditions in the order of notifications
 sleep 0.5s
+valgrindSleep 1
 
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
 
 #Subscribe for a LONG period of time (99 years - should give overflow in an int)
 echo "1: ++++++++++++++++++++"
@@ -95,14 +91,10 @@ echo
 # Sleep 11 seconds. 6 subscriptions arrive (at time 0, 2, 4, 6, 8, 10) as subscription doesn't expires.
 sleep 11s
 
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
 
 echo "2: ++++++++++++++++++++"
-curl localhost:${LISTENER_PORT}/dump -s -S 
+accumulatorDump
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_append.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_append.test
@@ -204,7 +204,8 @@ orionCurl --url "$url" --payload "$payload"
 echo "7: ++++++++++++++++++++"
 
 #Get accumulated data
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_update.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_update.test
@@ -178,7 +178,8 @@ echo
 
 
 echo "Accumulated data:"
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_wildcards_ontimeinterval.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/subscription_sequence_wildcards_ontimeinterval.test
@@ -106,11 +106,7 @@ echo
 
 # Wait 11 seconds, so we will receive 6 notifications (t=0, t=2, t=4, t=6, t=8, t=10)
 sleep 11
-# Sleep one second more if running under valgrind
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 1
-fi
+valgrindSleep 1
 
 echo "3: ++++++++++++++++++++"
 url=/v1/unsubscribeContext
@@ -124,7 +120,7 @@ echo
 
 # Get accumulated data (only the first notification and the notification times)
 echo "4: ++++++++++++++++++++"
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 TIMES=$(curl localhost:${LISTENER_PORT}/times -s -S)
 echo "TIMES: $TIMES"
 

--- a/test/functionalTest/cases/000_ngsi10_subscriptions/uri_params_and_subscriptions.test
+++ b/test/functionalTest/cases/000_ngsi10_subscriptions/uri_params_and_subscriptions.test
@@ -248,7 +248,7 @@ echo "================================================"
 #    - E1/attr2 in JSON
 #    - E1/attr3 in XML
 #    - E1/attr4 in JSON
-curl localhost:${LISTENER_PORT}/dump 2> /dev/null
+accumulatorDump
 
 
 --REGEXPECT--

--- a/test/functionalTest/cases/000_ngsi9_subscriptions/subscription_availability_expiration.test
+++ b/test/functionalTest/cases/000_ngsi9_subscriptions/subscription_availability_expiration.test
@@ -105,7 +105,8 @@ orionCurl --url "$url" --payload "${payload}"
 
 echo "3: ++++++++++++++++++++"
 #Get accumulated data
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/000_ngsi9_subscriptions/subscription_availability_sequence.test
+++ b/test/functionalTest/cases/000_ngsi9_subscriptions/subscription_availability_sequence.test
@@ -281,7 +281,7 @@ payload='<?xml version="1.0"?>
 orionCurl --url "$url" --payload "$payload"
 echo
 echo Accumulated data:
-curl localhost:${LISTENER_PORT}/dump -s -S 
+accumulatorDump
 echo
 
 --REGEXPECT--

--- a/test/functionalTest/cases/000_ngsi9_subscriptions/subscription_availability_wildcards_sequence.test
+++ b/test/functionalTest/cases/000_ngsi9_subscriptions/subscription_availability_wildcards_sequence.test
@@ -187,7 +187,8 @@ orionCurl --url "$url" --payload "${payload}"
 
 echo "7: ++++++++++++++++++++"
 #Get accumulated data
-curl localhost:${LISTENER_PORT}/dump -s -S 
+accumulatorDump
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK

--- a/test/functionalTest/cases/117_convop_using_standard_ops/deleteSubscriptionConvOp.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/deleteSubscriptionConvOp.test
@@ -110,7 +110,7 @@ echo
 
 echo "05. Dump accumulator, see E1/T1/A1"
 echo "=================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 
@@ -147,7 +147,7 @@ echo
 
 echo "08. Dump accumulator, still only the one notification"
 echo "====================================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextAvailabilityConvOp.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextAvailabilityConvOp.test
@@ -102,7 +102,7 @@ echo
 
 echo "03. Dump accumulator to see NOTHING"
 echo "==================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 
@@ -137,7 +137,7 @@ echo
 
 echo "05. Dump accumulator to see E1/T1"
 echo "================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 
@@ -161,7 +161,7 @@ echo
 
 echo "07. Dump accumulator to see E1/T1, one in JSON, one in XML"
 echo "=========================================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextConvOp.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/postSubscribeContextConvOp.test
@@ -106,7 +106,7 @@ echo
 
 echo "03. Dump accumulator to see NOTHING"
 echo "==================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 
@@ -136,7 +136,7 @@ echo
 
 echo "05. Dump accumulator to see E1/T1"
 echo "================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 
@@ -168,7 +168,7 @@ echo
 
 echo "07. Dump accumulator to see E1/T1, one in JSON, one in XML"
 echo "=========================================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/117_convop_using_standard_ops/putAvailabilitySubscriptionConvOp.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/putAvailabilitySubscriptionConvOp.test
@@ -180,7 +180,7 @@ echo
 
 echo "07. See notification of E1/A2 in accumulator"
 echo "============================================"
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 
@@ -217,7 +217,7 @@ echo
 
 echo "09. See no notification of E1/A1 in accumulator"
 echo "==============================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/117_convop_using_standard_ops/putSubscriptionConvOp.test
+++ b/test/functionalTest/cases/117_convop_using_standard_ops/putSubscriptionConvOp.test
@@ -166,7 +166,7 @@ echo
 
 echo "06. Dump accumulator, see E1/T1/A1+A2, in XML"
 echo "============================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 
@@ -193,7 +193,7 @@ echo
 
 echo "08. Dump accumulator, see two notifications, first one in XML, the second in JSON"
 echo "================================================================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 
@@ -223,7 +223,7 @@ echo
 
 echo "10. Dump accumulator, still the same two notifications"
 echo "======================================================"
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 
@@ -253,7 +253,7 @@ echo
 
 echo "12. Dump accumulator, see three notification, first one in XML, the rest in JSON"
 echo "================================================================================"
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/251_rush_support/rush.test
+++ b/test/functionalTest/cases/251_rush_support/rush.test
@@ -86,11 +86,8 @@ echo
 
 echo "3. Accumulator dump"
 echo "+++++++++++++++++++"
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 2
-fi
-curl localhost:$LISTENER_PORT/dump -s -S
+accumulatorDump
+
 
 --REGEXPECT--
 1. Subscribe to changes in  E/att

--- a/test/functionalTest/cases/251_rush_support/rush_default_port.test
+++ b/test/functionalTest/cases/251_rush_support/rush_default_port.test
@@ -86,11 +86,8 @@ echo
 
 echo "3. Accumulator dump"
 echo "+++++++++++++++++++"
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 2
-fi
-curl localhost:$LISTENER_PORT/dump -s -S
+accumulatorDump
+
 
 --REGEXPECT--
 1. Subscribe to changes in  E/att

--- a/test/functionalTest/cases/251_rush_support/rush_https.test
+++ b/test/functionalTest/cases/251_rush_support/rush_https.test
@@ -87,11 +87,8 @@ echo
 
 echo "3. Accumulator dump"
 echo "+++++++++++++++++++"
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 2
-fi
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
+
 
 --REGEXPECT--
 1. Subscribe to changes in E/att

--- a/test/functionalTest/cases/251_rush_support/rush_https_default_port.test
+++ b/test/functionalTest/cases/251_rush_support/rush_https_default_port.test
@@ -87,11 +87,8 @@ echo
 
 echo "3. Accumulator dump"
 echo "+++++++++++++++++++"
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 2
-fi
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
+
 
 --REGEXPECT--
 1. Subscribe to changes in E/att

--- a/test/functionalTest/cases/252_ngsi10_custom_metadata/custom_metadata_onchange.test
+++ b/test/functionalTest/cases/252_ngsi10_custom_metadata/custom_metadata_onchange.test
@@ -227,7 +227,7 @@ orionCurl --url "$url" --payload "${payload}" --json
 echo
 
 echo "=== Get accumulated data (4 messages)"
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 
 --REGEXPECT--

--- a/test/functionalTest/cases/252_ngsi10_custom_metadata/custom_metadata_ontimeinterval.test
+++ b/test/functionalTest/cases/252_ngsi10_custom_metadata/custom_metadata_ontimeinterval.test
@@ -200,7 +200,7 @@ orionCurl --url "$url" --payload "${payload}" --json
 sleep 1
 
 echo "=== Get accumulated data (4 messages)"
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 
 --REGEXPECT--
 === 1. Create ONTIMEINTERVAL subscription

--- a/test/functionalTest/cases/283_coap_support/coap_basic.test
+++ b/test/functionalTest/cases/283_coap_support/coap_basic.test
@@ -26,10 +26,12 @@ Coap Basic interaction
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
+valgrindSleep 2
 proxyCoapStart
 
 --SHELL--
 
+valgrindSleep 2
 echo "+++++++ Create entity +++++++++"
 url="/v1/contextEntities/Room1"
 payload='{
@@ -44,6 +46,7 @@ payload='{
 coapCurl --url "$url" --payload "$payload" --json -X post
 
 echo "+++++++ Query +++++++++"
+valgrindSleep 2
 coapCurl --url "/v1/contextEntities/Room1" --json
 
 echo "+++++++ Update +++++++++"
@@ -60,6 +63,7 @@ payload='{
 coapCurl --url "$url" --payload "$payload" --json -X put
 
 echo "+++++++ Query +++++++++"
+valgrindSleep 2
 coapCurl --url "/v1/contextEntities/Room1" --json
 
 --REGEXPECT--

--- a/test/functionalTest/cases/322_multitenancy/http_tenant_subscribe_and_update.test
+++ b/test/functionalTest/cases/322_multitenancy/http_tenant_subscribe_and_update.test
@@ -137,13 +137,15 @@ echo
 
 echo "5. Dump accumulator t_01"
 echo "+++++++++++++++++++++++++"
-curl localhost:${LISTENER_PORT}/dump --silent
+#curl localhost:${LISTENER_PORT}/dump --silent
+accumulatorDump
 echo
 
 
 echo "6. Dump accumulator t_02"
 echo "+++++++++++++++++++++++++"
-curl localhost:${LISTENER2_PORT}/dump --silent
+#curl localhost:${LISTENER2_PORT}/dump --silent
+accumulator2Dump
 echo
 
 

--- a/test/functionalTest/cases/322_multitenancy/http_tenant_subscribe_and_update.test
+++ b/test/functionalTest/cases/322_multitenancy/http_tenant_subscribe_and_update.test
@@ -137,14 +137,12 @@ echo
 
 echo "5. Dump accumulator t_01"
 echo "+++++++++++++++++++++++++"
-#curl localhost:${LISTENER_PORT}/dump --silent
 accumulatorDump
 echo
 
 
 echo "6. Dump accumulator t_02"
 echo "+++++++++++++++++++++++++"
-#curl localhost:${LISTENER2_PORT}/dump --silent
 accumulator2Dump
 echo
 

--- a/test/functionalTest/cases/322_multitenancy/tenant_in_notification.test
+++ b/test/functionalTest/cases/322_multitenancy/tenant_in_notification.test
@@ -87,7 +87,8 @@ echo
 
 echo "3. Accumulator dump"
 echo "+++++++++++++++++++"
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
+
 
 --REGEXPECT--
 1. Subscribe to changes in  E/att

--- a/test/functionalTest/cases/563_ngsi10_get_list_of_all_entities/all_entities_no_filter.test
+++ b/test/functionalTest/cases/563_ngsi10_get_list_of_all_entities/all_entities_no_filter.test
@@ -309,7 +309,7 @@ Date: REGEX(.*)
 5. Statistics
 =============
 HTTP/1.1 200 OK
-Content-Length: 275
+Content-Length: 27REGEX(\d+)
 Content-Type: application/xml
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/640_attribute_name_unique_key_field/notify_type_change.test
+++ b/test/functionalTest/cases/640_attribute_name_unique_key_field/notify_type_change.test
@@ -105,12 +105,7 @@ echo
 
 echo "05. Check that 2 notification arrived (initial one an the one due to step 3)"
 echo "============================================================================"
-# Get accumulated data - if running under valgrind, sleep 2 secs, to make sure the onchange notifications have time to arrive
-if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
-then
-  sleep 2
-fi
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/673_xauth_token/auth_token_from_subscribe_request.test
+++ b/test/functionalTest/cases/673_xauth_token/auth_token_from_subscribe_request.test
@@ -94,8 +94,8 @@ echo
 
 echo "03. Check that the X-Auth-Token from the subscribe request was propagated to accumulator"
 echo "========================================================================================"
-sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+#sleep 1
+accumulatorDump
 echo
 echo
 
@@ -131,8 +131,8 @@ echo
 
 echo "06. Check that the X-Auth-Token from the update subscription request was propagated to accumulator"
 echo "=================================================================================================="
-sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+#sleep 1
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/673_xauth_token/auth_token_from_subscribe_request.test
+++ b/test/functionalTest/cases/673_xauth_token/auth_token_from_subscribe_request.test
@@ -94,7 +94,6 @@ echo
 
 echo "03. Check that the X-Auth-Token from the subscribe request was propagated to accumulator"
 echo "========================================================================================"
-#sleep 1
 accumulatorDump
 echo
 echo
@@ -131,7 +130,6 @@ echo
 
 echo "06. Check that the X-Auth-Token from the update subscription request was propagated to accumulator"
 echo "=================================================================================================="
-#sleep 1
 accumulatorDump
 echo
 echo

--- a/test/functionalTest/cases/673_xauth_token/auth_token_three_steps.test
+++ b/test/functionalTest/cases/673_xauth_token/auth_token_three_steps.test
@@ -124,7 +124,6 @@ echo
 
 echo "04. Check that the X-Auth-Token from the subscribe request was propagated to accumulator"
 echo "========================================================================================"
-#sleep 1
 accumulatorDump
 echo
 echo
@@ -161,7 +160,6 @@ echo
 
 echo "07. Make sure the accumulator receives the Update, with the correct X-Auth token"
 echo "================================================================================"
-# sleep 1
 accumulatorDump
 echo
 echo

--- a/test/functionalTest/cases/673_xauth_token/auth_token_three_steps.test
+++ b/test/functionalTest/cases/673_xauth_token/auth_token_three_steps.test
@@ -124,8 +124,8 @@ echo
 
 echo "04. Check that the X-Auth-Token from the subscribe request was propagated to accumulator"
 echo "========================================================================================"
-sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+#sleep 1
+accumulatorDump
 echo
 echo
 
@@ -161,8 +161,8 @@ echo
 
 echo "07. Make sure the accumulator receives the Update, with the correct X-Auth token"
 echo "================================================================================"
-sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+# sleep 1
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/673_xauth_token/subscription.test
+++ b/test/functionalTest/cases/673_xauth_token/subscription.test
@@ -85,7 +85,6 @@ echo
 
 echo "03. Check that the X-Auth-Token was propagated to accumulator"
 echo "============================================================="
-#sleep 1
 accumulatorDump
 echo
 echo

--- a/test/functionalTest/cases/673_xauth_token/subscription.test
+++ b/test/functionalTest/cases/673_xauth_token/subscription.test
@@ -85,8 +85,8 @@ echo
 
 echo "03. Check that the X-Auth-Token was propagated to accumulator"
 echo "============================================================="
-sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+#sleep 1
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/674_servicepath_in_notifications/service_path_in_onchange_notification.test
+++ b/test/functionalTest/cases/674_servicepath_in_notifications/service_path_in_onchange_notification.test
@@ -106,7 +106,7 @@ echo
 
 echo "05. Query accumulator"
 echo "====================="
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/674_servicepath_in_notifications/service_path_in_ontimeinterval_notification.test
+++ b/test/functionalTest/cases/674_servicepath_in_notifications/service_path_in_ontimeinterval_notification.test
@@ -106,7 +106,6 @@ echo
 
 echo "05. Query accumulator"
 echo "====================="
-# sleep 2
 accumulatorDump
 echo
 echo

--- a/test/functionalTest/cases/674_servicepath_in_notifications/service_path_in_ontimeinterval_notification.test
+++ b/test/functionalTest/cases/674_servicepath_in_notifications/service_path_in_ontimeinterval_notification.test
@@ -106,8 +106,8 @@ echo
 
 echo "05. Query accumulator"
 echo "====================="
-sleep 2
-curl localhost:${LISTENER_PORT}/dump -s -S
+# sleep 2
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/674_servicepath_in_notifications/service_path_in_single_onchange_notification.test
+++ b/test/functionalTest/cases/674_servicepath_in_notifications/service_path_in_single_onchange_notification.test
@@ -89,7 +89,7 @@ echo
 
 echo "04. Query accumulator"
 echo "====================="
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_both_cities_with_isPattern_and_deeper_service_path.test
+++ b/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_both_cities_with_isPattern_and_deeper_service_path.test
@@ -103,7 +103,7 @@ echo
 echo "04. Check that the accumulator received the notification of both cities"
 echo "======================================================================="
 sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_exact_city_with_isPattern_and_deeper_service_path.test
+++ b/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_exact_city_with_isPattern_and_deeper_service_path.test
@@ -103,7 +103,7 @@ echo
 echo "04. Check that the accumulator received the initial notification of E/T Madrid only"
 echo "==================================================================================="
 sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_isPattern_and_deeper_service_path.test
+++ b/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_isPattern_and_deeper_service_path.test
@@ -103,7 +103,7 @@ echo
 echo "04. Check that the accumulator received the initial notification of E/T Madrid only"
 echo "==================================================================================="
 sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_recursive_service_path.test
+++ b/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_recursive_service_path.test
@@ -103,7 +103,7 @@ echo
 echo "04. Check that the accumulator received the initial notification of E/T Madrid only"
 echo "==================================================================================="
 sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_recursive_service_path_and_isPattern.test
+++ b/test/functionalTest/cases/675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_recursive_service_path_and_isPattern.test
@@ -103,7 +103,7 @@ echo
 echo "04. Check that the accumulator received the initial notification of E/T Madrid only"
 echo "==================================================================================="
 sleep 1
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/714_propagate_service_path/no_propagation_of_service_path_when_not_present.test
+++ b/test/functionalTest/cases/714_propagate_service_path/no_propagation_of_service_path_when_not_present.test
@@ -91,7 +91,7 @@ echo
 
 echo "03. Dump accumulator to see that the forward was made without service-path"
 echo "=========================================================================="
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/715_forward_xauth_token_to_cprs/propagate_xauth_token_for_update_and_query_standard_ops.test
+++ b/test/functionalTest/cases/715_forward_xauth_token_to_cprs/propagate_xauth_token_for_update_and_query_standard_ops.test
@@ -152,7 +152,7 @@ echo
 
 echo "06. Dump accumulator to see X-Auth headers (or not)"
 echo "==================================================="
-curl localhost:${LISTENER_PORT}/dump -s -S
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/725_multiservice_ignore/service_ignore_without_multiservice.test
+++ b/test/functionalTest/cases/725_multiservice_ignore/service_ignore_without_multiservice.test
@@ -26,6 +26,8 @@ Ignoring service header when not running in multiservice mode
 --SHELL-INIT--
 dbInit CB
 dbInit ${CB_DATABASE_NAME}-foo
+dbResetAll
+
 brokerStart CB 0-255 IPV4
 
 --SHELL--

--- a/test/functionalTest/cases/789_notifyFormat/notifyFormat_ngsi10.test
+++ b/test/functionalTest/cases/789_notifyFormat/notifyFormat_ngsi10.test
@@ -254,7 +254,7 @@ echo
 
 echo "09. Dump accumulator, see A1 in JSON, A2 in XML, A3 in XML and A4 in JSON"
 echo "========================================================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/cases/789_notifyFormat/notifyFormat_ngsi9.test
+++ b/test/functionalTest/cases/789_notifyFormat/notifyFormat_ngsi9.test
@@ -236,7 +236,7 @@ echo
 
 echo "09. Dump accumulator, see A1 in JSON, A2 in XML, A3 in XML and A4 in JSON"
 echo "========================================================================="
-curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+accumulatorDump
 echo
 echo
 

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -116,6 +116,21 @@ function dbDrop()
 
 # ------------------------------------------------------------------------------
 #
+# dbResetAll - 
+#
+function dbResetAll()
+{
+  all=$(echo show dbs | mongo --quiet | grep ftest | awk '{ print $1 }')
+  for db in $all
+  do
+    dbDrop $db
+  done
+}
+
+
+
+# ------------------------------------------------------------------------------
+#
 # localBrokerStart
 #
 function localBrokerStart()
@@ -427,6 +442,52 @@ function accumulatorStart()
    port_not_ok=$?
   done
 }
+
+
+
+# ------------------------------------------------------------------------------
+#
+# accumulatorDump
+#
+function accumulatorDump()
+{
+  if [ "$VALGRIND" == "1" ]
+  then
+    sleep 2
+  fi
+
+  curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+}
+
+
+# ------------------------------------------------------------------------------
+#
+# accumulator2Dump
+#
+function accumulator2Dump()
+{
+  if [ "$VALGRIND" == "1" ]
+  then
+    sleep 2
+  fi
+
+  curl localhost:${LISTENER2_PORT}/dump -s -S 2> /dev/null
+}
+
+
+# ------------------------------------------------------------------------------
+#
+# valgrindSleep
+#
+function valgrindSleep()
+{
+  if [ "$FUNC_TEST_RUNNING_UNDER_VALGRIND" == "true" ]
+  then
+    sleep $1
+  fi
+}
+
+
 
 # ------------------------------------------------------------------------------
 #
@@ -857,6 +918,7 @@ function coapCurl()
 
 export -f dbInit
 export -f dbDrop
+export -f dbResetAll
 export -f brokerStart
 export -f localBrokerStop
 export -f localBrokerStart
@@ -866,8 +928,11 @@ export -f proxyCoapStart
 export -f proxyCoapStop
 export -f accumulatorStart
 export -f accumulatorStop
+export -f accumulatorDump
+export -f accumulator2Dump
 export -f orionCurl
 export -f dbInsertEntity
 export -f mongoCmd
 export -f coapCurl
 export -f vMsg
+export -f valgrindSleep

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -451,12 +451,14 @@ function accumulatorStart()
 #
 function accumulatorDump()
 {
-  if [ "$VALGRIND" == "1" ]
-  then
-    sleep 2
-  fi
+  valgrindSleep 2
 
-  curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+  if [ "$1" == "IPV6" ]
+  then
+    curl -g [::1]:${LISTENER_PORT}/dump -s -S 2> /dev/null
+  else
+    curl localhost:${LISTENER_PORT}/dump -s -S 2> /dev/null
+  fi
 }
 
 
@@ -466,12 +468,14 @@ function accumulatorDump()
 #
 function accumulator2Dump()
 {
-  if [ "$VALGRIND" == "1" ]
-  then
-    sleep 2
-  fi
+  valgrindSleep 2
 
-  curl localhost:${LISTENER2_PORT}/dump -s -S 2> /dev/null
+  if [ "$1" == "IPV6" ]
+  then
+    curl -g [::1]:${LISTENER2_PORT}/dump -s -S 2> /dev/null
+  else
+    curl localhost:${LISTENER2_PORT}/dump -s -S 2> /dev/null
+  fi
 }
 
 


### PR DESCRIPTION
Lots of valgrind problems solved.
First of all the 'exit code 11'. This error occurs when we run valgrind on a 'non-debug-compiled' broker. Non-debug means that "/exit" is not recognized and without that the valgrind test suite cannot function.

Apart from that a few new functions implemented to take care of conditional sleeps for valgrind.
That and a few more tricks has gotten the number of failed functests  (under valgrind that completely changed the timing) to 3:

   subscription_sequence_ontimeinterval.test
   subscription_sequence_wildcards_ontimeinterval.test
   coap_basic.test

coap_basic.test almost works. Of its four part tests three are working now (before, all four failed).
subscription_sequence_ontimeinterval.test and subscription_sequence_wildcards_ontimeinterval.test are pretty much impossible to make work.
We could or in a '.*' in the case of valgrind, that's all I can think of.
Or completely change the test to not depend on exact seconds ...

REGEX((0|1)), REGEX((2|3)), etc, etc.

At least, now almost everything is working.
And thanks to the function "accumulatorDump" not so many failing functions will be added in the future.
