### PR TITLE
Rename db unittests

### DIFF
--- a/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
@@ -2611,7 +2611,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, mongoDbQueryFail)
     EXPECT_EQ(SccReceiverInternalError, res.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
 
-    EXPECT_EQ("collection: unittest.registrations "
+    EXPECT_EQ("collection: utest.registrations "
               "- query(): { query: { $or: [ { contextRegistration.entities: { $in: [ { id: \"E3\", type: \"T3\" }, { type: \"T3\", id: \"E3\" } ] } }, "
               "{ contextRegistration.entities.id: { $in: [] } } ], "
               "expiration: { $gt: 1360232700 }"
@@ -2642,7 +2642,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, mongoDBQueryAssociationFail)
     /* Prepare mock */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, _query("unittest.associations",_,_,_,_,_,_))
+    ON_CALL(*connectionMock, _query("utest.associations",_,_,_,_,_,_))
             .WillByDefault(Throw(e));
 
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
@@ -2662,7 +2662,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, mongoDBQueryAssociationFail)
     EXPECT_EQ(SccOk, ms);
     EXPECT_EQ(SccReceiverInternalError, res.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
-    EXPECT_EQ("Database error: collection: unittest.associations - query(): { query: { srcEnt: { $in: [ { id: \"E1\", type: \"T1\" } ] }, attrs.src: { $in: [ \"A4\" ] } }, orderby: { _id: 1 } } - exception: boom!!", res.errorCode.details);
+    EXPECT_EQ("Database error: collection: utest.associations - query(): { query: { srcEnt: { $in: [ { id: \"E1\", type: \"T1\" } ] }, attrs.src: { $in: [ \"A4\" ] } }, orderby: { _id: 1 } } - exception: boom!!", res.errorCode.details);
     EXPECT_EQ(0,res.responseVector.size());
 
     /* Release connection */

--- a/test/unittests/mongoBackend/mongoOntimeintervalOperations_test.cpp
+++ b/test/unittests/mongoBackend/mongoOntimeintervalOperations_test.cpp
@@ -270,7 +270,7 @@ TEST(mongoOntimeintervalOperations, mongoGetContextSubscriptionInfo_dbfail)
     /* Prepare mock */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, findOne("unittest.csubs",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.csubs",_,_,_))
             .WillByDefault(Throw(e));
 
     /* Forge the parameters */
@@ -489,7 +489,7 @@ TEST(mongoOntimeintervalOperations, mongoGetContextElementResponses_dbfail)
     /* Prepare mock */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock,_query("unittest.entities",_,_,_,_,_,_))
+    ON_CALL(*connectionMock,_query("utest.entities",_,_,_,_,_,_))
             .WillByDefault(Throw(e));
 
     /* Forge the parameters */
@@ -515,7 +515,7 @@ TEST(mongoOntimeintervalOperations, mongoGetContextElementResponses_dbfail)
 
     /* Check results */
     EXPECT_EQ(SccOk, ms);
-    EXPECT_EQ("collection: unittest.entities - "
+    EXPECT_EQ("collection: utest.entities - "
               "query(): { query: { $or: [ { _id.id: \"E1\", _id.type: \"T\" }, { _id.id: \"E2\", _id.type: \"T\" } ], _id.servicePath: { $in: [ /^/.*/, null ] }, "
               "attrNames: { $in: [ \"A1\", \"A2\", \"A3\", \"A4\" ] } }, orderby: { creDate: 1 } } - "
               "exception: boom!!", err);    
@@ -616,7 +616,7 @@ TEST(mongoOntimeintervalOperations, mongoUpdateCsubNewNotification_dbfail)
     /* Prepare mock */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, update("unittest.csubs",_,_,_,_,_))
+    ON_CALL(*connectionMock, update("utest.csubs",_,_,_,_,_))
             .WillByDefault(Throw(e));
 
     TimerMock* timerMock = new TimerMock();

--- a/test/unittests/mongoBackend/mongoQueryContextGeo_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContextGeo_test.cpp
@@ -69,7 +69,7 @@ static void prepareDatabase(void) {
 
   DBClientBase* connection = getMongoConnection();
 
-  connection->createIndex("unittest.entities", BSON("location.coords" << "2dsphere" ));
+  connection->createIndex("utest.entities", BSON("location.coords" << "2dsphere" ));
 
   BSONObj A = BSON("_id" << BSON("id" << "A" << "type" << "Point") <<
                      "attrNames" << BSON_ARRAY("pos" << "foo") <<

--- a/test/unittests/mongoBackend/mongoQueryContextGeo_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContextGeo_test.cpp
@@ -69,7 +69,7 @@ static void prepareDatabase(void) {
 
   DBClientBase* connection = getMongoConnection();
 
-  connection->createIndex("utest.entities", BSON("location.coords" << "2dsphere" ));
+  connection->createIndex("unittest.entities", BSON("location.coords" << "2dsphere" ));
 
   BSONObj A = BSON("_id" << BSON("id" << "A" << "type" << "Point") <<
                      "attrNames" << BSON_ARRAY("pos" << "foo") <<

--- a/test/unittests/mongoBackend/mongoQueryContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_test.cpp
@@ -3648,7 +3648,7 @@ TEST(mongoQueryContextRequest, mongoDbQueryFail)
 
     EXPECT_EQ(SccReceiverInternalError, res.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.entities - "
+    EXPECT_EQ("collection: utest.entities - "
               "query(): { query: { $or: [ { _id.id: \"E1\", _id.type: \"T1\" } ], _id.servicePath: { $in: [ /^/.*/, null ] } }, orderby: { creDate: 1 } } - "
               "exception: boom!!", res.errorCode.details);
     EXPECT_EQ(0,res.contextElementResponseVector.size());    

--- a/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
@@ -908,7 +908,7 @@ TEST(mongoQueryTypes, queryAllDbException)
   EXPECT_EQ(SccOk, ms); 
   EXPECT_EQ(SccReceiverInternalError, res.statusCode.code);
   EXPECT_EQ("Internal Server Error", res.statusCode.reasonPhrase);
-  EXPECT_EQ("database: unittest - "
+  EXPECT_EQ("database: utest - "
             "command: { aggregate: \"entities\", pipeline: [ { $match: { _id.servicePath: { $in: [ /^/.*/, null ] } } }, { $project: { _id: 1, attrNames: 1 } }, { $project: { attrNames: { $cond: [ { $eq: [ \"$attrNames\", [] ] }, [ null ], \"$attrNames\" ] } } }, { $unwind: \"$attrNames\" }, { $group: { _id: \"$_id.type\", attrs: { $addToSet: \"$attrNames\" } } }, { $sort: { _id: 1 } } ] } - "
             "exception: boom!!", res.statusCode.details);
   EXPECT_EQ(0,res.typeEntityVector.size());
@@ -950,7 +950,7 @@ TEST(mongoQueryTypes, queryAllGenericException)
 
   EXPECT_EQ(SccReceiverInternalError, res.statusCode.code);
   EXPECT_EQ("Internal Server Error", res.statusCode.reasonPhrase);
-  EXPECT_EQ("database: unittest - "
+  EXPECT_EQ("database: utest - "
             "command: { aggregate: \"entities\", pipeline: [ { $match: { _id.servicePath: { $in: [ /^/.*/, null ] } } }, { $project: { _id: 1, attrNames: 1 } }, { $project: { attrNames: { $cond: [ { $eq: [ \"$attrNames\", [] ] }, [ null ], \"$attrNames\" ] } } }, { $unwind: \"$attrNames\" }, { $group: { _id: \"$_id.type\", attrs: { $addToSet: \"$attrNames\" } } }, { $sort: { _id: 1 } } ] } - "
             "exception: generic", res.statusCode.details);
   EXPECT_EQ(0,res.typeEntityVector.size());
@@ -1463,7 +1463,7 @@ TEST(mongoQueryTypes, queryGiveyTypeDbException)
 
   EXPECT_EQ(SccReceiverInternalError, res.statusCode.code);
   EXPECT_EQ("Internal Server Error", res.statusCode.reasonPhrase);
-  EXPECT_EQ("database: unittest - "
+  EXPECT_EQ("database: utest - "
             "command: { aggregate: \"entities\", pipeline: [ { $match: { _id.type: \"Car\", _id.servicePath: { $in: [ /^/.*/, null ] } } }, { $project: { _id: 1, attrNames: 1 } }, { $unwind: \"$attrNames\" }, { $group: { _id: \"$_id.type\", attrs: { $addToSet: \"$attrNames\" } } }, { $unwind: \"$attrs\" }, { $group: { _id: \"$attrs\" } }, { $sort: { _id: 1 } } ] } - "
             "exception: boom!!", res.statusCode.details);
   EXPECT_EQ(0,res.entityType.contextAttributeVector.size());
@@ -1504,7 +1504,7 @@ TEST(mongoQueryTypes, queryGivenTypeGenericException)
 
   EXPECT_EQ(SccReceiverInternalError, res.statusCode.code);
   EXPECT_EQ("Internal Server Error", res.statusCode.reasonPhrase);
-  EXPECT_EQ("database: unittest - "
+  EXPECT_EQ("database: utest - "
             "command: { aggregate: \"entities\", pipeline: [ { $match: { _id.type: \"Car\", _id.servicePath: { $in: [ /^/.*/, null ] } } }, { $project: { _id: 1, attrNames: 1 } }, { $unwind: \"$attrNames\" }, { $group: { _id: \"$_id.type\", attrs: { $addToSet: \"$attrNames\" } } }, { $unwind: \"$attrs\" }, { $group: { _id: \"$attrs\" } }, { $sort: { _id: 1 } } ] } - "
             "exception: generic", res.statusCode.details);
   EXPECT_EQ(0,res.entityType.contextAttributeVector.size());

--- a/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
@@ -2720,8 +2720,8 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
      * random. ObjectId is 24 characters long.*/
     /* FIXME: a better approach would be to pass a regex filter to relace ObjectId by a constant string,
      * but I don't know how to work with regex in C++ */
-    std::string s1 = res.errorCode.details.substr(0, 71);
-    std::string s2 = res.errorCode.details.substr(71+24, res.errorCode.details.size()-71-24);
+    std::string s1 = res.errorCode.details.substr(0, 68);
+    std::string s2 = res.errorCode.details.substr(68+24, res.errorCode.details.size()-68-24);
     EXPECT_EQ("collection: utest.registrations "
               "- upsert update(): { _id: ObjectId('",s1);
     EXPECT_EQ("'), expiration: 1360232760, servicePath: \"/\", format: \"XML\", contextRegistration: [ { entities: [ { id: \"E1\", type: \"T1\" } ], attrs: [], providingApplication: \"http://dummy.com\" } ] } "

--- a/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
@@ -2687,11 +2687,11 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
             .WillByDefault(Return(1));
     ON_CALL(*connectionMock, findOne(_,_,_,_))
             .WillByDefault(Return(fakeEntity));
-    ON_CALL(*connectionMock, update("unittest.registrations",_,_,_,_,_))
+    ON_CALL(*connectionMock, update("utest.registrations",_,_,_,_,_))
             .WillByDefault(Throw(e));    
     ON_CALL(*cursorMockCAsub, more())
             .WillByDefault(Return(false));
-    ON_CALL(*connectionMock, _query("unittest.casubs",_,_,_,_,_,_))
+    ON_CALL(*connectionMock, _query("utest.casubs",_,_,_,_,_,_))
             .WillByDefault(Return(cursorMockCAsub));
 
     /* Forge the request (from "inside" to "outside") */
@@ -2722,7 +2722,7 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
      * but I don't know how to work with regex in C++ */
     std::string s1 = res.errorCode.details.substr(0, 71);
     std::string s2 = res.errorCode.details.substr(71+24, res.errorCode.details.size()-71-24);
-    EXPECT_EQ("collection: unittest.registrations "
+    EXPECT_EQ("collection: utest.registrations "
               "- upsert update(): { _id: ObjectId('",s1);
     EXPECT_EQ("'), expiration: 1360232760, servicePath: \"/\", format: \"XML\", contextRegistration: [ { entities: [ { id: \"E1\", type: \"T1\" } ], attrs: [], providingApplication: \"http://dummy.com\" } ] } "
               "- exception: boom!!", s2);
@@ -2839,7 +2839,7 @@ TEST(mongoRegisterContextRequest, AssociationsDbFail)
     /* Prepare mock */   
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, insert("unittest.associations",_,_,_))
+    ON_CALL(*connectionMock, insert("utest.associations",_,_,_))
             .WillByDefault(Throw(e));
 
     /* Forge the request (from "inside" to "outside") */

--- a/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
@@ -1016,7 +1016,7 @@ TEST(mongoRegisterContext_update, MongoDbFindOneFail)
     /* Prepare mock */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, findOne("unittest.registrations",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.registrations",_,_,_))
             .WillByDefault(Throw(e));
 
     /* Forge the request (from "inside" to "outside") */
@@ -1046,7 +1046,7 @@ TEST(mongoRegisterContext_update, MongoDbFindOneFail)
     EXPECT_TRUE(res.registrationId.isEmpty());
     EXPECT_EQ(SccReceiverInternalError, res.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.registrations "
+    EXPECT_EQ("collection: utest.registrations "
               "- findOne() _id: 51307b66f481db11bf860001 "
               "- exception: boom!!", res.errorCode.details);
 

--- a/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
@@ -2551,7 +2551,7 @@ TEST(mongoSubscribeContextAvailability, MongoDbInsertFail)
     /* Prepare mocks */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, insert("unittest.casubs",_,_,_))
+    ON_CALL(*connectionMock, insert("utest.casubs",_,_,_))
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -2587,7 +2587,7 @@ TEST(mongoSubscribeContextAvailability, MongoDbInsertFail)
     EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
     std::string s1 = res.errorCode.details.substr(0, 57);
     std::string s2 = res.errorCode.details.substr(57+24, res.errorCode.details.size()-57-24);
-    EXPECT_EQ("collection: unittest.casubs "
+    EXPECT_EQ("collection: utest.casubs "
               "- insert(): { _id: ObjectId('", s1);
     EXPECT_EQ("'), expiration: 1360236300, reference: \"http://notify.me\", entities: [ { id: \"E5\", type: \"T5\", isPattern: \"false\" } ], attrs: [], format: \"XML\" } "
               "- exception: boom!!", s2);

--- a/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
@@ -2585,8 +2585,8 @@ TEST(mongoSubscribeContextAvailability, MongoDbInsertFail)
     EXPECT_TRUE(res.subscriptionId.isEmpty());
     EXPECT_EQ(SccReceiverInternalError, res.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
-    std::string s1 = res.errorCode.details.substr(0, 57);
-    std::string s2 = res.errorCode.details.substr(57+24, res.errorCode.details.size()-57-24);
+    std::string s1 = res.errorCode.details.substr(0, 54);
+    std::string s2 = res.errorCode.details.substr(54+24, res.errorCode.details.size()-54-24);
     EXPECT_EQ("collection: utest.casubs "
               "- insert(): { _id: ObjectId('", s1);
     EXPECT_EQ("'), expiration: 1360236300, reference: \"http://notify.me\", entities: [ { id: \"E5\", type: \"T5\", isPattern: \"false\" } ], attrs: [], format: \"XML\" } "

--- a/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
@@ -7438,7 +7438,7 @@ TEST(mongoSubscribeContext, MongoDbInsertFail)
     /* Prepare mocks */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, insert("unittest.csubs",_,_,_))
+    ON_CALL(*connectionMock, insert("utest.csubs",_,_,_))
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -7480,7 +7480,7 @@ TEST(mongoSubscribeContext, MongoDbInsertFail)
 
     std::string s1 = res.subscribeError.errorCode.details.substr(0, 56);
     std::string s2 = res.subscribeError.errorCode.details.substr(56+24, res.subscribeError.errorCode.details.size()-56-24);
-    EXPECT_EQ("collection: unittest.csubs "
+    EXPECT_EQ("collection: utest.csubs "
               "- insert(): { _id: ObjectId('", s1);
     EXPECT_EQ("'), expiration: 1360236300, reference: \"http://notify.me\", entities: [ { id: \"E1\", type: \"T1\", isPattern: \"false\" } ], attrs: [], conditions: [ { type: \"ONTIMEINTERVAL\", value: 60 } ], format: \"XML\" } "
               "- exception: boom!!", s2);

--- a/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
@@ -7478,8 +7478,8 @@ TEST(mongoSubscribeContext, MongoDbInsertFail)
     EXPECT_EQ(SccReceiverInternalError, res.subscribeError.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.subscribeError.errorCode.reasonPhrase);
 
-    std::string s1 = res.subscribeError.errorCode.details.substr(0, 56);
-    std::string s2 = res.subscribeError.errorCode.details.substr(56+24, res.subscribeError.errorCode.details.size()-56-24);
+    std::string s1 = res.subscribeError.errorCode.details.substr(0, 53);
+    std::string s2 = res.subscribeError.errorCode.details.substr(53+24, res.subscribeError.errorCode.details.size()-53-24);
     EXPECT_EQ("collection: utest.csubs "
               "- insert(): { _id: ObjectId('", s1);
     EXPECT_EQ("'), expiration: 1360236300, reference: \"http://notify.me\", entities: [ { id: \"E1\", type: \"T1\", isPattern: \"false\" } ], attrs: [], conditions: [ { type: \"ONTIMEINTERVAL\", value: 60 } ], format: \"XML\" } "

--- a/test/unittests/mongoBackend/mongoUnsubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoUnsubscribeContextAvailability_test.cpp
@@ -190,7 +190,7 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbFindOneFail)
     /* Prepare mocks */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, findOne("unittest.casubs",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.casubs",_,_,_))
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -215,7 +215,7 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbFindOneFail)
     EXPECT_EQ("51307b66f481db11bf860001", res.subscriptionId.get());
     EXPECT_EQ(SccReceiverInternalError, res.statusCode.code);
     EXPECT_EQ("Internal Server Error", res.statusCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.casubs "
+    EXPECT_EQ("collection: utest.casubs "
               "- findOne() _id: 51307b66f481db11bf860001 "
               "- exception: boom!!", res.statusCode.details);
     
@@ -252,9 +252,9 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbRemoveFail)
                                        "entities" << BSON_ARRAY(BSON("id" << "E1" << "type" << "T1" << "isPattern" << "false")) <<
                                        "attrs" << BSONArray());
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, findOne("unittest.casubs",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.casubs",_,_,_))
             .WillByDefault(Return(fakeSub));
-    ON_CALL(*connectionMock, remove("unittest.casubs",_,_,_))
+    ON_CALL(*connectionMock, remove("utest.casubs",_,_,_))
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -279,7 +279,7 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbRemoveFail)
     EXPECT_EQ("51307b66f481db11bf860001", res.subscriptionId.get());
     EXPECT_EQ(SccReceiverInternalError, res.statusCode.code);
     EXPECT_EQ("Internal Server Error", res.statusCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.casubs "
+    EXPECT_EQ("collection: utest.casubs "
               "- remove() _id: 51307b66f481db11bf860001 "
               "- exception: boom!!", res.statusCode.details);
 

--- a/test/unittests/mongoBackend/mongoUnsubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUnsubscribeContext_test.cpp
@@ -216,7 +216,7 @@ TEST(mongoUnsubscribeContext, MongoDbFindOneFail)
     /* Prepare mocks */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, findOne("unittest.csubs",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.csubs",_,_,_))
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -245,7 +245,7 @@ TEST(mongoUnsubscribeContext, MongoDbFindOneFail)
     EXPECT_EQ("51307b66f481db11bf860001", res.subscriptionId.get());
     EXPECT_EQ(SccReceiverInternalError, res.statusCode.code);
     EXPECT_EQ("Internal Server Error", res.statusCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.csubs "
+    EXPECT_EQ("collection: utest.csubs "
               "- findOne() _id: 51307b66f481db11bf860001 "
               "- exception: boom!!", res.statusCode.details);
 
@@ -284,9 +284,9 @@ TEST(mongoUnsubscribeContext, MongoDbRemoveFail)
                                        "attrs" << BSONArray() <<
                                        "conditions" << BSONArray());
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, findOne("unittest.csubs",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.csubs",_,_,_))
             .WillByDefault(Return(fakeSub));
-    ON_CALL(*connectionMock, remove("unittest.csubs",_,_,_))
+    ON_CALL(*connectionMock, remove("utest.csubs",_,_,_))
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -315,7 +315,7 @@ TEST(mongoUnsubscribeContext, MongoDbRemoveFail)
     EXPECT_EQ("51307b66f481db11bf860001", res.subscriptionId.get());
     EXPECT_EQ(SccReceiverInternalError, res.statusCode.code);
     EXPECT_EQ("Internal Server Error", res.statusCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.csubs "
+    EXPECT_EQ("collection: utest.csubs "
               "- remove() _id: 51307b66f481db11bf860001 "
               "- exception: boom!!", res.statusCode.details);
 

--- a/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
@@ -10,7 +10,7 @@
 * License, or (at your option) any later version.
 *
 * Orion Context Broker is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* but WITHOUT ANY WARRANTY; without even the /*i*/mplied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
 * General Public License for more details.
 *
@@ -2743,7 +2743,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbFindOneFail)
     /* Prepare mocks */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, findOne("unittest.casubs",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.casubs",_,_,_))
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -2769,7 +2769,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbFindOneFail)
     EXPECT_TRUE(res.subscriptionId.isEmpty());
     EXPECT_EQ(SccReceiverInternalError, res.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.casubs "
+    EXPECT_EQ("collection: utest.casubs "
               "- findOne() _id: 51307b66f481db11bf860010 "
               "- exception: boom!!", res.errorCode.details);
 
@@ -2799,9 +2799,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbUpdateFail)
                                        "entities" << BSON_ARRAY(BSON("id" << "E1" << "type" << "T1" << "isPattern" << "false")) <<
                                        "attrs" << BSONArray());
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, update("unittest.casubs",_,_,_,_,_))
+    ON_CALL(*connectionMock, update("utest.casubs",_,_,_,_,_))
             .WillByDefault(Throw(e));
-    ON_CALL(*connectionMock, findOne("unittest.casubs",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.casubs",_,_,_))
             .WillByDefault(Return(fakeSub));
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextAvailabilityRequest(_,_,_,_))
@@ -2831,7 +2831,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbUpdateFail)
     EXPECT_TRUE(res.subscriptionId.isEmpty());
     EXPECT_EQ(SccReceiverInternalError, res.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.errorCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.casubs "
+    EXPECT_EQ("collection: utest.casubs "
               "- update() _id: 51307b66f481db11bf860010 "
               "- update() doc: { entities: [ { id: \"E5\", type: \"T5\", isPattern: \"false\" } ], attrs: [], expiration: 1360250700, reference: \"http://notify1.me\", format: \"XML\" } "
               "- exception: boom!!", res.errorCode.details);

--- a/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
@@ -10,7 +10,7 @@
 * License, or (at your option) any later version.
 *
 * Orion Context Broker is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the /*i*/mplied warranty of
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
 * General Public License for more details.
 *
@@ -2843,3 +2843,5 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbUpdateFail)
     delete timerMock;
 
 }
+
+

--- a/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
@@ -7255,7 +7255,7 @@ TEST(mongoUpdateContextSubscription, MongoDbFindOneFail)
     /* Prepare mocks */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, findOne("unittest.csubs",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.csubs",_,_,_))
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -7285,7 +7285,7 @@ TEST(mongoUpdateContextSubscription, MongoDbFindOneFail)
     EXPECT_TRUE(res.subscribeError.subscriptionId.isEmpty());
     EXPECT_EQ(SccReceiverInternalError, res.subscribeError.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.subscribeError.errorCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.csubs "
+    EXPECT_EQ("collection: utest.csubs "
               "- findOne() _id: 51307b66f481db11bf860001 "
               "- exception: boom!!", res.subscribeError.errorCode.details);
 
@@ -7318,9 +7318,9 @@ TEST(mongoUpdateContextSubscription, MongoDbUpdateFail)
                                        "conditions" << BSONArray());
 
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, update("unittest.csubs",_,_,_,_,_))
+    ON_CALL(*connectionMock, update("utest.csubs",_,_,_,_,_))
             .WillByDefault(Throw(e));
-    ON_CALL(*connectionMock, findOne("unittest.csubs",_,_,_))
+    ON_CALL(*connectionMock, findOne("utest.csubs",_,_,_))
             .WillByDefault(Return(fakeSub));
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -7355,7 +7355,7 @@ TEST(mongoUpdateContextSubscription, MongoDbUpdateFail)
     EXPECT_TRUE(res.subscribeError.subscriptionId.isEmpty());
     EXPECT_EQ(SccReceiverInternalError, res.subscribeError.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.subscribeError.errorCode.reasonPhrase);
-    EXPECT_EQ("collection: unittest.csubs "
+    EXPECT_EQ("collection: utest.csubs "
               "- update() _id: 51307b66f481db11bf860001 "
               "- update() doc: { entities: [ { id: \"E1\", type: \"T1\", isPattern: \"false\" } ], attrs: [], reference: \"http://notify1.me\", expiration: 1360250700, conditions: [], lastNotification: 15000000, format: \"XML\" } "
               "- exception: boom!!", res.subscribeError.errorCode.details);

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -9002,11 +9002,11 @@ TEST(mongoUpdateContextRequest, mongoDbUpdateFail)
             .WillByDefault(Return(fakeEn));
     ON_CALL(*cursorMockCsub, more())
             .WillByDefault(Return(false));
-    ON_CALL(*connectionMock, _query("unittest.entities",_,_,_,_,_,_))
+    ON_CALL(*connectionMock, _query("utest.entities",_,_,_,_,_,_))
             .WillByDefault(Return(cursorMockEnt));
-    ON_CALL(*connectionMock, _query("unittest.csubs",_,_,_,_,_,_))
+    ON_CALL(*connectionMock, _query("utest.csubs",_,_,_,_,_,_))
             .WillByDefault(Return(cursorMockCsub));
-    ON_CALL(*connectionMock, update("unittest.entities",_,_,_,_,_))
+    ON_CALL(*connectionMock, update("utest.entities",_,_,_,_,_))
             .WillByDefault(Throw(e));
 
     /* Set MongoDB connection */
@@ -9044,7 +9044,7 @@ TEST(mongoUpdateContextRequest, mongoDbUpdateFail)
     EXPECT_EQ(SccReceiverInternalError, RES_CER_STATUS(0).code);
     EXPECT_EQ("Internal Server Error", RES_CER_STATUS(0).reasonPhrase);
 
-    EXPECT_EQ("collection: unittest.entities "
+    EXPECT_EQ("collection: utest.entities "
               "- update() query: { _id.id: \"E1\", _id.type: \"T1\", _id.servicePath: { $exists: false } } "
               "- update() doc: { $set: { attrs.A1: { value: \"new_val\", type: \"TA1\", modDate: 1360232700 }, modDate: 1360232700 }, $unset: { location: 1 } } "
               "- exception: boom!!", RES_CER_STATUS(0).details);
@@ -9105,7 +9105,7 @@ TEST(mongoUpdateContextRequest, mongoDbQueryFail)
     EXPECT_EQ(0, RES_CER(0).contextAttributeVector.size());
     EXPECT_EQ(SccReceiverInternalError, RES_CER_STATUS(0).code);
     EXPECT_EQ("Internal Server Error", RES_CER_STATUS(0).reasonPhrase);
-    EXPECT_EQ("collection: unittest.entities "
+    EXPECT_EQ("collection: utest.entities "
               "- query(): { _id.id: \"E1\", _id.type: \"T1\", _id.servicePath: { $exists: false } } "
               "- exception: boom!!", RES_CER_STATUS(0).details);
 

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
@@ -3010,7 +3010,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_delete2Matches1Notifica
 *
 * FIXME: given that we can no "bypass" calls to the mocked function in which we
 * are not interested given the problem described in the mock constructor above
-* (in particular, I will need to bypass queries to "unittest.entities), I will leave
+* (in particular, I will need to bypass queries to "utest.entities), I will leave
 * finalization of this tests (current version is not working) upon resolution of
 * old issue #87
 */
@@ -3026,7 +3026,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, DISABLED_MongoDbQueryFail)
     /* Prepare mocks */
     const DBException e = DBException("boom!!", 33);
     DBClientConnectionMock* connectionMock = new DBClientConnectionMock();
-    ON_CALL(*connectionMock, _query("unittest.csubs",_,_,_,_,_,_))
+    ON_CALL(*connectionMock, _query("utest.csubs",_,_,_,_,_,_))
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();

--- a/test/unittests/testInit.h
+++ b/test/unittests/testInit.h
@@ -30,7 +30,7 @@
 #include "ngsi10/NotifyContextRequest.h"
 
 /* Collection names used for testing */
-#define DBPREFIX                    "unittest"
+#define DBPREFIX                    "utest"
 #define REGISTRATIONS_COLL          DBPREFIX ".registrations"
 #define ENTITIES_COLL               DBPREFIX ".entities"
 #define SUBSCRIBECONTEXT_COLL       DBPREFIX ".csubs"


### PR DESCRIPTION
Fixes #628 
The definition in testInit.h has been changed from 'unittest' to 'utest' and from those direct usages of 'unittest' stored in test/unittests/mongoBackend/