### PR TITLE
From PRINTF   to LM_F macro

### DIFF
--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -43,12 +43,6 @@
 
 
 
-/* ****************************************************************************
-*
-* PRINTF - 
-*/
-#define PRINTF printf
-
 
 /* ****************************************************************************
 *
@@ -163,3 +157,4 @@ extern int64_t parse8601(const std::string& s);
 extern void transactionIdSet(void);
 
 #endif  // SRC_LIB_COMMON_GLOBALS_H_
+	

--- a/src/lib/convenience/ContextAttributeResponseVector.cpp
+++ b/src/lib/convenience/ContextAttributeResponseVector.cpp
@@ -95,7 +95,7 @@ std::string ContextAttributeResponseVector::check
 */
 void ContextAttributeResponseVector::present(std::string indent)
 {
-  PRINTF("%lu ContextAttributeResponses", (uint64_t) vec.size());
+  LM_F(("%lu ContextAttributeResponses", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -125,12 +125,12 @@ std::string RegisterProviderRequest::check
 */
 void RegisterProviderRequest::present(std::string indent)
 {
-  PRINTF("%sRegisterProviderRequest:\n", indent.c_str());
+  LM_F(("%sRegisterProviderRequest:\n", indent.c_str()));
   metadataVector.present("Registration", indent + "  ");
   duration.present(indent + "  ");
   providingApplication.present(indent + "  ");
   registrationId.present(indent + "  ");
-  PRINTF("\n");
+  LM_F(("\n"));
 }
 
 

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -150,8 +150,8 @@ std::string UpdateContextAttributeRequest::check
 */
 void UpdateContextAttributeRequest::present(std::string indent)
 {
-  PRINTF("%stype:         %s", indent.c_str(), type.c_str());
-  PRINTF("%scontextValue: %s", indent.c_str(), contextValue.c_str());
+  LM_F(("%stype:         %s", indent.c_str(), type.c_str()));
+  LM_F(("%scontextValue: %s", indent.c_str(), contextValue.c_str()));
   metadataVector.present("ContextMetadata", indent);
 }
 

--- a/src/lib/jsonParse/jsonDiscoverContextAvailabilityRequest.cpp
+++ b/src/lib/jsonParse/jsonDiscoverContextAvailabilityRequest.cpp
@@ -257,7 +257,7 @@ std::string jsonDcarCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 
 
 
-#define PRINTF printf
+
 /* ****************************************************************************
 *
 * jsonDcarPresent - 
@@ -269,7 +269,7 @@ void jsonDcarPresent(ParseData* reqDataP)
     return;
   }
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqDataP->dcar.res.present("");
 }
 

--- a/src/lib/jsonParse/jsonNotifyContextAvailabilityRequest.cpp
+++ b/src/lib/jsonParse/jsonNotifyContextAvailabilityRequest.cpp
@@ -396,6 +396,6 @@ void jsonNcarPresent(ParseData* parseDataP)
   if (!lmTraceIsSet(LmtPresent))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   parseDataP->ncar.res.present("");
 }

--- a/src/lib/jsonParse/jsonNotifyContextRequest.cpp
+++ b/src/lib/jsonParse/jsonNotifyContextRequest.cpp
@@ -433,6 +433,6 @@ void jsonNcrPresent(ParseData* parseDataP)
   if (!lmTraceIsSet(LmtPresent))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   parseDataP->ncr.res.present("");
 }

--- a/src/lib/jsonParse/jsonQueryContextRequest.cpp
+++ b/src/lib/jsonParse/jsonQueryContextRequest.cpp
@@ -490,7 +490,7 @@ std::string jsonQcrCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 
 
 
-#define PRINTF printf
+
 /* ****************************************************************************
 *
 * jsonQcrPresent -
@@ -500,6 +500,6 @@ void jsonQcrPresent(ParseData* reqDataP)
   if (!lmTraceIsSet(LmtPresent))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqDataP->qcr.res.present("");
 }

--- a/src/lib/jsonParse/jsonRegisterContextRequest.cpp
+++ b/src/lib/jsonParse/jsonRegisterContextRequest.cpp
@@ -646,7 +646,7 @@ void jsonRcrPresent(ParseData* reqDataP)
     return;
   }
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
 
   reqDataP->rcr.res.contextRegistrationVector.present("");
   reqDataP->rcr.res.duration.present("");

--- a/src/lib/jsonParse/jsonUnsubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/jsonParse/jsonUnsubscribeContextAvailabilityRequest.cpp
@@ -102,7 +102,7 @@ void jsonUcarPresent(ParseData* parseDataP)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
 
   parseDataP->ucar.res.subscriptionId.present("");
 }

--- a/src/lib/jsonParse/jsonUnsubscribeContextRequest.cpp
+++ b/src/lib/jsonParse/jsonUnsubscribeContextRequest.cpp
@@ -102,7 +102,7 @@ void jsonUncrPresent(ParseData* parseDataP)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
 
   parseDataP->uncr.res.subscriptionId.present("");
 }

--- a/src/lib/jsonParse/jsonUpdateContextAttributeRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextAttributeRequest.cpp
@@ -187,7 +187,7 @@ void jsonUpcarPresent(ParseData* reqData)
     return;
   }
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqData->upcar.res.present("");
 }
 

--- a/src/lib/jsonParse/jsonUpdateContextRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextRequest.cpp
@@ -399,7 +399,7 @@ void jsonUpcrPresent(ParseData* reqDataP)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
 
   reqDataP->upcr.res.contextElementVector.present("");
   reqDataP->upcr.res.updateActionType.present("");

--- a/src/lib/ngsi/AttributeAssociation.cpp
+++ b/src/lib/ngsi/AttributeAssociation.cpp
@@ -25,6 +25,8 @@
 #include <stdio.h>
 #include <string>
 
+#include "logMsg/logMsg.h"
+
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/AttributeAssociation.h"
@@ -93,14 +95,14 @@ void AttributeAssociation::present(const std::string& indent, int ix)
 {
   if (ix == -1)
   {
-    PRINTF("%sAttribute Association:\n",       indent.c_str());
+    LM_F(("%sAttribute Association:\n",indent.c_str()));
   }
   else
   {
-    PRINTF("%sAttribute Association %d:\n",    indent.c_str(), ix);
+    LM_F(("%sAttribute Association %d:\n",indent.c_str(), ix));
   }
 
-  PRINTF("%s  Source: %s\n", indent.c_str(), source.c_str());
-  PRINTF("%s  Target: %s\n", indent.c_str(), target.c_str());
-  PRINTF("\n");
+  LM_F(("%s  Source: %s\n", indent.c_str(), source.c_str()));
+  LM_F(("%s  Target: %s\n", indent.c_str(), target.c_str()));
+  LM_F("\n");
 }

--- a/src/lib/ngsi/AttributeAssociation.cpp
+++ b/src/lib/ngsi/AttributeAssociation.cpp
@@ -97,12 +97,11 @@ void AttributeAssociation::present(const std::string& indent, int ix)
   {
     LM_F(("%sAttribute Association:\n",indent.c_str()));
   }
-  else
+else
   {
     LM_F(("%sAttribute Association %d:\n",indent.c_str(), ix));
   }
 
   LM_F(("%s  Source: %s\n", indent.c_str(), source.c_str()));
-  LM_F(("%s  Target: %s\n", indent.c_str(), target.c_str()));
-  LM_F("\n");
+  LM_F(("%s  Target: %s\n\n", indent.c_str(), target.c_str()));
 }

--- a/src/lib/ngsi/AttributeAssociationList.cpp
+++ b/src/lib/ngsi/AttributeAssociationList.cpp
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <string>
 
+#include "logMsg/logMsg.h"
 #include "common/Format.h"
 #include "common/tag.h"
 #include "common/globals.h"
@@ -103,7 +104,7 @@ std::string AttributeAssociationList::check
 */
 void AttributeAssociationList::present(const std::string& indent)
 {
-  PRINTF("%lu Attribute Associations", (uint64_t) vec.size());
+  LM_F(("%lu Attribute Associations", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/AttributeExpression.cpp
+++ b/src/lib/ngsi/AttributeExpression.cpp
@@ -97,11 +97,11 @@ void AttributeExpression::present(const std::string& indent)
 {
   if (string != "")
   {
-    PRINTF("%sAttributeExpression: %s\n", indent.c_str(), string.c_str());
+    LM_F(("%sAttributeExpression: %s\n", indent.c_str(), string.c_str()));
   }
   else
   {
-    PRINTF("%sNo AttributeExpression\n", indent.c_str());
+    LM_F(("%sNo AttributeExpression\n", indent.c_str()));
   }
 }
 

--- a/src/lib/ngsi/ConditionValueList.cpp
+++ b/src/lib/ngsi/ConditionValueList.cpp
@@ -89,10 +89,10 @@ std::string ConditionValueList::check
 */
 void ConditionValueList::present(const std::string& indent)
 {
-  PRINTF("%sConditionValue List\n",    indent.c_str());
+  LM_F(("%sConditionValue List\n",    indent.c_str()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
-    PRINTF("%s  %s\n", indent.c_str(), vec[ix].c_str());
+    LM_F(("%s  %s\n", indent.c_str(), vec[ix].c_str()));
 }
 
 

--- a/src/lib/ngsi/ContextElementVector.cpp
+++ b/src/lib/ngsi/ContextElementVector.cpp
@@ -87,7 +87,7 @@ std::string ContextElementVector::render
 */
 void ContextElementVector::present(const std::string& indent)
 {
-  PRINTF("%lu ContextElements", (uint64_t) vec.size());
+  LM_F(("%lu ContextElements", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextRegistration.cpp
+++ b/src/lib/ngsi/ContextRegistration.cpp
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <string>
 
+#include "logMsg/logMsg.h"
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/Request.h"
@@ -124,11 +125,11 @@ void ContextRegistration::present(const std::string& indent, int ix)
 {
   if (ix != -1)
   {
-    PRINTF("%sContext Registration %d:\n", indent.c_str(), ix);
+    LM_F(("%sContext Registration %d:\n", indent.c_str(), ix));
   }
   else
   {
-    PRINTF("%scontext registration:\n", indent.c_str());
+    LM_F(("%scontext registration:\n", indent.c_str()));
   }
 
   entityIdVector.present(indent + "  ");

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <string>
 
+#include "logMsg/logMsg.h"
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/ContextRegistrationAttribute.h"
@@ -138,10 +139,10 @@ std::string ContextRegistrationAttribute::check
 */
 void ContextRegistrationAttribute::present(int ix, const std::string& indent)
 {
-  PRINTF("%sAttribute %d:\n",    indent.c_str(), ix);
-  PRINTF("%s  Name:       %s\n", indent.c_str(), name.c_str());
-  PRINTF("%s  Type:       %s\n", indent.c_str(), type.c_str());
-  PRINTF("%s  isDomain:   %s\n", indent.c_str(), isDomain.c_str());
+  LM_F(("%sAttribute %d:\n",    indent.c_str(), ix));
+  LM_F(("%s  Name:       %s\n", indent.c_str(), name.c_str()));
+  LM_F(("%s  Type:       %s\n", indent.c_str(), type.c_str()));
+  LM_F(("%s  isDomain:   %s\n", indent.c_str(), isDomain.c_str()));
 
   metadataVector.present("Attribute", indent + "  ");
 }

--- a/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "logMsg/logMsg.h"
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/ContextRegistrationAttributeVector.h"
@@ -89,7 +90,7 @@ std::string ContextRegistrationAttributeVector::check
 */
 void ContextRegistrationAttributeVector::present(const std::string& indent)
 {
-  PRINTF("%lu ContextRegistrationAttributes", (uint64_t) vec.size());
+  LM_F(("%lu ContextRegistrationAttributes", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextRegistrationResponseVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponseVector.cpp
@@ -80,7 +80,7 @@ std::string ContextRegistrationResponseVector::render(Format format, const std::
 */
 void ContextRegistrationResponseVector::present(const std::string& indent)
 {
-  PRINTF("%lu ContextRegistrationResponses", (uint64_t) vec.size());
+  LM_F(("%lu ContextRegistrationResponses", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextRegistrationVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationVector.cpp
@@ -80,7 +80,7 @@ std::string ContextRegistrationVector::render(Format format, const std::string& 
 */
 void ContextRegistrationVector::present(const std::string& indent)
 {
-  PRINTF("%lu ContextRegistrations", (uint64_t) vec.size());
+  LM_F(("%lu ContextRegistrations", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/Duration.cpp
+++ b/src/lib/ngsi/Duration.cpp
@@ -142,17 +142,17 @@ int64_t Duration::parse(void)
 
 /* ****************************************************************************
 *
-* Duration::present -
+* Duration::present
 */
 void Duration::present(const std::string& indent)
 {
   if (string != "")
   {
-    PRINTF("%sDuration: %s\n", indent.c_str(), string.c_str());
+    LM_F(("%sDuration: %s\n", indent.c_str(), string.c_str()));
   }
   else
   {
-    PRINTF("%sNo Duration\n", indent.c_str());
+    LM_F(("%sNo Duration\n", indent.c_str()));
   }
 }
 

--- a/src/lib/ngsi/EntityIdVector.cpp
+++ b/src/lib/ngsi/EntityIdVector.cpp
@@ -108,7 +108,7 @@ std::string EntityIdVector::check
 */
 void EntityIdVector::present(const std::string& indent)
 {
-  PRINTF("%lu EntityIds:\n", (uint64_t) vec.size());
+  LM_F(("%lu EntityIds:\n", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/NotifyCondition.cpp
+++ b/src/lib/ngsi/NotifyCondition.cpp
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <string>
 
+#include "logMsg/logMsg.h"
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/Request.h"
@@ -119,14 +120,14 @@ void NotifyCondition::present(const std::string& indent, int ix)
 
   if (ix == -1)
   {
-    PRINTF("%sNotify Condition:\n", indent2.c_str());
+    LM_F(("%sNotify Condition:\n", indent2.c_str()));
   }
   else
   {
-    PRINTF("%sNotify Condition %d:\n", indent2.c_str(), ix);
+    LM_F(("%sNotify Condition %d:\n", indent2.c_str(), ix));
   }
 
-  PRINTF("%stype: %s\n", indent2.c_str(), type.c_str());
+  LM_F(("%stype: %s\n", indent2.c_str(), type.c_str()));
   condValueList.present(indent2);
   restriction.present(indent2);
 }

--- a/src/lib/ngsi/NotifyConditionVector.cpp
+++ b/src/lib/ngsi/NotifyConditionVector.cpp
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+#include "logMsg/logMsg.h"
+
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/NotifyConditionVector.h"
@@ -92,7 +94,7 @@ std::string NotifyConditionVector::check
 */
 void NotifyConditionVector::present(const std::string& indent)
 {
-  PRINTF("%lu NotifyConditions", (uint64_t) vec.size());
+  LM_F(("%lu NotifyConditions", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/Originator.cpp
+++ b/src/lib/ngsi/Originator.cpp
@@ -93,11 +93,11 @@ void Originator::present(const std::string& indent)
 {
   if (string != "")
   {
-    PRINTF("%sOriginator: %s\n", indent.c_str(), string.c_str());
+    LM_F(("%sOriginator: %s\n", indent.c_str(), string.c_str()));
   }
   else
   {
-    PRINTF("%sNo Originator", indent.c_str());
+    LM_F(("%sNo Originator", indent.c_str()));
   }
 }
 

--- a/src/lib/ngsi/ProvidingApplication.cpp
+++ b/src/lib/ngsi/ProvidingApplication.cpp
@@ -126,11 +126,11 @@ void ProvidingApplication::present(const std::string& indent)
 {
   if (string != "")
   {
-    PRINTF("%sProvidingApplication: %s\n", indent.c_str(), string.c_str());
+    LM_F(("%sProvidingApplication: %s\n", indent.c_str(), string.c_str()));
   }
   else
   {
-    PRINTF("%sNo ProvidingApplication\n", indent.c_str());
+    LM_F(("%sNo ProvidingApplication\n", indent.c_str()));
   }
 }
 

--- a/src/lib/ngsi/Reference.cpp
+++ b/src/lib/ngsi/Reference.cpp
@@ -101,11 +101,11 @@ void Reference::present(const std::string& indent)
 {
   if (string != "")
   {
-    PRINTF("%sReference: %s\n", indent.c_str(), string.c_str());
+    LM_F(("%sReference: %s\n", indent.c_str(), string.c_str()));
   }
   else
   {
-    PRINTF("%sNo Reference\n", indent.c_str());
+    LM_F(("%sNo Reference\n", indent.c_str()));
   }
 }
 

--- a/src/lib/ngsi/RegistrationId.cpp
+++ b/src/lib/ngsi/RegistrationId.cpp
@@ -101,11 +101,11 @@ void RegistrationId::present(const std::string& indent)
 {
   if (string != "")
   {
-    PRINTF("%sRegistrationId: %s\n", indent.c_str(), string.c_str());
+    LM_F(("%sRegistrationId: %s\n", indent.c_str(), string.c_str()));
   }
   else
   {
-    PRINTF("%sNo RegistrationId\n", indent.c_str());
+    LM_F(("%sNo RegistrationId\n", indent.c_str()));
   }
 }
 

--- a/src/lib/ngsi/RestrictionString.cpp
+++ b/src/lib/ngsi/RestrictionString.cpp
@@ -93,11 +93,11 @@ void RestrictionString::present(const std::string& indent)
 {
   if (string != "")
   {
-    PRINTF("%sRestrictionString: %s\n", indent.c_str(), string.c_str());
+    LM_F(("%sRestrictionString: %s\n", indent.c_str(), string.c_str()));
   }
   else
   {
-    PRINTF("%sNo RestrictionString\n", indent.c_str());
+    LM_F(("%sNo RestrictionString\n", indent.c_str()));
   }
 }
 

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -216,40 +216,40 @@ void Scope::present(const std::string& indent, int ix)
 {
   if (ix == -1)
   {
-    PRINTF("%sScope:\n",       indent.c_str());
+    LM_F(("%sScope:\n",       indent.c_str()));
   }
   else
   {
-    PRINTF("%sScope %d:\n",    indent.c_str(), ix);
+    LM_F(("%sScope %d:\n",    indent.c_str(), ix));
   }
 
-  PRINTF("%s  Type:     '%s'\n", indent.c_str(), type.c_str());
+  LM_F(("%s  Type:     '%s'\n", indent.c_str(), type.c_str()));
   
   if (oper != "")
-    PRINTF("%s  Operator: '%s'\n", indent.c_str(), oper.c_str());
+    LM_F(("%s  Operator: '%s'\n", indent.c_str(), oper.c_str()));
 
   if (areaType == orion::NoArea)
   {
-    PRINTF("%s  Value:    %s\n", indent.c_str(), value.c_str());
+    LM_F(("%s  Value:    %s\n", indent.c_str(), value.c_str()));
   }
   else if (areaType == orion::CircleType)
   {
-    PRINTF("%s  FI-WARE Circle Area:\n", indent.c_str());
-    PRINTF("%s    Radius:     %s\n", indent.c_str(), circle.radiusString().c_str());
-    PRINTF("%s    Longitude:  %s\n", indent.c_str(), circle.center.longitudeString().c_str());
-    PRINTF("%s    Latitude:   %s\n", indent.c_str(), circle.center.latitudeString().c_str());
-    PRINTF("%s    Inverted:   %s\n", indent.c_str(), circle.invertedString().c_str());
+    LM_F(("%s  FI-WARE Circle Area:\n", indent.c_str()));
+    LM_F(("%s    Radius:     %s\n", indent.c_str(), circle.radiusString().c_str()));
+    LM_F(("%s    Longitude:  %s\n", indent.c_str(), circle.center.longitudeString().c_str()));
+    LM_F(("%s    Latitude:   %s\n", indent.c_str(), circle.center.latitudeString().c_str()));
+    LM_F(("%s    Inverted:   %s\n", indent.c_str(), circle.invertedString().c_str()));
   }
   else if (areaType == orion::PolygonType)
   {
-    PRINTF("%s  FI-WARE Polygon Area (%lu vertices):\n", indent.c_str(), polygon.vertexList.size());
+    LM_F(("%s  FI-WARE Polygon Area (%lu vertices):\n", indent.c_str(), polygon.vertexList.size()));
 
-    PRINTF("%s    Inverted:   %s\n", indent.c_str(), polygon.invertedString().c_str());
+    LM_F(("%s    Inverted:   %s\n", indent.c_str(), polygon.invertedString().c_str()));
     for (unsigned int ix = 0; ix < polygon.vertexList.size(); ++ix)
     {
-      PRINTF("%s    Vertex %d\n", indent.c_str(), ix);
-      PRINTF("%s      Longitude:  %s\n", indent.c_str(), polygon.vertexList[ix]->longitudeString().c_str());
-      PRINTF("%s      Latitude:   %s\n", indent.c_str(), polygon.vertexList[ix]->latitudeString().c_str());
+      LM_F(("%s    Vertex %d\n", indent.c_str(), ix));
+      LM_F(("%s      Longitude:  %s\n", indent.c_str(), polygon.vertexList[ix]->longitudeString().c_str()));
+      LM_F(("%s      Latitude:   %s\n", indent.c_str(), polygon.vertexList[ix]->latitudeString().c_str()));
     }
   }
 }

--- a/src/lib/ngsi/ScopeVector.cpp
+++ b/src/lib/ngsi/ScopeVector.cpp
@@ -97,11 +97,11 @@ void ScopeVector::present(const std::string& indent)
 {
   if (vec.size() == 0)
   {
-    PRINTF("No scopes\n");
+    LM_F(("No scopes\n"));
   }
   else
   {
-    PRINTF("%lu Scopes:\n", (uint64_t) vec.size());
+    LM_F(("%lu Scopes:\n", (uint64_t) vec.size()));
   }
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)

--- a/src/lib/ngsi/SubscriptionId.cpp
+++ b/src/lib/ngsi/SubscriptionId.cpp
@@ -123,11 +123,11 @@ void SubscriptionId::present(const std::string& indent)
 {
   if (string != "")
   {
-    PRINTF("%sSubscriptionId: %s\n", indent.c_str(), string.c_str());
+    LM_F(("%sSubscriptionId: %s\n", indent.c_str(), string.c_str()));
   }
   else
   {
-    PRINTF("%sNo SubscriptionId\n", indent.c_str());
+    LM_F(("%sNo SubscriptionId\n", indent.c_str()));
   }
 }
 

--- a/src/lib/ngsi/Throttling.cpp
+++ b/src/lib/ngsi/Throttling.cpp
@@ -132,11 +132,11 @@ void Throttling::present(const std::string& indent)
 {
   if (string != "")
   {
-    PRINTF("%sThrottling: %s\n", indent.c_str(), string.c_str());
+    LM_F(("%sThrottling: %s\n", indent.c_str(), string.c_str()));
   }
   else
   {
-    PRINTF("%sNo Throttling\n", indent.c_str());
+    LM_F(("%sNo Throttling\n", indent.c_str()));
   }
 }
 

--- a/src/lib/ngsi10/NotifyContextResponse.cpp
+++ b/src/lib/ngsi10/NotifyContextResponse.cpp
@@ -84,9 +84,9 @@ std::string NotifyContextResponse::render(RequestType requestType, Format format
 */
 void NotifyContextResponse::present(const std::string& indent)
 {
-  PRINTF("%sNotifyContextResponse:", indent.c_str());
+  LM_F(("%sNotifyContextResponse:", indent.c_str()));
   responseCode.present(indent + "  ");
-  PRINTF("\n");
+  LM_F(("\n"));
 }
 
 

--- a/src/lib/ngsi9/NotifyContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityResponse.cpp
@@ -84,9 +84,9 @@ std::string NotifyContextAvailabilityResponse::render(RequestType requestType, F
 */
 void NotifyContextAvailabilityResponse::present(const std::string& indent)
 {
-  PRINTF("%sNotifyContextAvailabilityResponse:", indent.c_str());
+  LM_F(("%sNotifyContextAvailabilityResponse:", indent.c_str()));
   responseCode.present(indent + "  ");
-  PRINTF("\n");
+  LM_F(("\n"));
 }
 
 

--- a/src/lib/orionTypes/EntityTypeAttributesResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeAttributesResponse.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "logMsg/logMsg.h"
 #include "common/Format.h"
 #include "common/globals.h"
 #include "common/tag.h"
@@ -93,7 +94,7 @@ std::string EntityTypeAttributesResponse::check
 */
 void EntityTypeAttributesResponse::present(const std::string& indent)
 {
-  PRINTF("%sEntityTypeAttributesResponse:\n", indent.c_str());
+  LM_F(("%sEntityTypeAttributesResponse:\n", indent.c_str()));
   entityType.present("indent + "  "");
   statusCode.present("indent + "  "");
 }

--- a/src/lib/orionTypes/EntityTypesResponse.cpp
+++ b/src/lib/orionTypes/EntityTypesResponse.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "logMsg/logMsg.h"
 #include "common/Format.h"
 #include "common/globals.h"
 #include "common/tag.h"
@@ -93,7 +94,7 @@ std::string EntityTypesResponse::check
 */
 void EntityTypesResponse::present(const std::string& indent)
 {
-  PRINTF("%s%d EntityTypesResponses:\n", indent.c_str(), typeEntityVector.size());
+  LM_F(("%s%d EntityTypesResponses:\n", indent.c_str(), typeEntityVector.size()));
 
   typeEntityVector.present(indent + "  ");
   statusCode.present(indent + "  ");

--- a/src/lib/orionTypes/TypeEntity.cpp
+++ b/src/lib/orionTypes/TypeEntity.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "logMsg/logMsg.h"
 #include "common/tag.h"
 #include "ngsi/Request.h"
 #include "rest/uriParamNames.h"
@@ -134,7 +135,7 @@ std::string TypeEntity::check
 */
 void TypeEntity::present(const std::string& indent)
 {
-  PRINTF("%stype:   %s", indent.c_str(), type.c_str());
+  LM_F(("%stype:   %s", indent.c_str(), type.c_str()));
   contextAttributeVector.present(indent);
 }
 

--- a/src/lib/orionTypes/TypeEntityVector.cpp
+++ b/src/lib/orionTypes/TypeEntityVector.cpp
@@ -114,7 +114,7 @@ std::string TypeEntityVector::check
 */
 void TypeEntityVector::present(const std::string& indent)
 {
-  PRINTF("%lu TypeEntitys", (uint64_t) vec.size());
+  LM_F(("%lu TypeEntitys", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/xmlParse/xmlDiscoverContextAvailabilityRequest.cpp
+++ b/src/lib/xmlParse/xmlDiscoverContextAvailabilityRequest.cpp
@@ -215,7 +215,7 @@ std::string dcarCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 
 
 
-#define PRINTF printf
+
 /* ****************************************************************************
 *
 * dcarPresent -
@@ -227,7 +227,7 @@ void dcarPresent(ParseData* reqDataP)
     return;
   }
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqDataP->dcar.res.present("");
 }
 

--- a/src/lib/xmlParse/xmlNotifyContextAvailabilityRequest.cpp
+++ b/src/lib/xmlParse/xmlNotifyContextAvailabilityRequest.cpp
@@ -74,7 +74,7 @@ std::string ncarCheck(ParseData* parseDataP, ConnectionInfo* ciP)
 }
 
 
-#define PRINTF printf
+
 /* ****************************************************************************
 *
 * ncarPresent - 
@@ -86,7 +86,7 @@ void ncarPresent(ParseData* parseDataP)
     return;
   }
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   parseDataP->ncar.res.present("");
 }
 

--- a/src/lib/xmlParse/xmlNotifyContextRequest.cpp
+++ b/src/lib/xmlParse/xmlNotifyContextRequest.cpp
@@ -85,7 +85,7 @@ void ncrPresent(ParseData* parseDataP)
     return;
   }
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   parseDataP->ncr.res.subscriptionId.present("");
 }
 

--- a/src/lib/xmlParse/xmlQueryContextRequest.cpp
+++ b/src/lib/xmlParse/xmlQueryContextRequest.cpp
@@ -398,7 +398,7 @@ std::string qcrCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 }
 
 
-#define PRINTF printf
+
 /* ****************************************************************************
 *
 * qcrPresent -
@@ -410,7 +410,7 @@ void qcrPresent(ParseData* reqDataP)
     return;
   }
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqDataP->qcr.res.present("");
 }
 

--- a/src/lib/xmlParse/xmlQueryContextResponse.cpp
+++ b/src/lib/xmlParse/xmlQueryContextResponse.cpp
@@ -364,7 +364,7 @@ std::string qcrsCheck(ParseData* parseDataP, ConnectionInfo* ciP)
 }
 
 
-#define PRINTF printf
+
 /* ****************************************************************************
 *
 * qcrsPresent -

--- a/src/lib/xmlParse/xmlRegisterContextRequest.cpp
+++ b/src/lib/xmlParse/xmlRegisterContextRequest.cpp
@@ -495,7 +495,6 @@ std::string rcrCheck(ParseData* parseDataP, ConnectionInfo* ciP)
 }
 
 
-#define PRINTF printf
 /* ****************************************************************************
 *
 * rcrPresent -
@@ -507,7 +506,7 @@ void rcrPresent(ParseData* parseDataP)
     return;
   }
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   parseDataP->rcr.res.contextRegistrationVector.present("");
   parseDataP->rcr.res.duration.present("");
   parseDataP->rcr.res.registrationId.present("");

--- a/src/lib/xmlParse/xmlRegisterContextResponse.cpp
+++ b/src/lib/xmlParse/xmlRegisterContextResponse.cpp
@@ -164,7 +164,7 @@ void rcrsPresent(ParseData* reqData)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqData->rcrs.res.duration.present("");
   reqData->rcrs.res.registrationId.present("");
   reqData->rcrs.res.errorCode.present("");

--- a/src/lib/xmlParse/xmlUnsubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/xmlParse/xmlUnsubscribeContextAvailabilityRequest.cpp
@@ -80,7 +80,7 @@ std::string ucarCheck(ParseData* reqData, ConnectionInfo* ciP)
 }
 
 
-#define PRINTF printf
+
 /* ****************************************************************************
 *
 * ucarPresent -
@@ -90,7 +90,7 @@ void ucarPresent(ParseData* reqData)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqData->ucar.res.subscriptionId.present("");
 }
 

--- a/src/lib/xmlParse/xmlUnsubscribeContextRequest.cpp
+++ b/src/lib/xmlParse/xmlUnsubscribeContextRequest.cpp
@@ -80,7 +80,6 @@ std::string uncrCheck(ParseData* reqData, ConnectionInfo* ciP)
 
 
 
-#define PRINTF printf
 /* ****************************************************************************
 *
 * uncrPresent -
@@ -90,7 +89,7 @@ void uncrPresent(ParseData* reqData)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqData->uncr.res.present("");
 }
 

--- a/src/lib/xmlParse/xmlUpdateContextAttributeRequest.cpp
+++ b/src/lib/xmlParse/xmlUpdateContextAttributeRequest.cpp
@@ -77,7 +77,7 @@ void upcarPresent(ParseData* reqData)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqData->upcar.res.present("");
 }
 

--- a/src/lib/xmlParse/xmlUpdateContextAvailabilitySubscriptionRequest.cpp
+++ b/src/lib/xmlParse/xmlUpdateContextAvailabilitySubscriptionRequest.cpp
@@ -240,7 +240,7 @@ std::string ucasCheck(ParseData* reqData, ConnectionInfo* ciP)
 
 
 
-#define PRINTF printf
+
 /* ****************************************************************************
 *
 * ucasPresent -
@@ -250,7 +250,7 @@ void ucasPresent(ParseData* reqData)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqData->ucas.res.present("");
 }
 

--- a/src/lib/xmlParse/xmlUpdateContextResponse.cpp
+++ b/src/lib/xmlParse/xmlUpdateContextResponse.cpp
@@ -365,7 +365,7 @@ std::string upcrsCheck(ParseData* parseDataP, ConnectionInfo* ciP)
 }
 
 
-#define PRINTF printf
+
 /* ****************************************************************************
 *
 * upcrsPresent -
@@ -375,6 +375,6 @@ void upcrsPresent(ParseData* parseDataP)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   parseDataP->upcrs.res.present("");
 }

--- a/src/lib/xmlParse/xmlUpdateContextSubscriptionRequest.cpp
+++ b/src/lib/xmlParse/xmlUpdateContextSubscriptionRequest.cpp
@@ -405,7 +405,7 @@ void ucsrPresent(ParseData* reqData)
   if (!lmTraceIsSet(LmtDump))
     return;
 
-  PRINTF("\n\n");
+  LM_F(("\n\n"));
   reqData->ucsr.res.present("");
 }
 


### PR DESCRIPTION
It has been deleted the PRINTF macro present in the source code of /fiware_orion/src/lib/ngsi/ngsi9/ngsi10 and replaced using LM_F