### PR TITLE
Unhardwire format CPr at mongobackend

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - Add: support for MongoDB 2.6 (MongoDB 2.4 should *not* be used any longer as inverted geo-queries will not work in that version) (Issue #415)
 - Add: context providers full functionality (Issue #787)
+- Fix: unhardwire format to forward requests to context providers (Issue #722)
 - Fix: using proper GJSON for location.coords entities information (Issue #415)

--- a/src/lib/mongoBackend/MongoCommonRegister.cpp
+++ b/src/lib/mongoBackend/MongoCommonRegister.cpp
@@ -353,7 +353,8 @@ HttpStatusCode processRegisterContext
   RegisterContextResponse*  responseP,
   OID*                      id,
   const std::string&        tenant,
-  const std::string&        servicePath
+  const std::string&        servicePath,
+  const std::string&        format
 )
 {
     DBClientBase* connection = getMongoConnection();
@@ -380,6 +381,7 @@ HttpStatusCode processRegisterContext
     reg.append("_id", oid);
     reg.append(REG_EXPIRATION, expiration);
     reg.append(REG_SERVICE_PATH, servicePath);
+    reg.append(REG_FORMAT, format);
 
     /* We accumulate the subscriptions in a map. The key of the map is the string representing
      * subscription id */

--- a/src/lib/mongoBackend/MongoCommonRegister.h
+++ b/src/lib/mongoBackend/MongoCommonRegister.h
@@ -43,7 +43,8 @@ extern HttpStatusCode processRegisterContext
   RegisterContextResponse*  responseP,
   OID*                      id,
   const std::string&        tenant,
-  const std::string&        servicePath
+  const std::string&        servicePath,
+  const std::string&        format
 );
 
 

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1649,7 +1649,7 @@ bool registrationsQuery
         BSONObj r = cursor->next();
         LM_T(LmtMongo, ("retrieved document: '%s'", r.toString().c_str()));
 
-        /* Default format is XML, in the case the field ins not found in the registrations document (for pre-0.21.0 versions) */
+        /* Default format is XML, in the case the field is not found in the registrations document (for pre-0.21.0 versions) */
         Format format = r.hasField(REG_FORMAT) ? stringToFormat(STR_FIELD(r, REG_FORMAT)) : XML;
 
         std::vector<BSONElement> queryContextRegistrationV = r.getField(REG_CONTEXT_REGISTRATION).Array();

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -2082,10 +2082,13 @@ void fillContextProviders(ContextElementResponse* cer, ContextRegistrationRespon
     /* Search for some CPr in crrV */
     std::string perEntPa;
     std::string perAttrPa;
-    cprLookupByAttribute(cer->contextElement.entityId, ca->name, crrV, &perEntPa, &perAttrPa);
+    Format      perEntPaFormat = NOFORMAT;
+    Format      perAttrPaFormat= NOFORMAT;
+    cprLookupByAttribute(cer->contextElement.entityId, ca->name, crrV, &perEntPa, &perEntPaFormat, &perAttrPa, &perAttrPaFormat);
 
     /* Looking results after crrV processing */
     ca->providingApplication.set(perAttrPa == "" ? perEntPa : perAttrPa);
+    ca->providingApplication.setFormat(perAttrPa == "" ? perEntPaFormat : perAttrPaFormat);
     ca->found = (ca->providingApplication.get() != "");
   }
 }
@@ -2127,7 +2130,9 @@ void cprLookupByAttribute(EntityId&                          en,
                           const std::string&                 attrName,
                           ContextRegistrationResponseVector& crrV,
                           std::string*                       perEntPa,
-                          std::string*                       perAttrPa)
+                          Format*                            perEntPaFormat,
+                          std::string*                       perAttrPa,
+                          Format*                            perAttrPaFormat)
 {
   *perEntPa  = "";
   *perAttrPa = "";
@@ -2147,7 +2152,8 @@ void cprLookupByAttribute(EntityId&                          en,
       /* CRR without attributes (keep searching in other CRR) */
       if (crr->contextRegistration.contextRegistrationAttributeVector.size() == 0)
       {
-        *perEntPa = crr->contextRegistration.providingApplication.get();
+        *perEntPa       = crr->contextRegistration.providingApplication.get();
+        *perEntPaFormat = crr->contextRegistration.providingApplication.getFormat();
         break; /* enIx */
       }
 
@@ -2158,7 +2164,8 @@ void cprLookupByAttribute(EntityId&                          en,
         if (regAttrName == attrName)
         {
           /* We cannot "improve" this result keep searching in CRR vector, so we return */
-          *perAttrPa = crr->contextRegistration.providingApplication.get();
+          *perAttrPa       = crr->contextRegistration.providingApplication.get();
+          *perAttrPaFormat = crr->contextRegistration.providingApplication.getFormat();
           return;
         }
       }

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -2081,8 +2081,8 @@ void fillContextProviders(ContextElementResponse* cer, ContextRegistrationRespon
     cprLookupByAttribute(cer->contextElement.entityId, ca->name, crrV, &perEntPa, &perAttrPa);
 
     /* Looking results after crrV processing */
-    ca->providingApplication = perAttrPa == ""? perEntPa : perAttrPa;
-    ca->found = (ca->providingApplication != "");
+    ca->providingApplication.set(perAttrPa == "" ? perEntPa : perAttrPa);
+    ca->found = (ca->providingApplication.get() != "");
   }
 }
 

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -72,6 +72,7 @@ using namespace mongo;
 #define REG_ATTRS_TYPE              "type"
 #define REG_ATTRS_ISDOMAIN          "isDomain"
 #define REG_SERVICE_PATH            "servicePath"
+#define REG_FORMAT                  "format"
 
 #define ENT_ATTRS                    "attrs"
 #define ENT_ENTITY_ID                "id"

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -490,6 +490,8 @@ extern void cprLookupByAttribute(EntityId&                          en,
                                  const std::string&                 attrName,
                                  ContextRegistrationResponseVector& crrV,
                                  std::string*                       perEntPa,
-                                 std::string*                       perAttrPa);
+                                 Format*                            perEntPaFormat,
+                                 std::string*                       perAttrPa,
+                                 Format*                            perAttrPaFormat);
 
 #endif

--- a/src/lib/mongoBackend/mongoNotifyContextAvailability.cpp
+++ b/src/lib/mongoBackend/mongoNotifyContextAvailability.cpp
@@ -24,6 +24,7 @@
 */
 
 #include "common/sem.h"
+#include "logMsg/traceLevels.h"
 
 #include "mongoBackend/mongoNotifyContextAvailability.h"
 #include "mongoBackend/MongoGlobal.h"
@@ -37,12 +38,19 @@
 */
 HttpStatusCode mongoNotifyContextAvailability
 (
-  NotifyContextAvailabilityRequest*   requestP,
-  NotifyContextAvailabilityResponse*  responseP,
-  const std::string&                  tenant,
-  const std::string&                  servicePath
+  NotifyContextAvailabilityRequest*    requestP,
+  NotifyContextAvailabilityResponse*   responseP,
+  std::map<std::string, std::string>&  uriParam,
+  const std::string&                   tenant,
+  const std::string&                   servicePath
 )
 {
+    // FIXME P10: we have been discussing about changing the "notifyFormat" name for something more neutral and more
+    // meaningfull for *both* subscription notification and cpr forwards
+    std::string notifyFormat = uriParam[URI_PARAM_NOTIFY_FORMAT];
+
+    LM_T(LmtMongo, ("Notify Context Availability: '%s' format", notifyFormat.c_str()));
+
     reqSemTake(__FUNCTION__, "mongo ngsi9 notification");
 
     /* We ignore "subscriptionId" and "originator" in the request, as we don't have anything interesting
@@ -63,7 +71,7 @@ HttpStatusCode mongoNotifyContextAvailability
      * point of view, notifyContextAvailability is considered as a new registration (as no registratinId is
      * received in the notification message) */
     RegisterContextResponse rcres;
-    processRegisterContext(&rcr, &rcres, NULL, tenant, servicePath);
+    processRegisterContext(&rcr, &rcres, NULL, tenant, servicePath, notifyFormat);
 
     responseP->responseCode.fill(SccOk);
 

--- a/src/lib/mongoBackend/mongoNotifyContextAvailability.h
+++ b/src/lib/mongoBackend/mongoNotifyContextAvailability.h
@@ -26,6 +26,8 @@
 * Author: Fermín Galán
 */
 
+#include <map>
+
 #include "ngsi9/NotifyContextAvailabilityRequest.h"
 #include "ngsi9/NotifyContextAvailabilityResponse.h"
 
@@ -35,10 +37,11 @@
 */
 extern HttpStatusCode mongoNotifyContextAvailability
 (
-  NotifyContextAvailabilityRequest*   requestP,
-  NotifyContextAvailabilityResponse*  responseP,
-  const std::string&                  tenant      = "",
-  const std::string&                  servicePath = ""
+  NotifyContextAvailabilityRequest*    requestP,
+  NotifyContextAvailabilityResponse*   responseP,
+  std::map<std::string, std::string>&  uriParam,
+  const std::string&                   tenant      = "",
+  const std::string&                   servicePath = ""
 );
 
 #endif

--- a/src/lib/mongoBackend/mongoQueryContext.cpp
+++ b/src/lib/mongoBackend/mongoQueryContext.cpp
@@ -78,7 +78,7 @@ void fillContextProviders(ContextElementResponseVector& cerV, ContextRegistratio
 * addContextProviderEntity -
 *
 */
-void addContextProviderEntity(ContextElementResponseVector& cerV, EntityId* enP, std::string pa)
+void addContextProviderEntity(ContextElementResponseVector& cerV, EntityId* enP, ProvidingApplication pa)
 {
   for (unsigned int ix = 0; ix < cerV.size(); ++ix)
   {
@@ -107,7 +107,7 @@ void addContextProviderEntity(ContextElementResponseVector& cerV, EntityId* enP,
 *
 *
 */
-void addContextProviderAttribute(ContextElementResponseVector& cerV, EntityId* enP, ContextRegistrationAttribute* craP, const std::string& pa)
+void addContextProviderAttribute(ContextElementResponseVector& cerV, EntityId* enP, ContextRegistrationAttribute* craP, const ProvidingApplication& pa)
 {
   for (unsigned int ix = 0; ix < cerV.size(); ++ix)
   {
@@ -198,7 +198,7 @@ void addContextProviders(ContextElementResponseVector& cerV, ContextRegistration
       /* Registration without attributes */
       for (unsigned int jx = 0; jx < cr.entityIdVector.size(); ++jx)
       {
-        addContextProviderEntity(cerV, cr.entityIdVector.get(jx), cr.providingApplication.get());
+        addContextProviderEntity(cerV, cr.entityIdVector.get(jx), cr.providingApplication);
       }
     }
     else
@@ -208,7 +208,7 @@ void addContextProviders(ContextElementResponseVector& cerV, ContextRegistration
       {
         for (unsigned int aIx = 0; aIx < cr.contextRegistrationAttributeVector.size(); ++aIx)
         {
-          addContextProviderAttribute(cerV, cr.entityIdVector.get(eIx), cr.contextRegistrationAttributeVector.get(aIx), cr.providingApplication.get());
+          addContextProviderAttribute(cerV, cr.entityIdVector.get(eIx), cr.contextRegistrationAttributeVector.get(aIx), cr.providingApplication);
         }
       }
     }

--- a/src/lib/mongoBackend/mongoRegisterContext.cpp
+++ b/src/lib/mongoBackend/mongoRegisterContext.cpp
@@ -47,17 +47,22 @@ using namespace mongo;
 */
 HttpStatusCode mongoRegisterContext
 (
-  RegisterContextRequest*   requestP,
-  RegisterContextResponse*  responseP,
-  const std::string&        tenant,
-  const std::string&        servicePath
+  RegisterContextRequest*              requestP,
+  RegisterContextResponse*             responseP,
+  std::map<std::string, std::string>&  uriParam,
+  const std::string&                   tenant,
+  const std::string&                   servicePath
+
 )
-{    
+{
+    // FIXME P10: we have been discussing about changing the "notifyFormat" name for something more neutral and more
+    // meaningfull for *both* subscription notification and cpr forwards
+    std::string notifyFormat = uriParam[URI_PARAM_NOTIFY_FORMAT];
     std::string sPath = servicePath;
 
-    reqSemTake(__FUNCTION__, "ngsi9 register request");
+    LM_T(LmtMongo, ("Register Context Request: '%s' format", notifyFormat.c_str()));
 
-    LM_T(LmtMongo, ("Register Context Request"));
+    reqSemTake(__FUNCTION__, "ngsi9 register request");    
 
     DBClientBase* connection = getMongoConnection();
 
@@ -70,7 +75,7 @@ HttpStatusCode mongoRegisterContext
     /* Check if new registration */
     if (requestP->registrationId.isEmpty())
     {
-      HttpStatusCode result = processRegisterContext(requestP, responseP, NULL, tenant, sPath);
+      HttpStatusCode result = processRegisterContext(requestP, responseP, NULL, tenant, sPath, notifyFormat);
       reqSemGive(__FUNCTION__, "ngsi9 register request");
       return result;
     }
@@ -138,7 +143,7 @@ HttpStatusCode mongoRegisterContext
        return SccOk;
     }
 
-    HttpStatusCode result = processRegisterContext(requestP, responseP, &id, tenant, sPath);
+    HttpStatusCode result = processRegisterContext(requestP, responseP, &id, tenant, sPath, notifyFormat);
     reqSemGive(__FUNCTION__, "ngsi9 register request");
     return result;
 }

--- a/src/lib/mongoBackend/mongoRegisterContext.h
+++ b/src/lib/mongoBackend/mongoRegisterContext.h
@@ -26,6 +26,7 @@
 * Author: Fermin Galan Marquez
 */
 #include <string>
+#include <map>
 
 #include "ngsi9/RegisterContextRequest.h"
 #include "ngsi9/RegisterContextResponse.h"
@@ -38,10 +39,11 @@
 */
 extern HttpStatusCode mongoRegisterContext
 (
-  RegisterContextRequest*   requestP,
-  RegisterContextResponse*  responseP,
-  const std::string&        tenant       = "",
-  const std::string&        servicePath  = ""
+  RegisterContextRequest*              requestP,
+  RegisterContextResponse*             responseP,
+  std::map<std::string, std::string>&  uriParam,
+  const std::string&                   tenant       = "",
+  const std::string&                   servicePath  = ""
 );
 
 #endif

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -61,8 +61,10 @@ ContextAttribute::ContextAttribute()
   value                 = "";
   compoundValueP        = NULL;
   typeFromXmlAttribute  = "";
-  providingApplication  = "";
   found                 = true;
+
+  providingApplication.set("");
+  providingApplication.setFormat(XML);
 }
 
 
@@ -77,9 +79,11 @@ ContextAttribute::ContextAttribute(ContextAttribute* caP)
   type                  = caP->type;
   value                 = caP->value;
   compoundValueP        = (caP->compoundValueP)? caP->compoundValueP->clone() : NULL;
-  providingApplication  = caP->providingApplication;
   found                 = caP->found;
   typeFromXmlAttribute  = "";
+
+  providingApplication.set(caP->providingApplication.get());
+  providingApplication.setFormat(caP->providingApplication.getFormat());
 
   LM_T(LmtClone, ("Creating a ContextAttribute: compoundValueP at %p for attribute '%s' at %p",
                   compoundValueP,
@@ -118,9 +122,10 @@ ContextAttribute::ContextAttribute
   type                  = _type;
   value                 = _value;
   compoundValueP        = NULL;
-  typeFromXmlAttribute  = "";
-  providingApplication  = "";
   found                 = _found;
+
+  providingApplication.set("");
+  providingApplication.setFormat(XML);
 }
 
 
@@ -142,8 +147,10 @@ ContextAttribute::ContextAttribute
   type                  = _type;
   compoundValueP        = _compoundValueP->clone();
   typeFromXmlAttribute  = "";
-  providingApplication  = "";
   found                 = true;
+
+  providingApplication.set("");
+  providingApplication.setFormat(XML);
 }
 
 
@@ -349,7 +356,7 @@ void ContextAttribute::present(const std::string& indent, int ix)
     compoundValueP->show(indent + "  ");
   }
 
-  PRINTF("%s  PA:       %s\n", indent.c_str(), providingApplication.c_str());
+  PRINTF("%s  PA:       %s (%s)\n", indent.c_str(), providingApplication.get().c_str(), formatToString(providingApplication.getFormat()));
   PRINTF("%s  found:    %s\n", indent.c_str(), FT(found));
 
   metadataVector.present("Attribute", indent + "  ");

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -64,7 +64,7 @@ ContextAttribute::ContextAttribute()
   found                 = true;
 
   providingApplication.set("");
-  providingApplication.setFormat(XML);
+  providingApplication.setFormat(NOFORMAT);
 }
 
 
@@ -125,7 +125,7 @@ ContextAttribute::ContextAttribute
   found                 = _found;
 
   providingApplication.set("");
-  providingApplication.setFormat(XML);
+  providingApplication.setFormat(NOFORMAT);
 }
 
 
@@ -150,7 +150,7 @@ ContextAttribute::ContextAttribute
   found                 = true;
 
   providingApplication.set("");
-  providingApplication.setFormat(XML);
+  providingApplication.setFormat(NOFORMAT);
 }
 
 

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -31,6 +31,7 @@
 #include "ngsi/MetadataVector.h"
 #include "common/Format.h"
 #include "ngsi/Request.h"
+#include "ngsi/ProvidingApplication.h"
 #include "parse/CompoundValueNode.h"
 #include "rest/ConnectionInfo.h"
 
@@ -49,9 +50,9 @@ typedef struct ContextAttribute
                                            //          E.g. /v1/contextTypes
   MetadataVector  metadataVector;          // Optional
 
-  std::string     providingApplication;    // Not part of NGSI, used internally for CPr forwarding functionality
-  bool            found;                   // Not part of NGSI, used internally for CPr forwarding functionality (update case)
-                                           // It means attribute found either locally or remotely in prodiving application
+  ProvidingApplication     providingApplication;    // Not part of NGSI, used internally for CPr forwarding functionality
+  bool                     found;                   // Not part of NGSI, used internally for CPr forwarding functionality (update case)
+                                                    // It means attribute found either locally or remotely in prodiving application
 
   std::string                typeFromXmlAttribute;
   orion::CompoundValueNode*  compoundValueP;

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -153,7 +153,7 @@ void ContextElement::present(const std::string& indent, int ix)
   domainMetadataVector.present("Domain", indent + "  ");
   for (unsigned int ix = 0; ix < providingApplicationList.size(); ++ix)
   {
-    PRINTF("%s  PA: %s\n", indent.c_str(), providingApplicationList[ix].c_str());
+    PRINTF("%s  PA: %s (%s)\n", indent.c_str(), providingApplicationList[ix].get().c_str(), formatToString(providingApplicationList[ix].getFormat()));
   }
 }
 

--- a/src/lib/ngsi/ContextElement.h
+++ b/src/lib/ngsi/ContextElement.h
@@ -48,7 +48,7 @@ typedef struct ContextElement
   ContextAttributeVector   contextAttributeVector;  // Optional
   MetadataVector           domainMetadataVector;    // Optional
 
-  std::vector<std::string> providingApplicationList;    // Not part of NGSI, used internally for CPr forwarding functionality
+  std::vector<ProvidingApplication> providingApplicationList;    // Not part of NGSI, used internally for CPr forwarding functionality
 
   ContextElement();
 

--- a/src/lib/ngsi/ProvidingApplication.cpp
+++ b/src/lib/ngsi/ProvidingApplication.cpp
@@ -77,6 +77,15 @@ void ProvidingApplication::set(const std::string& value)
   string = value;
 }
 
+/* ****************************************************************************
+*
+* ProvidingApplication::setFormat -
+*/
+void ProvidingApplication::setFormat(const Format& f)
+{
+  format = f;
+}
+
 
 
 /* ****************************************************************************
@@ -86,6 +95,15 @@ void ProvidingApplication::set(const std::string& value)
 std::string ProvidingApplication::get(void)
 {
   return string;
+}
+
+/* ****************************************************************************
+*
+* ProvidingApplication::getFormat -
+*/
+Format ProvidingApplication::getFormat(void)
+{
+  return format;
 }
 
 

--- a/src/lib/ngsi/ProvidingApplication.cpp
+++ b/src/lib/ngsi/ProvidingApplication.cpp
@@ -33,6 +33,16 @@
 #include "ngsi/ProvidingApplication.h"
 
 
+/* ****************************************************************************
+*
+* ProvidingApplication::ProvidingApplication -
+*/
+ProvidingApplication::ProvidingApplication()
+{
+  /* It is better to have a default constructor that leave format with a random value */
+  string = "";
+  format = NOFORMAT;
+}
 
 /* ****************************************************************************
 *

--- a/src/lib/ngsi/ProvidingApplication.h
+++ b/src/lib/ngsi/ProvidingApplication.h
@@ -39,9 +39,12 @@
 typedef struct ProvidingApplication
 {
   std::string   string;
+  Format        format;                  // Not par of NGSI itself, used by the CB to specify the preferred format for CPr interaction
 
   void          set(const std::string& value);
+  void          setFormat(const Format& f);
   std::string   get(void);
+  Format        getFormat(void);
   bool          isEmpty(void);
   std::string   render(Format format, const std::string& indent, bool comma);
   void          present(const std::string& indent);

--- a/src/lib/ngsi/ProvidingApplication.h
+++ b/src/lib/ngsi/ProvidingApplication.h
@@ -41,6 +41,7 @@ typedef struct ProvidingApplication
   std::string   string;
   Format        format;                  // Not par of NGSI itself, used by the CB to specify the preferred format for CPr interaction
 
+  ProvidingApplication();
   void          set(const std::string& value);
   void          setFormat(const Format& f);
   std::string   get(void);

--- a/src/lib/ngsi/ProvidingApplication.h
+++ b/src/lib/ngsi/ProvidingApplication.h
@@ -39,7 +39,7 @@
 typedef struct ProvidingApplication
 {
   std::string   string;
-  Format        format;                  // Not par of NGSI itself, used by the CB to specify the preferred format for CPr interaction
+  Format        format;                  // Not part of NGSI itself, used by the CB to specify the preferred format for CPr interaction
 
   ProvidingApplication();
   void          set(const std::string& value);

--- a/src/lib/serviceRoutines/postNotifyContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postNotifyContextAvailability.cpp
@@ -79,7 +79,7 @@ std::string postNotifyContextAvailability
     return answer;
   }
 
-  ciP->httpStatusCode = mongoNotifyContextAvailability(&parseDataP->ncar.res, &ncar, ciP->tenant, ciP->servicePathV[0]);
+  ciP->httpStatusCode = mongoNotifyContextAvailability(&parseDataP->ncar.res, &ncar, ciP->uriParam, ciP->tenant, ciP->servicePathV[0]);
 
   answer = ncar.render(NotifyContextAvailability, ciP->outFormat, "");
   return answer;

--- a/src/lib/serviceRoutines/postRegisterContext.cpp
+++ b/src/lib/serviceRoutines/postRegisterContext.cpp
@@ -99,7 +99,7 @@ static void registerContextForward
   if (parseDataP->rcr.res.registrationId.isEmpty())
   {
     /* New registration case */
-    ciP->httpStatusCode  = mongoRegisterContext(&parseDataP->rcr.res, rcrP, ciP->tenant, ciP->servicePathV[0]);
+    ciP->httpStatusCode  = mongoRegisterContext(&parseDataP->rcr.res, rcrP, ciP->uriParam, ciP->tenant, ciP->servicePathV[0]);
 
     std::string payload  = parseDataP->rcr.res.render(RegisterContext, ciP->inFormat, "");
     std::string response = fordwardRegisterContext(fwdHost, fwdPort, ciP->tenant, ciP->httpHeaders.xauthToken, payload, ciP->servicePathV[0]);
@@ -143,7 +143,7 @@ static void registerContextForward
     /* Update case */
     std::string fwdRegId = mongoGetFwdRegId(parseDataP->rcr.res.registrationId.get(), ciP->tenant);
 
-    ciP->httpStatusCode  = mongoRegisterContext(&parseDataP->rcr.res, rcrP, ciP->tenant, ciP->servicePathV[0]);
+    ciP->httpStatusCode  = mongoRegisterContext(&parseDataP->rcr.res, rcrP, ciP->uriParam, ciP->tenant, ciP->servicePathV[0]);
     parseDataP->rcr.res.registrationId.set(fwdRegId);
     mongoSetFwdRegId(rcrP->registrationId.get(), fwdRegId, ciP->tenant);
     std::string payload = parseDataP->rcr.res.render(RegisterContext, ciP->inFormat, "");
@@ -199,7 +199,7 @@ std::string postRegisterContext
   }
   else
   {
-    ciP->httpStatusCode = mongoRegisterContext(&parseDataP->rcr.res, &rcr, ciP->tenant, ciP->servicePathV[0]);
+    ciP->httpStatusCode = mongoRegisterContext(&parseDataP->rcr.res, &rcr, ciP->uriParam, ciP->tenant, ciP->servicePathV[0]);
   }
 
   answer = rcr.render(RegisterContext, ciP->outFormat, "");

--- a/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
@@ -581,16 +581,19 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrsAll)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 2)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -650,6 +653,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrOneSingle)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -716,6 +720,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrOneMulti)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -777,11 +782,13 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrsSubset)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -844,21 +851,25 @@ TEST(mongoContextProvidersQueryRequest, noPatternSeveralCREs)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 2)->providingApplication.getFormat());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
   EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 3)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -921,16 +932,19 @@ TEST(mongoContextProvidersQueryRequest, noPatternSeveralRegistrations)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 2)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1080,21 +1094,25 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntity)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 2)->providingApplication.getFormat());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
   EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 3)->providingApplication.getFormat());
 
   /* Context Element response # 1 */
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
@@ -1111,16 +1129,19 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntity)
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(1, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 2)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 2)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1183,11 +1204,13 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiAttr)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1256,11 +1279,13 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1277,6 +1302,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1345,6 +1371,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternNoType)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr5.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1361,6 +1388,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternNoType)
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1377,6 +1405,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternNoType)
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->value);
   EXPECT_EQ("http://cr4.com", RES_CER_ATTR(2, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(2, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
   EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
@@ -1442,16 +1471,19 @@ TEST(mongoContextProvidersQueryRequest, pattern0Attr)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 2)->providingApplication.getFormat());
 
   /* Context Element response # 2 */
   EXPECT_EQ("E3", RES_CER(1).entityId.id);
@@ -1464,16 +1496,19 @@ TEST(mongoContextProvidersQueryRequest, pattern0Attr)
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 2)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 2)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1533,6 +1568,7 @@ TEST(mongoContextProvidersQueryRequest, pattern1AttrSingle)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1596,6 +1632,7 @@ TEST(mongoContextProvidersQueryRequest, pattern1AttrMulti)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1612,6 +1649,7 @@ TEST(mongoContextProvidersQueryRequest, pattern1AttrMulti)
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1676,11 +1714,13 @@ TEST(mongoContextProvidersQueryRequest, patternNAttr)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1697,11 +1737,13 @@ TEST(mongoContextProvidersQueryRequest, patternNAttr)
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(1, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(1, 1)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1809,6 +1851,7 @@ TEST(mongoContextProvidersQueryRequest, patternNoType)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1825,6 +1868,7 @@ TEST(mongoContextProvidersQueryRequest, patternNoType)
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1841,6 +1885,7 @@ TEST(mongoContextProvidersQueryRequest, patternNoType)
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->value);
   EXPECT_EQ("http://cr4.com", RES_CER_ATTR(2, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(2, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
   EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
@@ -1857,6 +1902,7 @@ TEST(mongoContextProvidersQueryRequest, patternNoType)
   EXPECT_EQ("", RES_CER_ATTR(3, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(3, 0)->value);
   EXPECT_EQ("http://cr5.com", RES_CER_ATTR(3, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(3, 0)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
   EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
@@ -1923,21 +1969,25 @@ TEST(mongoContextProvidersQueryRequest, mixPatternAndNotPattern)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 2)->providingApplication.getFormat());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
   EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 3)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1954,16 +2004,19 @@ TEST(mongoContextProvidersQueryRequest, mixPatternAndNotPattern)
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(1, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(1, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(1, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(1, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(1, 2)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1980,16 +2033,19 @@ TEST(mongoContextProvidersQueryRequest, mixPatternAndNotPattern)
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->value);
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(2, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(2, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(2, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(2, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 1)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(2, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(2, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(2, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(2, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 2)->value);
   EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(2, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(2, 2)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
   EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
@@ -2063,31 +2119,37 @@ TEST(mongoContextProvidersQueryRequest, severalCprs1)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cpr2.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 2)->providingApplication.getFormat());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
   EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 3)->providingApplication.getFormat());
 
   EXPECT_EQ("A5", RES_CER_ATTR(0, 4)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 4)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 4)->value);
   EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 4)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 4)->providingApplication.getFormat());
 
   EXPECT_EQ("A6", RES_CER_ATTR(0, 5)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 5)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 5)->value);
   EXPECT_EQ("http://cpr3.com", RES_CER_ATTR(0, 5)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 5)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -2155,26 +2217,31 @@ TEST(mongoContextProvidersQueryRequest, severalCprs2)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cpr2.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 2)->providingApplication.getFormat());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
   EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
+  EXPECT_EQ(XML,   RES_CER_ATTR(0, 3)->providingApplication.getFormat());
 
   EXPECT_EQ("A5", RES_CER_ATTR(0, 4)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 4)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 4)->value);
   EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 4)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 4)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -2227,7 +2294,9 @@ TEST(mongoContextProvidersQueryRequest, severalCprs3)
   EXPECT_EQ("false", RES_CER(0).entityId.isPattern);  
   ASSERT_EQ(2, RES_CER(0).providingApplicationList.size());
   EXPECT_EQ("http://cpr2.com", RES_CER(0).providingApplicationList[0].get());
+  EXPECT_EQ(XML, RES_CER(0).providingApplicationList[0].getFormat());
   EXPECT_EQ("http://cpr3.com", RES_CER(0).providingApplicationList[1].get());
+  EXPECT_EQ(XML, RES_CER(0).providingApplicationList[1].getFormat());
 
   ASSERT_EQ(3, RES_CER(0).contextAttributeVector.size());
 
@@ -2235,16 +2304,19 @@ TEST(mongoContextProvidersQueryRequest, severalCprs3)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cpr1.com", RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
   EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 2)->providingApplication.getFormat());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);

--- a/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
@@ -580,17 +580,17 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrsAll)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -649,7 +649,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrOneSingle)
   EXPECT_EQ("A4", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -715,7 +715,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrOneMulti)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -776,12 +776,12 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrsSubset)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -843,22 +843,22 @@ TEST(mongoContextProvidersQueryRequest, noPatternSeveralCREs)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
-  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 3)->providingApplication);
+  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -920,17 +920,17 @@ TEST(mongoContextProvidersQueryRequest, noPatternSeveralRegistrations)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1079,22 +1079,22 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntity)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
-  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 3)->providingApplication);
+  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
 
   /* Context Element response # 1 */
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
@@ -1110,17 +1110,17 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntity)
   EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(1, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 2)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1182,12 +1182,12 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiAttr)
   EXPECT_EQ("A3", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1255,12 +1255,12 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("A3", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1276,7 +1276,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("A3", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1344,7 +1344,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternNoType)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr5.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr5.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1360,7 +1360,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternNoType)
   EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1376,7 +1376,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternNoType)
   EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->value);
-  EXPECT_EQ("http://cr4.com", RES_CER_ATTR(2, 0)->providingApplication);
+  EXPECT_EQ("http://cr4.com", RES_CER_ATTR(2, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
   EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
@@ -1441,17 +1441,17 @@ TEST(mongoContextProvidersQueryRequest, pattern0Attr)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
 
   /* Context Element response # 2 */
   EXPECT_EQ("E3", RES_CER(1).entityId.id);
@@ -1463,17 +1463,17 @@ TEST(mongoContextProvidersQueryRequest, pattern0Attr)
   EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 2)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1532,7 +1532,7 @@ TEST(mongoContextProvidersQueryRequest, pattern1AttrSingle)
   EXPECT_EQ("A4", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1595,7 +1595,7 @@ TEST(mongoContextProvidersQueryRequest, pattern1AttrMulti)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1611,7 +1611,7 @@ TEST(mongoContextProvidersQueryRequest, pattern1AttrMulti)
   EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1675,12 +1675,12 @@ TEST(mongoContextProvidersQueryRequest, patternNAttr)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1696,12 +1696,12 @@ TEST(mongoContextProvidersQueryRequest, patternNAttr)
   EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(1, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(1, 1)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1808,7 +1808,7 @@ TEST(mongoContextProvidersQueryRequest, patternNoType)
   EXPECT_EQ("A2", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1824,7 +1824,7 @@ TEST(mongoContextProvidersQueryRequest, patternNoType)
   EXPECT_EQ("A2", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1840,7 +1840,7 @@ TEST(mongoContextProvidersQueryRequest, patternNoType)
   EXPECT_EQ("A2", RES_CER_ATTR(2, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->value);
-  EXPECT_EQ("http://cr4.com", RES_CER_ATTR(2, 0)->providingApplication);
+  EXPECT_EQ("http://cr4.com", RES_CER_ATTR(2, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
   EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
@@ -1856,7 +1856,7 @@ TEST(mongoContextProvidersQueryRequest, patternNoType)
   EXPECT_EQ("A2", RES_CER_ATTR(3, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(3, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(3, 0)->value);
-  EXPECT_EQ("http://cr5.com", RES_CER_ATTR(3, 0)->providingApplication);
+  EXPECT_EQ("http://cr5.com", RES_CER_ATTR(3, 0)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
   EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
@@ -1922,22 +1922,22 @@ TEST(mongoContextProvidersQueryRequest, mixPatternAndNotPattern)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
-  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 3)->providingApplication);
+  EXPECT_EQ("http://cr2.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -1953,17 +1953,17 @@ TEST(mongoContextProvidersQueryRequest, mixPatternAndNotPattern)
   EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(1, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(1, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(1, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(1, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(1, 2)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
@@ -1979,17 +1979,17 @@ TEST(mongoContextProvidersQueryRequest, mixPatternAndNotPattern)
   EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->value);
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(2, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(2, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(2, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(2, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 1)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(2, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(2, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(2, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(2, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(2, 2)->value);
-  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(2, 2)->providingApplication);
+  EXPECT_EQ("http://cr1.com",   RES_CER_ATTR(2, 2)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
   EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
@@ -2062,32 +2062,32 @@ TEST(mongoContextProvidersQueryRequest, severalCprs1)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cpr2.com",   RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("http://cpr2.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
-  EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 3)->providingApplication);
+  EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
 
   EXPECT_EQ("A5", RES_CER_ATTR(0, 4)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 4)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 4)->value);
-  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 4)->providingApplication);
+  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 4)->providingApplication.get());
 
   EXPECT_EQ("A6", RES_CER_ATTR(0, 5)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 5)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 5)->value);
-  EXPECT_EQ("http://cpr3.com", RES_CER_ATTR(0, 5)->providingApplication);
+  EXPECT_EQ("http://cpr3.com", RES_CER_ATTR(0, 5)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -2154,27 +2154,27 @@ TEST(mongoContextProvidersQueryRequest, severalCprs2)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cpr2.com",   RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("http://cpr2.com",   RES_CER_ATTR(0, 2)->providingApplication.get());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 3)->value);
-  EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 3)->providingApplication);
+  EXPECT_EQ("http://cpr1.com",   RES_CER_ATTR(0, 3)->providingApplication.get());
 
   EXPECT_EQ("A5", RES_CER_ATTR(0, 4)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 4)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 4)->value);
-  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 4)->providingApplication);
+  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 4)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
@@ -2226,25 +2226,25 @@ TEST(mongoContextProvidersQueryRequest, severalCprs3)
   EXPECT_EQ("T", RES_CER(0).entityId.type);
   EXPECT_EQ("false", RES_CER(0).entityId.isPattern);  
   ASSERT_EQ(2, RES_CER(0).providingApplicationList.size());
-  EXPECT_EQ("http://cpr2.com", RES_CER(0).providingApplicationList[0]);
-  EXPECT_EQ("http://cpr3.com", RES_CER(0).providingApplicationList[1]);
+  EXPECT_EQ("http://cpr2.com", RES_CER(0).providingApplicationList[0].get());
+  EXPECT_EQ("http://cpr3.com", RES_CER(0).providingApplicationList[1].get());
 
   ASSERT_EQ(3, RES_CER(0).contextAttributeVector.size());
 
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
-  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
-  EXPECT_EQ("http://cpr1.com", RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cpr1.com", RES_CER_ATTR(0, 1)->providingApplication.get());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
-  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 2)->providingApplication.get());
 
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);

--- a/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
@@ -78,6 +78,7 @@
 * - severalCprs1
 * - severalCprs2
 * - severalCprs3
+* - severalCprsFormat
 *
 * Note these tests are not "canonical" unit tests. Canon says that in this case we should have
 * mocked MongoDB. Actually, we think is very much powerful to check that everything is ok at
@@ -430,7 +431,7 @@ static void prepareDatabaseSeveralCprs1(bool addGenericRegistry)
 * prepareDatabaseSeveralCprs2 -
 *
 */
-static void prepareDatabaseSeveralCprs2(void)
+static void prepareDatabaseSeveralCprs2(bool withFormat = false)
 {
 
   /* Set database */
@@ -498,42 +499,61 @@ static void prepareDatabaseSeveralCprs2(void)
                      );
 
   /* 1879048191 corresponds to year 2029 so we avoid any expiration problem in the next 16 years :) */
-  BSONObj reg1 = BSON(
+  /*BSONObjBuilder reg1 = BSON(
               "_id" << OID("51307b66f481db11bf860001") <<
               "expiration" << 1879048191 <<
               "contextRegistration" << BSON_ARRAY(cr1)
-              );
+              );*/
+  BSONObjBuilder reg1;
+  reg1.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860001") <<
+                        "expiration" << 1879048191 <<
+                        "contextRegistration" << BSON_ARRAY(cr1)
+                        ));
 
-  BSONObj reg2 = BSON(
-              "_id" << OID("51307b66f481db11bf860002") <<
-              "expiration" << 1879048191 <<
-              "contextRegistration" << BSON_ARRAY(cr2)
-              );
+  BSONObjBuilder reg2;
+  reg2.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860002") <<
+                        "expiration" << 1879048191 <<
+                        "contextRegistration" << BSON_ARRAY(cr2)
+                        ));
 
-  BSONObj reg3 = BSON(
-              "_id" << OID("51307b66f481db11bf860003") <<
-              "expiration" << 1879048191 <<
-              "contextRegistration" << BSON_ARRAY(cr3)
-              );
+  BSONObjBuilder reg3;
+  reg3.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860003") <<
+                        "expiration" << 1879048191 <<
+                        "contextRegistration" << BSON_ARRAY(cr3)
+                        ));
 
-  BSONObj reg4 = BSON(
-              "_id" << OID("51307b66f481db11bf860004") <<
-              "expiration" << 1879048191 <<
-              "contextRegistration" << BSON_ARRAY(cr4)
-              );
+  BSONObjBuilder reg4;
+  reg4.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860004") <<
+                        "expiration" << 1879048191 <<
+                        "contextRegistration" << BSON_ARRAY(cr4)
+                        ));
 
-  BSONObj reg5 = BSON(
-              "_id" << OID("51307b66f481db11bf860005") <<
-              "expiration" << 1879048191 <<
-              "contextRegistration" << BSON_ARRAY(cr5)
-              );
+  BSONObjBuilder reg5;
+  reg5.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860005") <<
+                        "expiration" << 1879048191 <<
+                        "contextRegistration" << BSON_ARRAY(cr5)
+                        ));
+
+  if (withFormat)
+  {
+    reg1.appendElements(BSON("format" << "XML"));
+    reg2.appendElements(BSON("format" << "JSON"));
+    reg3.appendElements(BSON("format" << "XML"));
+    reg4.appendElements(BSON("format" << "JSON"));
+    reg5.appendElements(BSON("format" << "XML"));
+  }
 
   connection->insert(ENTITIES_COLL, en1);
-  connection->insert(REGISTRATIONS_COLL, reg1);
-  connection->insert(REGISTRATIONS_COLL, reg2);
-  connection->insert(REGISTRATIONS_COLL, reg3);
-  connection->insert(REGISTRATIONS_COLL, reg4);
-  connection->insert(REGISTRATIONS_COLL, reg5);
+  connection->insert(REGISTRATIONS_COLL, reg1.obj());
+  connection->insert(REGISTRATIONS_COLL, reg2.obj());
+  connection->insert(REGISTRATIONS_COLL, reg3.obj());
+  connection->insert(REGISTRATIONS_COLL, reg4.obj());
+  connection->insert(REGISTRATIONS_COLL, reg5.obj());
 
 }
 
@@ -2311,6 +2331,81 @@ TEST(mongoContextProvidersQueryRequest, severalCprs3)
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
   EXPECT_EQ("http://cpr1.com", RES_CER_ATTR(0, 1)->providingApplication.get());
   EXPECT_EQ(XML, RES_CER_ATTR(0, 1)->providingApplication.getFormat());
+
+  EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
+  EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
+  EXPECT_EQ("", RES_CER_ATTR(0, 2)->value);
+  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 2)->providingApplication.getFormat());
+
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  utExit();
+
+}
+
+/* ****************************************************************************
+*
+* severalCprsFormat -
+*
+* Query:  E1 - <null>
+* Result: E1 - A1 - 1
+*              A2 - fwd CPR1 - JSON
+*              A3 - fwd CPR2 - XML
+*
+*         CPR vector: [CPR2-XML, CPR3-JSON]
+*/
+TEST(mongoContextProvidersQueryRequest, severalCprsFormat)
+{
+  HttpStatusCode        ms;
+  QueryContextRequest   req;
+  QueryContextResponse  res;
+
+  /* Prepare database */
+  utInit();
+  prepareDatabaseSeveralCprs2(true);
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E1", "T", "false");
+  req.entityIdVector.push_back(&en);
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(1, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E1", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(2, RES_CER(0).providingApplicationList.size());
+  EXPECT_EQ("http://cpr2.com", RES_CER(0).providingApplicationList[0].get());
+  EXPECT_EQ(JSON, RES_CER(0).providingApplicationList[0].getFormat());
+  EXPECT_EQ("http://cpr3.com", RES_CER(0).providingApplicationList[1].get());
+  EXPECT_EQ(XML, RES_CER(0).providingApplicationList[1].getFormat());
+
+  ASSERT_EQ(3, RES_CER(0).contextAttributeVector.size());
+
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
+
+  EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+  EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
+  EXPECT_EQ("", RES_CER_ATTR(0, 1)->value);
+  EXPECT_EQ("http://cpr1.com", RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(JSON, RES_CER_ATTR(0, 1)->providingApplication.getFormat());
 
   EXPECT_EQ("A3", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);

--- a/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
@@ -2139,7 +2139,7 @@ TEST(mongoContextProvidersQueryRequest, severalCprs1)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
@@ -2237,7 +2237,7 @@ TEST(mongoContextProvidersQueryRequest, severalCprs2)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
@@ -2324,7 +2324,7 @@ TEST(mongoContextProvidersQueryRequest, severalCprs3)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
@@ -2399,7 +2399,7 @@ TEST(mongoContextProvidersQueryRequest, severalCprsFormat)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ("1", RES_CER_ATTR(0, 0)->value);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);

--- a/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
@@ -538,6 +538,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrOneSingle)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -604,6 +605,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrOneMulti)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -668,6 +670,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrsSubset)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -675,6 +678,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrsSubset)
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->value.size());
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 1)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->metadataVector.size());
 
@@ -737,6 +741,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternNoAttribute)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -872,6 +877,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiAttr)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -879,6 +885,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiAttr)
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->value.size());
   EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 1)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->metadataVector.size());
 
@@ -886,6 +893,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiAttr)
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 2)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(0, 2)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->metadataVector.size());
 
@@ -968,6 +976,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->value.size());
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -975,6 +984,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->value.size());
   EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 1)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->metadataVector.size());
 
@@ -982,6 +992,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 2)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(0, 2)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->metadataVector.size());
 
@@ -1000,6 +1011,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->value.size());
   EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(1, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->metadataVector.size());
 
@@ -1007,6 +1019,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(1, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->metadataVector.size());
 
@@ -1014,6 +1027,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 2)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 2)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(1, 2)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 2)->metadataVector.size());
 
@@ -1089,6 +1103,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternNoType)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("http://cr5.com", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -1493,6 +1508,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -1500,6 +1516,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("T", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->value.size());
   EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 1)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->metadataVector.size());
 
@@ -1518,6 +1535,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("T", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->value.size());
   EXPECT_EQ("http://cpr3.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(1, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->metadataVector.size());
 
@@ -1525,6 +1543,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("T", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(1, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->metadataVector.size());
 
@@ -1543,6 +1562,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(2, 0)->value.size());
   EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(2, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(2, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(2, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(2, 0)->metadataVector.size());
 
@@ -1550,6 +1570,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("", RES_CER_ATTR(2, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(2, 1)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(2, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(2, 1)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(2, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(2, 1)->metadataVector.size());
 
@@ -1568,6 +1589,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("", RES_CER_ATTR(3, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(3, 0)->value.size());
   EXPECT_EQ("http://cpr1.com", RES_CER_ATTR(3, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(3, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(3, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(3, 0)->metadataVector.size());
 

--- a/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
@@ -1523,7 +1523,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -1558,7 +1558,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("T", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(1, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->metadataVector.size());
 
@@ -1729,7 +1729,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprsFormat)
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -1764,7 +1764,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprsFormat)
   EXPECT_EQ("T", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
   EXPECT_TRUE(RES_CER_ATTR(1, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->metadataVector.size());
 

--- a/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
@@ -74,6 +74,7 @@
 * Cases involving more than one CPR:
 *
 * - severalCprs
+* - severalCprsFormat
 *
 * Note these tests are not "canonical" unit tests. Canon says that in this case we should have
 * mocked MongoDB. Actually, we think is very much powerful to check that everything is ok at
@@ -338,7 +339,7 @@ static void prepareDatabasePatternTrue(void)
 * prepareDatabaseSeveralCprs1 -
 *
 */
-static void prepareDatabaseSeveralCprs(void)
+static void prepareDatabaseSeveralCprs(bool withFormat = false)
 {
 
   /* Set database */
@@ -404,38 +405,52 @@ static void prepareDatabaseSeveralCprs(void)
                      );
 
   /* 1879048191 corresponds to year 2029 so we avoid any expiration problem in the next 16 years :) */
-  BSONObj reg1 = BSON(
-              "_id" << OID("51307b66f481db11bf860001") <<
-              "expiration" << 1879048191 <<
-              "contextRegistration" << BSON_ARRAY(cr1)
-              );
+  BSONObjBuilder reg1;
+  reg1.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860001") <<
+                        "expiration" << 1879048191 <<
+                        "contextRegistration" << BSON_ARRAY(cr1)
+                        ));
 
-  BSONObj reg2 = BSON(
-              "_id" << OID("51307b66f481db11bf860002") <<
-              "expiration" << 1879048191 <<
-              "contextRegistration" << BSON_ARRAY(cr2)
-              );
+  BSONObjBuilder reg2;
+  reg2.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860002") <<
+                        "expiration" << 1879048191 <<
+                        "contextRegistration" << BSON_ARRAY(cr2)
+                        ));
 
-  BSONObj reg3 = BSON(
-              "_id" << OID("51307b66f481db11bf860003") <<
-              "expiration" << 1879048191 <<
-              "contextRegistration" << BSON_ARRAY(cr3)
-              );
+  BSONObjBuilder reg3;
+  reg3.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860003") <<
+                        "expiration" << 1879048191 <<
+                        "contextRegistration" << BSON_ARRAY(cr3)
+                        ));
 
-  BSONObj reg4 = BSON(
-              "_id" << OID("51307b66f481db11bf860004") <<
-              "expiration" << 1879048191 <<
-              "contextRegistration" << BSON_ARRAY(cr4)
-              );
+  BSONObjBuilder reg4;
+  reg4.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860004") <<
+                        "expiration" << 1879048191 <<
+                        "contextRegistration" << BSON_ARRAY(cr4)
+                        ));
+
+  if (withFormat)
+  {
+    reg1.appendElements(BSON("format" << "JSON"));
+    reg2.appendElements(BSON("format" << "XML"));
+    reg3.appendElements(BSON("format" << "JSON"));
+    reg4.appendElements(BSON("format" << "XML"));
+  }
 
   connection->insert(ENTITIES_COLL, en1);
   connection->insert(ENTITIES_COLL, en2);
-  connection->insert(REGISTRATIONS_COLL, reg1);
-  connection->insert(REGISTRATIONS_COLL, reg2);
-  connection->insert(REGISTRATIONS_COLL, reg3);
-  connection->insert(REGISTRATIONS_COLL, reg4);
+  connection->insert(REGISTRATIONS_COLL, reg1.obj());
+  connection->insert(REGISTRATIONS_COLL, reg2.obj());
+  connection->insert(REGISTRATIONS_COLL, reg3.obj());
+  connection->insert(REGISTRATIONS_COLL, reg4.obj());
 
 }
+
+
 
 /* ****************************************************************************
 *
@@ -741,7 +756,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternNoAttribute)
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -893,7 +908,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiAttr)
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(0, 2)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 2)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(0, 2)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->metadataVector.size());
 
@@ -992,7 +1007,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(0, 2)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 2)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(0, 2)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->metadataVector.size());
 
@@ -1019,7 +1034,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(1, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->metadataVector.size());
 
@@ -1027,7 +1042,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 2)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(1, 2)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(1, 2)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(1, 2)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 2)->metadataVector.size());
 
@@ -1570,7 +1585,213 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("", RES_CER_ATTR(2, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(2, 1)->value.size());
   EXPECT_EQ("", RES_CER_ATTR(2, 1)->providingApplication.get());
-  EXPECT_EQ(XML, RES_CER_ATTR(2, 1)->providingApplication.getFormat());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(2, 1)->providingApplication.getFormat());
+  EXPECT_FALSE(RES_CER_ATTR(2, 1)->found);
+  EXPECT_EQ(0, RES_CER_ATTR(2, 1)->metadataVector.size());
+
+  EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+  EXPECT_EQ("", RES_CER_STATUS(2).details);
+
+  /* Context Element response # 4 */
+  EXPECT_EQ("E4", RES_CER(3).entityId.id);
+  EXPECT_EQ("T", RES_CER(3).entityId.type);
+  EXPECT_EQ("false", RES_CER(3).entityId.isPattern);
+  EXPECT_EQ(0, RES_CER(3).providingApplicationList.size());
+  ASSERT_EQ(1, RES_CER(3).contextAttributeVector.size());
+
+  EXPECT_EQ("A7", RES_CER_ATTR(3, 0)->name);
+  EXPECT_EQ("", RES_CER_ATTR(3, 0)->type);
+  EXPECT_EQ(0, RES_CER_ATTR(3, 0)->value.size());
+  EXPECT_EQ("http://cpr1.com", RES_CER_ATTR(3, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(3, 0)->providingApplication.getFormat());
+  EXPECT_TRUE(RES_CER_ATTR(3, 0)->found);
+  EXPECT_EQ(0, RES_CER_ATTR(3, 0)->metadataVector.size());
+
+  EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
+  EXPECT_EQ("", RES_CER_STATUS(3).details);
+
+  /* Check that every involved collection at MongoDB is as expected */
+  /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
+   * objects (see http://code.google.com/p/googletest/wiki/Primer#String_Comparison) */
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* entities collection */
+  BSONObj ent;
+  std::vector<BSONElement> attrs;
+  ASSERT_EQ(2, connection->count(ENTITIES_COLL, BSONObj()));
+
+  ent = connection->findOne(ENTITIES_COLL, BSON("_id.id" << "E1" << "_id.type" << "T"));
+  EXPECT_STREQ("E1", C_STR_FIELD(ent.getObjectField("_id"), "id"));
+  EXPECT_STREQ("T", C_STR_FIELD(ent.getObjectField("_id"), "type"));
+  EXPECT_EQ(1360232700, ent.getIntField("modDate"));
+  attrs = ent.getField("attrs").Array();
+  ASSERT_EQ(1, attrs.size());
+  BSONObj a1 = getAttr(attrs, "A1", "T");
+  EXPECT_STREQ("A1", C_STR_FIELD(a1, "name"));
+  EXPECT_STREQ("T",C_STR_FIELD(a1, "type"));
+  EXPECT_STREQ("10", C_STR_FIELD(a1, "value"));
+  EXPECT_EQ(1360232700, a1.getIntField("modDate"));
+
+  ent = connection->findOne(ENTITIES_COLL, BSON("_id.id" << "E2" << "_id.type" << "T"));
+  EXPECT_STREQ("E2", C_STR_FIELD(ent.getObjectField("_id"), "id"));
+  EXPECT_STREQ("T", C_STR_FIELD(ent.getObjectField("_id"), "type"));
+  EXPECT_EQ(1360232700, ent.getIntField("modDate"));
+  attrs = ent.getField("attrs").Array();
+  ASSERT_EQ(1, attrs.size());
+  BSONObj a3 = getAttr(attrs, "A3", "T");
+  EXPECT_STREQ("A3", C_STR_FIELD(a3, "name"));
+  EXPECT_STREQ("T",C_STR_FIELD(a3, "type"));
+  EXPECT_STREQ("30", C_STR_FIELD(a3, "value"));
+  EXPECT_EQ(1360232700, a3.getIntField("modDate"));
+
+  /* Release connection */
+  mongoDisconnect();
+
+  utExit();
+
+}
+
+/* ****************************************************************************
+*
+* severalCprsFormat -
+*
+* Update: E1 - (A1, A2)
+*         E2 - (A3, A4)
+*         E3 - (A5, A6)
+*         E4 - A7
+* Result: E1 - A1 - Up Ok
+*              A2 - fwd CPR2 / JSON
+*         E2 - A3 - Up ok
+*              A4 - fwd CPR3 / XML
+*         E3 - A5 - fwd CPR2 / JSON
+*              A6 - Not found
+*         E4 - A7 - fwd CPR1 / XML
+*
+*/
+TEST(mongoContextProvidersUpdateRequest, severalCprsFormat)
+{
+  HttpStatusCode         ms;
+  UpdateContextRequest   req;
+  UpdateContextResponse  res;
+
+  /* Prepare database */
+  utInit();
+  prepareDatabaseSeveralCprs(true);
+
+  /* Forge the request (from "inside" to "outside") */
+  ContextElement ce1, ce2, ce3, ce4;
+  ce1.entityId.fill("E1", "T", "false");
+  ContextAttribute ca1("A1", "T", "10");
+  ContextAttribute ca2("A2", "T", "20");
+  ce1.contextAttributeVector.push_back(&ca1);
+  ce1.contextAttributeVector.push_back(&ca2);
+  ce2.entityId.fill("E2", "T", "false");
+  ContextAttribute ca3("A4", "T", "40");
+  ContextAttribute ca4("A3", "T", "30");
+  ce2.contextAttributeVector.push_back(&ca3);
+  ce2.contextAttributeVector.push_back(&ca4);
+  ce3.entityId.fill("E3", "T", "false");
+  ContextAttribute ca5("A5", "T", "50");
+  ContextAttribute ca6("A6", "T", "60");
+  ce3.contextAttributeVector.push_back(&ca5);
+  ce3.contextAttributeVector.push_back(&ca6);
+  ce4.entityId.fill("E4", "T", "false");
+  ContextAttribute ca7("A7", "T", "70");
+  ce4.contextAttributeVector.push_back(&ca7);
+  req.contextElementVector.push_back(&ce1);
+  req.contextElementVector.push_back(&ce2);
+  req.contextElementVector.push_back(&ce3);
+  req.contextElementVector.push_back(&ce4);
+  req.updateActionType.set("UPDATE");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccOk, res.errorCode.code);
+  EXPECT_EQ("OK", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(4, res.contextElementResponseVector.size());
+  /* Context Element response # 1 */
+  EXPECT_EQ("E1", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  EXPECT_EQ(0, RES_CER(0).providingApplicationList.size());
+  ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
+  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
+  EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
+  EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
+
+  EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+  EXPECT_EQ("T", RES_CER_ATTR(0, 1)->type);
+  EXPECT_EQ(0, RES_CER_ATTR(0, 1)->value.size());
+  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 1)->providingApplication.get());
+  EXPECT_EQ(JSON, RES_CER_ATTR(0, 1)->providingApplication.getFormat());
+  EXPECT_TRUE(RES_CER_ATTR(0, 1)->found);
+  EXPECT_EQ(0, RES_CER_ATTR(0, 1)->metadataVector.size());
+
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E2", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  EXPECT_EQ(0, RES_CER(1).providingApplicationList.size());
+  ASSERT_EQ(2, RES_CER(1).contextAttributeVector.size());
+
+  EXPECT_EQ("A4", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("T", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ(0, RES_CER_ATTR(1, 0)->value.size());
+  EXPECT_EQ("http://cpr3.com", RES_CER_ATTR(1, 0)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 0)->providingApplication.getFormat());
+  EXPECT_TRUE(RES_CER_ATTR(1, 0)->found);
+  EXPECT_EQ(0, RES_CER_ATTR(1, 0)->metadataVector.size());
+
+  EXPECT_EQ("A3", RES_CER_ATTR(1, 1)->name);
+  EXPECT_EQ("T", RES_CER_ATTR(1, 1)->type);
+  EXPECT_EQ(0, RES_CER_ATTR(1, 1)->value.size());
+  EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication.get());
+  EXPECT_EQ(XML, RES_CER_ATTR(1, 1)->providingApplication.getFormat());
+  EXPECT_TRUE(RES_CER_ATTR(1, 1)->found);
+  EXPECT_EQ(0, RES_CER_ATTR(1, 1)->metadataVector.size());
+
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ("", RES_CER_STATUS(1).details);
+
+  /* Context Element response # 3 */
+  EXPECT_EQ("E3", RES_CER(2).entityId.id);
+  EXPECT_EQ("T", RES_CER(2).entityId.type);
+  EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+  EXPECT_EQ(0, RES_CER(2).providingApplicationList.size());
+  ASSERT_EQ(2, RES_CER(2).contextAttributeVector.size());
+
+  EXPECT_EQ("A5", RES_CER_ATTR(2, 0)->name);
+  EXPECT_EQ("", RES_CER_ATTR(2, 0)->type);
+  EXPECT_EQ(0, RES_CER_ATTR(2, 0)->value.size());
+  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(2, 0)->providingApplication.get());
+  EXPECT_EQ(JSON, RES_CER_ATTR(2, 0)->providingApplication.getFormat());
+  EXPECT_TRUE(RES_CER_ATTR(2, 0)->found);
+  EXPECT_EQ(0, RES_CER_ATTR(2, 0)->metadataVector.size());
+
+  EXPECT_EQ("A6", RES_CER_ATTR(2, 1)->name);
+  EXPECT_EQ("", RES_CER_ATTR(2, 1)->type);
+  EXPECT_EQ(0, RES_CER_ATTR(2, 1)->value.size());
+  EXPECT_EQ("", RES_CER_ATTR(2, 1)->providingApplication.get());
+  EXPECT_EQ(NOFORMAT, RES_CER_ATTR(2, 1)->providingApplication.getFormat());
   EXPECT_FALSE(RES_CER_ATTR(2, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(2, 1)->metadataVector.size());
 

--- a/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
@@ -537,7 +537,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrOneSingle)
   EXPECT_EQ("A4", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
-  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -603,7 +603,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrOneMulti)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -667,14 +667,14 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrsSubset)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->value.size());
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 1)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->metadataVector.size());
 
@@ -736,7 +736,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternNoAttribute)
   EXPECT_EQ("A5", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
-  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
   EXPECT_FALSE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -871,21 +871,21 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiAttr)
   EXPECT_EQ("A3", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->value.size());
-  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 1)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->metadataVector.size());
 
   EXPECT_EQ("A5", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->value.size());
-  EXPECT_EQ("", RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(0, 2)->providingApplication.get());
   EXPECT_FALSE(RES_CER_ATTR(0, 2)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->metadataVector.size());
 
@@ -967,21 +967,21 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("A3", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->value.size());
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(0, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
   EXPECT_EQ("A4", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->value.size());
-  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cr2.com", RES_CER_ATTR(0, 1)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->metadataVector.size());
 
   EXPECT_EQ("A5", RES_CER_ATTR(0, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 2)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->value.size());
-  EXPECT_EQ("", RES_CER_ATTR(0, 2)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(0, 2)->providingApplication.get());
   EXPECT_FALSE(RES_CER_ATTR(0, 2)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 2)->metadataVector.size());
 
@@ -999,21 +999,21 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("A3", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->value.size());
-  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cr1.com", RES_CER_ATTR(1, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(1, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->metadataVector.size());
 
   EXPECT_EQ("A4", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->value.size());
-  EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication.get());
   EXPECT_FALSE(RES_CER_ATTR(1, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->metadataVector.size());
 
   EXPECT_EQ("A5", RES_CER_ATTR(1, 2)->name);
   EXPECT_EQ("", RES_CER_ATTR(1, 2)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 2)->value.size());
-  EXPECT_EQ("", RES_CER_ATTR(1, 2)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(1, 2)->providingApplication.get());
   EXPECT_FALSE(RES_CER_ATTR(1, 2)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 2)->metadataVector.size());
 
@@ -1088,7 +1088,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternNoType)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
-  EXPECT_EQ("http://cr5.com", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("http://cr5.com", RES_CER_ATTR(0, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -1492,14 +1492,14 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
   EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
-  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
   EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
   EXPECT_EQ("T", RES_CER_ATTR(0, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->value.size());
-  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 1)->providingApplication);
+  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(0, 1)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(0, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(0, 1)->metadataVector.size());
 
@@ -1517,14 +1517,14 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("A4", RES_CER_ATTR(1, 0)->name);
   EXPECT_EQ("T", RES_CER_ATTR(1, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->value.size());
-  EXPECT_EQ("http://cpr3.com", RES_CER_ATTR(1, 0)->providingApplication);
+  EXPECT_EQ("http://cpr3.com", RES_CER_ATTR(1, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(1, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 0)->metadataVector.size());
 
   EXPECT_EQ("A3", RES_CER_ATTR(1, 1)->name);
   EXPECT_EQ("T", RES_CER_ATTR(1, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->value.size());
-  EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(1, 1)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(1, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(1, 1)->metadataVector.size());
 
@@ -1542,14 +1542,14 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("A5", RES_CER_ATTR(2, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(2, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(2, 0)->value.size());
-  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(2, 0)->providingApplication);
+  EXPECT_EQ("http://cpr2.com", RES_CER_ATTR(2, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(2, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(2, 0)->metadataVector.size());
 
   EXPECT_EQ("A6", RES_CER_ATTR(2, 1)->name);
   EXPECT_EQ("", RES_CER_ATTR(2, 1)->type);
   EXPECT_EQ(0, RES_CER_ATTR(2, 1)->value.size());
-  EXPECT_EQ("", RES_CER_ATTR(2, 1)->providingApplication);
+  EXPECT_EQ("", RES_CER_ATTR(2, 1)->providingApplication.get());
   EXPECT_FALSE(RES_CER_ATTR(2, 1)->found);
   EXPECT_EQ(0, RES_CER_ATTR(2, 1)->metadataVector.size());
 
@@ -1567,7 +1567,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_EQ("A7", RES_CER_ATTR(3, 0)->name);
   EXPECT_EQ("", RES_CER_ATTR(3, 0)->type);
   EXPECT_EQ(0, RES_CER_ATTR(3, 0)->value.size());
-  EXPECT_EQ("http://cpr1.com", RES_CER_ATTR(3, 0)->providingApplication);
+  EXPECT_EQ("http://cpr1.com", RES_CER_ATTR(3, 0)->providingApplication.get());
   EXPECT_TRUE(RES_CER_ATTR(3, 0)->found);
   EXPECT_EQ(0, RES_CER_ATTR(3, 0)->metadataVector.size());
 

--- a/test/unittests/mongoBackend/mongoNotifyContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoNotifyContextAvailability_test.cpp
@@ -25,6 +25,7 @@
 
 #include "gtest/gtest.h"
 #include "testInit.h"
+#include "unittest.h"
 
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
@@ -71,19 +72,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_At0_Ok)
   NotifyContextAvailabilityRequest   req;
   NotifyContextAvailabilityResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
-
-  /* Setup database */
-  setupDatabase();
+  utInit();
 
   /* Forge the request */
   req.subscriptionId.set("51307b66f481db11bf860001");
@@ -95,7 +84,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_At0_Ok)
   req.contextRegistrationResponseVector.push_back(&crr);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoNotifyContextAvailability(&req, &res);
+  ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -132,9 +121,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_At0_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -148,19 +135,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_At0_Ok)
   NotifyContextAvailabilityRequest   req;
   NotifyContextAvailabilityResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
-
-  /* Setup database */
-  setupDatabase();
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "");
@@ -171,7 +146,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_At0_Ok)
   req.contextRegistrationResponseVector.push_back(&crr);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoNotifyContextAvailability(&req, &res);
+  ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -208,9 +183,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_At0_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -224,19 +197,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_AtN_Ok)
   NotifyContextAvailabilityRequest   req;
   NotifyContextAvailabilityResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
-
-  /* Setup database */
-  setupDatabase();
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "T1");
@@ -251,7 +212,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_AtN_Ok)
   req.contextRegistrationResponseVector.push_back(&crr);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoNotifyContextAvailability(&req, &res);
+  ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -296,9 +257,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_AtN_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -312,19 +271,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_AtNnt_Ok)
   NotifyContextAvailabilityRequest   req;
   NotifyContextAvailabilityResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
-
-  /* Setup database */
-  setupDatabase();
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "T1");
@@ -339,7 +286,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_AtNnt_Ok)
   req.contextRegistrationResponseVector.push_back(&crr);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoNotifyContextAvailability(&req, &res);
+  ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -384,9 +331,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_AtNnt_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -400,19 +345,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_AtN_Ok)
   NotifyContextAvailabilityRequest   req;
   NotifyContextAvailabilityResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
-
-  /* Setup database */
-  setupDatabase();
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "");
@@ -427,7 +360,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_AtN_Ok)
   req.contextRegistrationResponseVector.push_back(&crr);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoNotifyContextAvailability(&req, &res);
+  ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -472,9 +405,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_AtN_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -488,19 +419,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_AtNnt_Ok)
   NotifyContextAvailabilityRequest   req;
   NotifyContextAvailabilityResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
-
-  /* Setup database */
-  setupDatabase();
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "");
@@ -515,7 +434,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_AtNnt_Ok)
   req.contextRegistrationResponseVector.push_back(&crr);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoNotifyContextAvailability(&req, &res);
+  ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -560,9 +479,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_AtNnt_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -576,19 +493,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_At0_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -601,7 +506,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_At0_Ok)
     req.contextRegistrationResponseVector.push_back(&crr);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -641,9 +546,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -657,19 +560,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_At0_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -682,7 +573,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_At0_Ok)
     req.contextRegistrationResponseVector.push_back(&crr);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -722,9 +613,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -738,19 +627,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_AtN_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -767,7 +644,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_AtN_Ok)
     req.contextRegistrationResponseVector.push_back(&crr);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -815,9 +692,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -831,19 +706,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_AtNnt_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -860,7 +723,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_AtNnt_Ok)
     req.contextRegistrationResponseVector.push_back(&crr);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -908,9 +771,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -924,19 +785,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_AtN_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -953,7 +802,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_AtN_Ok)
     req.contextRegistrationResponseVector.push_back(&crr);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1001,9 +850,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1017,19 +864,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_AtNnt_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1046,7 +881,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_AtNnt_Ok)
     req.contextRegistrationResponseVector.push_back(&crr);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1094,9 +929,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1110,19 +943,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_At0_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -1138,7 +959,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_At0_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1185,9 +1006,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1201,19 +1020,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_At0_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1229,7 +1036,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_At0_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1276,9 +1083,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1292,19 +1097,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_AtN_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -1328,7 +1121,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_AtN_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1392,9 +1185,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1408,19 +1199,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_AtNnt_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -1444,7 +1223,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_AtNnt_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1508,9 +1287,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utInit();
 
 }
 
@@ -1524,19 +1301,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_AtN_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1560,7 +1325,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_AtN_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1624,9 +1389,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1640,19 +1403,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_AtNnt_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1676,7 +1427,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_AtNnt_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1740,9 +1491,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1756,19 +1505,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_At0_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -1788,7 +1525,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_At0_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1842,9 +1579,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1858,19 +1593,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_At0_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1890,7 +1613,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_At0_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1944,9 +1667,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1960,19 +1681,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_AtN_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -2000,7 +1709,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_AtN_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2070,9 +1779,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -2086,19 +1793,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_AtNnt_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -2126,7 +1821,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_AtNnt_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2196,9 +1891,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -2212,19 +1905,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_AtN_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -2252,7 +1933,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_AtN_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2322,9 +2003,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -2338,19 +2017,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_AtNnt_Ok)
     NotifyContextAvailabilityRequest   req;
     NotifyContextAvailabilityResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
-    /* Setup database */
-    setupDatabase();
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -2378,7 +2045,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_AtNnt_Ok)
     req.contextRegistrationResponseVector.push_back(&crr2);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContextAvailability(&req, &res);
+    ms = mongoNotifyContextAvailability(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2448,8 +2115,6 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }

--- a/test/unittests/mongoBackend/mongoNotifyContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoNotifyContextAvailability_test.cpp
@@ -127,6 +127,136 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_At0_Ok)
 
 /* ****************************************************************************
 *
+* ce1_En1_At0_Ok_XML -
+*/
+TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_At0_Ok_XML)
+{
+  HttpStatusCode           ms;
+  NotifyContextAvailabilityRequest   req;
+  NotifyContextAvailabilityResponse  res;
+
+  utInit();
+
+  /* Forge the request */
+  req.subscriptionId.set("51307b66f481db11bf860001");
+  EntityId en("E1", "T1");
+  ContextRegistrationResponse crr;
+  crr.contextRegistration.entityIdVector.push_back(&en);
+  crr.contextRegistration.providingApplication.set("http://dummy.com");
+  crr.errorCode.fill(SccOk);
+  req.contextRegistrationResponseVector.push_back(&crr);
+
+  /* Invoke the function in mongoBackend library */
+  uriParams[URI_PARAM_NOTIFY_FORMAT] = "XML";
+  ms = mongoNotifyContextAvailability(&req, &res, uriParams);
+
+  /* Check that every involved collection at MongoDB is as expected */
+  /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
+   * objects (see http://code.google.com/p/googletest/wiki/Primer#String_Comparison) */
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* registrations collection: */
+  ASSERT_EQ(1, connection->count(REGISTRATIONS_COLL, BSONObj()));
+  BSONObj reg = connection->findOne(REGISTRATIONS_COLL, BSONObj());
+  std::string oid = reg.getField("_id").OID().str();
+  EXPECT_EQ(1360319100, reg.getIntField("expiration"));
+  EXPECT_STREQ("XML", reg.getStringField("format"));
+
+  std::vector<BSONElement> contextRegistrationV = reg.getField("contextRegistration").Array();
+  ASSERT_EQ(1, contextRegistrationV.size());
+  BSONObj contextRegistration = contextRegistrationV[0].embeddedObject();
+
+  EXPECT_STREQ("http://dummy.com", C_STR_FIELD(contextRegistration, "providingApplication"));
+  std::vector<BSONElement> entities = contextRegistration.getField("entities").Array();
+  ASSERT_EQ(1, entities.size());
+  BSONObj ent0 = entities[0].embeddedObject();
+  EXPECT_STREQ("E1", C_STR_FIELD(ent0, "id"));
+  EXPECT_STREQ("T1", C_STR_FIELD(ent0, "type"));
+
+  std::vector<BSONElement> attrs = contextRegistration.getField("attrs").Array();
+  EXPECT_EQ(0, attrs.size());
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+  EXPECT_EQ(SccOk, res.responseCode.code);
+  EXPECT_EQ("OK", res.responseCode.reasonPhrase);
+  EXPECT_EQ(0, res.responseCode.details.size());
+
+  /* Release connection */
+  mongoDisconnect();
+
+  utExit();
+
+}
+
+/* ****************************************************************************
+*
+* ce1_En1_At0_Ok_JSON -
+*/
+TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_At0_Ok_JSON)
+{
+  HttpStatusCode           ms;
+  NotifyContextAvailabilityRequest   req;
+  NotifyContextAvailabilityResponse  res;
+
+  utInit();
+
+  /* Forge the request */
+  req.subscriptionId.set("51307b66f481db11bf860001");
+  EntityId en("E1", "T1");
+  ContextRegistrationResponse crr;
+  crr.contextRegistration.entityIdVector.push_back(&en);
+  crr.contextRegistration.providingApplication.set("http://dummy.com");
+  crr.errorCode.fill(SccOk);
+  req.contextRegistrationResponseVector.push_back(&crr);
+
+  /* Invoke the function in mongoBackend library */
+  uriParams[URI_PARAM_NOTIFY_FORMAT] = "JSON";
+  ms = mongoNotifyContextAvailability(&req, &res, uriParams);
+
+  /* Check that every involved collection at MongoDB is as expected */
+  /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
+   * objects (see http://code.google.com/p/googletest/wiki/Primer#String_Comparison) */
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* registrations collection: */
+  ASSERT_EQ(1, connection->count(REGISTRATIONS_COLL, BSONObj()));
+  BSONObj reg = connection->findOne(REGISTRATIONS_COLL, BSONObj());
+  std::string oid = reg.getField("_id").OID().str();
+  EXPECT_EQ(1360319100, reg.getIntField("expiration"));
+  EXPECT_STREQ("JSON", reg.getStringField("format"));
+
+  std::vector<BSONElement> contextRegistrationV = reg.getField("contextRegistration").Array();
+  ASSERT_EQ(1, contextRegistrationV.size());
+  BSONObj contextRegistration = contextRegistrationV[0].embeddedObject();
+
+  EXPECT_STREQ("http://dummy.com", C_STR_FIELD(contextRegistration, "providingApplication"));
+  std::vector<BSONElement> entities = contextRegistration.getField("entities").Array();
+  ASSERT_EQ(1, entities.size());
+  BSONObj ent0 = entities[0].embeddedObject();
+  EXPECT_STREQ("E1", C_STR_FIELD(ent0, "id"));
+  EXPECT_STREQ("T1", C_STR_FIELD(ent0, "type"));
+
+  std::vector<BSONElement> attrs = contextRegistration.getField("attrs").Array();
+  EXPECT_EQ(0, attrs.size());
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+  EXPECT_EQ(SccOk, res.responseCode.code);
+  EXPECT_EQ("OK", res.responseCode.reasonPhrase);
+  EXPECT_EQ(0, res.responseCode.details.size());
+
+  /* Release connection */
+  mongoDisconnect();
+
+  utExit();
+
+}
+
+/* ****************************************************************************
+*
 * ce1_En1nt_At0_Ok -
 */
 TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_At0_Ok)

--- a/test/unittests/mongoBackend/mongoQueryContext_test.cpp.bak
+++ b/test/unittests/mongoBackend/mongoQueryContext_test.cpp.bak
@@ -1,0 +1,3779 @@
+/*
+*
+* Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Fermin Galan
+*/
+#include "unittest.h"
+
+#include "logMsg/logMsg.h"
+#include "logMsg/traceLevels.h"
+
+#include "common/globals.h"
+#include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoQueryContext.h"
+#include "ngsi/EntityId.h"
+#include "ngsi10/QueryContextRequest.h"
+#include "ngsi10/QueryContextResponse.h"
+
+#include "mongo/client/dbclient.h"
+
+/* ****************************************************************************
+*
+* Tests
+*
+* Note that these tests are similar in structure to the ones in DiscoverContextAvailability,
+* due to both operations behaves quite similar regarding entities and attributes matching
+*
+* With pagination:
+*
+* - paginationDetails
+* - paginationAll
+* - paginationOnlyFirst
+* - paginationOnlySecond
+* - paginationRange
+* - paginationNonExisting
+* - paginationNonExistingOverlap
+* - paginationNonExistingDetails
+*
+* With servicePath:
+*
+* - queryWithServicePathEntPatternType_2levels
+* - queryWithServicePathEntPatternType_1level
+* - queryWithServicePathEntPatternType_0levels
+* - queryWithServicePathEntPatternType_1levelbis
+* - queryWithIdenticalEntitiesButDifferentServicePath_case1
+* - queryWithIdenticalEntitiesButDifferentServicePath_case2
+* - queryWithIdenticalEntitiesButDifferentServicePath_case3
+* - queryWithIdenticalEntitiesButDifferentServicePath_case4
+* - queryWithServicePathEntPatternNoType_2levels
+* - queryWithServicePathEntPatternNoType_1level
+* - queryWithServicePathEntPatternNoType_0levels
+* - queryWithServicePathEntPatternNoType_1levelbis
+* - queryWithServicePathEntNoPatternTypeFail
+* - queryWithServicePathEntNoPatternTypeOk
+* - queryWithServicePathEntNoPatternNoType
+* - queryWithSeveralServicePaths
+*
+* With isPattern=false:
+*
+* - query1Ent0Attr
+* - query1Ent1Attr
+* - query1Ent1AttrSameName
+* - queryNEnt0Attr
+* - queryNEnt1AttrSingle
+* - queryNEnt1AttrMulti
+* - queryNEntNAttr
+* - query1Ent0AttrFail
+* - query1Ent1AttrFail
+* - query1EntWA0AttrFail
+* - query1EntWA1Attr
+* - queryNEntWA0Attr
+* - queryNEntWA1Attr
+* - queryNoType
+* - queryIdMetadata
+* - queryCustomMetadata
+*
+* (N=2 without loss of generality)
+* (WA = Without Attributes)
+*
+* With isPattern=true:
+*
+* - queryPattern0Attr
+* - queryPattern1AttrSingle
+* - queryPattern1AttrMulti
+* - queryPatternNAttr
+* - queryPatternFail
+* - queryMixPatternAndNotPattern
+* - queryNoTypePattern
+* - queryIdMetadataPattern
+* - queryCustomMetadataPattern
+*
+* Simulating fails in MongoDB connection:
+*
+* - mongoDbQueryFail
+*
+* Note these tests are not "canonical" unit tests. Canon says that in this case we should have
+* mocked MongoDB. Actually, we think is very much powerful to check that everything is ok at
+* MongoDB layer.
+*
+*/
+
+/* ****************************************************************************
+*
+* prepareDatabase -
+*
+* This function is called before every test, to populate some information in the
+* entities collection.
+*/
+static void prepareDatabase(void) {
+
+  /* Set database */
+  setupDatabase();
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* We create the following entities:
+   *
+   * - E1:
+   *     A1: val1
+   *     A2: val2
+   * - E2
+   *     A2: val2bis
+   *     A3: val3
+   * - E4
+   *     (no attrs)
+   * - E1*
+   *     A1: val1bis
+   *     A1*: val1bis2
+   * - E1**
+   *     A1: val1bis1
+   *
+   * (*) Means that entity/type is using same name but different type. This is included to check that type is
+   *     taken into account.
+   * (**)same name but without type
+   */
+
+  BSONObj en1 = BSON("_id" << BSON("id" << "E1" << "type" << "T1") <<
+                     "attrs" << BSON_ARRAY(
+                        BSON("name" << "A1" << "type" << "TA1" << "value" << "val1") <<
+                        BSON("name" << "A2" << "type" << "TA2" << "value" << "val2")
+                        )
+                    );
+
+  BSONObj en2 = BSON("_id" << BSON("id" << "E2" << "type" << "T2") <<
+                     "attrs" << BSON_ARRAY(
+                        BSON("name" << "A2" << "type" << "TA2" << "value" << "val2bis") <<
+                        BSON("name" << "A3" << "type" << "TA3" << "value" << "val3")
+                        )
+                    );
+
+  BSONObj en4 = BSON("_id" << BSON("id" << "E4" << "type" << "T4") <<
+                     "attrs" << BSONArray()
+                    );
+
+  BSONObj en5 = BSON("_id" << BSON("id" << "E1" << "type" << "T1bis") <<
+                     "attrs" << BSON_ARRAY(
+                        BSON("name" << "A1" << "type" << "TA1" << "value" << "val1bis") <<
+                        BSON("name" << "A1" << "type" << "TA1bis" << "value" << "val1bis2")
+                        )
+                    );
+
+  BSONObj en6 = BSON("_id" << BSON("id" << "E1") <<
+                     "attrs" << BSON_ARRAY(
+                        BSON("name" << "A1" << "type" << "TA1" << "value" << "val1bis1")
+                        )
+                    );
+
+  connection->insert(ENTITIES_COLL, en1);
+  connection->insert(ENTITIES_COLL, en2);
+  connection->insert(ENTITIES_COLL, en4);
+  connection->insert(ENTITIES_COLL, en5);
+  connection->insert(ENTITIES_COLL, en6);
+
+}
+
+/* ****************************************************************************
+*
+* prepareDatabasePatternTrue -
+*
+* This is a variant of populateDatabase function in which all entities have the same type,
+* to ease test for isPattern=true cases
+*/
+static void prepareDatabasePatternTrue(void) {
+
+  /* Set database */
+  setupDatabase();
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* We create the following entities:
+   *
+   * - E1:
+   *     A1: val1
+   *     A2: val2
+   * - E2
+   *     A2: val2bis
+   *     A3: val3
+   * - E1*:
+   *     A4: val4
+   *     A5: val5
+   * - E4
+   *     (no attrs)
+   * - E2**
+   *     A2: val2bis1
+   */
+
+  BSONObj en1 = BSON("_id" << BSON("id" << "E1" << "type" << "T") <<
+                     "attrs" << BSON_ARRAY(
+                        BSON("name" << "A1" << "type" << "TA1" << "value" << "val1") <<
+                        BSON("name" << "A2" << "type" << "TA2" << "value" << "val2")
+                        )
+                    );
+
+  BSONObj en2 = BSON("_id" << BSON("id" << "E2" << "type" << "T") <<
+                     "attrs" << BSON_ARRAY(
+                        BSON("name" << "A2" << "type" << "TA2" << "value" << "val2bis") <<
+                        BSON("name" << "A3" << "type" << "TA3" << "value" << "val3")
+                        )
+                    );
+
+  BSONObj en4 = BSON("_id" << BSON("id" << "E4" << "type" << "T") <<
+                     "attrs" << BSONArray()
+                    );
+
+  BSONObj en5 = BSON("_id" << BSON("id" << "E1" << "type" << "Tbis") <<
+                     "attrs" << BSON_ARRAY(
+                        BSON("name" << "A4" << "type" << "TA4" << "value" << "val4") <<
+                        BSON("name" << "A5" << "type" << "TA5" << "value" << "val5")
+                        )
+                    );
+
+  BSONObj en6 = BSON("_id" << BSON("id" << "E2") <<
+                     "attrs" << BSON_ARRAY(
+                        BSON("name" << "A2" << "type" << "TA2" << "value" << "val2bis1")
+                        )
+                    );
+
+  connection->insert(ENTITIES_COLL, en1);
+  connection->insert(ENTITIES_COLL, en2);
+  connection->insert(ENTITIES_COLL, en4);
+  connection->insert(ENTITIES_COLL, en5);
+  connection->insert(ENTITIES_COLL, en6);
+
+}
+
+/* ****************************************************************************
+*
+* prepareDatabaseWithAttributeIds -
+*
+* This function is called before every test, to populate some information in the
+* entities collection.
+*/
+static void prepareDatabaseWithAttributeIds(void) {
+
+    /* Start with the base entities */
+    prepareDatabase();
+
+    /* Add some entities with metadata ID */
+
+    DBClientBase* connection = getMongoConnection();
+    BSONObj en1 = BSON("_id" << BSON("id" << "E10" << "type" << "T") <<
+                       "attrs" << BSON_ARRAY(
+                          BSON("name" << "A1" << "type" << "TA1" << "value" << "A" << "id" << "ID1") <<
+                          BSON("name" << "A1" << "type" << "TA1" << "value" << "B" << "id" << "ID2") <<
+                          BSON("name" << "A1" << "type" << "TA11" << "value" << "C") <<
+                          BSON("name" << "A2" << "type" << "TA2" << "value" << "D")
+                          )
+                      );
+
+    BSONObj en2 = BSON("_id" << BSON("id" << "E11" << "type" << "T") <<
+                       "attrs" << BSON_ARRAY(
+                          BSON("name" << "A1" << "type" << "TA1" << "value" << "E" << "id" << "ID1") <<
+                          BSON("name" << "A1" << "type" << "TA1" << "value" << "F" << "id" << "ID2") <<
+                          BSON("name" << "A1" << "type" << "TA11" << "value" << "G") <<
+                          BSON("name" << "A2" << "type" << "TA2" << "value" << "H")
+                          )
+                      );
+
+    connection->insert(ENTITIES_COLL, en1);
+    connection->insert(ENTITIES_COLL, en2);
+
+}
+
+/* ****************************************************************************
+*
+* prepareDatabaseWithAttributeCustomMetadata -
+*
+* This function is called before every test, to populate some information in the
+* entities collection.
+*/
+static void prepareDatabaseWithCustomMetadata(void) {
+
+    /* Start with the base entities */
+    prepareDatabase();
+
+    /* Add some entities with metadata ID */
+
+    DBClientBase* connection = getMongoConnection();
+    BSONObj en1 = BSON("_id" << BSON("id" << "E10" << "type" << "T") <<
+                       "attrs" << BSON_ARRAY(
+                          BSON("name" << "A1" << "type" << "TA1" << "value" << "A" <<
+                               "md" << BSON_ARRAY(BSON("name" << "MD1" << "type" << "TMD1" << "value" << "1") <<
+                                                  BSON("name" << "MD2" << "type" << "TMD2" << "value" << "2")
+                                                 )
+                               ) <<
+                          BSON("name" << "A1" << "type" << "TA11" << "value" << "B" <<
+                               "md" << BSON_ARRAY(BSON("name" << "MD1" << "type" << "TMD1" << "value" << "3") <<
+                                                  BSON("name" << "MD2" << "type" << "TMD2" << "value" << "4")
+                                                 )
+                               ) <<
+                          BSON("name" << "A2" << "type" << "TA2" << "value" << "C" <<
+                               "md" << BSON_ARRAY(BSON("name" << "MD1" << "type" << "TMD1" << "value" << "5") <<
+                                                  BSON("name" << "MD2" << "type" << "TMD2" << "value" << "6")
+                                                 )
+                               )
+                          )
+                      );
+
+    BSONObj en2 = BSON("_id" << BSON("id" << "E11" << "type" << "T") <<
+                       "attrs" << BSON_ARRAY(
+                           BSON("name" << "A1" << "type" << "TA1" << "value" << "D" <<
+                                "md" << BSON_ARRAY(BSON("name" << "MD1" << "type" << "TMD1" << "value" << "7") <<
+                                                   BSON("name" << "MD2" << "type" << "TMD2" << "value" << "8")
+                                                  )
+                                ) <<
+                           BSON("name" << "A1" << "type" << "TA11" << "value" << "E" <<
+                                "md" << BSON_ARRAY(BSON("name" << "MD1" << "type" << "TMD1" << "value" << "9") <<
+                                                   BSON("name" << "MD2" << "type" << "TMD2" << "value" << "10")
+                                                  )
+                                ) <<
+                           BSON("name" << "A2" << "type" << "TA2" << "value" << "F" <<
+                                "md" << BSON_ARRAY(BSON("name" << "MD1" << "type" << "TMD1" << "value" << "11") <<
+                                                   BSON("name" << "MD2" << "type" << "TMD2" << "value" << "12")
+                                                  )
+                                )
+                          )
+                      );
+
+    connection->insert(ENTITIES_COLL, en1);
+    connection->insert(ENTITIES_COLL, en2);
+}
+
+/* ****************************************************************************
+*
+* prepareDatabaseWithServicePath -
+*
+*/
+static void prepareDatabaseWithServicePath(const std::string modifier)
+{
+  /* Set database */
+  setupDatabase();
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* We create the following entities:
+   *
+   * - E1:  { Type: T, ServicePath: /home,        Attribute: { A1, a1  } }
+   * - E2:  { Type: T, ServicePath: /home/kz,     Attribute: { A1, a2  } }
+   * - E3:  { Type: T, ServicePath: /home/fg,     Attribute: { A1, a3  } }
+   * - E4:  { Type: T, ServicePath: /home/kz/e4,  Attribute: { A1, a4  } }
+   * - E5:  { Type: T, ServicePath: /home/kz/e5,  Attribute: { A1, a5  } }
+   * - E6:  { Type: T, ServicePath: /home/fg/e6,  Attribute: { A1, a6  } }
+   * - E7:  { Type: T, ServicePath: /home2,       Attribute: { A1, a7  } }
+   * - E8:  { Type: T, ServicePath: /home2/kz,    Attribute: { A1, a8  } }
+   * - E9:  { Type: T, ServicePath: "",           Attribute: { A1, a9  } }
+   * - E10: { Type: T, ServicePath: NO,           Attribute: { A1, a10 } }
+   * - E11: { Type: T, ServicePath: /home3/e11,   Attribute: { A1, a11 } }
+   * - E12: { Type: T, ServicePath: /home3/e12,   Attribute: { A1, a12 } }
+   * - E13: { Type: T, ServicePath: /home3/e13,   Attribute: { A1, a13 } }
+   *
+   */
+
+  BSONObj e01 = BSON("_id" << BSON("id" << "E1"  << "type" << "T" << "servicePath" << "/home")       << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a1")));
+  BSONObj e02 = BSON("_id" << BSON("id" << "E2"  << "type" << "T" << "servicePath" << "/home/kz")    << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a2")));
+  BSONObj e03 = BSON("_id" << BSON("id" << "E3"  << "type" << "T" << "servicePath" << "/home/fg")    << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a3")));
+  BSONObj e04 = BSON("_id" << BSON("id" << "E4"  << "type" << "T" << "servicePath" << "/home/kz/e4") << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a4")));
+  BSONObj e05 = BSON("_id" << BSON("id" << "E5"  << "type" << "T" << "servicePath" << "/home/kz/e5") << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a5")));
+  BSONObj e06 = BSON("_id" << BSON("id" << "E6"  << "type" << "T" << "servicePath" << "/home/fg/e6") << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a6")));
+  BSONObj e07 = BSON("_id" << BSON("id" << "E7"  << "type" << "T" << "servicePath" << "/home2")      << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a7")));
+  BSONObj e08 = BSON("_id" << BSON("id" << "E8"  << "type" << "T" << "servicePath" << "/home2/kz")   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a8")));
+  BSONObj e09 = BSON("_id" << BSON("id" << "E9"  << "type" << "T" << "servicePath" << "")            << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a9")));
+  BSONObj e10 = BSON("_id" << BSON("id" << "E10" << "type" << "T")                                   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a10")));
+
+  BSONObj e11 = BSON("_id" << BSON("id" << "E11" << "type" << "T" << "servicePath" << "/home3/e11")   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a11")));
+  BSONObj e12 = BSON("_id" << BSON("id" << "E12" << "type" << "T" << "servicePath" << "/home3/e12")   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a12")));
+  BSONObj e13 = BSON("_id" << BSON("id" << "E13" << "type" << "T" << "servicePath" << "/home3/e13")   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a13")));
+
+  connection->insert(ENTITIES_COLL, e01);
+  connection->insert(ENTITIES_COLL, e02);
+  connection->insert(ENTITIES_COLL, e03);
+  connection->insert(ENTITIES_COLL, e04);
+  connection->insert(ENTITIES_COLL, e05);
+  connection->insert(ENTITIES_COLL, e06);
+  connection->insert(ENTITIES_COLL, e07);
+  connection->insert(ENTITIES_COLL, e08);
+  connection->insert(ENTITIES_COLL, e09);
+  connection->insert(ENTITIES_COLL, e10);
+  connection->insert(ENTITIES_COLL, e11);
+  connection->insert(ENTITIES_COLL, e12);
+  connection->insert(ENTITIES_COLL, e13);
+
+  if (modifier == "")
+    return;
+
+  if (modifier == "patternNoType")
+  {
+    BSONObj e = BSON("_id" << BSON("id" << "E" << "type" << "OOO" << "servicePath" << "/home/kz/123")   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "ae_1")));
+    connection->insert(ENTITIES_COLL, e);
+  }
+  else if (modifier == "noPatternNoType")
+  {
+    BSONObj e = BSON("_id" << BSON("id" << "E3" << "type" << "OOO" << "servicePath" << "/home/fg/124")   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "ae_2")));
+    connection->insert(ENTITIES_COLL, e);
+  }
+  else if (modifier == "IdenticalEntitiesButDifferentServicePaths")
+  {
+    BSONObj ie1 = BSON("_id" << BSON("id" << "IE" << "type" << "T" << "servicePath" << "/home/fg/01")   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "ie_01")));
+    BSONObj ie2 = BSON("_id" << BSON("id" << "IE" << "type" << "T" << "servicePath" << "/home/fg/02")   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "ie_02")));
+    BSONObj ie3 = BSON("_id" << BSON("id" << "IE" << "type" << "T" << "servicePath" << "/home/fg/03")   << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "ie_03")));
+
+    connection->insert(ENTITIES_COLL, ie1);
+    connection->insert(ENTITIES_COLL, ie2);
+    connection->insert(ENTITIES_COLL, ie3);
+  }
+}
+
+/* ****************************************************************************
+*
+* prepareDatabaseWithServicePath -
+*
+*/
+static void prepareDatabaseForPagination(void)
+{
+  /* Set database */
+  setupDatabase();
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* We create the following entities:
+   *
+   * - E1:  { Type: T, Attribute: { A1, a1  } }
+   * - E2:  { Type: T, Attribute: { A1, a2  } }
+   * - E3:  { Type: T, Attribute: { A1, a3  } }
+   * - E4:  { Type: T, Attribute: { A1, a4  } }
+   * - E5:  { Type: T, Attribute: { A1, a5  } }
+   * - E6:  { Type: T, Attribute: { A1, a6  } }
+   *
+   */
+
+  BSONObj e01 = BSON("_id" << BSON("id" << "E1"  << "type" << "T") << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a1")));
+  BSONObj e02 = BSON("_id" << BSON("id" << "E2"  << "type" << "T") << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a2")));
+  BSONObj e03 = BSON("_id" << BSON("id" << "E3"  << "type" << "T") << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a3")));
+  BSONObj e04 = BSON("_id" << BSON("id" << "E4"  << "type" << "T") << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a4")));
+  BSONObj e05 = BSON("_id" << BSON("id" << "E5"  << "type" << "T") << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a5")));
+  BSONObj e06 = BSON("_id" << BSON("id" << "E6"  << "type" << "T") << "attrs" << BSON_ARRAY(BSON("name" << "A1" << "type" << "TA1" << "value" << "a6")));
+
+  connection->insert(ENTITIES_COLL, e01);
+  connection->insert(ENTITIES_COLL, e02);
+  connection->insert(ENTITIES_COLL, e03);
+  connection->insert(ENTITIES_COLL, e04);
+  connection->insert(ENTITIES_COLL, e05);
+  connection->insert(ENTITIES_COLL, e06);
+}
+
+/* ****************************************************************************
+*
+* paginationDetails -
+*
+*/
+TEST(mongoQueryContextRequest, paginationDetails)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    utInit();
+
+    /* Prepare database */
+    prepareDatabaseForPagination();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E.*", "T", "true");
+    req.entityIdVector.push_back(&en);
+    uriParams[URI_PARAM_PAGINATION_DETAILS]  = "on";
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector , uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccOk, res.errorCode.code);
+    EXPECT_EQ("OK", res.errorCode.reasonPhrase);
+    EXPECT_EQ("Count: 6", res.errorCode.details);
+
+    ASSERT_EQ(6, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("a1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("a2", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Context Element response # 3 */
+    EXPECT_EQ("E3", RES_CER(2).entityId.id);
+    EXPECT_EQ("T", RES_CER(2).entityId.type);
+    EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+    EXPECT_EQ("a3", RES_CER_ATTR(2, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+    /* Context Element response # 4 */
+    EXPECT_EQ("E4", RES_CER(3).entityId.id);
+    EXPECT_EQ("T", RES_CER(3).entityId.type);
+    EXPECT_EQ("false", RES_CER(3).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(3).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(3, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(3, 0)->type);
+    EXPECT_EQ("a4", RES_CER_ATTR(3, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
+
+    /* Context Element response # 5 */
+    EXPECT_EQ("E5", RES_CER(4).entityId.id);
+    EXPECT_EQ("T", RES_CER(4).entityId.type);
+    EXPECT_EQ("false", RES_CER(4).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(4).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(4, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(4, 0)->type);
+    EXPECT_EQ("a5", RES_CER_ATTR(4, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(4).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(4).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(4).details.size());
+
+    /* Context Element response # 6 */
+    EXPECT_EQ("E6", RES_CER(5).entityId.id);
+    EXPECT_EQ("T", RES_CER(5).entityId.type);
+    EXPECT_EQ("false", RES_CER(5).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(5).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(5, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(5, 0)->type);
+    EXPECT_EQ("a6", RES_CER_ATTR(5, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(5).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(5).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(5).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+
+    utExit();
+}
+
+/* ****************************************************************************
+*
+* paginationAll -
+*
+*/
+TEST(mongoQueryContextRequest, paginationAll)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    utInit();
+
+    /* Prepare database */
+    prepareDatabaseForPagination();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E.*", "T", "true");
+    req.entityIdVector.push_back(&en);
+    uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
+    /* Using default offset/limit */
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector , uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(6, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("a1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("a2", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Context Element response # 3 */
+    EXPECT_EQ("E3", RES_CER(2).entityId.id);
+    EXPECT_EQ("T", RES_CER(2).entityId.type);
+    EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+    EXPECT_EQ("a3", RES_CER_ATTR(2, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+    /* Context Element response # 4 */
+    EXPECT_EQ("E4", RES_CER(3).entityId.id);
+    EXPECT_EQ("T", RES_CER(3).entityId.type);
+    EXPECT_EQ("false", RES_CER(3).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(3).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(3, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(3, 0)->type);
+    EXPECT_EQ("a4", RES_CER_ATTR(3, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
+
+    /* Context Element response # 5 */
+    EXPECT_EQ("E5", RES_CER(4).entityId.id);
+    EXPECT_EQ("T", RES_CER(4).entityId.type);
+    EXPECT_EQ("false", RES_CER(4).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(4).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(4, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(4, 0)->type);
+    EXPECT_EQ("a5", RES_CER_ATTR(4, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(4).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(4).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(4).details.size());
+
+    /* Context Element response # 6 */
+    EXPECT_EQ("E6", RES_CER(5).entityId.id);
+    EXPECT_EQ("T", RES_CER(5).entityId.type);
+    EXPECT_EQ("false", RES_CER(5).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(5).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(5, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(5, 0)->type);
+    EXPECT_EQ("a6", RES_CER_ATTR(5, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(5).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(5).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(5).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+
+    utExit();
+}
+
+/* ****************************************************************************
+*
+* paginationOnlyFirst -
+*
+*/
+TEST(mongoQueryContextRequest, paginationOnlyFirst)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    utInit();
+
+    /* Prepare database */
+    prepareDatabaseForPagination();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E.*", "T", "true");
+    req.entityIdVector.push_back(&en);
+    uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
+    uriParams[URI_PARAM_PAGINATION_LIMIT] = "1";
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector , uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("a1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+
+    utExit();
+}
+
+/* ****************************************************************************
+*
+* paginationOnlySecond -
+*
+*/
+TEST(mongoQueryContextRequest, paginationOnlySecond)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    utInit();
+
+    /* Prepare database */
+    prepareDatabaseForPagination();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E.*", "T", "true");
+    req.entityIdVector.push_back(&en);
+    uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
+    uriParams[URI_PARAM_PAGINATION_OFFSET] = "1";
+    uriParams[URI_PARAM_PAGINATION_LIMIT]  = "1";
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector , uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E2", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("a2", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+
+    utExit();
+}
+
+/* ****************************************************************************
+*
+* paginationRange -
+*
+*/
+TEST(mongoQueryContextRequest, paginationRange)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    utInit();
+
+    /* Prepare database */
+    prepareDatabaseForPagination();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E.*", "T", "true");
+    req.entityIdVector.push_back(&en);
+    uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
+    uriParams[URI_PARAM_PAGINATION_OFFSET] = "2";
+    uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector , uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(3, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E3", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("a3", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E4", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("a4", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Context Element response # 3 */
+    EXPECT_EQ("E5", RES_CER(2).entityId.id);
+    EXPECT_EQ("T", RES_CER(2).entityId.type);
+    EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+    EXPECT_EQ("a5", RES_CER_ATTR(2, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+
+    utExit();
+}
+
+/* ****************************************************************************
+*
+* paginationNonExisting -
+*
+*/
+TEST(mongoQueryContextRequest, paginationNonExisting)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    utInit();
+
+    /* Prepare database */
+    prepareDatabaseForPagination();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E.*", "T", "true");
+    req.entityIdVector.push_back(&en);
+    uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
+    uriParams[URI_PARAM_PAGINATION_OFFSET] = "7";
+    uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector , uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccContextElementNotFound, res.errorCode.code);
+    EXPECT_EQ("No context element found", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(0, res.contextElementResponseVector.size());
+
+    /* Release connection */
+    mongoDisconnect();
+
+    utExit();
+}
+
+/* ****************************************************************************
+*
+* paginationNonExistingOverlap -
+*
+*/
+TEST(mongoQueryContextRequest, paginationNonExistingOverlap)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    utInit();
+
+    /* Prepare database */
+    prepareDatabaseForPagination();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E.*", "T", "true");
+    req.entityIdVector.push_back(&en);
+    uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
+    uriParams[URI_PARAM_PAGINATION_OFFSET] = "5";
+    uriParams[URI_PARAM_PAGINATION_LIMIT]  = "4";
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector , uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E6", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("a6", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+
+    utExit();
+}
+
+/* ****************************************************************************
+*
+* paginationNonExistingDetails -
+*
+*/
+TEST(mongoQueryContextRequest, paginationNonExistingDetails)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    utInit();
+
+    /* Prepare database */
+    prepareDatabaseForPagination();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E.*", "T", "true");
+    req.entityIdVector.push_back(&en);
+    uriParams[URI_PARAM_PAGINATION_OFFSET]   = "7";
+    uriParams[URI_PARAM_PAGINATION_LIMIT]    = "3";
+    uriParams[URI_PARAM_PAGINATION_DETAILS]  = "on";
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector , uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccContextElementNotFound, res.errorCode.code);
+    EXPECT_EQ("No context element found", res.errorCode.reasonPhrase);
+    EXPECT_EQ("Number of matching entities: 6. Offset is 7", res.errorCode.details);
+
+    ASSERT_EQ(0, res.contextElementResponseVector.size());
+
+    /* Release connection */
+    mongoDisconnect();
+
+    utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntPatternType_2levels -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_2levels)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("patternType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E.*", "T", "true");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.push_back("/home/kz/#");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(3, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E2", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a2", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E4", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("a4", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  /* Context Element response # 3 */
+  EXPECT_EQ("E5", RES_CER(2).entityId.id);
+  EXPECT_EQ("T", RES_CER(2).entityId.type);
+  EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+  EXPECT_EQ("a5", RES_CER_ATTR(2, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntPatternType_1level -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_1level)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("patternType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E.*", "T", "true");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.push_back("/home/#");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(6, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E1", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a1", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E2", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("a2", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  /* Context Element response # 3 */
+  EXPECT_EQ("E3", RES_CER(2).entityId.id);
+  EXPECT_EQ("T", RES_CER(2).entityId.type);
+  EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+  EXPECT_EQ("a3", RES_CER_ATTR(2, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+  /* Context Element response # 4 */
+  EXPECT_EQ("E4", RES_CER(3).entityId.id);
+  EXPECT_EQ("T", RES_CER(3).entityId.type);
+  EXPECT_EQ("false", RES_CER(3).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(3).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(3, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(3, 0)->type);
+  EXPECT_EQ("a4", RES_CER_ATTR(3, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
+
+  /* Context Element response # 5 */
+  EXPECT_EQ("E5", RES_CER(4).entityId.id);
+  EXPECT_EQ("T", RES_CER(4).entityId.type);
+  EXPECT_EQ("false", RES_CER(4).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(4).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(4, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(4, 0)->type);
+  EXPECT_EQ("a5", RES_CER_ATTR(4, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(4).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(4).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(4).details.size());
+
+  /* Context Element response # 6 */
+  EXPECT_EQ("E6", RES_CER(5).entityId.id);
+  EXPECT_EQ("T", RES_CER(5).entityId.type);
+  EXPECT_EQ("false", RES_CER(5).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(5).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(5, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(5, 0)->type);
+  EXPECT_EQ("a6", RES_CER_ATTR(5, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(5).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(5).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(5).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntPatternType_0levels -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_0levels)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("patternType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E1\\d", "T", "true");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(4, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E10", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a10", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E11", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("a11", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  /* Context Element response # 3 */
+  EXPECT_EQ("E12", RES_CER(2).entityId.id);
+  EXPECT_EQ("T", RES_CER(2).entityId.type);
+  EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+  EXPECT_EQ("a12", RES_CER_ATTR(2, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+  /* Context Element response # 4 */
+  EXPECT_EQ("E13", RES_CER(3).entityId.id);
+  EXPECT_EQ("T", RES_CER(3).entityId.type);
+  EXPECT_EQ("false", RES_CER(3).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(3).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(3, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(3, 0)->type);
+  EXPECT_EQ("a13", RES_CER_ATTR(3, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntPatternType_1levelbis -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_1levelbis)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("patternType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E.*", "T", "true");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.push_back("/home2/#");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(2, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E7", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a7", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E8", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("a8", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithIdenticalEntitiesButDifferentServicePaths_case1 -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithIdenticalEntitiesButDifferentServicePaths_case1)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("IdenticalEntitiesButDifferentServicePaths");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("IE", "T", "false");
+  req.entityIdVector.push_back(&en);
+
+  // Test that three items are found for Service path /home/fg
+  servicePathVector.clear();
+  servicePathVector.push_back("/home/fg/#");
+
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(3, res.contextElementResponseVector.size());
+
+  EXPECT_EQ("IE", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("ie_01", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  EXPECT_EQ("IE", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("ie_02", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  EXPECT_EQ("IE", RES_CER(2).entityId.id);
+  EXPECT_EQ("T", RES_CER(2).entityId.type);
+  EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+  EXPECT_EQ("ie_03", RES_CER_ATTR(2, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithIdenticalEntitiesButDifferentServicePaths_case2 -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithIdenticalEntitiesButDifferentServicePaths_case2)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("IdenticalEntitiesButDifferentServicePaths");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("IE", "T", "false");
+  req.entityIdVector.push_back(&en);
+
+  // Test that only ONE item AND the right one is found for Service paths /home/fg/01, /home/fg/02, and /home/fg/03
+  servicePathVector.clear();
+  servicePathVector.push_back("/home/fg/01");
+
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(1, res.contextElementResponseVector.size());
+
+  EXPECT_EQ("IE", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("ie_01", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithIdenticalEntitiesButDifferentServicePaths_case3 -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithIdenticalEntitiesButDifferentServicePaths_case3)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("IdenticalEntitiesButDifferentServicePaths");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("IE", "T", "false");
+  req.entityIdVector.push_back(&en);
+
+  // Same test for /home/fg/02
+  servicePathVector.clear();
+  servicePathVector.push_back("/home/fg/02");
+
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(1, res.contextElementResponseVector.size());
+
+  EXPECT_EQ("IE", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("ie_02", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithIdenticalEntitiesButDifferentServicePaths_case4 -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithIdenticalEntitiesButDifferentServicePaths_case4)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("IdenticalEntitiesButDifferentServicePaths");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("IE", "T", "false");
+  req.entityIdVector.push_back(&en);
+
+  // Same test for /home/fg/03
+
+  servicePathVector.clear();
+  servicePathVector.push_back("/home/fg/03");
+
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(1, res.contextElementResponseVector.size());
+
+  EXPECT_EQ("IE", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("ie_03", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntPatternNoType_2levels -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_2levels)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("patternNoType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E.*", "", "true");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.push_back("/home/kz/#");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(4, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E2", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a2", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E4", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("a4", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  /* Context Element response # 3 */
+  EXPECT_EQ("E5", RES_CER(2).entityId.id);
+  EXPECT_EQ("T", RES_CER(2).entityId.type);
+  EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+  EXPECT_EQ("a5", RES_CER_ATTR(2, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+  /* Context Element response # 4 */
+  EXPECT_EQ("E", RES_CER(3).entityId.id);
+  EXPECT_EQ("OOO", RES_CER(3).entityId.type);
+  EXPECT_EQ("false", RES_CER(3).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(3).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(3, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(3, 0)->type);
+  EXPECT_EQ("ae_1", RES_CER_ATTR(3, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntPatternNoType_1level -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_1level)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("patternNoType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E.*", "", "true");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.push_back("/home/#");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(7, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E1", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a1", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E2", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("a2", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  /* Context Element response # 3 */
+  EXPECT_EQ("E3", RES_CER(2).entityId.id);
+  EXPECT_EQ("T", RES_CER(2).entityId.type);
+  EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+  EXPECT_EQ("a3", RES_CER_ATTR(2, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+  /* Context Element response # 4 */
+  EXPECT_EQ("E4", RES_CER(3).entityId.id);
+  EXPECT_EQ("T", RES_CER(3).entityId.type);
+  EXPECT_EQ("false", RES_CER(3).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(3).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(3, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(3, 0)->type);
+  EXPECT_EQ("a4", RES_CER_ATTR(3, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
+
+  /* Context Element response # 5 */
+  EXPECT_EQ("E5", RES_CER(4).entityId.id);
+  EXPECT_EQ("T", RES_CER(4).entityId.type);
+  EXPECT_EQ("false", RES_CER(4).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(4).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(4, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(4, 0)->type);
+  EXPECT_EQ("a5", RES_CER_ATTR(4, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(4).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(4).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(4).details.size());
+
+  /* Context Element response # 6 */
+  EXPECT_EQ("E6", RES_CER(5).entityId.id);
+  EXPECT_EQ("T", RES_CER(5).entityId.type);
+  EXPECT_EQ("false", RES_CER(5).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(5).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(5, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(5, 0)->type);
+  EXPECT_EQ("a6", RES_CER_ATTR(5, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(5).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(5).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(5).details.size());
+
+  /* Context Element response # 7 */
+  EXPECT_EQ("E", RES_CER(6).entityId.id);
+  EXPECT_EQ("OOO", RES_CER(6).entityId.type);
+  EXPECT_EQ("false", RES_CER(6).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(6).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(6, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(6, 0)->type);
+  EXPECT_EQ("ae_1", RES_CER_ATTR(6, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(6).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(6).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(6).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntPatternNoType_0levels -
+*
+* FIXME P4: Fermin to inspect whether the function has enough EXPECTs
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_0levels)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("patternNoType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E1\\d", "", "true");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(4, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E10", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a10", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E11", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("a11", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  /* Context Element response # 3 */
+  EXPECT_EQ("E12", RES_CER(2).entityId.id);
+  EXPECT_EQ("T", RES_CER(2).entityId.type);
+  EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+  EXPECT_EQ("a12", RES_CER_ATTR(2, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+  /* Context Element response # 4 */
+  EXPECT_EQ("E13", RES_CER(3).entityId.id);
+  EXPECT_EQ("T", RES_CER(3).entityId.type);
+  EXPECT_EQ("false", RES_CER(3).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(3).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(3, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(3, 0)->type);
+  EXPECT_EQ("a13", RES_CER_ATTR(3, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntPatternNoType_1levelbis -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_1levelbis)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("patternNoType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E.*", "", "true");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.push_back("/home2/#");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(2, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E7", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a7", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E8", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("a8", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntNoPatternTypeFail -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntNoPatternTypeFail)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("noPatternType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E3", "T", "false");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.push_back("/home/kz");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccContextElementNotFound, res.errorCode.code);
+  EXPECT_EQ("No context element found", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  EXPECT_EQ(0, res.contextElementResponseVector.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntNoPatternTypeOk -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntNoPatternTypeOk)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("noPatternType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E3", "T", "false");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.push_back("/home/fg");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(1, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E3", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a3", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithServicePathEntNoPatternNoType -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithServicePathEntNoPatternNoType)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("noPatternNoType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E3", "", "false");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.push_back("/home/fg/#");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(SccNone, res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(2, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E3", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a3", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E3", RES_CER(1).entityId.id);
+  EXPECT_EQ("OOO", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("ae_2", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* queryWithSeveralServicePaths -
+*
+*/
+TEST(mongoQueryContextRequest, queryWithSeveralServicePaths)
+{
+  HttpStatusCode         ms;
+  QueryContextRequest    req;
+  QueryContextResponse   res;
+
+  utInit();
+
+  /* Prepare database */
+  prepareDatabaseWithServicePath("patternType");
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E.*", "T", "true");
+  req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
+  servicePathVector.push_back("/home/kz/e4");
+  servicePathVector.push_back("/home3/e12");
+
+  /* Invoke the function in mongoBackend library */
+  ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+
+  EXPECT_EQ(0 , res.errorCode.code);
+  EXPECT_EQ("", res.errorCode.reasonPhrase);
+  EXPECT_EQ("", res.errorCode.details);
+
+  ASSERT_EQ(2, res.contextElementResponseVector.size());
+
+  /* Context Element response # 1 */
+  EXPECT_EQ("E4", RES_CER(0).entityId.id);
+  EXPECT_EQ("T", RES_CER(0).entityId.type);
+  EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+  EXPECT_EQ("a4", RES_CER_ATTR(0, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+  /* Context Element response # 2 */
+  EXPECT_EQ("E12", RES_CER(1).entityId.id);
+  EXPECT_EQ("T", RES_CER(1).entityId.type);
+  EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+  ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+  EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+  EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+  EXPECT_EQ("a12", RES_CER_ATTR(1, 0)->value);
+  EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+  EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+  EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+  utExit();
+}
+
+/* ****************************************************************************
+*
+* query1Ent0Attr -
+*
+* Discover:  E1 - no attrs
+* Result:    E1 - (A1, A2)
+*
+* This test also checks that querying for type (E1) doesn't match with no-typed
+* entities (E1** is not returned)
+*
+*/
+TEST(mongoQueryContextRequest, query1Ent0Attr)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E1", "T1", "false");
+    req.entityIdVector.push_back(&en);
+
+    /* Invoke the function in mongoBackend library */
+    servicePathVector.clear();
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* query1Ent1Attr -
+*
+* Discover:  E1 - A1
+* Result:    E1 - A1
+*/
+TEST(mongoQueryContextRequest, query1Ent1Attr)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E1", "T1", "false");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector , uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* query1Ent1AttrSameName -
+*
+* Discover:  E1* - A1
+* Result:    E1* - (A1, A1*)  [same name but different type]
+*/
+TEST(mongoQueryContextRequest, query1Ent1AttrSameName)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E1", "T1bis", "false");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */    
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1bis", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1bis", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA1bis", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val1bis2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryNEnt0Attr -
+*
+* Discover:  (E1, E2) -no attrs
+* Result:    E1 - (A1, A2)
+*            E2 - (A3, A4)
+*/
+TEST(mongoQueryContextRequest, queryNEnt0Attr)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en1("E1", "T1", "false");
+    EntityId en2("E2", "T2", "false");
+    req.entityIdVector.push_back(&en1);
+    req.entityIdVector.push_back(&en2);
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T2", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val2bis", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ("A3", RES_CER_ATTR(1, 1)->name);
+    EXPECT_EQ("TA3", RES_CER_ATTR(1, 1)->type);
+    EXPECT_EQ("val3", RES_CER_ATTR(1, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryNEnt1AttrSingle -
+*
+* Discover:  (E1, E2) - A1
+* Result:    E1 - A1
+*/
+TEST(mongoQueryContextRequest, queryNEnt1AttrSingle)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en1("E1", "T1", "false");
+    EntityId en2("E2", "T2", "false");
+    req.entityIdVector.push_back(&en1);
+    req.entityIdVector.push_back(&en2);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryNEnt1AttrMulti -
+*
+* Discover:  (E1, E2) - A2
+* Result:    E1 - A2
+*            E2 - A2
+*/
+TEST(mongoQueryContextRequest, queryNEnt1AttrMulti)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;  
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en1("E1", "T1", "false");
+    EntityId en2("E2", "T2", "false");
+    req.entityIdVector.push_back(&en1);
+    req.entityIdVector.push_back(&en2);
+    req.attributeList.push_back("A2");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T2", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val2bis", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryNEntNAttr -
+*
+* Discover:  (E1, E2) - (A1, A3)
+* Result:    E1 - A1
+*            E2 - A3
+*/
+TEST(mongoQueryContextRequest, queryNEntNAttr)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en1("E1", "T1", "false");
+    EntityId en2("E2", "T2", "false");
+    req.entityIdVector.push_back(&en1);
+    req.entityIdVector.push_back(&en2);
+    req.attributeList.push_back("A1");
+    req.attributeList.push_back("A3");
+
+    /* Invoke the function in mongoBackend library */
+    servicePathVector.clear();
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T2", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A3", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA3", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val3", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* query1Ent0AttrFail -
+*
+* Discover:  E3 - no attrs
+* Result:    none
+*/
+TEST(mongoQueryContextRequest, query1Ent0AttrFail)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E3", "T3", "false");
+    req.entityIdVector.push_back(&en);
+
+    /* Invoke the function in mongoBackend library */    
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccContextElementNotFound, res.errorCode.code);
+    EXPECT_EQ("No context element found", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+    EXPECT_EQ(0,res.contextElementResponseVector.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* query1Ent1AttrFail -
+*
+* Discover:  E1 - A3
+* Result:    none
+*/
+TEST(mongoQueryContextRequest, query1Ent1AttrFail)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E1", "T1", "false");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A3");
+
+    /* Invoke the function in mongoBackend library */
+    servicePathVector.clear();    
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccContextElementNotFound, res.errorCode.code);
+    EXPECT_EQ("No context element found", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+    EXPECT_EQ(0,res.contextElementResponseVector.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+
+/* ****************************************************************************
+*
+* query1EntWA0AttrFail -
+*
+* Discover:  E4 - A1
+* Result:    none
+*/
+TEST(mongoQueryContextRequest, query1EntWA0AttrFail)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E4", "T4", "false");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccContextElementNotFound, res.errorCode.code);
+    EXPECT_EQ("No context element found", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+    EXPECT_EQ(0,res.contextElementResponseVector.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* query1EntWA1Attr -
+*
+* Discover:  E4 - none
+* Result:    E4 - none
+*/
+TEST(mongoQueryContextRequest, query1EntWA1Attr)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E4", "T4", "false");
+    req.entityIdVector.push_back(&en);
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccContextElementNotFound, res.errorCode.code);
+    EXPECT_EQ("No context element found", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(0, res.contextElementResponseVector.size());
+
+#if 0
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E4", RES_CER(0).entityId.id);
+    EXPECT_EQ("T4", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    EXPECT_EQ(0, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+#endif
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryNEntWA0Attr -
+*
+* Discover:  (E1, E4) - none
+* Result:    E1 - A1, A2
+*            E4 - none
+*/
+TEST(mongoQueryContextRequest, queryNEntWA0Attr)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en1("E1", "T1", "false");
+    EntityId en2("E4", "T4", "false");
+    req.entityIdVector.push_back(&en1);
+    req.entityIdVector.push_back(&en2);
+
+    /* Invoke the function in mongoBackend library */    
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+#if 0
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E4", RES_CER(1).entityId.id);
+    EXPECT_EQ("T4", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    EXPECT_EQ(0, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+#endif
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryNEntWA1Attr -
+*
+* Discover:  (E1, E4) - A1
+* Result:    E1 - A1
+*/
+TEST(mongoQueryContextRequest, queryNEntWA1Attr)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en1("E1", "T1", "false");
+    EntityId en2("E4", "T4", "false");
+    req.entityIdVector.push_back(&en1);
+    req.entityIdVector.push_back(&en2);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */    
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryNoType -
+*
+* Discover:  E1
+* Result:    E1   - A1
+*            E1*  - A1, A1*
+*            E1** - A1
+*
+* Note that this case checks matching of no-type in the query for both the case in
+* which the returned entity has type (E1 and E1*) and the case in which it has no type (E1**)
+*
+*/
+TEST(mongoQueryContextRequest, queryNoType)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabase();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E1", "", "false");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(3, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T1", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response #2 */
+    EXPECT_EQ("E1", RES_CER(1).entityId.id);
+    EXPECT_EQ("T1bis", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val1bis", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 1)->name);
+    EXPECT_EQ("TA1bis", RES_CER_ATTR(1, 1)->type);
+    EXPECT_EQ("val1bis2", RES_CER_ATTR(1, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Context Element response #3 */
+    EXPECT_EQ("E1", RES_CER(2).entityId.id);
+    EXPECT_EQ(0, RES_CER(2).entityId.type.size());
+    EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(2).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(2, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(2, 0)->type);
+    EXPECT_EQ("val1bis1", RES_CER_ATTR(2, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryIdMetadata -
+*
+*/
+TEST(mongoQueryContextRequest, queryIdMetadata)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabaseWithAttributeIds();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E10", "T", "false");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E10", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(3, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("A", RES_CER_ATTR(0, 0)->value);
+    ASSERT_EQ(1, RES_CER_ATTR(0, 0)->metadataVector.size());
+    EXPECT_EQ("ID", RES_CER_ATTR(0, 0)->metadataVector.get(0)->name);
+    EXPECT_EQ("string", RES_CER_ATTR(0, 0)->metadataVector.get(0)->type);
+    EXPECT_EQ("ID1", RES_CER_ATTR(0, 0)->metadataVector.get(0)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("B", RES_CER_ATTR(0, 1)->value);
+    ASSERT_EQ(1, RES_CER_ATTR(0, 1)->metadataVector.size());
+    EXPECT_EQ("ID", RES_CER_ATTR(0, 1)->metadataVector.get(0)->name);
+    EXPECT_EQ("string", RES_CER_ATTR(0, 1)->metadataVector.get(0)->type);
+    EXPECT_EQ("ID2", RES_CER_ATTR(0, 1)->metadataVector.get(0)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 2)->name);
+    EXPECT_EQ("TA11", RES_CER_ATTR(0, 2)->type);
+    EXPECT_EQ("C", RES_CER_ATTR(0, 2)->value);
+    ASSERT_EQ(0, RES_CER_ATTR(0, 2)->metadataVector.size());
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryCustomMetadata -
+*
+*/
+TEST(mongoQueryContextRequest, queryCustomMetadata)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabaseWithCustomMetadata();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E10", "T", "false");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E10", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("A", RES_CER_ATTR(0, 0)->value);
+    ASSERT_EQ(2, RES_CER_ATTR(0, 0)->metadataVector.size());
+    EXPECT_EQ("MD1", RES_CER_ATTR(0, 0)->metadataVector.get(0)->name);
+    EXPECT_EQ("TMD1", RES_CER_ATTR(0, 0)->metadataVector.get(0)->type);
+    EXPECT_EQ("1", RES_CER_ATTR(0, 0)->metadataVector.get(0)->value);
+    EXPECT_EQ("MD2", RES_CER_ATTR(0, 0)->metadataVector.get(1)->name);
+    EXPECT_EQ("TMD2", RES_CER_ATTR(0, 0)->metadataVector.get(1)->type);
+    EXPECT_EQ("2", RES_CER_ATTR(0, 0)->metadataVector.get(1)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA11", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("B", RES_CER_ATTR(0, 1)->value);
+    ASSERT_EQ(2, RES_CER_ATTR(0, 1)->metadataVector.size());
+    EXPECT_EQ("MD1", RES_CER_ATTR(0, 1)->metadataVector.get(0)->name);
+    EXPECT_EQ("TMD1", RES_CER_ATTR(0, 1)->metadataVector.get(0)->type);
+    EXPECT_EQ("3", RES_CER_ATTR(0, 1)->metadataVector.get(0)->value);
+    EXPECT_EQ("MD2", RES_CER_ATTR(0, 1)->metadataVector.get(1)->name);
+    EXPECT_EQ("TMD2", RES_CER_ATTR(0, 1)->metadataVector.get(1)->type);
+    EXPECT_EQ("4", RES_CER_ATTR(0, 1)->metadataVector.get(1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+
+/* ****************************************************************************
+*
+* queryPattern0Attr -
+*
+* Discover:  E[1-2] - none
+* Result:    E1 - (A1, A2)
+*            E2 - (A2, A3)
+*
+* This test also checks that querying for type (E[1-2]) doesn't match with no-typed
+* entities (E1** is not returned)
+*
+*/
+TEST(mongoQueryContextRequest, queryPattern0Attr)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabasePatternTrue();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E[1-2]", "T", "true");
+    req.entityIdVector.push_back(&en);
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val2bis", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ("A3", RES_CER_ATTR(1, 1)->name);
+    EXPECT_EQ("TA3", RES_CER_ATTR(1, 1)->type);
+    EXPECT_EQ("val3", RES_CER_ATTR(1, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryPattern1AttrSingle -
+*
+* Discover:  E[1-2] - A1
+* Result:    E1 - A1
+*/
+TEST(mongoQueryContextRequest, queryPattern1AttrSingle)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabasePatternTrue();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E[1-2]", "T", "true");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryPattern1AttrMulti -
+*
+* Discover:  E[1-2] - A2
+* Result:    E1 - A2
+*            E2 - A2
+*/
+TEST(mongoQueryContextRequest, queryPattern1AttrMulti)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabasePatternTrue();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E[1-2]", "T", "true");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A2");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val2bis", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryPatternNAttr -
+*
+* Discover:  E[1-2] - (A1, A2)
+* Result:    E1 - (A1, A2)
+*            E2 - A2
+*/
+TEST(mongoQueryContextRequest, queryPatternNAttr)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabasePatternTrue();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E[1-2]", "T", "true");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+    req.attributeList.push_back("A2");
+
+    /* Invoke the function in mongoBackend library */    
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val2bis", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryPatternFail -
+*
+* Discover:  R.* - none
+* Result:    none
+*/
+TEST(mongoQueryContextRequest, queryPatternFail)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabasePatternTrue();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("R.*", "T", "true");
+    req.entityIdVector.push_back(&en);
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccContextElementNotFound, res.errorCode.code);
+    EXPECT_EQ("No context element found", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+    EXPECT_EQ(0,res.contextElementResponseVector.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryMixPatternAndNotPattern -
+*
+* Discover:  (E[1-2]. E4) - none
+* Result:    E1 - (A1, A2)
+*            E2 - (A2 ,A3)
+*            E4 - none
+*/
+TEST(mongoQueryContextRequest, queryMixPatternAndNotPattern)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabasePatternTrue();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en1("E[1-2]", "T", "true");
+    EntityId en2("E4", "T", "false");
+    req.entityIdVector.push_back(&en1);
+    req.entityIdVector.push_back(&en2);
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+#if 0
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(3, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val2bis", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ("A3", RES_CER_ATTR(1, 1)->name);
+    EXPECT_EQ("TA3", RES_CER_ATTR(1, 1)->type);
+    EXPECT_EQ("val3", RES_CER_ATTR(1, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Context Element response # 3 */
+    EXPECT_EQ("E4", RES_CER(2).entityId.id);
+    EXPECT_EQ("T", RES_CER(2).entityId.type);
+    EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+    EXPECT_EQ(0, RES_CER(2).contextAttributeVector.size());
+    EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+#endif
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val2bis", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ("A3", RES_CER_ATTR(1, 1)->name);
+    EXPECT_EQ("TA3", RES_CER_ATTR(1, 1)->type);
+    EXPECT_EQ("val3", RES_CER_ATTR(1, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryNoTypePattern -
+*
+* Discover:  E[1-2]
+* Result:    E1   - A1, A2
+*            E2   - A2 ,A3
+*            E1*  - A4, A5
+*            E2** - A2
+*
+* Note that this case checks matching of no-type in the query for both the case in
+* which the returned entity has type (E1, E2 and E1*) and the case in which it has no type (E2**)
+*
+*/
+TEST(mongoQueryContextRequest, queryNoTypePattern)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabasePatternTrue();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E[1-2]", "", "true");
+    req.entityIdVector.push_back(&en);
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(4, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E1", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->value);
+    EXPECT_EQ("A2", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("val2", RES_CER_ATTR(0, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("val2bis", RES_CER_ATTR(1, 0)->value);
+    EXPECT_EQ("A3", RES_CER_ATTR(1, 1)->name);
+    EXPECT_EQ("TA3", RES_CER_ATTR(1, 1)->type);
+    EXPECT_EQ("val3", RES_CER_ATTR(1, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    /* Context Element response # 3 */
+    EXPECT_EQ("E1", RES_CER(2).entityId.id);
+    EXPECT_EQ("Tbis", RES_CER(2).entityId.type);
+    EXPECT_EQ("false", RES_CER(2).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(2).contextAttributeVector.size());
+    EXPECT_EQ("A4", RES_CER_ATTR(2, 0)->name);
+    EXPECT_EQ("TA4", RES_CER_ATTR(2, 0)->type);
+    EXPECT_EQ("val4", RES_CER_ATTR(2, 0)->value);
+    EXPECT_EQ("A5", RES_CER_ATTR(2, 1)->name);
+    EXPECT_EQ("TA5", RES_CER_ATTR(2, 1)->type);
+    EXPECT_EQ("val5", RES_CER_ATTR(2, 1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+    /* Context Element response # 4 */
+    EXPECT_EQ("E2", RES_CER(3).entityId.id);
+    EXPECT_EQ(0, RES_CER(3).entityId.type.size());
+    EXPECT_EQ("false", RES_CER(3).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(3).contextAttributeVector.size());
+    EXPECT_EQ("A2", RES_CER_ATTR(3, 0)->name);
+    EXPECT_EQ("TA2", RES_CER_ATTR(3, 0)->type);
+    EXPECT_EQ("val2bis1", RES_CER_ATTR(3, 0)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryIdMetadataPattern -
+*
+*/
+TEST(mongoQueryContextRequest, queryIdMetadataPattern)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabaseWithAttributeIds();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E1[0-1]", "T", "true");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E10", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(3, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("A", RES_CER_ATTR(0, 0)->value);
+    ASSERT_EQ(1, RES_CER_ATTR(0, 0)->metadataVector.size());
+    EXPECT_EQ("ID", RES_CER_ATTR(0, 0)->metadataVector.get(0)->name);
+    EXPECT_EQ("string", RES_CER_ATTR(0, 0)->metadataVector.get(0)->type);
+    EXPECT_EQ("ID1", RES_CER_ATTR(0, 0)->metadataVector.get(0)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("B", RES_CER_ATTR(0, 1)->value);
+    ASSERT_EQ(1, RES_CER_ATTR(0, 1)->metadataVector.size());
+    EXPECT_EQ("ID", RES_CER_ATTR(0, 1)->metadataVector.get(0)->name);
+    EXPECT_EQ("string", RES_CER_ATTR(0, 1)->metadataVector.get(0)->type);
+    EXPECT_EQ("ID2", RES_CER_ATTR(0, 1)->metadataVector.get(0)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 2)->name);
+    EXPECT_EQ("TA11", RES_CER_ATTR(0, 2)->type);
+    EXPECT_EQ("C", RES_CER_ATTR(0, 2)->value);
+    ASSERT_EQ(0, RES_CER_ATTR(0, 2)->metadataVector.size());
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E11", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(3, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("E", RES_CER_ATTR(1, 0)->value);
+    ASSERT_EQ(1, RES_CER_ATTR(1, 0)->metadataVector.size());
+    EXPECT_EQ("ID", RES_CER_ATTR(1, 0)->metadataVector.get(0)->name);
+    EXPECT_EQ("string", RES_CER_ATTR(1, 0)->metadataVector.get(0)->type);
+    EXPECT_EQ("ID1", RES_CER_ATTR(1, 0)->metadataVector.get(0)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 1)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(1, 1)->type);
+    EXPECT_EQ("F", RES_CER_ATTR(1, 1)->value);
+    ASSERT_EQ(1, RES_CER_ATTR(1, 1)->metadataVector.size());
+    EXPECT_EQ("ID", RES_CER_ATTR(1, 1)->metadataVector.get(0)->name);
+    EXPECT_EQ("string", RES_CER_ATTR(1, 1)->metadataVector.get(0)->type);
+    EXPECT_EQ("ID2", RES_CER_ATTR(1, 1)->metadataVector.get(0)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 2)->name);
+    EXPECT_EQ("TA11", RES_CER_ATTR(1, 2)->type);
+    EXPECT_EQ("G", RES_CER_ATTR(1, 2)->value);
+    ASSERT_EQ(0, RES_CER_ATTR(1, 2)->metadataVector.size());
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* queryCustomMetadataPattern -
+*
+*/
+TEST(mongoQueryContextRequest, queryCustomMetadataPattern)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare database */
+    prepareDatabaseWithCustomMetadata();
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E1[0-1]", "T", "true");
+    req.entityIdVector.push_back(&en);
+    req.attributeList.push_back("A1");
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccNone, res.errorCode.code);
+    EXPECT_EQ("", res.errorCode.reasonPhrase);
+    EXPECT_EQ("", res.errorCode.details);
+
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
+    /* Context Element response # 1 */
+    EXPECT_EQ("E10", RES_CER(0).entityId.id);
+    EXPECT_EQ("T", RES_CER(0).entityId.type);
+    EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(0).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
+    EXPECT_EQ("A", RES_CER_ATTR(0, 0)->value);
+    ASSERT_EQ(2, RES_CER_ATTR(0, 0)->metadataVector.size());
+    EXPECT_EQ("MD1", RES_CER_ATTR(0, 0)->metadataVector.get(0)->name);
+    EXPECT_EQ("TMD1", RES_CER_ATTR(0, 0)->metadataVector.get(0)->type);
+    EXPECT_EQ("1", RES_CER_ATTR(0, 0)->metadataVector.get(0)->value);
+    EXPECT_EQ("MD2", RES_CER_ATTR(0, 0)->metadataVector.get(1)->name);
+    EXPECT_EQ("TMD2", RES_CER_ATTR(0, 0)->metadataVector.get(1)->type);
+    EXPECT_EQ("2", RES_CER_ATTR(0, 0)->metadataVector.get(1)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(0, 1)->name);
+    EXPECT_EQ("TA11", RES_CER_ATTR(0, 1)->type);
+    EXPECT_EQ("B", RES_CER_ATTR(0, 1)->value);
+    ASSERT_EQ(2, RES_CER_ATTR(0, 1)->metadataVector.size());
+    EXPECT_EQ("MD1", RES_CER_ATTR(0, 1)->metadataVector.get(0)->name);
+    EXPECT_EQ("TMD1", RES_CER_ATTR(0, 1)->metadataVector.get(0)->type);
+    EXPECT_EQ("3", RES_CER_ATTR(0, 1)->metadataVector.get(0)->value);
+    EXPECT_EQ("MD2", RES_CER_ATTR(0, 1)->metadataVector.get(1)->name);
+    EXPECT_EQ("TMD2", RES_CER_ATTR(0, 1)->metadataVector.get(1)->type);
+    EXPECT_EQ("4", RES_CER_ATTR(0, 1)->metadataVector.get(1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E11", RES_CER(1).entityId.id);
+    EXPECT_EQ("T", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(2, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("TA1", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ("D", RES_CER_ATTR(1, 0)->value);
+    ASSERT_EQ(2, RES_CER_ATTR(1, 0)->metadataVector.size());
+    EXPECT_EQ("MD1", RES_CER_ATTR(1, 0)->metadataVector.get(0)->name);
+    EXPECT_EQ("TMD1", RES_CER_ATTR(1, 0)->metadataVector.get(0)->type);
+    EXPECT_EQ("7", RES_CER_ATTR(1, 0)->metadataVector.get(0)->value);
+    EXPECT_EQ("MD2", RES_CER_ATTR(1, 0)->metadataVector.get(1)->name);
+    EXPECT_EQ("TMD2", RES_CER_ATTR(1, 0)->metadataVector.get(1)->type);
+    EXPECT_EQ("8", RES_CER_ATTR(1, 0)->metadataVector.get(1)->value);
+    EXPECT_EQ("A1", RES_CER_ATTR(1, 1)->name);
+    EXPECT_EQ("TA11", RES_CER_ATTR(1, 1)->type);
+    EXPECT_EQ("E", RES_CER_ATTR(1, 1)->value);
+    ASSERT_EQ(2, RES_CER_ATTR(1, 1)->metadataVector.size());
+    EXPECT_EQ("MD1", RES_CER_ATTR(1, 1)->metadataVector.get(0)->name);
+    EXPECT_EQ("TMD1", RES_CER_ATTR(1, 1)->metadataVector.get(0)->type);
+    EXPECT_EQ("9", RES_CER_ATTR(1, 1)->metadataVector.get(0)->value);
+    EXPECT_EQ("MD2", RES_CER_ATTR(1, 1)->metadataVector.get(1)->name);
+    EXPECT_EQ("TMD2", RES_CER_ATTR(1, 1)->metadataVector.get(1)->type);
+    EXPECT_EQ("10", RES_CER_ATTR(1, 1)->metadataVector.get(1)->value);
+    EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
+    EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
+
+    /* Release connection */
+    mongoDisconnect();
+}
+
+/* ****************************************************************************
+*
+* mongoDbQueryFail -
+*
+*/
+TEST(mongoQueryContextRequest, mongoDbQueryFail)
+{
+    HttpStatusCode         ms;
+    QueryContextRequest   req;
+    QueryContextResponse  res;
+
+    /* Prepare mock */
+    const DBException e = DBException("boom!!", 33);
+    DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
+    ON_CALL(*connectionMock, _query(_,_,_,_,_,_,_))
+            .WillByDefault(Throw(e));
+
+    /* Set MongoDB connection */
+    mongoConnect(connectionMock);    
+
+    /* Forge the request (from "inside" to "outside") */
+    EntityId en("E1", "T1", "false");
+    req.entityIdVector.push_back(&en);
+
+    /* Invoke the function in mongoBackend library */
+    ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams);
+
+    /* Check response is as expected */
+    EXPECT_EQ(SccOk, ms);
+
+    EXPECT_EQ(SccReceiverInternalError, res.errorCode.code);
+    EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
+    EXPECT_EQ("collection: unittest.entities - "
+              "query(): { query: { $or: [ { _id.id: \"E1\", _id.type: \"T1\" } ], _id.servicePath: { $in: [ /^/.*/, null ] } }, orderby: { creDate: 1 } } - "
+              "exception: boom!!", res.errorCode.details);
+    EXPECT_EQ(0,res.contextElementResponseVector.size());    
+
+    /* Release dynamic memory used by response (mongoBackend allocates it) */
+    res.contextElementResponseVector.release();    
+
+    /* Release mock */
+    delete connectionMock;
+}

--- a/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
@@ -191,6 +191,144 @@ TEST(mongoRegisterContextRequest, ce1_En1_At0_Ok)
 
 /* ****************************************************************************
 *
+* ce1_En1_At0_Ok_XML -
+*/
+TEST(mongoRegisterContextRequest, ce1_En1_At0_Ok_XML)
+{
+  HttpStatusCode           ms;
+  RegisterContextRequest   req;
+  RegisterContextResponse  res;
+
+  utInit();
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E1", "T1");
+  ContextRegistration cr;
+  cr.entityIdVector.push_back(&en);
+  cr.providingApplication.set("http://dummy.com");
+  req.contextRegistrationVector.push_back(&cr);
+  req.duration.set("PT1M");
+
+  /* Prepare database */
+  prepareDatabase();
+
+  /* Invoke the function in mongoBackend library */
+  uriParams[URI_PARAM_NOTIFY_FORMAT] = "XML";
+  ms = mongoRegisterContext(&req, &res, uriParams);
+
+  /* Check that every involved collection at MongoDB is as expected */
+  /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
+   * objects (see http://code.google.com/p/googletest/wiki/Primer#String_Comparison) */
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* registrations collection: */
+  ASSERT_EQ(1, connection->count(REGISTRATIONS_COLL, BSONObj()));
+  BSONObj reg = connection->findOne(REGISTRATIONS_COLL, BSONObj());
+  std::string oid = reg.getField("_id").OID().str();
+  EXPECT_EQ(1360232760, reg.getIntField("expiration"));
+  EXPECT_STREQ("XML", reg.getStringField("format"));
+
+  std::vector<BSONElement> contextRegistrationV = reg.getField("contextRegistration").Array();
+  ASSERT_EQ(1, contextRegistrationV.size());
+  BSONObj contextRegistration = contextRegistrationV[0].embeddedObject();
+
+  EXPECT_STREQ("http://dummy.com", C_STR_FIELD(contextRegistration, "providingApplication"));
+  std::vector<BSONElement> entities = contextRegistration.getField("entities").Array();
+  ASSERT_EQ(1, entities.size());
+  BSONObj ent0 = entities[0].embeddedObject();
+  EXPECT_STREQ("E1", C_STR_FIELD(ent0, "id"));
+  EXPECT_STREQ("T1", C_STR_FIELD(ent0, "type"));
+
+  std::vector<BSONElement> attrs = contextRegistration.getField("attrs").Array();
+  EXPECT_EQ(0, attrs.size());
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+  EXPECT_EQ("PT1M", res.duration.get());
+  EXPECT_EQ(oid, res.registrationId.get());
+  EXPECT_EQ(SccOk, res.errorCode.code);
+  EXPECT_EQ("OK", res.errorCode.reasonPhrase);
+  EXPECT_EQ(0, res.errorCode.details.size());
+
+  /* Release connection */
+  mongoDisconnect();
+
+  utExit();
+
+}
+
+/* ****************************************************************************
+*
+* ce1_En1_At0_Ok_JSON -
+*/
+TEST(mongoRegisterContextRequest, ce1_En1_At0_Ok_JSON)
+{
+  HttpStatusCode           ms;
+  RegisterContextRequest   req;
+  RegisterContextResponse  res;
+
+  utInit();
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E1", "T1");
+  ContextRegistration cr;
+  cr.entityIdVector.push_back(&en);
+  cr.providingApplication.set("http://dummy.com");
+  req.contextRegistrationVector.push_back(&cr);
+  req.duration.set("PT1M");
+
+  /* Prepare database */
+  prepareDatabase();
+
+  /* Invoke the function in mongoBackend library */
+  uriParams[URI_PARAM_NOTIFY_FORMAT] = "JSON";
+  ms = mongoRegisterContext(&req, &res, uriParams);
+
+  /* Check that every involved collection at MongoDB is as expected */
+  /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
+   * objects (see http://code.google.com/p/googletest/wiki/Primer#String_Comparison) */
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* registrations collection: */
+  ASSERT_EQ(1, connection->count(REGISTRATIONS_COLL, BSONObj()));
+  BSONObj reg = connection->findOne(REGISTRATIONS_COLL, BSONObj());
+  std::string oid = reg.getField("_id").OID().str();
+  EXPECT_EQ(1360232760, reg.getIntField("expiration"));
+  EXPECT_STREQ("JSON", reg.getStringField("format"));
+
+  std::vector<BSONElement> contextRegistrationV = reg.getField("contextRegistration").Array();
+  ASSERT_EQ(1, contextRegistrationV.size());
+  BSONObj contextRegistration = contextRegistrationV[0].embeddedObject();
+
+  EXPECT_STREQ("http://dummy.com", C_STR_FIELD(contextRegistration, "providingApplication"));
+  std::vector<BSONElement> entities = contextRegistration.getField("entities").Array();
+  ASSERT_EQ(1, entities.size());
+  BSONObj ent0 = entities[0].embeddedObject();
+  EXPECT_STREQ("E1", C_STR_FIELD(ent0, "id"));
+  EXPECT_STREQ("T1", C_STR_FIELD(ent0, "type"));
+
+  std::vector<BSONElement> attrs = contextRegistration.getField("attrs").Array();
+  EXPECT_EQ(0, attrs.size());
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+  EXPECT_EQ("PT1M", res.duration.get());
+  EXPECT_EQ(oid, res.registrationId.get());
+  EXPECT_EQ(SccOk, res.errorCode.code);
+  EXPECT_EQ("OK", res.errorCode.reasonPhrase);
+  EXPECT_EQ(0, res.errorCode.details.size());
+
+  /* Release connection */
+  mongoDisconnect();
+
+  utExit();
+
+}
+
+/* ****************************************************************************
+*
 * ce1_En1nt_At0_Ok -
 */
 TEST(mongoRegisterContextRequest, ce1_En1nt_At0_Ok)

--- a/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
@@ -24,6 +24,7 @@
 */
 #include "gtest/gtest.h"
 #include "testInit.h"
+#include "unittest.h"
 
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
@@ -131,16 +132,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_At0_Ok)
   RegisterContextRequest   req;
   RegisterContextResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "T1");
@@ -154,7 +146,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_At0_Ok)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -193,9 +185,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_At0_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -209,16 +199,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_At0_Ok)
   RegisterContextRequest   req;
   RegisterContextResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "");
@@ -232,7 +213,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_At0_Ok)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -271,9 +252,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_At0_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -287,16 +266,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_AtN_Ok)
   RegisterContextRequest   req;
   RegisterContextResponse  res; 
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "T1");
@@ -314,7 +284,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_AtN_Ok)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -361,9 +331,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_AtN_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -377,16 +345,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_AtNnt_Ok)
   RegisterContextRequest   req;
   RegisterContextResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "T1");
@@ -404,7 +363,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_AtNnt_Ok)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -451,9 +410,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_AtNnt_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -466,16 +423,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_AtN_Ok)
   RegisterContextRequest   req;
   RegisterContextResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "");
@@ -493,7 +441,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_AtN_Ok)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  mongoRegisterContext(&req, &res);
+  mongoRegisterContext(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -532,9 +480,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_AtN_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -548,16 +494,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_AtNnt_Ok)
   RegisterContextRequest   req;
   RegisterContextResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "");
@@ -575,7 +512,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_AtNnt_Ok)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -622,9 +559,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_AtNnt_Ok)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -638,16 +573,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_At0_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -663,7 +589,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_At0_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -705,9 +631,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -721,16 +645,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_At0_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -746,7 +661,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_At0_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -788,9 +703,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -804,16 +717,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_AtN_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;    
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -834,7 +738,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_AtN_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -884,9 +788,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -900,16 +802,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_AtNnt_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -930,7 +823,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_AtNnt_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -980,9 +873,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -996,16 +887,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_AtN_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1026,7 +908,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_AtN_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1076,9 +958,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1092,16 +972,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_AtNnt_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1122,7 +993,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_AtNnt_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1172,9 +1043,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1188,16 +1057,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_At0_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;    
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -1215,7 +1075,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_At0_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1264,9 +1124,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1280,16 +1138,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_At0_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1307,7 +1156,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_At0_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1356,9 +1205,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1372,16 +1219,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_AtN_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -1407,7 +1245,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_AtN_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1473,9 +1311,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1489,16 +1325,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_AtNnt_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -1524,7 +1351,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_AtNnt_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1590,9 +1417,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1606,16 +1431,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_AtN_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1641,7 +1457,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_AtN_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1707,9 +1523,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1723,16 +1537,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_AtNnt_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1758,7 +1563,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_AtNnt_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1824,9 +1629,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1840,16 +1643,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_At0_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -1871,7 +1665,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_At0_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -1927,9 +1721,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -1943,16 +1735,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_At0_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -1974,7 +1757,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_At0_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2030,9 +1813,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_At0_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -2046,16 +1827,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_AtN_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -2085,7 +1857,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_AtN_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2157,9 +1929,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -2173,16 +1943,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_AtNnt_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "T1");
@@ -2212,7 +1973,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_AtNnt_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2284,9 +2045,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -2300,16 +2059,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_AtN_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -2339,7 +2089,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_AtN_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2411,9 +2161,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_AtN_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -2427,16 +2175,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_AtNnt_Ok)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en1("E1", "");
@@ -2466,7 +2205,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_AtNnt_Ok)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2538,9 +2277,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_AtNnt_Ok)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 
 }
 
@@ -2588,7 +2325,7 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability1)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -2660,7 +2397,7 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability2)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -2729,7 +2466,7 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability3)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -2761,16 +2498,7 @@ TEST(mongoRegisterContextRequest, defaultDuration)
   RegisterContextRequest   req;
   RegisterContextResponse  res;
 
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "T1");
@@ -2783,7 +2511,7 @@ TEST(mongoRegisterContextRequest, defaultDuration)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -2822,9 +2550,7 @@ TEST(mongoRegisterContextRequest, defaultDuration)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -2839,15 +2565,9 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
     RegisterContextRequest   req;
     RegisterContextResponse  res;   
 
-    /* Set database */
-    setupDatabase();
+    utInit();
 
     /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
     const DBException e = DBException("boom!!", 33);
     BSONObj fakeEntity = BSON("_id" << BSON("id" << "E1" << "type" << "T1"));
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
@@ -2863,11 +2583,6 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
     ON_CALL(*connectionMock, _query("unittest.casubs",_,_,_,_,_,_))
             .WillByDefault(Return(cursorMockCAsub));
 
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
-
     /* Forge the request (from "inside" to "outside") */
     EntityId en("E1", "T1");
     ContextRegistration cr;
@@ -2880,7 +2595,7 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
     mongoConnect(connectionMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2897,13 +2612,11 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
     std::string s2 = res.errorCode.details.substr(71+24, res.errorCode.details.size()-71-24);
     EXPECT_EQ("collection: unittest.registrations "
               "- upsert update(): { _id: ObjectId('",s1);
-    EXPECT_EQ("'), expiration: 1360232760, servicePath: \"/\", contextRegistration: [ { entities: [ { id: \"E1\", type: \"T1\" } ], attrs: {}, providingApplication: \"http://dummy.com\" } ] } "
+    EXPECT_EQ("'), expiration: 1360232760, servicePath: \"/\", format: \"XML\", contextRegistration: [ { entities: [ { id: \"E1\", type: \"T1\" } ], attrs: {}, providingApplication: \"http://dummy.com\" } ] } "
               "- exception: boom!!", s2);
 
     /* Release mock */
     delete connectionMock;
-    delete timerMock;
-    delete notifierMock;
 
     /* Reconnect to database in not-mocked way */
     mongoConnect("localhost");
@@ -2912,6 +2625,8 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
     DBClientBase* connection = getMongoConnection();
     EXPECT_EQ(0, connection->count(REGISTRATIONS_COLL, BSONObj()));
     EXPECT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
+
+    utExit();
 
 }
 
@@ -2938,11 +2653,7 @@ TEST(mongoRegisterContextRequest, AssociationsOk)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     ContextRegistration cr;
@@ -2964,7 +2675,7 @@ TEST(mongoRegisterContextRequest, AssociationsOk)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2999,8 +2710,7 @@ TEST(mongoRegisterContextRequest, AssociationsOk)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
+    utExit();
 
 }
 
@@ -3014,12 +2724,9 @@ TEST(mongoRegisterContextRequest, AssociationsDbFail)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
+    /* Prepare mock */   
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
     ON_CALL(*connectionMock, insert("unittest.associations",_,_))
@@ -3048,7 +2755,7 @@ TEST(mongoRegisterContextRequest, AssociationsDbFail)
     mongoConnect(connectionMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3056,11 +2763,10 @@ TEST(mongoRegisterContextRequest, AssociationsDbFail)
     EXPECT_TRUE(res.registrationId.isEmpty());
     EXPECT_EQ(SccReceiverInternalError, res.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
-    EXPECT_EQ("", res.errorCode.details);
+    EXPECT_EQ("", res.errorCode.details);    
 
     /* Release mock */
-    delete connectionMock;
-    delete timerMock;
+    delete connectionMock;    
 
     /* Reconnect to database in not-mocked way */
     mongoConnect("localhost");
@@ -3069,4 +2775,6 @@ TEST(mongoRegisterContextRequest, AssociationsDbFail)
     DBClientBase* connection = getMongoConnection();
     EXPECT_EQ(0, connection->count(ASSOCIATIONS_COLL, BSONObj()));
     EXPECT_EQ(0, connection->count(REGISTRATIONS_COLL, BSONObj()));
+
+    utExit();
 }

--- a/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
@@ -57,6 +57,8 @@ using ::testing::Return;
 * - updateCaseNotFound
 * - updateCaseWrongIdString
 * - updateWrongIdNoHex
+* - updateFromXmlToJson
+* - updateFromJsonToXml
 *
 * - MongoDbFindOneFail
 *
@@ -74,7 +76,7 @@ using ::testing::Return;
 * registrations collection.
 *
 */
-static void prepareDatabase(void) {
+static void prepareDatabase(bool withFormat = false) {
 
   /* Set database */
   setupDatabase();
@@ -115,19 +117,27 @@ static void prepareDatabase(void) {
                          )
                      );
 
-  BSONObj reg1 = BSON(
-              "_id" << OID("51307b66f481db11bf860001") <<
-              "expiration" << 10000000 <<              
-              "contextRegistration" << BSON_ARRAY(cr1) <<
-              "servicePath" << "/"
-              );
+  BSONObjBuilder reg1;
+  reg1.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860001") <<
+                        "expiration" << 10000000 <<
+                        "contextRegistration" << BSON_ARRAY(cr1) <<
+                        "servicePath" << "/"
+                        ));
 
-  BSONObj reg2 = BSON(
-              "_id" << OID("51307b66f481db11bf860002") <<
-              "expiration" << 20000000 <<              
-              "contextRegistration" << BSON_ARRAY(cr2 << cr3) <<
-              "servicePath" << "/"
-              );
+  BSONObjBuilder reg2;
+  reg2.appendElements(BSON(
+                        "_id" << OID("51307b66f481db11bf860002") <<
+                        "expiration" << 20000000 <<
+                        "contextRegistration" << BSON_ARRAY(cr2 << cr3) <<
+                        "servicePath" << "/"
+                        ));
+
+  if (withFormat)
+  {
+    reg1.appendElements(BSON("format" << "XML"));
+    reg2.appendElements(BSON("format" << "JSON"));
+  }
 
   /* 1879048191 corresponds to year 2029 so we avoid any expiration problem in the next 16 years :) */
   BSONObj sub1 = BSON("_id" << OID("51307b66f481db11bf860010") <<
@@ -142,8 +152,8 @@ static void prepareDatabase(void) {
                       "entities" << BSON_ARRAY(BSON("id" << "E5" << "type" << "T5" << "isPattern" << "false")) <<
                       "attrs" << BSON_ARRAY("A1"));
 
-  connection->insert(REGISTRATIONS_COLL, reg1);
-  connection->insert(REGISTRATIONS_COLL, reg2);
+  connection->insert(REGISTRATIONS_COLL, reg1.obj());
+  connection->insert(REGISTRATIONS_COLL, reg2.obj());
 
   connection->insert(SUBSCRIBECONTEXTAVAIL_COLL, sub1);
   connection->insert(SUBSCRIBECONTEXTAVAIL_COLL, sub2);
@@ -752,6 +762,241 @@ TEST(DISABLED_mongoRegisterContext_update, updateWrongIdNoHex)
     mongoDisconnect();
 
     utExit();
+}
+
+/* ****************************************************************************
+*
+* updateFromXmlToJson -
+*/
+TEST(mongoRegisterContext_update, updateFromXmlToJson)
+{
+  HttpStatusCode           ms;
+  RegisterContextRequest   req;
+  RegisterContextResponse  res;
+
+  utInit();
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E1", "T1");
+  ContextRegistrationAttribute cra("A1", "TA1", "true");
+  ContextRegistration cr;
+  cr.entityIdVector.push_back(&en);
+  cr.contextRegistrationAttributeVector.push_back(&cra);
+  cr.providingApplication.set("http://newurl.com");
+  req.contextRegistrationVector.push_back(&cr);
+  req.registrationId.set("51307b66f481db11bf860001");
+  req.duration.set("PT1M");
+
+  /* Prepare database */
+  prepareDatabase(true);
+
+  /* Invoke the function in mongoBackend library */
+  uriParams[URI_PARAM_NOTIFY_FORMAT] = "JSON";
+  ms = mongoRegisterContext(&req, &res, uriParams, "", "/");
+
+  /* Check that every involved collection at MongoDB is as expected */
+  /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
+   * objects (see http://code.google.com/p/googletest/wiki/Primer#String_Comparison) */
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* registrations collection: */
+  ASSERT_EQ(2, connection->count(REGISTRATIONS_COLL, BSONObj()));
+
+  BSONObj reg, contextRegistration, ent, ent0, attr0;
+  std::vector<BSONElement> contextRegistrationV, entities, attrs;
+
+  /* reg #1 */
+  reg = connection->findOne(REGISTRATIONS_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
+  EXPECT_EQ("51307b66f481db11bf860001", reg.getField("_id").OID().str());
+  EXPECT_EQ(1360232760, reg.getIntField("expiration"));
+  EXPECT_STREQ("JSON", reg.getStringField("format"));
+
+  contextRegistrationV = reg.getField("contextRegistration").Array();
+  ASSERT_EQ(1, contextRegistrationV.size());
+  contextRegistration = contextRegistrationV[0].embeddedObject();
+
+  EXPECT_STREQ("http://newurl.com", C_STR_FIELD(contextRegistration, "providingApplication"));
+  entities = contextRegistration.getField("entities").Array();
+  ASSERT_EQ(1, entities.size());
+  ent0 = entities[0].embeddedObject();
+  EXPECT_STREQ("E1", C_STR_FIELD(ent0, "id"));
+  EXPECT_STREQ("T1", C_STR_FIELD(ent0, "type"));
+
+  attrs = contextRegistration.getField("attrs").Array();
+  ASSERT_EQ(1, attrs.size());
+  attr0 = attrs[0].embeddedObject();
+  EXPECT_STREQ("A1", C_STR_FIELD(attr0, "name"));
+  EXPECT_STREQ("TA1", C_STR_FIELD(attr0, "type"));
+  EXPECT_STREQ("true", C_STR_FIELD(attr0, "isDomain"));
+
+  /* reg #2 (untouched) */
+  reg = connection->findOne(REGISTRATIONS_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
+  EXPECT_EQ("51307b66f481db11bf860002", reg.getField("_id").OID().str());
+  EXPECT_EQ(20000000, reg.getIntField("expiration"));
+  EXPECT_STREQ("JSON", reg.getStringField("format"));
+
+  contextRegistrationV = reg.getField("contextRegistration").Array();
+  ASSERT_EQ(2, contextRegistrationV.size());
+  contextRegistration = contextRegistrationV[0].embeddedObject();
+
+  EXPECT_STREQ("http://cr1.com", C_STR_FIELD(contextRegistration, "providingApplication"));
+  entities = contextRegistration.getField("entities").Array();
+  ASSERT_EQ(1, entities.size());
+  ent0 = entities[0].embeddedObject();
+  EXPECT_STREQ("E1", C_STR_FIELD(ent0, "id"));
+  EXPECT_STREQ("T1", C_STR_FIELD(ent0, "type"));
+
+  attrs = contextRegistration.getField("attrs").Array();
+  ASSERT_EQ(1, attrs.size());
+  attr0 = attrs[0].embeddedObject();
+  EXPECT_STREQ("A1", C_STR_FIELD(attr0, "name"));
+  EXPECT_STREQ("TA1", C_STR_FIELD(attr0, "type"));
+  EXPECT_STREQ("true", C_STR_FIELD(attr0, "isDomain"));
+
+  contextRegistration = contextRegistrationV[1].embeddedObject();
+
+  EXPECT_STREQ("http://cr2.com", C_STR_FIELD(contextRegistration, "providingApplication"));
+  entities = contextRegistration.getField("entities").Array();
+  ASSERT_EQ(1, entities.size());
+  ent0 = entities[0].embeddedObject();
+  EXPECT_STREQ("E1", C_STR_FIELD(ent0, "id"));
+  EXPECT_STREQ("T1", C_STR_FIELD(ent0, "type"));
+
+  attrs = contextRegistration.getField("attrs").Array();
+  ASSERT_EQ(1, attrs.size());
+  attr0 = attrs[0].embeddedObject();
+  EXPECT_STREQ("A1", C_STR_FIELD(attr0, "name"));
+  EXPECT_STREQ("TA1", C_STR_FIELD(attr0, "type"));
+  EXPECT_STREQ("true", C_STR_FIELD(attr0, "isDomain"));
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+  EXPECT_EQ("PT1M", res.duration.get());
+  EXPECT_EQ("51307b66f481db11bf860001", res.registrationId.get());
+  EXPECT_EQ(SccOk, res.errorCode.code);
+  EXPECT_EQ("OK", res.errorCode.reasonPhrase);
+  EXPECT_EQ(0, res.errorCode.details.size());
+
+  /* Release connection */
+  mongoDisconnect();
+
+  utExit();
+
+}
+
+
+/* ****************************************************************************
+*
+* updateFromJsonToXml -
+*/
+TEST(mongoRegisterContext_update, updateFromJsonToXml)
+{
+  HttpStatusCode           ms;
+  RegisterContextRequest   req;
+  RegisterContextResponse  res;
+
+  utInit();
+
+  /* Forge the request (from "inside" to "outside") */
+  EntityId en("E1", "T1");
+  ContextRegistrationAttribute cra("A1", "TA1", "true");
+  ContextRegistration cr;
+  cr.entityIdVector.push_back(&en);
+  cr.contextRegistrationAttributeVector.push_back(&cra);
+  cr.providingApplication.set("http://newurl.com");
+  req.contextRegistrationVector.push_back(&cr);
+  req.registrationId.set("51307b66f481db11bf860002");
+  req.duration.set("PT1M");
+
+  /* Prepare database */
+  prepareDatabase(true);
+
+  /* Invoke the function in mongoBackend library */
+  uriParams[URI_PARAM_NOTIFY_FORMAT] = "XML";
+  ms = mongoRegisterContext(&req, &res, uriParams);
+
+  /* Check that every involved collection at MongoDB is as expected */
+  /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
+   * objects (see http://code.google.com/p/googletest/wiki/Primer#String_Comparison) */
+
+  DBClientBase* connection = getMongoConnection();
+
+  /* registrations collection: */
+  ASSERT_EQ(2, connection->count(REGISTRATIONS_COLL, BSONObj()));
+
+  BSONObj reg, contextRegistration, ent, ent0, attr0, attr1, attr2;
+  std::vector<BSONElement> contextRegistrationV, entities, attrs;
+
+  /* reg #1 (untouched) */
+  reg = connection->findOne(REGISTRATIONS_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
+  EXPECT_EQ("51307b66f481db11bf860001", reg.getField("_id").OID().str());
+  EXPECT_EQ(10000000, reg.getIntField("expiration"));
+  EXPECT_STREQ("XML", reg.getStringField("format"));
+
+  contextRegistrationV = reg.getField("contextRegistration").Array();
+  ASSERT_EQ(1, contextRegistrationV.size());
+  contextRegistration = contextRegistrationV[0].embeddedObject();
+
+  EXPECT_STREQ("http://cr1.com", C_STR_FIELD(contextRegistration, "providingApplication"));
+  entities = contextRegistration.getField("entities").Array();
+  ASSERT_EQ(1, entities.size());
+  ent0 = entities[0].embeddedObject();
+  EXPECT_STREQ("E1", C_STR_FIELD(ent0, "id"));
+  EXPECT_STREQ("T1", C_STR_FIELD(ent0, "type"));
+
+  attrs = contextRegistration.getField("attrs").Array();
+  ASSERT_EQ(3, attrs.size());
+  attr0 = attrs[0].embeddedObject();
+  attr1 = attrs[1].embeddedObject();
+  attr2 = attrs[2].embeddedObject();
+  EXPECT_STREQ("A1", C_STR_FIELD(attr0, "name"));
+  EXPECT_STREQ("TA1", C_STR_FIELD(attr0, "type"));
+  EXPECT_STREQ("true", C_STR_FIELD(attr0, "isDomain"));
+  EXPECT_STREQ("A2", C_STR_FIELD(attr1, "name"));
+  EXPECT_STREQ("TA2", C_STR_FIELD(attr1, "type"));
+  EXPECT_STREQ("false", C_STR_FIELD(attr1, "isDomain"));
+  EXPECT_STREQ("A3", C_STR_FIELD(attr2, "name"));
+  EXPECT_STREQ("TA3", C_STR_FIELD(attr2, "type"));
+  EXPECT_STREQ("true", C_STR_FIELD(attr2, "isDomain"));
+
+  /* reg #2 */
+  reg = connection->findOne(REGISTRATIONS_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
+  EXPECT_EQ("51307b66f481db11bf860002", reg.getField("_id").OID().str());
+  EXPECT_EQ(1360232760, reg.getIntField("expiration"));
+  EXPECT_STREQ("XML", reg.getStringField("format"));
+
+  contextRegistrationV = reg.getField("contextRegistration").Array();
+  ASSERT_EQ(1, contextRegistrationV.size());
+  contextRegistration = contextRegistrationV[0].embeddedObject();
+
+  EXPECT_STREQ("http://newurl.com", C_STR_FIELD(contextRegistration, "providingApplication"));
+  entities = contextRegistration.getField("entities").Array();
+  ASSERT_EQ(1, entities.size());
+  ent0 = entities[0].embeddedObject();
+  EXPECT_STREQ("E1", C_STR_FIELD(ent0, "id"));
+  EXPECT_STREQ("T1", C_STR_FIELD(ent0, "type"));
+
+  attrs = contextRegistration.getField("attrs").Array();
+  ASSERT_EQ(1, attrs.size());
+  attr0 = attrs[0].embeddedObject();
+  EXPECT_STREQ("A1", C_STR_FIELD(attr0, "name"));
+  EXPECT_STREQ("TA1", C_STR_FIELD(attr0, "type"));
+  EXPECT_STREQ("true", C_STR_FIELD(attr0, "isDomain"));
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, ms);
+  EXPECT_EQ("PT1M", res.duration.get());
+  EXPECT_EQ("51307b66f481db11bf860002", res.registrationId.get());
+  EXPECT_EQ(SccOk, res.errorCode.code);
+  EXPECT_EQ("OK", res.errorCode.reasonPhrase);
+  EXPECT_EQ(0, res.errorCode.details.size());
+
+  /* Release connection */
+  mongoDisconnect();
+
+  utExit();
+
 }
 
 /* ****************************************************************************

--- a/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
@@ -24,6 +24,7 @@
 */
 #include "gtest/gtest.h"
 #include "testInit.h"
+#include "unittest.h"
 
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
@@ -159,17 +160,7 @@ TEST(mongoRegisterContext_update, updateCase1)
   RegisterContextRequest   req;
   RegisterContextResponse  res;
 
-  
-  /* Prepare mock */
-  NotifierMock* notifierMock = new NotifierMock();
-  EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-          .Times(0);
-  setNotifier(notifierMock);
-
-  TimerMock* timerMock = new TimerMock();
-  ON_CALL(*timerMock, getCurrentTime())
-          .WillByDefault(Return(1360232700));
-  setTimer(timerMock);
+  utInit();
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E1", "T1");
@@ -186,7 +177,7 @@ TEST(mongoRegisterContext_update, updateCase1)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res, "", "/");
+  ms = mongoRegisterContext(&req, &res, uriParams, "", "/");
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -273,9 +264,7 @@ TEST(mongoRegisterContext_update, updateCase1)
   /* Release connection */
   mongoDisconnect();
 
-  /* Delete mock */
-  delete timerMock;
-  delete notifierMock;
+  utExit();
 
 }
 
@@ -289,16 +278,7 @@ TEST(mongoRegisterContext_update, updateCase2)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-            .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en("E1", "T1");
@@ -315,7 +295,7 @@ TEST(mongoRegisterContext_update, updateCase2)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -394,9 +374,7 @@ TEST(mongoRegisterContext_update, updateCase2)
     /* Release connection */
     mongoDisconnect();
 
-    /* Delete mock */
-    delete timerMock;
-    delete notifierMock;
+    utExit();
 }
 
 /* ****************************************************************************
@@ -409,11 +387,7 @@ TEST(mongoRegisterContext_update, updateNotFound)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en("E1", "T1");
@@ -430,7 +404,7 @@ TEST(mongoRegisterContext_update, updateNotFound)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -525,8 +499,7 @@ TEST(mongoRegisterContext_update, updateNotFound)
     /* Release connection */
     mongoDisconnect();
 
-    /* Release mock */
-    delete notifierMock;
+    utExit();
 }
 
 /* ****************************************************************************
@@ -539,16 +512,7 @@ TEST(mongoRegisterContext_update, updateWrongIdString)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
-
-    TimerMock* timerMock = new TimerMock();
-    ON_CALL(*timerMock, getCurrentTime())
-       .WillByDefault(Return(1360232700));
-    setTimer(timerMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en("E1", "T1");
@@ -565,7 +529,7 @@ TEST(mongoRegisterContext_update, updateWrongIdString)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -660,9 +624,7 @@ TEST(mongoRegisterContext_update, updateWrongIdString)
     /* Release connection */
     mongoDisconnect();
 
-    /* Release mock */
-    delete notifierMock;
-    delete timerMock;
+    utExit();
 }
 
 /* ****************************************************************************
@@ -677,11 +639,7 @@ TEST(DISABLED_mongoRegisterContext_update, updateWrongIdNoHex)
     RegisterContextRequest   req;
     RegisterContextResponse  res;
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
+    utInit();
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en("E1", "T1");
@@ -698,7 +656,7 @@ TEST(DISABLED_mongoRegisterContext_update, updateWrongIdNoHex)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -793,8 +751,7 @@ TEST(DISABLED_mongoRegisterContext_update, updateWrongIdNoHex)
     /* Release connection */
     mongoDisconnect();
 
-    /* Release mock */
-    delete notifierMock;
+    utExit();
 }
 
 /* ****************************************************************************
@@ -807,12 +764,9 @@ TEST(mongoRegisterContext_update, MongoDbFindOneFail)
     RegisterContextRequest   req;
     RegisterContextResponse  res;   
 
-    /* Prepare mock */
-    NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
-            .Times(0);
-    setNotifier(notifierMock);
+    utInit();
 
+    /* Prepare mock */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
     ON_CALL(*connectionMock, findOne("unittest.registrations",_,_,_))
@@ -829,11 +783,14 @@ TEST(mongoRegisterContext_update, MongoDbFindOneFail)
     req.registrationId.set("51307b66f481db11bf860001");
     req.duration.set("PT1M");
 
+    /* Prepare database */
+    prepareDatabase();
+
     /* Set MongoDB connection */
     mongoConnect(connectionMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoRegisterContext(&req, &res);
+    ms = mongoRegisterContext(&req, &res, uriParams);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -847,7 +804,6 @@ TEST(mongoRegisterContext_update, MongoDbFindOneFail)
 
     /* Release mock */    
     delete connectionMock;
-    delete notifierMock;
 
     /* Reconnect to database in not-mocked way */
     mongoConnect("localhost");
@@ -934,6 +890,8 @@ TEST(mongoRegisterContext_update, MongoDbFindOneFail)
     EXPECT_STREQ("TA1", C_STR_FIELD(attr0, "type"));
     EXPECT_STREQ("true", C_STR_FIELD(attr0, "isDomain"));
 
+    utExit();
+
 }
 
 /* ****************************************************************************
@@ -980,7 +938,7 @@ TEST(mongoRegisterContext_update, NotifyContextAvailability1)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -1053,7 +1011,7 @@ TEST(mongoRegisterContext_update, NotifyContextAvailability2)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -1123,7 +1081,7 @@ TEST(mongoRegisterContext_update, NotifyContextAvailability3)
   prepareDatabase();
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoRegisterContext(&req, &res);
+  ms = mongoRegisterContext(&req, &res, uriParams);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -4030,6 +4030,7 @@ TEST(mongoUpdateContextRequest, updateEntityFails)
     EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
     EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
+    EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
     EXPECT_FALSE(RES_CER_ATTR(0, 0)->found);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -4961,6 +4962,7 @@ TEST(mongoUpdateContextRequest, updateAttrNotFoundFail)
     EXPECT_EQ("TA8", RES_CER_ATTR(0, 0)->type);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
     EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
+    EXPECT_EQ(NOFORMAT, RES_CER_ATTR(0, 0)->providingApplication.getFormat());
     EXPECT_FALSE(RES_CER_ATTR(0, 0)->found);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -4029,7 +4029,7 @@ TEST(mongoUpdateContextRequest, updateEntityFails)
     EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
     EXPECT_EQ("", RES_CER_ATTR(0, 0)->type);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
-    EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication);
+    EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
     EXPECT_FALSE(RES_CER_ATTR(0, 0)->found);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 
@@ -4960,7 +4960,7 @@ TEST(mongoUpdateContextRequest, updateAttrNotFoundFail)
     EXPECT_EQ("A8", RES_CER_ATTR(0, 0)->name);
     EXPECT_EQ("TA8", RES_CER_ATTR(0, 0)->type);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->value.size());
-    EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication);
+    EXPECT_EQ("", RES_CER_ATTR(0, 0)->providingApplication.get());
     EXPECT_FALSE(RES_CER_ATTR(0, 0)->found);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->metadataVector.size());
 


### PR DESCRIPTION
This implements the part of #722 corresponding to mongoBackend. Note that the base feature/ branch for this PR has been branched from feature/787_cprs_full_functional instead of develop, given that feature/787_cprs_full_functional has the last snapshoot of mongoBackend (I don't like it but I don't have another option :( ).

At some point (probably when both query *and* update forward functionally get completed) we have to do the feature/787_cprs_full_functional -> feature/722_unhardwire_format_cpr, getting many compilation errors, but easy to solve (just use `providingApplication.get()` instead just `providingApplication`).

Tested using unit test (only failing the ones that was already failing in feature/787_cprs_full_functional) and test harness (there are fails due to feature/787_cprs_full_functional, but it seems that register context related tests are mostly ok).