### PR TITLE
Bug/remove traces  

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,4 +4,5 @@ Add: New operation "GET /v2/entities" (Issue #947)
 Add: New operation "GET /v2" (Issue #956)
 Fix: ONCHANGE subscription sends notification when value under condition it is not updated with updateContext-APPEND in some cases (Issue #943)
 Add: Reuse curl context for outgoing notifications, so now connections are persistent if the HTTP server doesn't close them
+Fix: remove unconditional tracing on xmlTreat()/jsonTreat() which was impacting on performance (specially in high-load scenarios)
 

--- a/src/lib/jsonParse/jsonRequest.cpp
+++ b/src/lib/jsonParse/jsonRequest.cpp
@@ -265,16 +265,12 @@ std::string jsonTreat
     ciP->compoundValueP->shortShow("after parse: ");
   }
 
-  reqP->present(parseDataP);
-
   LM_T(LmtParseCheck, ("Calling check for JSON parsed tree (%s)", ciP->payloadWord));
   res = reqP->check(parseDataP, ciP);
   if (res != "OK")
   {
     LM_W(("Bad Input (%s: %s)", reqP->keyword.c_str(), res.c_str()));
   }
-
-  reqP->present(parseDataP);
 
   return res;
 }

--- a/src/lib/xmlParse/xmlRequest.cpp
+++ b/src/lib/xmlParse/xmlRequest.cpp
@@ -371,8 +371,6 @@ std::string xmlTreat
     }
   }
 
-  reqP->present(parseDataP);
-
   if (check != "OK")
   {
     if (errorMsgP)


### PR DESCRIPTION
Remove unconditional tracing on xmlTreat()/jsonTreat() which was impacting on performance (specially in high-load scenarios)