### PR TITLE
ADD comment about NGSI list archives

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-cookbook.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-cookbook.apib
@@ -3,35 +3,16 @@ HOST: http://fiware-ngsi2.apiblueprint.org/
 
 # FIWARE-NGSI Simple API (v2) Cookbook
 
-<!--
- Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
-
- This file is part of Orion Context Broker.
-
- Orion Context Broker is free software: you can redistribute it and/or
- modify it under the terms of the GNU Affero General Public License as
- published by the Free Software Foundation, either version 3 of the
- License, or (at your option) any later version.
-
- Orion Context Broker is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
- General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License
- along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
-
- For those usages not covered by this license please contact with
- iot_support at tid dot es
--->
-
 FIWARE-NGSI Simple API (v2) Cookbook.
 
 This is a cookbook with recipes that show how to use FIWARE-NGSI v2 aka FIWARE-NGSI Simple API.
 Use this examples for learning and enjoy!
 
 This is a work in progress and is changing on a daily basis.
-Please send your comments to fiware-ngsi@lists.fiware.org
+Please send your comments to fiware-ngsi@lists.fiware.org. You can
+trace the discussions checking the archives of the mailing list:
+https://lists.fiware.org/private/fiware-ngsi/ (list subscription
+required).
 
 Please check the following [FI-WARE Open Specification Legal Notice (essential patents license)](http://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/FI-WARE_Open_Specification_Legal_Notice_%28essential_patents_license%29) to understand the rights to use this specification.
 

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -6,7 +6,10 @@ HOST: http://orion.lab.fiware.org/
 FIWARE-NGSI Simple API (v2) Specification.
 
 This is a work in progress and is changing on a daily basis.
-Please send your comments to fiware-ngsi@lists.fiware.org
+Please send your comments to fiware-ngsi@lists.fiware.org. You can
+trace the discussions checking the archives of the mailing list:
+https://lists.fiware.org/private/fiware-ngsi/ (list subscription
+required).
 
 In addition, note that a list of currently open discussions is available at
 


### PR DESCRIPTION
In addition, I have removed the licence header in the cookbook .apib (which was defferred due to a hurry in a past PR).