### PR TITLE
FIX files compliance script to support more flexible copyright line

### DIFF
--- a/scripts/check_files_compliance.py
+++ b/scripts/check_files_compliance.py
@@ -27,7 +27,7 @@ import re
 from sys import argv
 
 header = []
-header.append('\s*Copyright 201[3|4|5] Telefonica Investigacion y Desarrollo, S.A.U$')
+header.append('\s*Copyright( \(c\))? 201[3|4|5] Telefonica Investigacion y Desarrollo, S.A.U$')
 header.append('\s*$')
 header.append('\s*This file is part of Orion Context Broker.$')
 header.append('\s*$')


### PR DESCRIPTION
After this PR, both:

```
Copyright 2013
```

and

```
Copyright (c) 2013
```

are supported in the license header