### PR TITLE
FIX apiary specification document after refining #1022

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -29,91 +29,79 @@ An entity is represented by a a JSON object which contain the following properti
 * `id` for the entity ID, represented by a JSON string. If the entity has an `id` attribute itself it will be ignored.
 * `type` for the entity type, represented by a JSON string. If the entity has a `type` attribute itself it will be ignored.
   If the entity doesn't have a type, then this property is not included.
-* A collection of properties, one per entity attribute. Property values can be single values or they can include,
-  `type` and properties representing metadata as well. Property values which correspond to the primitive JSON datatypes
-  "string", "number" and "boolean" and with no metadata are rendered as regular JSON values. Property values
-  which specify a custom type or include metadata are rendered as JSON objects with the following properties:
-  * `value`: for the attribute value, rendered as a regular JSON value depending on the type. Attributes with an
-    user-defined informative types are rendered as JSON strings (TBD).
-  * `type`: a JSON string which represents the attribute type provided at attribute creation time.
-  * A collection of properties one per metadata field associated to the attribute value. Metadata properties follow the
-    same representation rules that applies to properties which represent attributes (except that a metadata
-    cannot have metadata properties). 
+* A collection of properties, one per entity attribute. Properties representing attributes with no metadata
+  or type are rendered as regular JSON values. Properties representing attributes which specify a type or include
+  metadata are rendered as JSON objects with the following properties:
+  * `value`: for the attribute value, rendered as a regular JSON value (string, number or boolean), object or array.
+  * `type`: a JSON string which represents the user-defined NGSI attribute type.
+  * A collection of properties one per metadata field associated to the attribute value. Metadata properties follow
+    the same representation rules that applies to properties which represent attributes (except that a metadata
+    cannot have metadata properties).
 
-Canonical format description (TBD).
+### Special attribute types
 
-### Predefined types
+Generally speaking, user-defined attribute types are informative, they are processed by the NGSIv2 server in
+an opaque way. Nonetheless, the types described below are used to convey an special meaning
 
-All attribute types not included in the list below are considered *user-defined informative* types. The values of
-user-defined informative types are represented by JSON string.
-
-* `number` (or `Number`):  identifies numbers, either integer or float.
-They are associated to JSON number type (see https://developer.mozilla.org/en-US/docs/Glossary/Number).
-Operators allowed are: greater than, lesser than, greater or equal, lesser or equal and range.
+* `date`:  identifies dates, in ISO8601 format. These attributes can be used with the
+  greater than, lesser than, greater or equal, lesser or equal and range query operators. Eg:
 
 ```
-"temperature": 32.5
+  "timestamp": {
+    "value": "2017-06-17T07:21:24.238Z",
+    "type: "date"
+  }
 ```
 
-* `string` (or `String`): identifies text string. They are represented by JSON strings (see https://developer.mozilla.org/en-US/docs/Glossary/String).
+* `geo:point`: identifies the location of the entity in geo-location queries. If an entity have several attributes
+  of this type all them define a possible location for the entity from a geo-location query point of view. (TBD:
+  check feasibility).
 
 ```
-"msg": "Hello world"
-```
-
-* `boolean` (or `Boolean`): identifies a logical value, either true or false. They are represented by JSON booleans (see https://developer.mozilla.org/en-US/docs/Glossary/Boolean).
-
-```
-"active": true
-```
-
-* `date` (or `Date`):  identifies dates, in ISO8601 format. They are represented by JSON strings. Operators allowed are:
-greater than, lesser than, greater or equal, lesser or equal and range.
-
-```
-"timestamp": "2017-06-17T07:21:24.238Z"
-```
-
-
-* `geo:point`: identifies a geolocation. They are represented by JSON strings. An
-entity can only have one `geo:point` attribute (TBD: this is yet under discussion, one possibility is
-there can be multiple points associated to an entity but an entity can only be located on one place).
-
-```
-{
-  ...
   "location": {
     "value": "41.3763726, 2.1864475,14",
     "type": "geo:point"
   }
-}
 ```
 
-At creation or update time, the type has to be coherent with the value of the attribute, e.g the following
-will result in an error response:
+### Canonical format description
 
-(TBD: this behaviour is under discussion, specially the case for the "myType" with JSON number for the value)
+This is a variant of the represention format aimed at clients that need a regular representation of the entities
+and attributes, that can be used in the operations that support the `canonical` option.
+
+* Entity `type` is mandatory. If the entity has no type, JSON `null` is used.
+* Property `attrs` is mandatory and includes a JSON object for the attributes.
+* Each attribute is described always with `value`, `type` and `metadata`. All fields are mandatory (attributes
+  without type use JSON `null` for that property).
+* Each metadata is described always with `value` and `type`. Both fields are mandatory (metadata
+  without type use JSON `null` for that property).
 
 ```
 {
-  "value": "23.5", -> value should be: 23.5
-  "type": "number"
-}
-
-
-{
-  "value": 23.5,   -> value should be: "23.5"
-  "type": "string"
-}
-
-{
-  "value": "23.5", -> value should be: "23.5" (user defined types always use JSON strings as value)
-  "type": "myType"
-}
-
-{
-  "value": "foo, bar", -> it is not correctly formated as coordinates
-  "type": "geo:point"
+  "type": "Room",
+  "id": "Boe_Idearium",
+  "attrs": {
+    "speed": {
+      "value": 88,
+      "type": null,
+      "metadata": { }
+    },
+    "pressure": {
+      "value": 12.1,
+      "type": null,
+      "metadata": { }
+    },
+    "temperature": {
+      "value": 22,
+      "type": "urn:phenomenum:temperature",
+      "metadata": { }
+    },
+    "colour": {
+      "value": "black",
+      "type": "myString",
+      "metadata": { }
+    }
+  }
 }
 ```
 
@@ -123,6 +111,14 @@ In the case of being present, the error payload is JSON object including the fol
 
 * `error` (mandatory): a textual description of the error.
 * `description` (optional): additional information about the error.
+
+Error list (HTTP response code in paranthesis):
+
+* NotFound (404). The context element referred in the request has not been found.
+* TooManyResults (409). There are several results that match with the resource identification used
+  in the request. This typically the case of requesting an entity with not enough information and the
+  solution is to enhance entity identification adding more information, e.g. adding entity type
+  and/or service path.
 
 ## API Entry Point [/v2]
 
@@ -222,17 +218,21 @@ temperature<=20
     </ul>
   </li>
   <li>Greater than: <code>&gt;</code>. The value is a single element, e.g. <code>temperature&gt;40</code>. It
-  matches entities which attribute value is strictly greater than that value. It can only
-  be used with attributes which contain dates or numbers.</li>
+  matches entities which attribute value is strictly greater than that value. It only makes sense when
+  used with attributes which contain dates or numbers (using with attributes of other type might lead to
+  unexpected results).</li>
   <li>Lesser than: <code>&lt;</code>. The value is a single element, e.g. <code>temperature&lt;40</code>. It
-  matches entities which attribute value is strictly lesser than that value. It can only
-  be used with attributes which contain dates or numbers.</li>
+  matches entities which attribute value is strictly lesser than that value. It only makes sense when
+  used with attributes which contain dates or numbers (using with attributes of other type might lead to
+  unexpected results).</li>
   <li>Greater or equal than: <code>&gt;=</code>. The value is a single element, e.g. <code>temperature&gt;=40</code>.
-  It matches entities which attribute value is greater than or equal to that value. It can only
-  be used with attributes which contain dates or numbers.</li>
+  It matches entities which attribute value is greater than or equal to that value. It only makes sense when
+  used with attributes which contain dates or numbers (using with attributes of other type might lead to
+  unexpected results).</li>
   <li>Lesser or equal than: <code>&lt;=</code>. The value is a single element, e.g. <code>temperature&lt;=40</code>. It
-  matches entities which attribute value is lesser than or equal to that value. It can only
-  be used with attributes which contain dates or numbers.</li>
+  matches entities which attribute value is lesser than or equal to that value. It only makes sense when
+  used with attributes which contain dates or numbers (using with attributes of other type might lead to
+  unexpected results).</li>
 </ul>
 
 <p>In the case of equal or inequal, if the value to match include a <code>,</code>, you can use simple quote
@@ -509,18 +509,9 @@ Response:
 
 + Response 204
 
-### Remove entity atributes [DELETE /v2/entities/{entityId}?{attrs}]
+### Remove entity atributes [DELETE /v2/entities/{entityId}]
 
-<table style="width: 100%; margin: 12px 0 0 0;">
-<tr><td colspan="2"><strong>Required Parameters</strong></td></tr>
-<tr><td colspan="2">none</td></tr>
-<tr><td colspan="2"><strong>Optional Parameters</strong></td></tr>
-<tr>
-  <td style="padding-right: 40px; width: 140px;">attrs</td>
-  <td>Comma-separated list of attribute names which data will be removed. If this parameter is not
-  included, the entity itself is removed.</td>
-</tr>
-</table>
+Delete the entity.
 
 Response:
 
@@ -529,9 +520,10 @@ Response:
 
 + Parameters
     + entityId: Boe_Idearium (required, string) - Entity ID
-    + attrs: temperature,humidity (optional, string) - Attributes to be removed. Coma separated list.
 
 + Response 204
+
+<!--
 
 ## Entity by type and ID [/v2/entities/type/{entityType}/id/{entityId}{?attrs,options}]
 
@@ -681,16 +673,7 @@ Response:
 
 ### Remove entity attributes [DELETE /v2/entities/type/{entityType}/id/{entityId}?{attrs}]
 
-<table style="width: 100%; margin: 12px 0 0 0;">
-<tr><td colspan="2"><strong>Required Parameters</strong></td></tr>
-<tr><td colspan="2">none</td></tr>
-<tr><td colspan="2"><strong>Optional Parameters</strong></td></tr>
-<tr>
-  <td style="padding-right: 40px; width: 140px;">attrs</td>
-  <td>Comma-separated list of attribute names which data will be removed. If this parameter is not
-  included, the entity itself is removed.</td>
-</tr>
-</table>
+Delete the entity.
 
 Response:
 
@@ -700,9 +683,10 @@ Response:
 + Parameters
     + entityId: Boe_Idearium (required, string) - Entity ID
     + entityType: Room (required, string) - Entity Type
-    + attrs: temperature,humidity (optional, string) - Attributes to be deleted. Coma separated list.
 
 + Response 204
+
+-->
 
 ## Attribute by Entity ID [/v2/entities/{entityId}/attrs/{attrName}]
 
@@ -765,6 +749,8 @@ Response:
     + attrName: temperature (required, string) - Attribute name
 
 + Response 204
+
+<!--
 
 ## Attribute by Entity Type and ID [/v2/entities/type/{entityType}/id/{entityId}/attrs/{attrName}]
 
@@ -831,6 +817,8 @@ Response:
 
 + Response 204
 
+-->
+
 ## Attribute Value by Entity ID [/v2/entities/{entityId}/attrs/{attrName}/value{?options}]
 
 ### Get attribute data [GET /v2/entities/{entityId}/attrs/{attrName}/value{?options}]
@@ -884,6 +872,8 @@ Response:
         }
 
 + Response 200
+
+<!--
 
 ## Attribute Value by Entity type and ID [/v2/entities/type/{entityType}/id/{entityId}/attrs/{attrName}/value{?options}]
 
@@ -941,6 +931,8 @@ Response:
 
 + Response 200
 
+-->
+
 ## Entity types [/v2/types{?limit,offset,options}]
 
 ### Retrieve entity types [GET /v2/types/{?limit,offset,options}]
@@ -957,13 +949,16 @@ This operation supports two options:
 <ul>
   <li><code>count</code>: when used, the total types number is returned as a HTTP in the
   response name <code>X-Total-Count</code>.</li>
-  <li><code>collapsed</code>: when used, the response payload is a JSON array with a
+  <li><code>values</code>: when used, the response payload is a JSON array with a
   list of entity types.</li>
 </td></tr>
 </table>
 
-Returns a list of entity types, either as JSON object (including the union set of attribute names along all the entities in each type) or
-a JSON array (just type name), depending on the `collapsed` option.
+If `values` option is not use, the operation returns a JSON object which properties are entity types. The properties
+value is a JSON object with information about the type: `attrs` (the union set of attribute names along all the entities
+of such type) and `count` (the number of entities belonging to that type).
+
+If `values` option is used, the operation returns a JSON array with the list of entity types names as strings.
 
 Response code:
 
@@ -977,23 +972,45 @@ Response code:
 + Response 200 (application/json)
 
         {
-         "Car": [
-            "speed",
-            "fuel",
-            "temperature"
-         ],
-         "Room": [
-            "pressure",
-            "hummidity",
-            "temperature"
-         ]
+          "Car": {
+            "attrs": {
+              "speed": {
+                "type": null
+              },
+              "fuel": {
+                "type": "gasoline"
+              },
+              "fuel": {
+                "type": "diesel"
+              },
+              "temperature": {
+                "type": "urn:phenomenum:temperature"
+              }
+            },
+            "count": 12
+          },
+          "Room": {
+            "attrs": {
+              "pressure": {
+                "type": null
+              },
+              "hummidity": {
+                "type": "percentage"
+              },
+              "temperature": {
+                "type": "urn:phenomenum:temperature"
+              }
+            },
+            "count": 7
+          }
         }
 
 ## Entity type [/v2/type/{entityType}]
 
 ### Retrieve entity type [GET /v2/type/{entityType}]
 
-Returns the union set of attribute names along all the entities belonging to the type as a JSON array.
+The operation returns a JSON object with information about the type: `attrs` (the union set of attribute names along all
+the entities of such type) and `count` (the number of entities belonging to that type).
 
 Response code:
 
@@ -1005,11 +1022,20 @@ Response code:
 
 + Response 200 (application/json)
 
-        [
-            "pressure",
-            "hummidity",
-            "temperature"
-        ]
+          {
+            "attrs": {
+              "pressure": {
+                "type": null
+              },
+              "hummidity": {
+                "type": "percentage"
+              },
+              "temperature": {
+                "type": "urn:phenomenum:temperature"
+              }
+            },
+            "count": 7
+          }
 
 ## Context Subscriptions [/v2/entities/{entityId}/subscriptions]
 


### PR DESCRIPTION
Implementing changes after our discussion on June 26th on issue #1022 topics:

* Commenting out sections on `/type/<type>/id/<id>` in order to have a shorter and cleaner specification
* Clarifying how JSON types and NGSI types works (including some remarks regarding appliying filtering to non-numeric and non-date types). Dates and geo:point are the only special NGSI types for CB (both string-based from a JSON type point of view).
* Including cannonical representation definition.
* Fixing "GET /v2/types" and "GET /v2/types/{type}" operations
* Removing `?attrs` paramter in "DELETE /v2/entities/{id}" and "DELETE /v2/entities/type/{type}/id/{id}" operations