### PR TITLE
Hardening/orion curl rewrite

### DIFF
--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -117,7 +117,6 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
   {
     char* cP = (char*) val;
 
-    LM_M(("value for URI_PARAM_PAGINATION_OFFSET: '%s'", cP));
     while (*cP != 0)
     {
       if ((*cP < '0') || (*cP > '9'))
@@ -135,7 +134,6 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
   {
     char* cP = (char*) val;
 
-    LM_M(("value for URI_PARAM_PAGINATION_LIMIT: '%s'", cP));
     while (*cP != 0)
     {
       if ((*cP < '0') || (*cP > '9'))
@@ -208,8 +206,6 @@ static int httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, co
 {
   HttpHeaders*  headerP = (HttpHeaders*) cbDataP;
   std::string   key     = ckey;
-
-  LM_M(("Got header %s: %s", ckey, value));
 
   LM_T(LmtHttpHeaders, ("HTTP Header:   %s: %s", key.c_str(), value));
 
@@ -758,8 +754,6 @@ static int connectionTreat
     //
     char            ip[32];
     unsigned short  port = 0;
-
-    LM_M(("New incoming connection: %s", url));
 
     const union MHD_ConnectionInfo* mciP = MHD_get_connection_info(connection, MHD_CONNECTION_INFO_CLIENT_ADDRESS);
     if (mciP != NULL)

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -518,8 +518,13 @@ static char* removeTrailingSlash(std::string path)
 */
 int servicePathSplit(ConnectionInfo* ciP)
 {
+#if 0
   //
   // Special case: empty service-path 
+  //
+  // FIXME P4: We're not sure what this 'fix' really fixes.
+  //           Must implement a functest to reproduce this situation.
+  //           And, if that is not possible, just remove the whole thing
   //
   if ((ciP->httpHeaders.servicePathReceived == true) && (ciP->servicePath == ""))
   {
@@ -528,7 +533,7 @@ int servicePathSplit(ConnectionInfo* ciP)
     LM_W(("Bad Input (empty service path)"));
     return -1;
   }
-
+#endif
 
   int servicePaths = stringSplit(ciP->servicePath, ',', ciP->servicePathV);
 

--- a/test/functionalTest/cases/000_bad_requests/pagination_error_in_uri_params.test
+++ b/test/functionalTest/cases/000_bad_requests/pagination_error_in_uri_params.test
@@ -37,7 +37,7 @@ echo
 echo
 
 echo "+++++ 2. bad characters in URI param 'offset'"
-url="/v1/queryContext?limit=0&offset=qwe"
+url="/v1/queryContext?offset=qwe"
 payload='NO PAYLOAD NECESSARY'
 orionCurl --url "$url" --payload "$payload"
 echo
@@ -90,7 +90,7 @@ Date: REGEX(.*)
 
 +++++ 3. URI param 'limit' == 0
 HTTP/1.1 400 Bad Request
-Content-Length: 173
+Content-Length: 175
 Content-Type: application/xml
 Date: REGEX(.*)
 
@@ -98,7 +98,7 @@ Date: REGEX(.*)
 <orionError>
   <code>400</code>
   <reasonPhrase>Bad Request</reasonPhrase>
-  <details>Bad pagination limit: /000000/ [a value of ZERO is unaccepted]</details>
+  <details>Bad pagination limit: /000000/ [a value of ZERO is unacceptable]</details>
 </orionError>
 
 

--- a/test/functionalTest/cases/672_forbidden_chars_in_url/all_forbidden_chars_in_uri.test
+++ b/test/functionalTest/cases/672_forbidden_chars_in_url/all_forbidden_chars_in_uri.test
@@ -58,7 +58,7 @@ echo
 
 echo '03. Test the forbidden character "'
 echo "=================================="
-orionCurl --url '/test/with/forbidden/character/"' --json
+orionCurl --url '/test/with/forbidden/character/\"' --json
 echo
 echo
 

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -37,7 +37,6 @@ export CONTEXTBROKER_HARNESS_FUNCTIONS_SOURCED="YES"
 
 if [ "$ORION_FT_DEBUG" == "1" ]
 then
-  echo ORION_FT_DEBUG: $ORION_FT_DEBUG > /tmp/kz
   _debug='on'
 else
   _debug='off'

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -41,6 +41,40 @@ cd - > /dev/null 2>&1
 
 
 
+# ------------------------------------------------------------------------------
+#
+# Debug mode?
+#
+if [ "$ORION_FT_DEBUG" == "1" ]
+then
+  _debug='on'
+fi
+
+
+
+# ------------------------------------------------------------------------------
+#
+# dMsg2 - debug output
+#
+function dMsg2()
+{
+  if [ "$_debug" == "on" ]
+  then
+    echo $* >> /tmp/orionFuncTestDebug.log
+  fi
+}
+
+
+# -----------------------------------------------------------------------------
+#
+# Log file for debugging
+#
+rm -f /tmp/orionFuncTestDebug.log
+echo $(date) > /tmp/orionFuncTestDebug.log
+dMsg2 Functional Tests Starting ...
+
+
+
 # -----------------------------------------------------------------------------
 #
 # Env vars

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -52,26 +52,12 @@ fi
 
 
 
-# ------------------------------------------------------------------------------
-#
-# dMsg2 - debug output
-#
-function dMsg2()
-{
-  if [ "$_debug" == "on" ]
-  then
-    echo $* >> /tmp/orionFuncTestDebug.log
-  fi
-}
-
-
 # -----------------------------------------------------------------------------
 #
 # Log file for debugging
 #
 rm -f /tmp/orionFuncTestDebug.log
 echo $(date) > /tmp/orionFuncTestDebug.log
-dMsg2 Functional Tests Starting ...
 
 
 
@@ -339,6 +325,7 @@ fi
 #
 # Preparations - cd to the test directory
 #
+dMsg Functional Tests Starting ...
 if [ "$dirOrFile" != "" ] && [ -d "$dirOrFile" ]
 then
   cd $dirOrFile


### PR DESCRIPTION
Complete rewrite of the function 'orionCurl'.
Some of the changes:
  - the payload is now always sent to a file and -d @<path> is used for curl (internal change only) - /tmp/orionFuncTestPayload (in case no file was used by the caller)
  - it is now possible to read/understand the function :-)
  - ORION_FT_DEBUG=1 turns of debugging (output to /tmp/orionFuncTestDebug.log)
  - New parameters: -H and --header (to add headers to curl)
  