### PR TITLE
Feature/911 sem wait time measures

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,4 @@
 - Add: New CLI parameter for the mutex policy: -mutexPolicy (Issue #910)
-
+- Add: Measuring the accumulated time waiting for the DB semaphores.
+       The measures are added to the REST request /statistics, but only if
+       the new CLI parameter -mutexTimeStat is set (Issue #911)

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -212,6 +212,7 @@ char            rush[256];
 long            dbTimeout;
 long            httpTimeout;
 char            mutexPolicy[16];
+bool            mutexTimeStat;
 
 
 
@@ -247,6 +248,7 @@ char            mutexPolicy[16];
 #define HTTP_TMO_DESC       "timeout in milliseconds for forwards and notifications"
 #define MAX_L               900000
 #define MUTEX_POLICY_DESC   "mutex policy (none/read/write/all)"
+#define MUTEX_TIMESTAT_DESC "measure total semaphore waiting time"
 
 
 
@@ -284,6 +286,7 @@ PaArgument paArgs[] =
 
   { "-httpTimeout",  &httpTimeout,  "HTTP_TIMEOUT",   PaLong,   PaOpt, -1,         -1,     MAX_L, HTTP_TMO_DESC      },
   { "-mutexPolicy",  mutexPolicy,   "MUTEX_POLICY",   PaString, PaOpt, _i "all",   PaNL,   PaNL,  MUTEX_POLICY_DESC  },
+  { "-mutexTimeStat", &mutexTimeStat,  "MUTEX_TIME_STAT",  PaBool,   PaOpt, false,      false,  true,  MUTEX_TIMESTAT_DESC   },
 
   PA_END_OF_ARGS
 };
@@ -1435,7 +1438,7 @@ int main(int argC, char* argV[])
 
   pidFile();
   SemRequestType policy = policyGet(mutexPolicy);
-  orionInit(orionExit, ORION_VERSION, policy);
+  orionInit(orionExit, ORION_VERSION, policy, mutexTimeStat);
   mongoInit(dbHost, rplSet, dbName, user, pwd, dbTimeout);
   contextBrokerInit(ngsi9Only, dbName, mtenant);
   curl_global_init(CURL_GLOBAL_NOTHING);

--- a/src/lib/common/globals.cpp
+++ b/src/lib/common/globals.cpp
@@ -47,6 +47,7 @@ int                    startTime         = -1;
 int                    statisticsTime    = -1;
 OrionExitFunction      orionExitFunction = NULL;
 static struct timeval  logStartTime;
+bool                   semTimeStatistics = false;
 
 
 
@@ -90,7 +91,7 @@ void transactionIdSet(void)
 *
 * orionInit - 
 */
-void orionInit(OrionExitFunction exitFunction, const char* version, SemRequestType reqPolicy)
+void orionInit(OrionExitFunction exitFunction, const char* version, SemRequestType reqPolicy, bool semTimeStat)
 {
   // Give the rest library the correct version string of this executable
   versionSet(version);
@@ -99,7 +100,7 @@ void orionInit(OrionExitFunction exitFunction, const char* version, SemRequestTy
   orionExitFunction = exitFunction;
 
   // Initialize the semaphore used by mongoBackend
-  semInit(reqPolicy);
+  semInit(reqPolicy, semTimeStat);
 
   // Set timer object (singleton)
   setTimer(new Timer());
@@ -112,8 +113,8 @@ void orionInit(OrionExitFunction exitFunction, const char* version, SemRequestTy
   }
 
   // Set start time and statisticsTime used by REST interface
-  startTime      = logStartTime.tv_sec;
-  statisticsTime = startTime;
+  startTime         = logStartTime.tv_sec;
+  statisticsTime    = startTime;
 
   strncpy(transactionId, "N/A", sizeof(transactionId));
 }

--- a/src/lib/common/globals.cpp
+++ b/src/lib/common/globals.cpp
@@ -113,8 +113,8 @@ void orionInit(OrionExitFunction exitFunction, const char* version, SemRequestTy
   }
 
   // Set start time and statisticsTime used by REST interface
-  startTime         = logStartTime.tv_sec;
-  statisticsTime    = startTime;
+  startTime      = logStartTime.tv_sec;
+  statisticsTime = startTime;
 
   strncpy(transactionId, "N/A", sizeof(transactionId));
 }

--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -82,6 +82,7 @@ extern bool               harakiri;
 extern int                startTime;
 extern int                statisticsTime;
 extern OrionExitFunction  orionExitFunction;
+extern bool               semTimeStatistics;
 
 
 
@@ -89,7 +90,7 @@ extern OrionExitFunction  orionExitFunction;
 *
 * orionInit - 
 */
-extern void orionInit(OrionExitFunction exitFunction, const char* version, SemRequestType reqPolicy);
+extern void orionInit(OrionExitFunction exitFunction, const char* version, SemRequestType reqPolicy, bool semTimeStat);
 
 
 

--- a/src/lib/common/sem.cpp
+++ b/src/lib/common/sem.cpp
@@ -89,7 +89,6 @@ int semInit(SemRequestType _reqPolicy, bool semTimeStat, int shared, int takenIn
 
   // Measure accumulated semaphore waiting time?
   semTimeStatistics = semTimeStat;
-  LM_M(("KZ: semTimeStatistics == %s", (semTimeStatistics == true)? "true" : "false"));
   return 0;
 }
 
@@ -101,8 +100,6 @@ int semInit(SemRequestType _reqPolicy, bool semTimeStat, int shared, int takenIn
 */
 static void difftimeofday(struct timespec* endTime, struct timespec* startTime, struct timespec* diffTime)
 {
-  LM_M(("KZ: In difftimeofday"));
-
   diffTime->tv_nsec = endTime->tv_nsec - startTime->tv_nsec;
   diffTime->tv_sec  = endTime->tv_sec  - startTime->tv_sec;
 

--- a/src/lib/common/sem.cpp
+++ b/src/lib/common/sem.cpp
@@ -50,6 +50,7 @@ static SemRequestType  reqPolicy;
 */
 static struct timespec accReqSemTime   = { 0, 0 };
 static struct timespec accMongoSemTime = { 0, 0 };
+static struct timespec accTransSemTime = { 0, 0 };
 
 
 
@@ -96,9 +97,9 @@ int semInit(SemRequestType _reqPolicy, bool semTimeStat, int shared, int takenIn
 
 /* ****************************************************************************
 *
-* difftimeofday - 
+* clock_difftime - 
 */
-static void difftimeofday(struct timespec* endTime, struct timespec* startTime, struct timespec* diffTime)
+static void clock_difftime(struct timespec* endTime, struct timespec* startTime, struct timespec* diffTime)
 {
   diffTime->tv_nsec = endTime->tv_nsec - startTime->tv_nsec;
   diffTime->tv_sec  = endTime->tv_sec  - startTime->tv_sec;
@@ -114,9 +115,9 @@ static void difftimeofday(struct timespec* endTime, struct timespec* startTime, 
 
 /* ****************************************************************************
 *
-* addtimeofday - 
+* clock_addtime - 
 */
-static void addtimeofday(struct timespec* accTime, struct timespec* diffTime)
+static void clock_addtime(struct timespec* accTime, struct timespec* diffTime)
 {
   accTime->tv_nsec += diffTime->tv_nsec;
   accTime->tv_sec  += diffTime->tv_sec;
@@ -173,8 +174,8 @@ int reqSemTake(const char* who, const char* what, SemRequestType reqType, bool* 
   {
     clock_gettime(CLOCK_REALTIME, &endTime);
 
-    difftimeofday(&endTime, &startTime, &diffTime);
-    addtimeofday(&accReqSemTime, &diffTime);
+    clock_difftime(&endTime, &startTime, &diffTime);
+    clock_addtime(&accReqSemTime, &diffTime);
   }
 
   LM_T(LmtReqSem, ("%s has the 'req' semaphore", who));
@@ -223,6 +224,24 @@ void semTimeMongoGet(char* buf, int bufLen)
 
 /* ****************************************************************************
 *
+* semTimeTransGet - get accumulated trans semaphore waiting time
+*/
+void semTimeTransGet(char* buf, int bufLen)
+{
+  if (semTimeStatistics)
+  {
+    snprintf(buf, bufLen, "%lu.%09d", accTransSemTime.tv_sec, (int) accTransSemTime.tv_nsec);
+  }
+  else
+  {
+    snprintf(buf, bufLen, "Disabled");
+  }
+}
+
+
+
+/* ****************************************************************************
+*
 * semTimeReqReset - 
 */
 void semTimeReqReset(void)
@@ -241,6 +260,18 @@ void semTimeMongoReset(void)
 {
   accMongoSemTime.tv_sec  = 0;
   accMongoSemTime.tv_nsec = 0;
+}
+
+
+
+/* ****************************************************************************
+*
+* semTimeTransReset - 
+*/
+void semTimeTransReset(void)
+{
+  accTransSemTime.tv_sec  = 0;
+  accTransSemTime.tv_nsec = 0;
 }
 
 
@@ -270,8 +301,8 @@ int mongoSemTake(const char* who, const char* what)
   {
     clock_gettime(CLOCK_REALTIME, &endTime);
 
-    difftimeofday(&endTime, &startTime, &diffTime);
-    addtimeofday(&accMongoSemTime, &diffTime);
+    clock_difftime(&endTime, &startTime, &diffTime);
+    clock_addtime(&accMongoSemTime, &diffTime);
   }
 
   LM_T(LmtMongoSem, ("%s has the 'mongo' semaphore", who));
@@ -290,7 +321,26 @@ int transSemTake(const char* who, const char* what)
   int r;
 
   LM_T(LmtTransSem, ("%s taking the 'trans' semaphore for '%s'", who, what));
+
+  struct timespec startTime;
+  struct timespec endTime;
+  struct timespec diffTime;
+
+  if (semTimeStatistics)
+  {
+    clock_gettime(CLOCK_REALTIME, &startTime);
+  }
+
   r = sem_wait(&transSem);
+
+  if (semTimeStatistics)
+  {
+    clock_gettime(CLOCK_REALTIME, &endTime);
+
+    clock_difftime(&endTime, &startTime, &diffTime);
+    clock_addtime(&accTransSemTime, &diffTime);
+  }
+
   LM_T(LmtTransSem, ("%s has the 'trans' semaphore", who));
 
   return r;

--- a/src/lib/common/sem.h
+++ b/src/lib/common/sem.h
@@ -47,7 +47,13 @@ typedef enum SemRequestType
 *
 * semInit -
 */
-extern int semInit(SemRequestType _reqPolicy = SemReadWriteOp, int shared = 0, int takenInitially = 1);
+extern int semInit
+(
+  SemRequestType  _reqPolicy     = SemReadWriteOp,
+  bool            semTimeStat    = false,
+  int             shared         = 0,
+  int             takenInitially = 1
+);
 
 
 
@@ -68,5 +74,23 @@ extern int transSemTake(const char* who, const char* what);
 extern int reqSemGive(const char* who, const char* what = NULL, bool taken = true);
 extern int mongoSemGive(const char* who, const char* what = NULL);
 extern int transSemGive(const char* who, const char* what = NULL);
+
+
+
+/* ****************************************************************************
+*
+* semTimeXxxGet - get accumulated semaphore waiting time
+*/
+extern void semTimeReqGet(char* buf, int bufLen);
+extern void semTimeMongoGet(char* buf, int bufLen);
+
+
+
+/* ****************************************************************************
+*
+* semTimeXxxReset - 
+*/
+extern void semTimeReqReset(void);
+extern void semTimeMongoReset(void);
 
 #endif  // SRC_LIB_COMMON_SEM_H_

--- a/src/lib/common/sem.h
+++ b/src/lib/common/sem.h
@@ -83,6 +83,7 @@ extern int transSemGive(const char* who, const char* what = NULL);
 */
 extern void semTimeReqGet(char* buf, int bufLen);
 extern void semTimeMongoGet(char* buf, int bufLen);
+extern void semTimeTransGet(char* buf, int bufLen);
 
 
 
@@ -92,5 +93,6 @@ extern void semTimeMongoGet(char* buf, int bufLen);
 */
 extern void semTimeReqReset(void);
 extern void semTimeMongoReset(void);
+extern void semTimeTransReset(void);
 
 #endif  // SRC_LIB_COMMON_SEM_H_

--- a/src/lib/serviceRoutines/statisticsTreat.cpp
+++ b/src/lib/serviceRoutines/statisticsTreat.cpp
@@ -136,6 +136,7 @@ std::string statisticsTreat
 
     semTimeReqReset();
     semTimeMongoReset();
+    semTimeTransReset();
 
     out += startTag(indent, tag, ciP->outFormat, true, true);
     out += valueTag(indent2, "message", "All statistics counter reset", ciP->outFormat);
@@ -414,6 +415,10 @@ std::string statisticsTreat
     char mongoSemaphoreWaitingTime[64];
     semTimeMongoGet(mongoSemaphoreWaitingTime, sizeof(mongoSemaphoreWaitingTime));
     out += TAG_ADD_STRING("dbSemaphoreWaitingTime", mongoSemaphoreWaitingTime);
+
+    char transSemaphoreWaitingTime[64];
+    semTimeTransGet(transSemaphoreWaitingTime, sizeof(transSemaphoreWaitingTime));
+    out += TAG_ADD_STRING("transactionSemaphoreWaitingTime", transSemaphoreWaitingTime);
   }
 
   int now = getCurrentTime();

--- a/src/lib/serviceRoutines/statisticsTreat.cpp
+++ b/src/lib/serviceRoutines/statisticsTreat.cpp
@@ -32,6 +32,7 @@
 #include "common/globals.h"
 #include "common/tag.h"
 #include "common/statistics.h"
+#include "common/sem.h"
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
@@ -43,7 +44,8 @@
 *
 * TAG_ADD - 
 */
-#define TAG_ADD(tag, counter) valueTag(indent2, tag, counter + 1, ciP->outFormat, true)
+#define TAG_ADD_COUNTER(tag, counter) valueTag(indent2, tag, counter + 1, ciP->outFormat, true)
+#define TAG_ADD_STRING(tag, value)  valueTag(indent2, tag, value, ciP->outFormat, true)
 
 
 
@@ -132,6 +134,8 @@ std::string statisticsTreat
     noOfInvalidRequests                             = -1;
     noOfRegisterResponses                           = -1;
 
+    semTimeReqReset();
+
     out += startTag(indent, tag, ciP->outFormat, true, true);
     out += valueTag(indent2, "message", "All statistics counter reset", ciP->outFormat);
     indent2 = (ciP->outFormat == JSON)? indent + "  " : indent;
@@ -143,261 +147,272 @@ std::string statisticsTreat
 
   if (noOfXmlRequests != -1)
   {
-    out += TAG_ADD("xmlRequests", noOfXmlRequests);
+    out += TAG_ADD_COUNTER("xmlRequests", noOfXmlRequests);
   }
 
   if (noOfJsonRequests != -1)
   {
-    out += TAG_ADD("jsonRequests", noOfJsonRequests);
+    out += TAG_ADD_COUNTER("jsonRequests", noOfJsonRequests);
   }
 
   if (noOfRegistrations != -1)
   {
-    out += TAG_ADD("registrations", noOfRegistrations);
+    out += TAG_ADD_COUNTER("registrations", noOfRegistrations);
   }
 
   if (noOfRegistrationUpdates != -1)
   {
-    out += TAG_ADD("registrationUpdates", noOfRegistrationUpdates);
+    out += TAG_ADD_COUNTER("registrationUpdates", noOfRegistrationUpdates);
   }
 
   if (noOfDiscoveries != -1)
   {
-    out += TAG_ADD("discoveries", noOfDiscoveries);
+    out += TAG_ADD_COUNTER("discoveries", noOfDiscoveries);
   }
 
   if (noOfAvailabilitySubscriptions != -1)
   {
-    out += TAG_ADD("availabilitySubscriptions", noOfAvailabilitySubscriptions);
+    out += TAG_ADD_COUNTER("availabilitySubscriptions", noOfAvailabilitySubscriptions);
   }
 
   if (noOfAvailabilitySubscriptionUpdates != -1)
   {
-    out += TAG_ADD("availabilitySubscriptionUpdates", noOfAvailabilitySubscriptionUpdates);
+    out += TAG_ADD_COUNTER("availabilitySubscriptionUpdates", noOfAvailabilitySubscriptionUpdates);
   }
 
   if (noOfAvailabilityUnsubscriptions != -1)
   {
-    out += TAG_ADD("availabilityUnsubscriptions", noOfAvailabilityUnsubscriptions);
+    out += TAG_ADD_COUNTER("availabilityUnsubscriptions", noOfAvailabilityUnsubscriptions);
   }
 
   if (noOfAvailabilityNotificationsReceived != -1)
   {
-    out += TAG_ADD("availabilityNotificationsReceived", noOfAvailabilityNotificationsReceived);
+    out += TAG_ADD_COUNTER("availabilityNotificationsReceived", noOfAvailabilityNotificationsReceived);
   }
 
   if (noOfQueries != -1)
   {
-    out += TAG_ADD("queries", noOfQueries);
+    out += TAG_ADD_COUNTER("queries", noOfQueries);
   }
 
   if (noOfUpdates != -1)
   {
-    out += TAG_ADD("updates", noOfUpdates);
+    out += TAG_ADD_COUNTER("updates", noOfUpdates);
   }
 
   if (noOfSubscriptions != -1)
   {
-    out += TAG_ADD("subscriptions", noOfSubscriptions);
+    out += TAG_ADD_COUNTER("subscriptions", noOfSubscriptions);
   }
 
   if (noOfSubscriptionUpdates != -1)
   {
-    out += TAG_ADD("subscriptionUpdates", noOfSubscriptionUpdates);
+    out += TAG_ADD_COUNTER("subscriptionUpdates", noOfSubscriptionUpdates);
   }
 
   if (noOfUnsubscriptions != -1)
   {
-    out += TAG_ADD("unsubscriptions", noOfUnsubscriptions);
+    out += TAG_ADD_COUNTER("unsubscriptions", noOfUnsubscriptions);
   }
 
   if (noOfNotificationsReceived != -1)
   {
-    out += TAG_ADD("notificationsReceived", noOfNotificationsReceived);
+    out += TAG_ADD_COUNTER("notificationsReceived", noOfNotificationsReceived);
   }
 
   if (noOfQueryContextResponses != -1)
   {
-    out += TAG_ADD("queryResponsesReceived", noOfQueryContextResponses);
+    out += TAG_ADD_COUNTER("queryResponsesReceived", noOfQueryContextResponses);
   }
 
   if (noOfUpdateContextResponses != -1)
   {
-    out += TAG_ADD("updateResponsesReceived", noOfUpdateContextResponses);
+    out += TAG_ADD_COUNTER("updateResponsesReceived", noOfUpdateContextResponses);
   }
 
   if (noOfQueryContextResponses != -1)
   {
-    out += TAG_ADD("queryResponsesReceived", noOfQueryContextResponses);
+    out += TAG_ADD_COUNTER("queryResponsesReceived", noOfQueryContextResponses);
   }
 
   if (noOfUpdateContextResponses != -1)
   {
-    out += TAG_ADD("updateResponsesReceived", noOfUpdateContextResponses);
+    out += TAG_ADD_COUNTER("updateResponsesReceived", noOfUpdateContextResponses);
   }
 
   if (noOfContextEntitiesByEntityId != -1)
   {
-    out += TAG_ADD("contextEntitiesByEntityId", noOfContextEntitiesByEntityId);
+    out += TAG_ADD_COUNTER("contextEntitiesByEntityId", noOfContextEntitiesByEntityId);
   }
 
   if (noOfContextEntityAttributes != -1)
   {
-    out += TAG_ADD("contextEntityAttributes", noOfContextEntityAttributes);
+    out += TAG_ADD_COUNTER("contextEntityAttributes", noOfContextEntityAttributes);
   }
 
   if (noOfEntityByIdAttributeByName != -1)
   {
-    out += TAG_ADD("entityByIdAttributeByName", noOfEntityByIdAttributeByName);
+    out += TAG_ADD_COUNTER("entityByIdAttributeByName", noOfEntityByIdAttributeByName);
   }
 
   if (noOfContextEntityTypes != -1)
   {
-    out += TAG_ADD("contextEntityTypes", noOfContextEntityTypes);
+    out += TAG_ADD_COUNTER("contextEntityTypes", noOfContextEntityTypes);
   }
 
   if (noOfContextEntityTypeAttributeContainer != -1)
   {
-    out += TAG_ADD("contextEntityTypeAttributeContainer", noOfContextEntityTypeAttributeContainer);
+    out += TAG_ADD_COUNTER("contextEntityTypeAttributeContainer", noOfContextEntityTypeAttributeContainer);
   }
 
   if (noOfContextEntityTypeAttribute != -1)
   {
-    out += TAG_ADD("contextEntityTypeAttribute", noOfContextEntityTypeAttribute);
+    out += TAG_ADD_COUNTER("contextEntityTypeAttribute", noOfContextEntityTypeAttribute);
   }
 
 
   if (noOfIndividualContextEntity != -1)
   {
-    out += TAG_ADD("individualContextEntity", noOfIndividualContextEntity);
+    out += TAG_ADD_COUNTER("individualContextEntity", noOfIndividualContextEntity);
   }
 
   if (noOfIndividualContextEntityAttributes != -1)
   {
-    out += TAG_ADD("individualContextEntityAttributes", noOfIndividualContextEntityAttributes);
+    out += TAG_ADD_COUNTER("individualContextEntityAttributes", noOfIndividualContextEntityAttributes);
   }
 
   if (noOfIndividualContextEntityAttribute != -1)
   {
-    out += TAG_ADD("individualContextEntityAttribute", noOfIndividualContextEntityAttribute);
+    out += TAG_ADD_COUNTER("individualContextEntityAttribute", noOfIndividualContextEntityAttribute);
   }
 
   if (noOfUpdateContextElement != -1)
   {
-    out += TAG_ADD("updateContextElement", noOfUpdateContextElement);
+    out += TAG_ADD_COUNTER("updateContextElement", noOfUpdateContextElement);
   }
 
   if (noOfAppendContextElement != -1)
   {
-    out += TAG_ADD("appendContextElement", noOfAppendContextElement);
+    out += TAG_ADD_COUNTER("appendContextElement", noOfAppendContextElement);
   }
 
   if (noOfUpdateContextAttribute != -1)
   {
-    out += TAG_ADD("updateContextAttribute", noOfUpdateContextAttribute);
+    out += TAG_ADD_COUNTER("updateContextAttribute", noOfUpdateContextAttribute);
   }
 
 
   if (noOfNgsi10ContextEntityTypes != -1)
   {
-    out += TAG_ADD("contextEntityTypesNgsi10", noOfNgsi10ContextEntityTypes);
+    out += TAG_ADD_COUNTER("contextEntityTypesNgsi10", noOfNgsi10ContextEntityTypes);
   }
 
   if (noOfNgsi10ContextEntityTypesAttributeContainer != -1)
   {
-    out += TAG_ADD("contextEntityTypeAttributeContainerNgsi10", noOfNgsi10ContextEntityTypesAttributeContainer);
+    out += TAG_ADD_COUNTER("contextEntityTypeAttributeContainerNgsi10", noOfNgsi10ContextEntityTypesAttributeContainer);
   }
 
   if (noOfNgsi10ContextEntityTypesAttribute != -1)
   {
-    out += TAG_ADD("contextEntityTypeAttributeNgsi10", noOfNgsi10ContextEntityTypesAttribute);
+    out += TAG_ADD_COUNTER("contextEntityTypeAttributeNgsi10", noOfNgsi10ContextEntityTypesAttribute);
   }
 
   if (noOfNgsi10SubscriptionsConvOp != -1)
   {
-    out += TAG_ADD("subscriptionsNgsi10ConvOp", noOfNgsi10SubscriptionsConvOp);
+    out += TAG_ADD_COUNTER("subscriptionsNgsi10ConvOp", noOfNgsi10SubscriptionsConvOp);
   }
 
 
   if (noOfAllContextEntitiesRequests != -1)
   {
-    out += TAG_ADD("allContextEntitiesRequests", noOfAllContextEntitiesRequests);
+    out += TAG_ADD_COUNTER("allContextEntitiesRequests", noOfAllContextEntitiesRequests);
   }
 
   if (noOfAllEntitiesWithTypeAndIdRequests != -1)
   {
-    out += TAG_ADD("allContextEntitiesWithTypeAndIdRequests", noOfAllEntitiesWithTypeAndIdRequests);
+    out += TAG_ADD_COUNTER("allContextEntitiesWithTypeAndIdRequests", noOfAllEntitiesWithTypeAndIdRequests);
   }
 
   if (noOfIndividualContextEntityAttributeWithTypeAndId != -1)
   {
-    out += TAG_ADD("individualContextEntityAttributeWithTypeAndId", noOfIndividualContextEntityAttributeWithTypeAndId);
+    out += TAG_ADD_COUNTER("individualContextEntityAttributeWithTypeAndId", noOfIndividualContextEntityAttributeWithTypeAndId);
   }
 
   if (noOfAttributeValueInstanceWithTypeAndId != -1)
   {
-    out += TAG_ADD("attributeValueInstanceWithTypeAndId", noOfAttributeValueInstanceWithTypeAndId);
+    out += TAG_ADD_COUNTER("attributeValueInstanceWithTypeAndId", noOfAttributeValueInstanceWithTypeAndId);
   }
 
   if (noOfContextEntitiesByEntityIdAndType != -1)
   {
-    out += TAG_ADD("contextEntitiesByEntityIdAndType", noOfContextEntitiesByEntityIdAndType);
+    out += TAG_ADD_COUNTER("contextEntitiesByEntityIdAndType", noOfContextEntitiesByEntityIdAndType);
   }
 
   if (noOfEntityByIdAttributeByNameIdAndType != -1)
   {
-    out += TAG_ADD("entityByIdAttributeByNameIdAndType", noOfEntityByIdAttributeByNameIdAndType);
+    out += TAG_ADD_COUNTER("entityByIdAttributeByNameIdAndType", noOfEntityByIdAttributeByNameIdAndType);
   }
 
   if (noOfLogRequests != -1)
   {
-    out += TAG_ADD("logRequests", noOfLogRequests);
+    out += TAG_ADD_COUNTER("logRequests", noOfLogRequests);
   }
 
   if (noOfVersionRequests != -1)
   {
-    out += TAG_ADD("versionRequests", noOfVersionRequests);
+    out += TAG_ADD_COUNTER("versionRequests", noOfVersionRequests);
   }
 
   if (noOfExitRequests != -1)
   {
-    out += TAG_ADD("exitRequests", noOfExitRequests);
+    out += TAG_ADD_COUNTER("exitRequests", noOfExitRequests);
   }
 
   if (noOfLeakRequests != -1)
   {
-    out += TAG_ADD("leakRequests", noOfLeakRequests);
+    out += TAG_ADD_COUNTER("leakRequests", noOfLeakRequests);
   }
 
   if (noOfStatisticsRequests != -1)
   {
-    out += TAG_ADD("statisticsRequests", noOfStatisticsRequests);
+    out += TAG_ADD_COUNTER("statisticsRequests", noOfStatisticsRequests);
   }
 
   if (noOfInvalidRequests != -1)
   {
-    out += TAG_ADD("invalidRequests", noOfInvalidRequests);
+    out += TAG_ADD_COUNTER("invalidRequests", noOfInvalidRequests);
   }
 
   if (noOfRegisterResponses != -1)
   {
-    out += TAG_ADD("registerResponses", noOfRegisterResponses);
+    out += TAG_ADD_COUNTER("registerResponses", noOfRegisterResponses);
   }
 
 
   if (noOfRegistrationErrors != -1)
   {
-    out += TAG_ADD("registrationErrors", noOfRegistrationErrors);
+    out += TAG_ADD_COUNTER("registrationErrors", noOfRegistrationErrors);
   }
 
   if (noOfRegistrationUpdateErrors != -1)
   {
-    out += TAG_ADD("registrationUpdateErrors", noOfRegistrationUpdateErrors);
+    out += TAG_ADD_COUNTER("registrationUpdateErrors", noOfRegistrationUpdateErrors);
   }
 
   if (noOfDiscoveryErrors != -1)
   {
-    out += TAG_ADD("discoveryErrors", noOfDiscoveryErrors);
+    out += TAG_ADD_COUNTER("discoveryErrors", noOfDiscoveryErrors);
+  }
+
+  if (semTimeStatistics)
+  {
+    char requestSemaphoreWaitingTime[64];
+    semTimeReqGet(requestSemaphoreWaitingTime, sizeof(requestSemaphoreWaitingTime));
+    out += TAG_ADD_STRING("requestSemaphoreWaitingTime", requestSemaphoreWaitingTime);
+
+    char mongoSemaphoreWaitingTime[64];
+    semTimeMongoGet(mongoSemaphoreWaitingTime, sizeof(mongoSemaphoreWaitingTime));
+    out += TAG_ADD_STRING("dbSemaphoreWaitingTime", mongoSemaphoreWaitingTime);
   }
 
   int now = getCurrentTime();

--- a/src/lib/serviceRoutines/statisticsTreat.cpp
+++ b/src/lib/serviceRoutines/statisticsTreat.cpp
@@ -135,6 +135,7 @@ std::string statisticsTreat
     noOfRegisterResponses                           = -1;
 
     semTimeReqReset();
+    semTimeMongoReset();
 
     out += startTag(indent, tag, ciP->outFormat, true, true);
     out += valueTag(indent2, "message", "All statistics counter reset", ciP->outFormat);

--- a/test/functionalTest/cases/000_cli/command_line_options.test
+++ b/test/functionalTest/cases/000_cli/command_line_options.test
@@ -57,5 +57,6 @@ Usage: contextBroker  [option '-U' (extended usage)]
                       [option '-multiservice' (service multi tenancy mode)]
                       [option '-httpTimeout' <timeout in milliseconds for forwards and notifications>]
                       [option '-mutexPolicy' <mutex policy (none/read/write/all)>]
+                      [option '-mutexTimeStat' (measure total semaphore waiting time)]
                       
 --TEARDOWN--

--- a/test/functionalTest/cases/000_statistics_operation/statistics_with_semaphores.test
+++ b/test/functionalTest/cases/000_statistics_operation/statistics_with_semaphores.test
@@ -43,7 +43,7 @@ echo
 --REGEXPECT--
 +++++ 1. statistics in XML
 HTTP/1.1 200 OK
-Content-Length: 327
+Content-Length: 408
 Content-Type: application/xml
 Date: REGEX(.*)
 
@@ -53,6 +53,7 @@ Date: REGEX(.*)
   <statisticsRequests>1</statisticsRequests>
   <requestSemaphoreWaitingTime>REGEX(\d+.\d+)</requestSemaphoreWaitingTime>
   <dbSemaphoreWaitingTime>REGEX(\d+.\d+)</dbSemaphoreWaitingTime>
+  <transactionSemaphoreWaitingTime>REGEX(\d+.\d+)</transactionSemaphoreWaitingTime>
   <uptime_in_secs>REGEX(1?\d)</uptime_in_secs>
   <measuring_interval_in_secs>REGEX(1?\d)</measuring_interval_in_secs>
 </orion>
@@ -60,7 +61,7 @@ Date: REGEX(.*)
 
 +++++ 2. statistics in JSON
 HTTP/1.1 200 OK
-Content-Length: 269
+Content-Length: 324
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -71,6 +72,7 @@ Date: REGEX(.*)
         "measuring_interval_in_secs": "REGEX(1?\d)", 
         "requestSemaphoreWaitingTime": "REGEX(\d+.\d+)", 
         "statisticsRequests": "2", 
+        "transactionSemaphoreWaitingTime": "REGEX(\d+.\d+)", 
         "uptime_in_secs": "REGEX(1?\d)", 
         "xmlRequests": "1"
     }

--- a/test/functionalTest/cases/000_statistics_operation/statistics_with_semaphores.test
+++ b/test/functionalTest/cases/000_statistics_operation/statistics_with_semaphores.test
@@ -1,0 +1,81 @@
+# Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+statistics
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0 IPv4 -mutexTimeStat
+
+--SHELL--
+# curl localhost:${CB_PORT}/statistics 2> /dev/null | xmllint --format -
+echo "+++++ 1. statistics in XML"
+orionCurl --url /statistics 
+echo
+echo
+
+
+echo "+++++ 2. statistics in JSON"
+orionCurl --url /statistics --json
+echo
+
+
+--REGEXPECT--
++++++ 1. statistics in XML
+HTTP/1.1 200 OK
+Content-Length: 327
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<orion>
+  <xmlRequests>1</xmlRequests>
+  <statisticsRequests>1</statisticsRequests>
+  <requestSemaphoreWaitingTime>REGEX(\d+.\d+)</requestSemaphoreWaitingTime>
+  <dbSemaphoreWaitingTime>REGEX(\d+.\d+)</dbSemaphoreWaitingTime>
+  <uptime_in_secs>REGEX(1?\d)</uptime_in_secs>
+  <measuring_interval_in_secs>REGEX(1?\d)</measuring_interval_in_secs>
+</orion>
+
+
++++++ 2. statistics in JSON
+HTTP/1.1 200 OK
+Content-Length: 269
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "orion": {
+        "dbSemaphoreWaitingTime": "REGEX(\d+.\d+)", 
+        "jsonRequests": "1", 
+        "measuring_interval_in_secs": "REGEX(1?\d)", 
+        "requestSemaphoreWaitingTime": "REGEX(\d+.\d+)", 
+        "statisticsRequests": "2", 
+        "uptime_in_secs": "REGEX(1?\d)", 
+        "xmlRequests": "1"
+    }
+}
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/unittests/main_UnitTest.cpp
+++ b/test/unittests/main_UnitTest.cpp
@@ -105,7 +105,7 @@ int main(int argC, char** argV)
     paParse(paArgs, 1, argV, 1, false);
 
   LM_M(("Init tests"));
-  orionInit(exitFunction, orionUnitTestVersion, SemReadWriteOp);
+  orionInit(exitFunction, orionUnitTestVersion, SemReadWriteOp, false);
   setupDatabase();
 
   LM_M(("Run all tests"));


### PR DESCRIPTION
Implements #911

Added the accumulated waiting time on database semaphores to the statistics information for the REST service /statistics.
However, this new feature is enabled only if the broker is started with the new CLI parameter 
-mutexTimeStat
