### PR TITLE
Remove all XML format

### DIFF
--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -236,7 +236,8 @@ Fields:
     below (we think they're quite straightforward)
 -   **count**: the number of notifications sent associated to
     the subscription.
--   **format**: the format to use to send notifications, or "JSON".
+-   **format**: the format to use to send notification, either "XML" or "JSON".
+    However, note that XML has been deprecated in Orion 0.23.0 and that this field eventually will be removed.
 
 Example document:
 
@@ -302,7 +303,8 @@ Fields:
     notification sent associated to a given subscription.
 -   **count**: the number of notifications sent associated to
     the subscription.
--   **format**: the format to use to send notifications, "JSON".
+-   **format**: the format to use to send notification, either "XML" or "JSON".
+    However, note that XML has been deprecated in Orion 0.23.0 and that this field eventually will be removed.
 
 Example document:
 

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -236,8 +236,7 @@ Fields:
     below (we think they're quite straightforward)
 -   **count**: the number of notifications sent associated to
     the subscription.
--   **format**: the format to use to send notifications, either "XML"
-    or "JSON".
+-   **format**: the format to use to send notifications, or "JSON".
 
 Example document:
 
@@ -273,7 +272,7 @@ Example document:
        }
    ],
    "count": 27,
-   "format": "XML"
+   "format": "JSON"
  }
 ```
 

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -302,7 +302,7 @@ Fields:
     notification sent associated to a given subscription.
 -   **count**: the number of notifications sent associated to
     the subscription.
--   **format**: the format to use to send notifications,"JSON".
+-   **format**: the format to use to send notifications, "JSON".
 
 Example document:
 

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -303,8 +303,7 @@ Fields:
     notification sent associated to a given subscription.
 -   **count**: the number of notifications sent associated to
     the subscription.
--   **format**: the format to use to send notifications, either "XML"
-    or "JSON".
+-   **format**: the format to use to send notifications,"JSON".
 
 Example document:
 
@@ -331,6 +330,6 @@ Example document:
    ],
    "lastNotification" : 1381132312,
    "count": 42,
-   "format": "XML"
+   "format": "JSON"
  }
 ```

--- a/doc/manuals/admin/management_api.md
+++ b/doc/manuals/admin/management_api.md
@@ -31,7 +31,6 @@ A sample <i>statistics</i> response:
 
 ```
  <orion>
-   <xmlRequests>16</xmlRequests>
    <jsonRequests>1</jsonRequests>
    <registrations>5</registrations>
    <discoveries>10</discoveries>

--- a/doc/manuals/user/append_and_delete.md
+++ b/doc/manuals/user/append_and_delete.md
@@ -7,185 +7,180 @@ with an example.
 
 We start creating a simple entity 'E1' with one attribute named 'A':
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                            {
-          <contextElement>                                                                                                                "type": "T",
-            <entityId type="T" isPattern="false">                                                                                         "isPattern": "false",
-              <id>E1</id>                                                                                                                 "id": "E1",
-            </entityId>                                                                                                                   "attributes": [
-            <contextAttributeList>                                                                                                        {
-              <contextAttribute>                                                                                                            "name": "A",
-                <name>A</name>                                                                                                              "type": "TA",
-                <type>TA</type>                                                                                                             "value": "1"
-                <contextValue>1</contextValue>                                                                                            }
-              </contextAttribute>                                                                                                         ]
-            </contextAttributeList>                                                                                                     }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "APPEND"
-        <updateAction>APPEND</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+        {
+          "type": "T",
+          "isPattern": "false",
+          "id": "E1",
+          "attributes": [
+          {
+              "name": "A",
+              "type": "TA",
+              "value": "1"
+          }
+          ]
+        }
+        ],
+        "updateAction": "APPEND"
+      }
+      EOF                                                                                                                      
   
 Now, in order to append a new attribute (let's name it 'B') we use
 updateContext APPEND with an entityId matching 'E1':
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                            {
-          <contextElement>                                                                                                                "type": "T",
-            <entityId type="T" isPattern="false">                                                                                         "isPattern": "false",
-              <id>E1</id>                                                                                                                 "id": "E1",
-            </entityId>                                                                                                                   "attributes": [
-            <contextAttributeList>                                                                                                        {
-              <contextAttribute>                                                                                                            "name": "B",
-                <name>B</name>                                                                                                              "type": "TB",
-                <type>TB</type>                                                                                                             "value": "2"
-                <contextValue>2</contextValue>                                                                                            }
-              </contextAttribute>                                                                                                         ]
-            </contextAttributeList>                                                                                                     }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "APPEND"
-        <updateAction>APPEND</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+	{
+          "type": "T",
+          "isPattern": "false",
+          "id": "E1",
+          "attributes": [
+          {
+              "name": "B",
+              "type": "TB",
+              "value": "2"
+          }
+          ]
+        }
+        ],
+        "updateAction": "APPEND"
+      }
+      EOF                                                                                                                      
   
 Now we can check with a query to that entity that both attributes A and
 B are there:
 
-      curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/xml' | xmllint --format -       curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+     curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
-      <?xml version="1.0"?>                          {
-      <contextElementResponse>                           "contextElement": {
-        <contextElement>                                     "attributes": [
-          <entityId type="" isPattern="false">                   {
-            <id>E1</id>                                              "name": "B",
-          </entityId>                                                "type": "TB",
-          <contextAttributeList>                                     "value": "2"
-            <contextAttribute>                                   },
-              <name>A</name>                                     {
-              <type>TA</type>                                        "name": "A",
-              <contextValue>1</contextValue>                         "type": "TA",
-            </contextAttribute>                                      "value": "1"
-            <contextAttribute>                                   }
-              <name>B</name>                                 ],
-              <type>TB</type>                                "id": "E1",
-              <contextValue>2</contextValue>                 "isPattern": "false",
-            </contextAttribute>                              "type": ""
-          </contextAttributeList>                        },
-        </contextElement>                                "statusCode": {
-        <statusCode>                                         "code": "200",
-          <code>200</code>                                   "reasonPhrase": "OK"
-          <reasonPhrase>OK</reasonPhrase>                }
-        </statusCode>                                }
-      </contextElementResponse>                  
+     {
+       "contextElement": {
+	  "attributes": [
+          {
+            "name": "B",
+	    "type": "TB",
+	    "value": "2"
+          },
+          {
+            "name": "A",
+            "type": "TA",
+            "value": "1"
+          }
+          ],
+              "id": "E1",
+              "isPattern": "false",
+	      "type": ""
+          },
+        "statusCode": {
+	  "code": "200",
+          "reasonPhrase": "OK"
+        }
+     }
   
 We can also remove attributes in a similar way, using the DELETE action
 type. For example, to remove attribute 'A' we will use (note the empty
 contextValue element):
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                            {
-          <contextElement>                                                                                                                "type": "T",
-            <entityId type="T" isPattern="false">                                                                                         "isPattern": "false",
-              <id>E1</id>                                                                                                                 "id": "E1",
-            </entityId>                                                                                                                   "attributes": [
-            <contextAttributeList>                                                                                                        {
-              <contextAttribute>                                                                                                            "name": "A",
-                <name>A</name>                                                                                                              "type": "TA",
-                <type>TA</type>                                                                                                             "value": ""
-                <contextValue/>                                                                                                           }
-              </contextAttribute>                                                                                                         ]
-            </contextAttributeList>                                                                                                     }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "DELETE"
-        <updateAction>DELETE</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+     (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+     {
+      "contextElements": [
+      {
+         "type": "T",
+         "isPattern": "false",
+         "id": "E1",
+         "attributes": [
+         {
+              "name": "A",
+              "type": "TA",
+              "value": ""
+         }
+         ]
+       }
+       ],
+        "updateAction": "DELETE"
+     }
+     EOF                                                                                                                      
   
 Now, a query to the entity shows attribute B:
 
-      curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/xml' | xmllint --format -       curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
-      <?xml version="1.0"?>                          {
-      <contextElementResponse>                           "contextElement": {
-        <contextElement>                                     "attributes": [
-          <entityId type="" isPattern="false">                   {
-            <id>E1</id>                                              "name": "B",
-          </entityId>                                                "type": "TB",
-          <contextAttributeList>                                     "value": "2"
-            <contextAttribute>                                   }
-              <name>B</name>                                 ],
-              <type>TB</type>                                "id": "E1",
-              <contextValue>2</contextValue>                 "isPattern": "false",
-            </contextAttribute>                              "type": ""
-          </contextAttributeList>                        },
-        </contextElement>                                "statusCode": {
-        <statusCode>                                         "code": "200",
-          <code>200</code>                                   "reasonPhrase": "OK"
-          <reasonPhrase>OK</reasonPhrase>                }
-        </statusCode>                                }
-      </contextElementResponse>                  
+      {
+      "contextElement": {
+        "attributes": [
+        {
+            "name": "B",
+            "type": "TB",
+            "value": "2"
+        }
+        ],
+            "id": "E1",
+            "isPattern": "false",
+            "type": ""
+        },
+        "statusCode": {
+	  "code": "200",
+          "reasonPhrase": "OK"
+          }
+        }
+        
   
 You can also use convenience operations with POST and DELETE verbs to
 add and delete attributes. Try the following:
 
 Add a new attribute 'C' and 'D':
 
-      (curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/xml' -X POST -d @- | xmllint --format - ) << EOF       (curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                                      {
-      <appendContextElementRequest>                                                                                                                 "attributes" : [
-        <contextAttributeList>                                                                                                                        {
-          <contextAttribute>                                                                                                                            "name" : "C",
-            <name>C</name>                                                                                                                              "type" : "TC",
-            <type>TC</type>                                                                                                                             "value" : "3"
-            <contextValue>3</contextValue>                                                                                                            },
-          </contextAttribute>                                                                                                                         {
-          <contextAttribute>                                                                                                                            "name" : "D",
-            <name>D</name>                                                                                                                              "type" : "TD",
-            <type>TD</type>                                                                                                                             "value" : "4"
-            <contextValue>4</contextValue>                                                                                                            }
-          </contextAttribute>                                                                                                                       ]
-        </contextAttributeList>                                                                                                                   }
-      </appendContextElementRequest>                                                                                                              EOF
-      EOF                                                                                                                                     
+     (curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+     {
+	"attributes" : [
+        {
+          "name" : "C",
+          "type" : "TC",
+          "value" : "3"
+        },
+        {
+          "name" : "D",
+          "type" : "TD",
+          "value" : "4"
+        }
+        ]
+     }
+     EOF
+                                                                                                                                           
   
 Remove attribute 'B':
 
-      curl localhost:1026/v1/contextEntities/E1/attributes/B -s -S --header 'Content-Type: application/xml' -X DELETE | xmllint --format -       curl localhost:1026/v1/contextEntities/E1/attribute/B -s -S --header 'Content-Type: application/json' -X DELETE --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextEntities/E1/attribute/B -s -S --header 'Content-Type: application/json' -X DELETE --header 'Accept: application/json' | python -mjson.tool
 
 Query entity (should see 'C' and 'D', but not 'B'):
   
-      curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/xml' | xmllint --format -       curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
-      <?xml version="1.0"?>                          {
-      <contextElementResponse>                           "contextElement": {
-        <contextElement>                                     "attributes": [
-          <entityId type="" isPattern="false">                   {
-            <id>E1</id>                                              "name": "C",
-          </entityId>                                                "type": "TC",
-          <contextAttributeList>                                     "value": "3"
-            <contextAttribute>                                   },
-              <name>C</name>                                     {
-              <type>TC</type>                                        "name": "D",
-              <contextValue>3</contextValue>                         "type": "TD",
-            </contextAttribute>                                      "value": "4"
-            <contextAttribute>                                   }
-              <name>D</name>                                 ],
-              <type>TD</type>                                "id": "E1",
-              <contextValue>4</contextValue>                 "isPattern": "false",
-            </contextAttribute>                              "type": ""
-          </contextAttributeList>                        },
-        </contextElement>                                "statusCode": {
-        <statusCode>                                         "code": "200",
-          <code>200</code>                                   "reasonPhrase": "OK"
-          <reasonPhrase>OK</reasonPhrase>                }
-        </statusCode>                                }
-      </contextElementResponse>                  
+      {
+      "contextElement": {
+        "attributes": [
+        {
+            "name": "C",
+            "type": "TC",
+            "value": "3"
+        },
+        {
+            "name": "D",
+            "type": "TD",
+            "value": "4"
+        }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+        },
+        "statusCode": {
+	  "code": "200",
+          "reasonPhrase": "OK"
+          }
+       }                
   
 # Deleting entities
 
@@ -197,23 +192,21 @@ their corresponding metadata. In order to do so, the updateContext
 operation is used, with DELETE as actionType and with an empty
 attributeList, as in the following example:
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                           {
-          <contextElement>                                                                                                                "type": "T",
-            <entityId type="T" isPattern="false">                                                                                         "isPattern": "false",
-              <id>E1</id>                                                                                                                 "id": "E1"
-            </entityId>                                                                                                                 }
-            <contextAttributeList/>                                                                                                   ],
-          </contextElement>                                                                                                           "updateAction": "DELETE"
-        </contextElementList>                                                                                                       }
-        <updateAction>DELETE</updateAction>                                                                                         EOF
-      </updateContextRequest>                                                                                                   
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+	{
+          "type": "T",
+          "isPattern": "false",
+          "id": "E1"
+        }
+        ],
+        "updateAction": "DELETE"
+      }
+      EOF                                                                                                                     
  
 You can also use the following equivalent convenience operation:
 
-      curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/xml' -X DELETE       curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X DELETE
+      curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X DELETE
 
 

--- a/doc/manuals/user/append_and_delete.md
+++ b/doc/manuals/user/append_and_delete.md
@@ -108,23 +108,23 @@ Now, a query to the entity shows attribute B:
       curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
       {
-      "contextElement": {
-        "attributes": [
-        {
-            "name": "B",
-            "type": "TB",
-            "value": "2"
-        }
-        ],
-            "id": "E1",
-            "isPattern": "false",
-            "type": ""
-        },
-        "statusCode": {
-	  "code": "200",
-          "reasonPhrase": "OK"
-          }
-        }
+	  "contextElement": {
+	      "attributes": [
+		  {
+		      "name": "B",
+		      "type": "TB",
+		      "value": "2"
+		  }
+	      ],
+	      "id": "E1",
+	      "isPattern": "false",
+	      "type": ""
+	  },
+	  "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
+	  }
+      }
         
   
 You can also use convenience operations with POST and DELETE verbs to

--- a/doc/manuals/user/append_and_delete.md
+++ b/doc/manuals/user/append_and_delete.md
@@ -8,45 +8,28 @@ with an example.
 We start creating a simple entity 'E1' with one attribute named 'A':
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      {
-	"contextElements": [
-        {
-          "type": "T",
-          "isPattern": "false",
-          "id": "E1",
-          "attributes": [
-          {
-              "name": "A",
-              "type": "TA",
-              "value": "1"
-          }
-          ]
-        }
-        ],
-        "updateAction": "APPEND"
-      }
-      EOF                                                                                                                      
+                                                                                                                    
   
 Now, in order to append a new attribute (let's name it 'B') we use
 updateContext APPEND with an entityId matching 'E1':
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"contextElements": [
-	{
-          "type": "T",
-          "isPattern": "false",
-          "id": "E1",
-          "attributes": [
-          {
-              "name": "B",
-              "type": "TB",
-              "value": "2"
-          }
-          ]
-        }
-        ],
-        "updateAction": "APPEND"
+	  "contextElements": [
+	      {
+		  "type": "T",
+		  "isPattern": "false",
+		  "id": "E1",
+		  "attributes": [
+		      {
+			  "name": "A",
+			  "type": "TA",
+			  "value": "1"
+		      }
+		  ]
+	      }
+	  ],
+	  "updateAction": "APPEND"
       }
       EOF                                                                                                                      
   
@@ -54,59 +37,58 @@ Now we can check with a query to that entity that both attributes A and
 B are there:
 
      curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
-
-     {
-       "contextElement": {
-	  "attributes": [
-          {
-            "name": "B",
-	    "type": "TB",
-	    "value": "2"
-          },
-          {
-            "name": "A",
-            "type": "TA",
-            "value": "1"
-          }
-          ],
-              "id": "E1",
-              "isPattern": "false",
+      {
+	  "contextElement": {
+	      "attributes": [
+		  {
+		      "name": "B",
+		      "type": "TB",
+		      "value": "2"
+		  },
+		  {
+		      "name": "A",
+		      "type": "TA",
+		      "value": "1"
+		  }
+	      ],
+	      "id": "E1",
+	      "isPattern": "false",
 	      "type": ""
-          },
-        "statusCode": {
-	  "code": "200",
-          "reasonPhrase": "OK"
-        }
-     }
+	  },
+	  "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
+	  }
+      }
+
   
 We can also remove attributes in a similar way, using the DELETE action
 type. For example, to remove attribute 'A' we will use (note the empty
 contextValue element):
 
      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-     {
-      "contextElements": [
       {
-         "type": "T",
-         "isPattern": "false",
-         "id": "E1",
-         "attributes": [
-         {
-              "name": "A",
-              "type": "TA",
-              "value": ""
-         }
-         ]
-       }
-       ],
-        "updateAction": "DELETE"
-     }
-     EOF                                                                                                                      
+	  "contextElements": [
+	      {
+		  "type": "T",
+		  "isPattern": "false",
+		  "id": "E1",
+		  "attributes": [
+		      {
+			  "name": "A",
+			  "type": "TA",
+			  "value": ""
+		      }
+		  ]
+	      }
+	  ],
+	  "updateAction": "DELETE"
+      }
+      EOF                                                                                                                      
   
 Now, a query to the entity shows attribute B:
 
       curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
-
       {
 	  "contextElement": {
 	      "attributes": [
@@ -125,6 +107,7 @@ Now, a query to the entity shows attribute B:
 	      "reasonPhrase": "OK"
 	  }
       }
+
         
   
 You can also use convenience operations with POST and DELETE verbs to
@@ -133,21 +116,21 @@ add and delete attributes. Try the following:
 Add a new attribute 'C' and 'D':
 
      (curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-     {
-	"attributes" : [
-        {
-          "name" : "C",
-          "type" : "TC",
-          "value" : "3"
-        },
-        {
-          "name" : "D",
-          "type" : "TD",
-          "value" : "4"
-        }
-        ]
-     }
-     EOF
+      {
+	  "attributes": [
+	      {
+		  "name": "C",
+		  "type": "TC",
+		  "value": "3"
+	      },
+	      {
+		  "name": "D",
+		  "type": "TD",
+		  "value": "4"
+	      }
+	  ]
+      }
+      EOF
                                                                                                                                            
   
 Remove attribute 'B':
@@ -157,30 +140,29 @@ Remove attribute 'B':
 Query entity (should see 'C' and 'D', but not 'B'):
   
       curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
-
       {
-      "contextElement": {
-        "attributes": [
-        {
-            "name": "C",
-            "type": "TC",
-            "value": "3"
-        },
-        {
-            "name": "D",
-            "type": "TD",
-            "value": "4"
-        }
-        ],
-        "id": "E1",
-        "isPattern": "false",
-        "type": ""
-        },
-        "statusCode": {
-	  "code": "200",
-          "reasonPhrase": "OK"
-          }
-       }                
+	  "contextElement": {
+	      "attributes": [
+		  {
+		      "name": "C",
+		      "type": "TC",
+		      "value": "3"
+		  },
+		  {
+		      "name": "D",
+		      "type": "TD",
+		      "value": "4"
+		  }
+	      ],
+	      "id": "E1",
+	      "isPattern": "false",
+	      "type": ""
+	  },
+	  "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
+	  }
+      }               
   
 # Deleting entities
 
@@ -194,14 +176,14 @@ attributeList, as in the following example:
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"contextElements": [
-	{
-          "type": "T",
-          "isPattern": "false",
-          "id": "E1"
-        }
-        ],
-        "updateAction": "DELETE"
+	  "contextElements": [
+	      {
+		  "type": "T",
+		  "isPattern": "false",
+		  "id": "E1"
+	      }
+	  ],
+	  "updateAction": "DELETE"
       }
       EOF                                                                                                                     
  

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -8,9 +8,9 @@ source of the context information for the entities/attributes included
 in that registration. We call that source the "Context Provider" (or
 CPr, for short).
 
-        ...                                                                           ...
-      <providingApplication>http://mysensors.com/Rooms</providingApplication>       "providingApplication" : "http://mysensors.com/Rooms"
-      ...                                                                           ...
+     ...                                                                           
+     "providingApplication" : "http://mysensors.com/Rooms"
+     ...                                                                           
   
 If Orion receives a query or update operation (either in the standard or
 in the convenience family) and it cannot find the targeted context
@@ -32,49 +32,51 @@ Let's illustrate this with an example.
     Street4 temperature. Let's assume that the Context Provider exposes
     its API on <http://sensor48.mycity.com/ngsi10>
 
-     (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-     {
-	"contextRegistrations": [
-	{
-	    "entities": [
-	    {
-              "type": "Street",
-              "isPattern": "false",
-              "id": "Street4"
-            }
-            ],
-            "attributes": [
-            {
-                "name": "temperature",
-                "type": "float",
-                "isDomain": "false"
-            }
-            ],
-        "providingApplication": "http://sensor48.mycity.com/v1"
-        }
-        ],
-       "duration": "P1M"
+      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "contextRegistrations": [
+	      {
+		  "entities": [
+		      {
+			  "type": "Street",
+			  "isPattern": "false",
+			  "id": "Street4"
+		      }
+		  ],
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "isDomain": "false"
+		      }
+		  ],
+		  "providingApplication": "http://sensor48.mycity.com/v1"
+	      }
+	  ],
+	  "duration": "P1M"
       }
       EOF
-  
+      
 -   Next, consider that a client queries the Street4 temperature
     (message number 2).
 
-     (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-     {
-	"entities": [
-        {
-          "type": "Street",
-          "isPattern": "false",
-          "id": "Street4"
-        }
-        ],
-        "attributes" : [
-	  "temperature"
-     ]
-     }
-     EOF
+    
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	      {
+		  "type": "Street",
+		  "isPattern": "false",
+		  "id": "Street4"
+	      }
+	  ],
+	  "attributes": [
+	      "temperature"
+	  ]
+      }
+      EOF
   
+
 -   Orion doesn't know the Street 4 temperature, but it knows (due to
     the registration in the previous step) that the Context Provider at
     <http://sensor48.mycity.com/v1> knows that, so it forwards the query
@@ -84,42 +86,43 @@ Let's illustrate this with an example.
     "/queryContext" operation).
 
       {
-        "entities": [
-        {
-          "type": "Street",
-          "isPattern": "false",
-	  "id": "Street4"
-        }
-        ],
-        "attributes" : [
-	  "temperature"
-      ]
+	  "entities": [
+	      {
+		  "type": "Street",
+		  "isPattern": "false",
+		  "id": "Street4"
+	      }
+	  ],
+	  "attributes": [
+	      "temperature"
+	  ]
       }
+      
 -   The Context Provider at <http://sensor48.mycity.com/ngsi10> responds
     with the data (message number 4).
 
       {
-	"contextResponses": [
-	{
-	    "contextElement": {
-	      "attributes": [
-              {
-                "name": "temperature",
-		"type": "float",
-		"value": "16"
-              }
-              ],
-                "id": "Street4",
-                 "isPattern": "false",
-                "type": "Street"
-              },
-            "statusCode": {
-	      "code": "200",
-             "reasonPhrase": "OK"
-             }
-         }
-         ]
-       }
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": "16"
+			  }
+		      ],
+		      "id": "Street4",
+		      "isPattern": "false",
+		      "type": "Street"
+		      },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	  ]
+      }
                                   
   
 -   Orion fordwars the response to the client (message number 5). Note
@@ -134,13 +137,13 @@ Let's illustrate this with an example.
 	  "contextResponses": [
 	      {
 		  "contextElement": {
-		    "attributes": [
-			{
+		      "attributes": [
+			  {
 			      "name": "temperature",
 			      "type": "float",
 			      "value": "16"
-			}
-			],
+			  }
+		      ],
 		      "id": "Street4",
 		      "isPattern": "false",
 		      "type": "Street"
@@ -150,9 +153,9 @@ Let's illustrate this with an example.
 		      "details": "Redirected to context provider http://sensor48.mycity.com/ngsi10",
 		      "reasonPhrase": "OK"
 		  }
-	    }
+	      }
 	  ]
-      }                                                    
+      }
   
 The Context Providers and request forwarding functionality was developed
 in release 0.15.0. Previous version

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -129,30 +129,30 @@ Let's illustrate this with an example.
     "the process is *completely* transparent"). The client can use
     (or ignore) that information. Orion doesn't store the
     Street4 temperature.
-     {
-	"contextResponses": [
-	{
-	    "contextElement": {
-		"attributes": [
-		{
-		    "name": "temperature",
-		    "type": "float",
-		    "value": "16"
-		}
-		],
-            "id": "Street4",
-            "isPattern": "false",
-            "type": "Street"
-            },
-            "statusCode": {
-              "code": "200",
-	      "details": "Redirected to context provider http://sensor48.mycity.com/ngsi10"
-	      "reasonPhrase": "OK"
-            }
-       }
-       ]
-     }
-                                                                   
+    
+      {
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		    "attributes": [
+			{
+			      "name": "temperature",
+			      "type": "float",
+			      "value": "16"
+			}
+			],
+		      "id": "Street4",
+		      "isPattern": "false",
+		      "type": "Street"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "details": "Redirected to context provider http://sensor48.mycity.com/ngsi10",
+		      "reasonPhrase": "OK"
+		  }
+	    }
+	  ]
+      }                                                    
   
 The Context Providers and request forwarding functionality was developed
 in release 0.15.0. Previous version

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -27,10 +27,10 @@ Let's illustrate this with an example.
 
 ![](QueryContextWithContextProvider.png "QueryContextWithContextProvider.png")
 
--   First (message number 1), the application (maybe on behalf of a
-    Context Provider) registers the Context Provider at Orion for the
-    Street4 temperature. Let's assume that the Context Provider exposes
-    its API on <http://sensor48.mycity.com/ngsi10>
+-First (message number 1), the application (maybe on behalf of a
+Context Provider) registers the Context Provider at Orion for the
+Street4 temperature. Let's assume that the Context Provider exposes
+its API on <http://sensor48.mycity.com/ngsi10>
 
       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
@@ -57,8 +57,8 @@ Let's illustrate this with an example.
       }
       EOF
       
--   Next, consider that a client queries the Street4 temperature
-    (message number 2).
+-Next, consider that a client queries the Street4 temperature
+(message number 2).
 
     
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
@@ -77,13 +77,13 @@ Let's illustrate this with an example.
       EOF
   
 
--   Orion doesn't know the Street 4 temperature, but it knows (due to
-    the registration in the previous step) that the Context Provider at
-    <http://sensor48.mycity.com/v1> knows that, so it forwards the query
-    (message number 3) to the URL
-    <http://sensor48.mycity.com/v1/queryContext> (i.e. the URL used in
-    the Providing Application field at registration time, plus the
-    "/queryContext" operation).
+-Orion doesn't know the Street 4 temperature, but it knows (due to
+the registration in the previous step) that the Context Provider at
+<http://sensor48.mycity.com/v1> knows that, so it forwards the query
+(message number 3) to the URL
+<http://sensor48.mycity.com/v1/queryContext> (i.e. the URL used in
+the Providing Application field at registration time, plus the
+"/queryContext" operation).
 
       {
 	  "entities": [
@@ -98,8 +98,8 @@ Let's illustrate this with an example.
 	  ]
       }
       
--   The Context Provider at <http://sensor48.mycity.com/ngsi10> responds
-    with the data (message number 4).
+-The Context Provider at <http://sensor48.mycity.com/ngsi10> responds
+with the data (message number 4).
 
       {
 	  "contextResponses": [
@@ -125,13 +125,13 @@ Let's illustrate this with an example.
       }
                                   
   
--   Orion fordwars the response to the client (message number 5). Note
-    that the response is not exactly the same, as it includes a
-    reference to the Context Provider that has resolved it (that's why
-    it is said that "the process is *mostly* transparent" instead of
-    "the process is *completely* transparent"). The client can use
-    (or ignore) that information. Orion doesn't store the
-    Street4 temperature.
+-Orion fordwars the response to the client (message number 5). Note
+that the response is not exactly the same, as it includes a
+reference to the Context Provider that has resolved it (that's why
+it is said that "the process is *mostly* transparent" instead of
+"the process is *completely* transparent"). The client can use
+(or ignore) that information. Orion doesn't store the
+Street4 temperature.
     
       {
 	  "contextResponses": [

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -32,48 +32,48 @@ Let's illustrate this with an example.
     Street4 temperature. Let's assume that the Context Provider exposes
     its API on <http://sensor48.mycity.com/ngsi10>
 
-      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                    {
-      <registerContextRequest>                                                                                                                     "contextRegistrations": [
-        <contextRegistrationList>                                                                                                                      {
-          <contextRegistration>                                                                                                                            "entities": [
-            <entityIdList>                                                                                                                                     {
-              <entityId type="Street" isPattern="false">                                                                                                           "type": "Stret",
-                <id>Street4</id>                                                                                                                                   "isPattern": "false",
-              </entityId>                                                                                                                                          "id": "Street4"
-            </entityIdList>                                                                                                                                    }
-            <contextRegistrationAttributeList>                                                                                                             ],
-              <contextRegistrationAttribute>                                                                                                               "attributes": [
-                <name>temperature</name>                                                                                                                       {
-                <type>float</type>                                                                                                                                 "name": "temperature",
-                <isDomain>false</isDomain>                                                                                                                         "type": "float",
-              </contextRegistrationAttribute>                                                                                                                      "isDomain": "false"
-            </contextRegistrationAttributeList>                                                                                                                }
-            <providingApplication>http://sensor48.mycity.com/v1</providingApplication>                                                                     ],
-        </contextRegistration>                                                                                                                             "providingApplication": "http://sensor48.mycity.com/v1"
-        </contextRegistrationList>                                                                                                                     }
-        <duration>P1M</duration>                                                                                                                   ],
-      </registerContextRequest>                                                                                                                    "duration": "P1M"
-      EOF                                                                                                                                      }
-                                                                                                                                               EOF
+     (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+     {
+	"contextRegistrations": [
+	{
+	    "entities": [
+	    {
+              "type": "Street",
+              "isPattern": "false",
+              "id": "Street4"
+            }
+            ],
+            "attributes": [
+            {
+                "name": "temperature",
+                "type": "float",
+                "isDomain": "false"
+            }
+            ],
+        "providingApplication": "http://sensor48.mycity.com/v1"
+        }
+        ],
+       "duration": "P1M"
+      }
+      EOF
   
 -   Next, consider that a client queries the Street4 temperature
     (message number 2).
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                           "entities": [
-        <entityIdList>                                                                                                                    {
-          <entityId type="Street" isPattern="false">                                                                                          "type": "Street",
-            <id>Street4</id>                                                                                                                  "isPattern": "false",
-          </entityId>                                                                                                                         "id": "Street4"
-        </entityIdList>                                                                                                                   }
-        <attributeList>                                                                                                               ],
-          <attribute>temperature</attribute>                                                                                          "attributes" : [
-        </attributeList>                                                                                                                  "temperature"
-      </queryContextRequest>                                                                                                          ]
-      EOF                                                                                                                         }
-                                                                                                                                  EOF
+     (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+     {
+	"entities": [
+        {
+          "type": "Street",
+          "isPattern": "false",
+          "id": "Street4"
+        }
+        ],
+        "attributes" : [
+	  "temperature"
+     ]
+     }
+     EOF
   
 -   Orion doesn't know the Street 4 temperature, but it knows (due to
     the registration in the previous step) that the Context Provider at
@@ -83,44 +83,44 @@ Let's illustrate this with an example.
     the Providing Application field at registration time, plus the
     "/queryContext" operation).
 
-      <queryContextRequest>                                {
-        <entityIdList>                                         "entities": [
-          <entityId type="Street" isPattern="false">               {
-            <id>Street4</id>                                           "type": "Street",
-          </entityId>                                                  "isPattern": "false",
-        </entityIdList>                                                "id": "Street4"
-        <attributeList>                                            }
-          <attribute>temperature</attribute>                   ],
-        </attributeList>                                       "attributes" : [
-      </queryContextRequest>                                       "temperature"
-      EOF                                                      ]
-                                                           }
+      {
+        "entities": [
+        {
+          "type": "Street",
+          "isPattern": "false",
+	  "id": "Street4"
+        }
+        ],
+        "attributes" : [
+	  "temperature"
+      ]
+      }
 -   The Context Provider at <http://sensor48.mycity.com/ngsi10> responds
     with the data (message number 4).
 
-      <?xml version="1.0"?>                                    {
-      <queryContextResponse>                                       "contextResponses": [
-        <contextResponseList>                                          {
-          <contextElementResponse>                                         "contextElement": {
-            <contextElement>                                                   "attributes": [
-              <entityId type="Street" isPattern="false">                           {
-                <id>Street4</id>                                                       "name": "temperature",
-              </entityId>                                                              "type": "float",
-              <contextAttributeList>                                                   "value": "16"
-                <contextAttribute>                                                 }
-                  <name>temperature</name>                                     ],
-                  <type>float</type>                                           "id": "Street4",
-                  <contextValue>16</contextValue>                              "isPattern": "false",
-                </contextAttribute>                                            "type": "Street"
-              </contextAttributeList>                                      },
-            </contextElement>                                              "statusCode": {
-            <statusCode>                                                       "code": "200",
-              <code>200</code>                                                 "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                              }
-            </statusCode>                                              }
-          </contextElementResponse>                                ]
-        </contextResponseList>                                 }
-      </queryContextResponse>                              
+      {
+	"contextResponses": [
+	{
+	    "contextElement": {
+	      "attributes": [
+              {
+                "name": "temperature",
+		"type": "float",
+		"value": "16"
+              }
+              ],
+                "id": "Street4",
+                 "isPattern": "false",
+                "type": "Street"
+              },
+            "statusCode": {
+	      "code": "200",
+             "reasonPhrase": "OK"
+             }
+         }
+         ]
+       }
+                                  
   
 -   Orion fordwars the response to the client (message number 5). Note
     that the response is not exactly the same, as it includes a
@@ -129,32 +129,30 @@ Let's illustrate this with an example.
     "the process is *completely* transparent"). The client can use
     (or ignore) that information. Orion doesn't store the
     Street4 temperature.
-                                                                                                        {
-                                                                                                            "contextResponses": [
-      <?xml version="1.0"?>                                                                                     {
-      <queryContextResponse>                                                                                        "contextElement": {
-        <contextResponseList>                                                                                           "attributes": [
-          <contextElementResponse>                                                                                          {
-            <contextElement>                                                                                                    "name": "temperature",
-              <entityId type="Street" isPattern="false">                                                                        "type": "float",
-                <id>Street4</id>                                                                                                "value": "16"
-              </entityId>                                                                                                   }
-              <contextAttributeList>                                                                                    ],
-                <contextAttribute>                                                                                      "id": "Street4",
-                  <name>temperature</name>                                                                              "isPattern": "false",
-                  <type>float</type>                                                                                    "type": "Street"
-                  <contextValue>16</contextValue>                                                                   },
-                </contextAttribute>                                                                                 "statusCode": {
-              </contextAttributeList>                                                                                   "code": "200",
-            </contextElement>                                                                                           "details": "Redirected to context provider http://sensor48.mycity.com/ngsi10"
-            <statusCode>                                                                                                "reasonPhrase": "OK"
-              <code>200</code>                                                                                      }
-              <details>Redirected to context provider http://sensor48.mycity.com/ngsi10</details>               }
-              <reasonPhrase>OK</reasonPhrase>                                                               ]
-            </statusCode>                                                                               }
-          </contextElementResponse>                                                                 
-        </contextResponseList>                                                                      
-      </queryContextResponse>                                                                       
+     {
+	"contextResponses": [
+	{
+	    "contextElement": {
+		"attributes": [
+		{
+		    "name": "temperature",
+		    "type": "float",
+		    "value": "16"
+		}
+		],
+            "id": "Street4",
+            "isPattern": "false",
+            "type": "Street"
+            },
+            "statusCode": {
+              "code": "200",
+	      "details": "Redirected to context provider http://sensor48.mycity.com/ngsi10"
+	      "reasonPhrase": "OK"
+            }
+       }
+       ]
+     }
+                                                                   
   
 The Context Providers and request forwarding functionality was developed
 in release 0.15.0. Previous version

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -32,8 +32,8 @@ Let's illustrate this with an example.
       Context Provider) registers the Context Provider at Orion for the
       Street4 temperature. Let's assume that the Context Provider exposes
       its API on <http://sensor48.mycity.com/ngsi10>
+      
 <!-- -->
-
       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "contextRegistrations": [
@@ -59,11 +59,13 @@ Let's illustrate this with an example.
       }
       EOF
       
+      
+      
 -     Next, consider that a client queries the Street4 temperature
       (message number 2).
+
       
 <!-- -->
-    
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "entities": [

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -57,9 +57,10 @@ its API on <http://sensor48.mycity.com/ngsi10>
       }
       EOF
       
--Next, consider that a client queries the Street4 temperature
-(message number 2).
-
+-     Next, consider that a client queries the Street4 temperature
+      (message number 2).
+      
+<!-- -->
     
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
@@ -75,16 +76,19 @@ its API on <http://sensor48.mycity.com/ngsi10>
 	  ]
       }
       EOF
-  
 
--Orion doesn't know the Street 4 temperature, but it knows (due to
-the registration in the previous step) that the Context Provider at
-<http://sensor48.mycity.com/v1> knows that, so it forwards the query
-(message number 3) to the URL
-<http://sensor48.mycity.com/v1/queryContext> (i.e. the URL used in
-the Providing Application field at registration time, plus the
-"/queryContext" operation).
+<!-- -->
 
+-     Orion doesn't know the Street 4 temperature, but it knows (due to
+      the registration in the previous step) that the Context Provider at
+      <http://sensor48.mycity.com/v1> knows that, so it forwards the query
+      (message number 3) to the URL
+      <http://sensor48.mycity.com/v1/queryContext> (i.e. the URL used in
+      the Providing Application field at registration time, plus the
+      "/queryContext" operation).
+
+
+<!-- -->
       {
 	  "entities": [
 	      {
@@ -97,9 +101,12 @@ the Providing Application field at registration time, plus the
 	      "temperature"
 	  ]
       }
-      
--The Context Provider at <http://sensor48.mycity.com/ngsi10> responds
-with the data (message number 4).
+
+
+<!-- -->
+
+-     The Context Provider at <http://sensor48.mycity.com/ngsi10> responds
+      with the data (message number 4).
 
       {
 	  "contextResponses": [
@@ -123,16 +130,18 @@ with the data (message number 4).
 	      }
 	  ]
       }
-                                  
-  
--Orion fordwars the response to the client (message number 5). Note
-that the response is not exactly the same, as it includes a
-reference to the Context Provider that has resolved it (that's why
-it is said that "the process is *mostly* transparent" instead of
-"the process is *completely* transparent"). The client can use
-(or ignore) that information. Orion doesn't store the
-Street4 temperature.
-    
+
+<!-- -->                         
+
+-     Orion fordwars the response to the client (message number 5). Note
+      that the response is not exactly the same, as it includes a
+      reference to the Context Provider that has resolved it (that's why
+      it is said that "the process is *mostly* transparent" instead of
+      "the process is *completely* transparent"). The client can use
+      (or ignore) that information. Orion doesn't store the
+      Street4 temperature.
+ 
+<!-- --> 
       {
 	  "contextResponses": [
 	      {

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -27,7 +27,7 @@ Let's illustrate this with an example.
 
 ![](QueryContextWithContextProvider.png "QueryContextWithContextProvider.png")
 
-<!-- -->
+
 -     First (message number 1), the application (maybe on behalf of a
       Context Provider) registers the Context Provider at Orion for the
       Street4 temperature. Let's assume that the Context Provider exposes
@@ -79,7 +79,7 @@ Let's illustrate this with an example.
       }
       EOF
 
-<!-- -->
+
 
 -     Orion doesn't know the Street 4 temperature, but it knows (due to
       the registration in the previous step) that the Context Provider at
@@ -105,7 +105,6 @@ Let's illustrate this with an example.
       }
 
 
-<!-- -->
 
 -     The Context Provider at <http://sensor48.mycity.com/ngsi10> responds
       with the data (message number 4).
@@ -134,7 +133,6 @@ Let's illustrate this with an example.
 	  ]
       }
 
-<!-- -->                         
 
 -     Orion fordwars the response to the client (message number 5). Note
       that the response is not exactly the same, as it includes a

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -27,10 +27,12 @@ Let's illustrate this with an example.
 
 ![](QueryContextWithContextProvider.png "QueryContextWithContextProvider.png")
 
--First (message number 1), the application (maybe on behalf of a
-Context Provider) registers the Context Provider at Orion for the
-Street4 temperature. Let's assume that the Context Provider exposes
-its API on <http://sensor48.mycity.com/ngsi10>
+<!-- -->
+-     First (message number 1), the application (maybe on behalf of a
+      Context Provider) registers the Context Provider at Orion for the
+      Street4 temperature. Let's assume that the Context Provider exposes
+      its API on <http://sensor48.mycity.com/ngsi10>
+<!-- -->
 
       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
@@ -108,6 +110,7 @@ its API on <http://sensor48.mycity.com/ngsi10>
 -     The Context Provider at <http://sensor48.mycity.com/ngsi10> responds
       with the data (message number 4).
 
+<!-- -->
       {
 	  "contextResponses": [
 	      {

--- a/doc/manuals/user/duration.md
+++ b/doc/manuals/user/duration.md
@@ -7,11 +7,10 @@ subscribeContextAvailability a default of 24 hours is used. You will get
 a confirmation of the duration in these cases in the response, e.g. for
 a registerContext:
 
-      <?xml version="1.0"?>                                             {
-      <registerContextResponse>                                             "duration": "PT24H",
-        <registrationId>51bf1e0ada053170df590f20</registrationId>           "registrationId": "52f38a64261c371af12b8565"
-        <duration>PT24H</duration>                                      }
-      </registerContextResponse>                                    
+      {
+      "duration": "PT24H",
+         "registrationId": "52f38a64261c371af12b8565"
+      }                             
 
 ## Extending duration
 

--- a/doc/manuals/user/filtering.md
+++ b/doc/manuals/user/filtering.md
@@ -14,7 +14,7 @@ element:
       {
 	"entities": [
         {
-	    type": "myEntityType",
+	    "type": "myEntityType",
             "isPattern": "true",
 	    "id": ".*"
         }

--- a/doc/manuals/user/filtering.md
+++ b/doc/manuals/user/filtering.md
@@ -10,26 +10,25 @@ As a general rule, filters used in standard operation use a scope
 element:
 
  
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                              {
-          <entityId type="myEntType" isPattern="true">                                                                                "type": "myEntityType",
-            <id>.*</id>                                                                                                               "isPattern": "true",
-          </entityId>                                                                                                                 "id": ".*"
-        </entityIdList>                                                                                                             }
-        <attributeList>                                                                                                             ],
-        </attributeList>                                                                                                            "restriction": {
-        <restriction>                                                                                                                 "scopes": [
-          <scope>                                                                                                                       {
-            <operationScope>                                                                                                              "type" : "FIWARE::Filter::foobar",
-              <scopeType>FIWARE::Filter::foobar</scopeType>                                                                               "value" : ...
-              <scopeValue>...</scopeValue>                                                                                              }
-            </operationScope>                                                                                                         ]
-          </scope>                                                                                                                  }
-        </restriction>                                                                                                            }
-      </queryContextRequest>                                                                                                      EOF
-      EOF                                                                                                                     
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"entities": [
+        {
+	    type": "myEntityType",
+            "isPattern": "true",
+	    "id": ".*"
+        }
+        ],
+        "restriction": {
+        "scopes": [
+        {
+            "type" : "FIWARE::Filter::foobar",
+            "value" : ...
+        }
+        ]
+        }
+       }
+       EOF                                                                                                                 
 
 while filters in convenience operations are included as parameters in
 the URL:
@@ -45,16 +44,16 @@ result is a logic "and" between all of them.
 
 The scope correspoding to this type is "FIWARE::Filter::Existence". 
 
-      ...                                                            ...
-        <restriction>                                                  "restriction": {
-          <scope>                                                        "scopes": [
-            <operationScope>                                               {
-              <scopeType>FIWARE::Filter::Existence</scopeType>               "type" : "FIWARE::Filter::Existence",
-              <scopeValue>entity::type</scopeValue>                          "value" : "entity::type"
-            </operationScope>                                              }
-          </scope>                                                       ]
-        </restriction>                                                 }
-      ...                                                            ...
+      ...                                                           
+        "restriction": {
+          "scopes": [
+          {
+              "type" : "FIWARE::Filter::Existence",
+              "value" : "entity::type"
+          }
+          ]
+        }
+      ...                                                           
   
 The URL parameter corresponding to this filter is 'exist'.
 
@@ -67,16 +66,16 @@ existence is the entity type, corresponding to "entity::type".
 
 The scope corresponding to this type is "FIWARE::Filter::Not::Existence".
 
-      ...                                                                 ...
-        <restriction>                                                       "restriction": {
-          <scope>                                                             "scopes": [
-            <operationScope>                                                    {
-              <scopeType>FIWARE::Filter::Not::Existence</scopeType>               "type" : "FIWARE::Filter::Not::Existence",
-              <scopeValue>entity::type</scopeValue>                               "value" : "entity::type"
-            </operationScope>                                                   }
-          </scope>                                                            ]
-        </restriction>                                                      }
-      ...                                                                 ...
+      ...                                                                
+        "restriction": {
+          "scopes": [
+          {
+              "type" : "FIWARE::Filter::Not::Existence",
+              "value" : "entity::type"
+          }
+          ]
+        }
+      ...                                                                
   
 The URL parameter corresponding to this filter is '!exist'.
 
@@ -94,15 +93,15 @@ There is no scope corresponding to this filter, given that you can use
 the usual entity type:
 
   --------------------------------------------------------------------------------------
-  XML                                              JSON
-  ------------------------------------------------ -------------------------------------
-      ...                                              ...
-          <entityId type="Room" isPattern="...">               {
-            <id>...</id>                                           "type": "Room",
-          </entityId>                                              "isPattern": "...",
-      ...                                                          "id": "..."
-                                                               }
-                                                       ...
+  JSON
+  --------------------------------------------------------------------------------------
+      ...                                            
+          {
+            "type": "Room",
+	    "isPattern": "...",
+	    "id": "..."
+          }
+      ...
   --------------------------------------------------------------------------------------
 
 The URL parameter corresponding to this filter is 'entity::type'.

--- a/doc/manuals/user/filtering.md
+++ b/doc/manuals/user/filtering.md
@@ -12,23 +12,23 @@ element:
  
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"entities": [
-        {
-	    "type": "myEntityType",
-            "isPattern": "true",
-	    "id": ".*"
-        }
-        ],
-        "restriction": {
-        "scopes": [
-        {
-            "type" : "FIWARE::Filter::foobar",
-            "value" : ...
-        }
-        ]
-        }
-       }
-       EOF                                                                                                                 
+	  "entities": [
+	      {
+		  "type": "myEntityType",
+		  "isPattern": "true",
+		  "id": ".*"
+	      }
+	  ],
+	  "restriction": {
+	      "scopes": [
+		  {
+		      "type": "FIWARE::Filter::foobar",
+		      "value": "..."
+		  }
+	      ]
+	  }
+      }
+      EOF                                                                                                                 
 
 while filters in convenience operations are included as parameters in
 the URL:
@@ -45,14 +45,16 @@ result is a logic "and" between all of them.
 The scope correspoding to this type is "FIWARE::Filter::Existence". 
 
       ...                                                           
-        "restriction": {
-          "scopes": [
-          {
-              "type" : "FIWARE::Filter::Existence",
-              "value" : "entity::type"
-          }
-          ]
-        }
+	{
+	  "restriction": {
+		"scopes": [
+		  {
+			"type": "FIWARE::Filter::Existence",
+			"value": "entity::type"
+		  }
+		]
+	    }
+	}
       ...                                                           
   
 The URL parameter corresponding to this filter is 'exist'.
@@ -67,14 +69,16 @@ existence is the entity type, corresponding to "entity::type".
 The scope corresponding to this type is "FIWARE::Filter::Not::Existence".
 
       ...                                                                
-        "restriction": {
-          "scopes": [
-          {
-              "type" : "FIWARE::Filter::Not::Existence",
-              "value" : "entity::type"
-          }
-          ]
-        }
+	{
+	  "restriction": {
+	      "scopes": [
+		  {
+		      "type": "FIWARE::Filter::Not::Existence",
+		      "value": "entity::type"
+		  }
+	      ]
+	  }
+	}
       ...                                                                
   
 The URL parameter corresponding to this filter is '!exist'.

--- a/doc/manuals/user/filtering.md
+++ b/doc/manuals/user/filtering.md
@@ -45,16 +45,16 @@ result is a logic "and" between all of them.
 The scope correspoding to this type is "FIWARE::Filter::Existence". 
 
       ...                                                           
-	{
+      {
 	  "restriction": {
-		"scopes": [
+	      "scopes": [
 		  {
-			"type": "FIWARE::Filter::Existence",
-			"value": "entity::type"
+		      "type": "FIWARE::Filter::Existence",
+		      "value": "entity::type"
 		  }
-		]
-	    }
-	}
+	      ]
+	  }
+      }
       ...                                                           
   
 The URL parameter corresponding to this filter is 'exist'.
@@ -69,7 +69,7 @@ existence is the entity type, corresponding to "entity::type".
 The scope corresponding to this type is "FIWARE::Filter::Not::Existence".
 
       ...                                                                
-	{
+      {
 	  "restriction": {
 	      "scopes": [
 		  {
@@ -78,7 +78,7 @@ The scope corresponding to this type is "FIWARE::Filter::Not::Existence".
 		  }
 	      ]
 	  }
-	}
+      }
       ...                                                                
   
 The URL parameter corresponding to this filter is '!exist'.
@@ -100,11 +100,11 @@ the usual entity type:
   JSON
   --------------------------------------------------------------------------------------
       ...                                            
-          {
-            "type": "Room",
-	    "isPattern": "...",
-	    "id": "..."
-          }
+      {
+	  "type": "Room",
+	  "isPattern": "...",
+	  "id": "..."
+      }
       ...
   --------------------------------------------------------------------------------------
 

--- a/doc/manuals/user/filtering.md
+++ b/doc/manuals/user/filtering.md
@@ -23,7 +23,7 @@ element:
 	      "scopes": [
 		  {
 		      "type": "FIWARE::Filter::foobar",
-		      "value": "..."
+		      "value": ""
 		  }
 	      ]
 	  }

--- a/doc/manuals/user/geolocation.md
+++ b/doc/manuals/user/geolocation.md
@@ -17,29 +17,29 @@ example, the following updateContext request creates the entity "Madrid"
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "contextElements": [
-	  {
-	      "type": "City",
-	      "isPattern": "false",
-	      "id": "Madrid",
-          "attributes": [
-          {
-              "name": "position",
-              "type": "coords",
-              "value": "40.418889, -3.691944",
-	      "metadatas": [
 	      {
-                 "name": "location",
-                 "type": "string",
-                 "value": "WGS84"
+		  "type": "City",
+		  "isPattern": "false",
+		  "id": "Madrid",
+		  "attributes": [
+		      {
+			  "name": "position",
+			  "type": "coords",
+			  "value": "40.418889, -3.691944",
+			  "metadatas": [
+			      {
+				  "name": "location",
+				  "type": "string",
+				  "value": "WGS84"
+			      }
+			  ]
+		      }
+		  ]
 	      }
-	      ]
-          }
-          ]
-          }
-          ],
-        "updateAction": "APPEND"
-       }
-       EOF                                                                                                                      
+	  ],
+	  "updateAction": "APPEND"
+      }
+      EOF                                                                                                                      
 
 Additional comments:
 
@@ -88,7 +88,6 @@ the following scenario: three entities (A, B and C, of type "Point")
 have been created in Orion Context Broker, each one in the coordinates
 shown in the following picture.
 
-![alt tag](orion-geo-points.png "orion-geo-points.png")
 ![](orion-geo-points.png "orion-geo-points.png")
 
 Let's consider a query whose scope is the internal area to the square
@@ -105,42 +104,42 @@ query would be A and B.
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "entities": [
-	  {
-	  "type": "Point",
-	  "isPattern": "true",
-	  "id": ".*"
-	  }
+	      {
+		  "type": "Point",
+		  "isPattern": "true",
+		  "id": ".*"
+	      }
 	  ],
 	  "restriction": {
-	    "scopes": [
-	    {
-	    "type" : "FIWARE::Location",
-	    "value" : {
-	      "polygon": {
-		"vertices": [
+	      "scopes": [
 		  {
-		    "latitude": "0",
-		    "longitude": "0"
-		  },
-		  {
-		    "latitude": "0",
-		    "longitude": "6"
-		  },
-		  {
-		    "latitude": "6",
-		    "longitude": "6"
-		  },
-		  {
-		    "latitude": "6",
-		    "longitude": "0"
+		      "type": "FIWARE::Location",
+		      "value": {
+			  "polygon": {
+			      "vertices": [
+				  {
+				      "latitude": "0",
+				      "longitude": "0"
+				  },
+				  {
+				      "latitude": "0",
+				      "longitude": "6"
+				  },
+				  {
+				      "latitude": "6",
+				      "longitude": "6"
+				  },
+				  {
+				      "latitude": "6",
+				      "longitude": "0"
+				  }
+			      ]
+			  }
+		      }
 		  }
-		  ]
-		  }
-		}
-	      }
 	      ]
-	    }
 	  }
+      }
 	  EOF                                                                                                         
 
 Let's consider a query whose scope is the internal area to the rectangle
@@ -150,44 +149,44 @@ defined by coordinates (3, 3), (3, 8), (11, 8) and (11, 3).
 
 The result of the query would be B and C.
 
-	(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-	{
-	"entities": [
-	{
-	  "type": "Point",
-	  "isPattern": "true",
-	  "id": ".*"
-	}
-	],
-	"restriction": {
-	  "scopes": [
-	    {
-	      "type" : "FIWARE::Location",
-	      "value" : {
-	      "polygon": {
-		  "vertices": [
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	      {
+		  "type": "Point",
+		  "isPattern": "true",
+		  "id": ".*"
+	      }
+	  ],
+	  "restriction": {
+	      "scopes": [
 		  {
-		    "latitude": "3",
-		    "longitude": "3"
-		  },
-		  {
-		    "latitude": "3",
-		    "longitude": "8"
-		  },
-		  {
-		     "latitude": "11",
-		     "longitude": "8"
-		  },
-		  {
-		     "latitude": "11",
-		     "longitude": "3"
+		      "type": "FIWARE::Location",
+		      "value": {
+			  "polygon": {
+			      "vertices": [
+				  {
+				      "latitude": "3",
+				      "longitude": "3"
+				  },
+				  {
+				      "latitude": "3",
+				      "longitude": "8"
+				  },
+				  {
+				      "latitude": "11",
+				      "longitude": "8"
+				  },
+				  {
+				      "latitude": "11",
+				      "longitude": "3"
+				  }
+			      ]
+			  }
+		      }
 		  }
-		  ]
-	      }
-	      }
-	    }
-	    ]
-	}
+	      ]
+	  }
       }
       EOF
                                                                                                                  
@@ -199,43 +198,43 @@ to "true".
 
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"entities": [
-	{
-	  "type": "Point",
-	  "isPattern": "true",
-	  "id": ".*"
-	}
-	],
-	"restriction": {
-	    "scopes": [
-	    {
-	    "type" : "FIWARE::Location",
-	    "value" : {
-	      "polygon": {
-		"vertices": [
-		{
-		  "latitude": "3",
-		  "longitude": "3"
-		},
-		{
-		  "latitude": "3",
-		  "longitude": "8"
-		},
-		{
-		  "latitude": "11",
-		  "longitude": "8"
-		},
-		{
-		  "latitude": "11",
-		  "longitude": "3"
-		}
-		],
-		"inverted": "true"
-		}
-	    }
+	  "entities": [
+	      {
+		  "type": "Point",
+		  "isPattern": "true",
+		  "id": ".*"
+	      }
+	  ],
+	  "restriction": {
+	      "scopes": [
+		  {
+		      "type": "FIWARE::Location",
+		      "value": {
+			  "polygon": {
+			      "vertices": [
+				  {
+				      "latitude": "3",
+				      "longitude": "3"
+				  },
+				  {
+				      "latitude": "3",
+				      "longitude": "8"
+				  },
+				  {
+				      "latitude": "11",
+				      "longitude": "8"
+				  },
+				  {
+				      "latitude": "11",
+				      "longitude": "3"
+				  }
+			      ],
+			      "inverted": "true"
+			  }
+		      }
+		  }
+	      ]
 	  }
-	  ]
-	}
       }
       EOF                                                                                                            
 
@@ -248,40 +247,40 @@ The result of the query would be A.
 
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"entities": [
-	{
-	    "type": "Point",
-	    "isPattern": "true",
-	    "id": ".*"
-	}
-	],
+	  "entities": [
+	      {
+		  "type": "Point",
+		  "isPattern": "true",
+		  "id": ".*"
+	      }
+	  ],
 	  "restriction": {
-	    "scopes": [
-	    {
-	      "type" : "FIWARE::Location",
-	      "value" : {
-		"polygon": {
-		  "vertices": [
+	      "scopes": [
 		  {
-		    "latitude": "0",
-		    "longitude": "0"
-		  },
-		  {
-		    "latitude": "0",
-		    "longitude": "6"
-		  },
-		  {
-		    "latitude": "6",
-		    "longitude": "0"
+		      "type": "FIWARE::Location",
+		      "value": {
+			  "polygon": {
+			      "vertices": [
+				  {
+				      "latitude": "0",
+				      "longitude": "0"
+				  },
+				  {
+				      "latitude": "0",
+				      "longitude": "6"
+				  },
+				  {
+				      "latitude": "6",
+				      "longitude": "0"
+				  }
+			      ]
+			  }
+		      }
 		  }
-		  ]
-	      }
-	      }
-	    }
-	    ]
+	      ]
 	  }
-	}
-	EOF
+      }
+      EOF
                                                                                                                      
 
 However, if we consider the query to the external area to that triangle
@@ -291,40 +290,40 @@ would be B and C.
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "entities": [
-	  {
-	    "type": "Point",
-	    "isPattern": "true",
-	    "id": ".*"
-	  }
+	      {
+		  "type": "Point",
+		  "isPattern": "true",
+		  "id": ".*"
+	      }
 	  ],
 	  "restriction": {
-	    "scopes": [
-	    {
-	      "type" : "FIWARE::Location",
-	      "value" : {
-		"polygon": {
-		  "vertices": [
+	      "scopes": [
 		  {
-		    "latitude": "0",
-		    "longitude": "0"
-		  },
-		  {
-		    "latitude": "0",
-		    "longitude": "6"
-		  },
-		  {
-		    "latitude": "6",
-		    "longitude": "0"
+		      "type": "FIWARE::Location",
+		      "value": {
+			  "polygon": {
+			      "vertices": [
+				  {
+				      "latitude": "0",
+				      "longitude": "0"
+				  },
+				  {
+				      "latitude": "0",
+				      "longitude": "6"
+				  },
+				  {
+				      "latitude": "6",
+				      "longitude": "0"
+				  }
+			      ],
+			      "inverted": "true"
+			  }
+		      }
 		  }
-		  ],
-		  "inverted": "true"
-		}
-	      }
-	    }
-	    ]
-	    }
-	}
-	EOF
+	      ]
+	  }
+      }
+      EOF
                                                                                                                     
 
 Now, in order to illustrate circle areas, let's consider the following
@@ -350,28 +349,28 @@ center), centerLongitude (the longitude of the circle center) and radius
 (in meters). The result of the query would be Madrid and Leganes.
 
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-	{
+      {
 	  "entities": [
-	  {
-	    "type": "City",
-	    "isPattern": "true",
-	    "id": ".*"
-	  }
+	      {
+		  "type": "City",
+		  "isPattern": "true",
+		  "id": ".*"
+	      }
 	  ],
-	"restriction": {
-	    "scopes": [
-	    {
-	      "type" : "FIWARE::Location",
-	      "value" : {
-	      "circle": {
-	      "centerLatitude": "40.418889",
-	      "centerLongitude": "-3.691944",
-	      "radius": "13500"
-	      }
-	      }
-	    }
-	  ]
-	 }
+	  "restriction": {
+	      "scopes": [
+		  {
+		      "type": "FIWARE::Location",
+		      "value": {
+			  "circle": {
+			      "centerLatitude": "40.418889",
+			      "centerLongitude": "-3.691944",
+			      "radius": "13500"
+			  }
+		      }
+		  }
+	      ]
+	  }
       }
       EOF                                                                                                                                                                                                                                     
 
@@ -384,28 +383,28 @@ The result of the query would be Madrid, Leganes and Alcobendas.
 
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"entities": [
-	{
-	  "type": "City",
-	  "isPattern": "true",
-	  "id": ".*"
-	}
-	],
-	"restriction": {
-	"scopes": [
-	{
-	    "type" : "FIWARE::Location",
-	    "value" : {
-	      "circle": {
-		"centerLatitude": "40.418889",
-		"centerLongitude": "-3.691944",
-		"radius": "15000"
+	  "entities": [
+	      {
+		  "type": "City",
+		  "isPattern": "true",
+		  "id": ".*"
 	      }
-	      }
-	    }
-	    ]
+	  ],
+	  "restriction": {
+	      "scopes": [
+		  {
+		      "type": "FIWARE::Location",
+		      "value": {
+			  "circle": {
+			      "centerLatitude": "40.418889",
+			      "centerLongitude": "-3.691944",
+			      "radius": "15000"
+			  }
+		      }
+		  }
+	      ]
 	  }
-	}
+      }
       EOF
 Let's consider a query whose scope is outside a radius of 13.5 km (13500
 meters) centred in Madrid.
@@ -417,27 +416,27 @@ be Alcobendas.
 
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"entities": [
-	{
-	  "type": "City",
-	  "isPattern": "true",
-	  "id": ".*"
-	}
-	],
-	  "restriction": {
-	  "scopes": [
-	  {
-	    "type" : "FIWARE::Location",
-	    "value" : {
-	      "circle": {
-		"centerLatitude": "40.418889",
-		"centerLongitude": "-3.691944",
-		"radius": "13500",
-		"inverted": "true"
+	  "entities": [
+	      {
+		  "type": "City",
+		  "isPattern": "true",
+		  "id": ".*"
 	      }
-	    }
+	  ],
+	  "restriction": {
+	      "scopes": [
+		  {
+		      "type": "FIWARE::Location",
+		      "value": {
+			  "circle": {
+			      "centerLatitude": "40.418889",
+			      "centerLongitude": "-3.691944",
+			      "radius": "13500",
+			      "inverted": "true"
+			  }
+		      }
+		  }
+	      ]
 	  }
-	  ]
-	}
       }
       EOF                                                                                                                   

--- a/doc/manuals/user/geolocation.md
+++ b/doc/manuals/user/geolocation.md
@@ -14,33 +14,32 @@ entity) defines the location, the "location" metadata is used. For
 example, the following updateContext request creates the entity "Madrid"
 (of type "City") with attribute "position" defined as location.
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                         {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                          {
-          <contextElement>                                                                                                              "type": "City",
-            <entityId type="City" isPattern="false">                                                                                    "isPattern": "false",
-              <id>Madrid</id>                                                                                                           "id": "Madrid",
-            </entityId>                                                                                                                 "attributes": [
-            <contextAttributeList>                                                                                                      {
-              <contextAttribute>                                                                                                          "name": "position",
-                <name>position</name>                                                                                                     "type": "coords",
-                <type>coords</type>                                                                                                       "value": "40.418889, -3.691944",
-                <contextValue>40.418889, -3.691944</contextValue>                                                                         "metadatas": [
-                <metadata>                                                                                                                {
-                  <contextMetadata>                                                                                                         "name": "location",
-                    <name>location</name>                                                                                                   "type": "string",
-                    <type>string</type>                                                                                                     "value": "WGS84"
-                    <value>WGS84</value>                                                                                                  }
-                  </contextMetadata>                                                                                                      ]
-                </metadata>                                                                                                             }
-              </contextAttribute>                                                                                                       ]
-            </contextAttributeList>                                                                                                   }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "APPEND"
-        <updateAction>APPEND</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "contextElements": [
+	  {
+	      "type": "City",
+	      "isPattern": "false",
+	      "id": "Madrid",
+          "attributes": [
+          {
+              "name": "position",
+              "type": "coords",
+              "value": "40.418889, -3.691944",
+	      "metadatas": [
+	      {
+                 "name": "location",
+                 "type": "string",
+                 "value": "WGS84"
+	      }
+	      ]
+          }
+          ]
+          }
+          ],
+        "updateAction": "APPEND"
+       }
+       EOF                                                                                                                      
 
 Additional comments:
 
@@ -89,6 +88,7 @@ the following scenario: three entities (A, B and C, of type "Point")
 have been created in Orion Context Broker, each one in the coordinates
 shown in the following picture.
 
+![alt tag](orion-geo-points.png "orion-geo-points.png")
 ![](orion-geo-points.png "orion-geo-points.png")
 
 Let's consider a query whose scope is the internal area to the square
@@ -102,47 +102,46 @@ elements, each one containing a couple of elements (latitude and
 longitude) that provide the coordinates of the vertex. The result of the
 query would be A and B.
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                              {
-              <entityId type="Point" isPattern="true">                                                                                "type": "Point",
-                <id>.*</id>                                                                                                           "isPattern": "true",
-              </entityId>                                                                                                             "id": ".*"
-        </entityIdList>                                                                                                             }
-        <attributeList>                                                                                                             ],
-        </attributeList>                                                                                                            "restriction": {
-        <restriction>                                                                                                                 "scopes": [
-          <scope>                                                                                                                     {
-            <operationScope>                                                                                                            "type" : "FIWARE::Location",
-              <scopeType>FIWARE::Location</scopeType>                                                                                   "value" : {
-              <scopeValue>                                                                                                                "polygon": {
-                <polygon>                                                                                                                   "vertices": [
-                  <vertexList>                                                                                                              {
-                    <vertex>                                                                                                                  "latitude": "0",
-                      <latitude>0</latitude>                                                                                                  "longitude": "0"
-                      <longitude>0</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "0",
-                      <latitude>0</latitude>                                                                                                  "longitude": "6"
-                      <longitude>6</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "6",
-                      <latitude>6</latitude>                                                                                                  "longitude": "6"
-                      <longitude>6</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "6",
-                      <latitude>6</latitude>                                                                                                  "longitude": "0"
-                      <longitude>0</longitude>                                                                                              }
-                    </vertex>                                                                                                               ]
-                  </vertexList>                                                                                                           }
-                </polygon>                                                                                                              }
-              </scopeValue>                                                                                                           }
-            </operationScope>                                                                                                         ]
-          </scope>                                                                                                                  }
-        </restriction>                                                                                                            }
-      </queryContextRequest>                                                                                                      EOF
-      EOF                                                                                                                     
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	  {
+	  "type": "Point",
+	  "isPattern": "true",
+	  "id": ".*"
+	  }
+	  ],
+	  "restriction": {
+	    "scopes": [
+	    {
+	    "type" : "FIWARE::Location",
+	    "value" : {
+	      "polygon": {
+		"vertices": [
+		  {
+		    "latitude": "0",
+		    "longitude": "0"
+		  },
+		  {
+		    "latitude": "0",
+		    "longitude": "6"
+		  },
+		  {
+		    "latitude": "6",
+		    "longitude": "6"
+		  },
+		  {
+		    "latitude": "6",
+		    "longitude": "0"
+		  }
+		  ]
+		  }
+		}
+	      }
+	      ]
+	    }
+	  }
+	  EOF                                                                                                         
 
 Let's consider a query whose scope is the internal area to the rectangle
 defined by coordinates (3, 3), (3, 8), (11, 8) and (11, 3).
@@ -151,95 +150,94 @@ defined by coordinates (3, 3), (3, 8), (11, 8) and (11, 3).
 
 The result of the query would be B and C.
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                              {
-              <entityId type="Point" isPattern="true">                                                                                "type": "Point",
-                <id>.*</id>                                                                                                           "isPattern": "true",
-              </entityId>                                                                                                             "id": ".*"
-        </entityIdList>                                                                                                             }
-        <attributeList>                                                                                                             ],
-        </attributeList>                                                                                                            "restriction": {
-        <restriction>                                                                                                                 "scopes": [
-          <scope>                                                                                                                     {
-            <operationScope>                                                                                                            "type" : "FIWARE::Location",
-              <scopeType>FIWARE::Location</scopeType>                                                                                   "value" : {
-              <scopeValue>                                                                                                                "polygon": {
-                <polygon>                                                                                                                   "vertices": [
-                  <vertexList>                                                                                                              {
-                    <vertex>                                                                                                                  "latitude": "3",
-                      <latitude>3</latitude>                                                                                                  "longitude": "3"
-                      <longitude>3</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "3",
-                      <latitude>3</latitude>                                                                                                  "longitude": "8"
-                      <longitude>8</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "11",
-                      <latitude>11</latitude>                                                                                                 "longitude": "8"
-                      <longitude>8</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "11",
-                      <latitude>11</latitude>                                                                                                 "longitude": "3"
-                      <longitude>3</longitude>                                                                                              }
-                    </vertex>                                                                                                               ]
-                  </vertexList>                                                                                                           }
-                </polygon>                                                                                                              }
-              </scopeValue>                                                                                                           }
-            </operationScope>                                                                                                         ]
-          </scope>                                                                                                                  }
-        </restriction>                                                                                                            }
-      </queryContextRequest>                                                                                                      EOF
-      EOF                                                                                                                     
+	(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+	{
+	"entities": [
+	{
+	  "type": "Point",
+	  "isPattern": "true",
+	  "id": ".*"
+	}
+	],
+	"restriction": {
+	  "scopes": [
+	    {
+	      "type" : "FIWARE::Location",
+	      "value" : {
+	      "polygon": {
+		  "vertices": [
+		  {
+		    "latitude": "3",
+		    "longitude": "3"
+		  },
+		  {
+		    "latitude": "3",
+		    "longitude": "8"
+		  },
+		  {
+		     "latitude": "11",
+		     "longitude": "8"
+		  },
+		  {
+		     "latitude": "11",
+		     "longitude": "3"
+		  }
+		  ]
+	      }
+	      }
+	    }
+	    ]
+	}
+      }
+      EOF
+                                                                                                                 
 
 However, if we consider the query to the external area to that
 rectangle, the result of the query would be A. To specify that we refer
 to the area external to the polygon we include the inverted element set
 to "true".
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                              {
-              <entityId type="Point" isPattern="true">                                                                                "type": "Point",
-                <id>.*</id>                                                                                                           "isPattern": "true",
-              </entityId>                                                                                                             "id": ".*"
-        </entityIdList>                                                                                                             }
-        <attributeList>                                                                                                             ],
-        </attributeList>                                                                                                            "restriction": {
-        <restriction>                                                                                                                 "scopes": [
-          <scope>                                                                                                                     {
-            <operationScope>                                                                                                            "type" : "FIWARE::Location",
-              <scopeType>FIWARE::Location</scopeType>                                                                                   "value" : {
-              <scopeValue>                                                                                                                "polygon": {
-                <polygon>                                                                                                                   "vertices": [
-                  <vertexList>                                                                                                              {
-                    <vertex>                                                                                                                  "latitude": "3",
-                      <latitude>3</latitude>                                                                                                  "longitude": "3"
-                      <longitude>3</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "3",
-                      <latitude>3</latitude>                                                                                                  "longitude": "8"
-                      <longitude>8</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "11",
-                      <latitude>11</latitude>                                                                                                 "longitude": "8"
-                      <longitude>8</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "11",
-                      <latitude>11</latitude>                                                                                                 "longitude": "3"
-                      <longitude>3</longitude>                                                                                              }
-                    </vertex>                                                                                                               ],
-                  </vertexList>                                                                                                             "inverted": "true"
-                  <inverted>true</inverted>                                                                                               }
-                </polygon>                                                                                                              }
-              </scopeValue>                                                                                                           }
-            </operationScope>                                                                                                         ]
-          </scope>                                                                                                                  }
-        </restriction>                                                                                                            }
-      </queryContextRequest>                                                                                                      EOF
-      EOF                                                                                                                     
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"entities": [
+	{
+	  "type": "Point",
+	  "isPattern": "true",
+	  "id": ".*"
+	}
+	],
+	"restriction": {
+	    "scopes": [
+	    {
+	    "type" : "FIWARE::Location",
+	    "value" : {
+	      "polygon": {
+		"vertices": [
+		{
+		  "latitude": "3",
+		  "longitude": "3"
+		},
+		{
+		  "latitude": "3",
+		  "longitude": "8"
+		},
+		{
+		  "latitude": "11",
+		  "longitude": "8"
+		},
+		{
+		  "latitude": "11",
+		  "longitude": "3"
+		}
+		],
+		"inverted": "true"
+		}
+	    }
+	  }
+	  ]
+	}
+      }
+      EOF                                                                                                            
 
 Let's consider a query whose scope is the internal area to the triangle
 defined by coordinates (0, 0), (0, 6) and (6, 0).
@@ -248,86 +246,86 @@ defined by coordinates (0, 0), (0, 6) and (6, 0).
 
 The result of the query would be A.
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                              {
-              <entityId type="Point" isPattern="true">                                                                                "type": "Point",
-                <id>.*</id>                                                                                                           "isPattern": "true",
-              </entityId>                                                                                                             "id": ".*"
-        </entityIdList>                                                                                                             }
-        <attributeList>                                                                                                             ],
-        </attributeList>                                                                                                            "restriction": {
-        <restriction>                                                                                                                 "scopes": [
-          <scope>                                                                                                                     {
-            <operationScope>                                                                                                            "type" : "FIWARE::Location",
-              <scopeType>FIWARE::Location</scopeType>                                                                                   "value" : {
-              <scopeValue>                                                                                                                "polygon": {
-                <polygon>                                                                                                                   "vertices": [
-                  <vertexList>                                                                                                              {
-                    <vertex>                                                                                                                  "latitude": "0",
-                      <latitude>0</latitude>                                                                                                  "longitude": "0"
-                      <longitude>0</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "0",
-                      <latitude>0</latitude>                                                                                                  "longitude": "6"
-                      <longitude>6</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "6",
-                      <latitude>6</latitude>                                                                                                  "longitude": "0"
-                      <longitude>0</longitude>                                                                                              }
-                    </vertex>                                                                                                               ]
-                  </vertexList>                                                                                                           }
-                </polygon>                                                                                                              }
-              </scopeValue>                                                                                                           }
-            </operationScope>                                                                                                         ]
-          </scope>                                                                                                                  }
-        </restriction>                                                                                                            }
-      </queryContextRequest>                                                                                                      EOF
-      EOF                                                                                                                     
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"entities": [
+	{
+	    "type": "Point",
+	    "isPattern": "true",
+	    "id": ".*"
+	}
+	],
+	  "restriction": {
+	    "scopes": [
+	    {
+	      "type" : "FIWARE::Location",
+	      "value" : {
+		"polygon": {
+		  "vertices": [
+		  {
+		    "latitude": "0",
+		    "longitude": "0"
+		  },
+		  {
+		    "latitude": "0",
+		    "longitude": "6"
+		  },
+		  {
+		    "latitude": "6",
+		    "longitude": "0"
+		  }
+		  ]
+	      }
+	      }
+	    }
+	    ]
+	  }
+	}
+	EOF
+                                                                                                                     
 
 However, if we consider the query to the external area to that triangle
 (using the inverted element set to "true"), the result of the query
 would be B and C.
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                              {
-              <entityId type="Point" isPattern="true">                                                                                "type": "Point",
-                <id>.*</id>                                                                                                           "isPattern": "true",
-              </entityId>                                                                                                             "id": ".*"
-        </entityIdList>                                                                                                             }
-        <attributeList>                                                                                                             ],
-        </attributeList>                                                                                                            "restriction": {
-        <restriction>                                                                                                                 "scopes": [
-          <scope>                                                                                                                     {
-            <operationScope>                                                                                                            "type" : "FIWARE::Location",
-              <scopeType>FIWARE::Location</scopeType>                                                                                   "value" : {
-              <scopeValue>                                                                                                                "polygon": {
-                <polygon>                                                                                                                   "vertices": [
-                  <vertexList>                                                                                                              {
-                    <vertex>                                                                                                                  "latitude": "0",
-                      <latitude>0</latitude>                                                                                                  "longitude": "0"
-                      <longitude>0</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "0",
-                      <latitude>0</latitude>                                                                                                  "longitude": "6"
-                      <longitude>6</longitude>                                                                                              },
-                    </vertex>                                                                                                               {
-                    <vertex>                                                                                                                  "latitude": "6",
-                      <latitude>6</latitude>                                                                                                  "longitude": "0"
-                      <longitude>0</longitude>                                                                                              }
-                    </vertex>                                                                                                               ],
-                  </vertexList>                                                                                                             "inverted": "true"
-                  <inverted>true</inverted>                                                                                               }
-                </polygon>                                                                                                              }
-              </scopeValue>                                                                                                           }
-            </operationScope>                                                                                                         ]
-          </scope>                                                                                                                  }
-        </restriction>                                                                                                            }
-      </queryContextRequest>                                                                                                      EOF
-      EOF                                                                                                                     
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	  {
+	    "type": "Point",
+	    "isPattern": "true",
+	    "id": ".*"
+	  }
+	  ],
+	  "restriction": {
+	    "scopes": [
+	    {
+	      "type" : "FIWARE::Location",
+	      "value" : {
+		"polygon": {
+		  "vertices": [
+		  {
+		    "latitude": "0",
+		    "longitude": "0"
+		  },
+		  {
+		    "latitude": "0",
+		    "longitude": "6"
+		  },
+		  {
+		    "latitude": "6",
+		    "longitude": "0"
+		  }
+		  ],
+		  "inverted": "true"
+		}
+	      }
+	    }
+	    ]
+	    }
+	}
+	EOF
+                                                                                                                    
 
 Now, in order to illustrate circle areas, let's consider the following
 scenario: three entities (representing the cities of Madrid, Alcobendas
@@ -351,32 +349,31 @@ include a three elements: centerLatitude (the latitude of the circle
 center), centerLongitude (the longitude of the circle center) and radius
 (in meters). The result of the query would be Madrid and Leganes.
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                              {
-              <entityId type="City" isPattern="true">                                                                                 "type": "City",
-                <id>.*</id>                                                                                                           "isPattern": "true",
-              </entityId>                                                                                                             "id": ".*"
-        </entityIdList>                                                                                                             }
-        <attributeList>                                                                                                             ],
-        </attributeList>                                                                                                            "restriction": {
-        <restriction>                                                                                                                 "scopes": [
-          <scope>                                                                                                                     {
-            <operationScope>                                                                                                            "type" : "FIWARE::Location",
-              <scopeType>FIWARE::Location</scopeType>                                                                                   "value" : {
-              <scopeValue>                                                                                                                "circle": {
-                <circle>                                                                                                                    "centerLatitude": "40.418889",
-                  <centerLatitude>40.418889</centerLatitude>                                                                                "centerLongitude": "-3.691944",
-                  <centerLongitude>-3.691944</centerLongitude>                                                                              "radius": "13500"
-                  <radius>13500</radius>                                                                                                  }
-                </circle>                                                                                                               }
-              </scopeValue>                                                                                                           }
-            </operationScope>                                                                                                         ]
-          </scope>                                                                                                                  }
-        </restriction>                                                                                                            }
-      </queryContextRequest>                                                                                                      EOF
-      EOF                                                                                                                     
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+	{
+	  "entities": [
+	  {
+	    "type": "City",
+	    "isPattern": "true",
+	    "id": ".*"
+	  }
+	  ],
+	"restriction": {
+	    "scopes": [
+	    {
+	      "type" : "FIWARE::Location",
+	      "value" : {
+	      "circle": {
+	      "centerLatitude": "40.418889",
+	      "centerLongitude": "-3.691944",
+	      "radius": "13500"
+	      }
+	      }
+	    }
+	  ]
+	 }
+      }
+      EOF                                                                                                                                                                                                                                     
 
 Let's consider a query whose scope is inside a radius of 15 km (15000
 meters) centred in Madrid.
@@ -385,33 +382,31 @@ meters) centred in Madrid.
 
 The result of the query would be Madrid, Leganes and Alcobendas.
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                              {
-              <entityId type="City" isPattern="true">                                                                                 "type": "City",
-                <id>.*</id>                                                                                                           "isPattern": "true",
-              </entityId>                                                                                                             "id": ".*"
-        </entityIdList>                                                                                                             }
-        <attributeList>                                                                                                             ],
-        </attributeList>                                                                                                            "restriction": {
-        <restriction>                                                                                                                 "scopes": [
-          <scope>                                                                                                                     {
-            <operationScope>                                                                                                            "type" : "FIWARE::Location",
-              <scopeType>FIWARE::Location</scopeType>                                                                                   "value" : {
-              <scopeValue>                                                                                                                "circle": {
-                <circle>                                                                                                                    "centerLatitude": "40.418889",
-                  <centerLatitude>40.418889</centerLatitude>                                                                                "centerLongitude": "-3.691944",
-                  <centerLongitude>-3.691944</centerLongitude>                                                                              "radius": "15000"
-                  <radius>15000</radius>                                                                                                  }
-                </circle>                                                                                                               }
-              </scopeValue>                                                                                                           }
-            </operationScope>                                                                                                         ]
-          </scope>                                                                                                                  }
-        </restriction>                                                                                                            }
-      </queryContextRequest>                                                                                                      EOF
-      EOF                                                                                                                     
-
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"entities": [
+	{
+	  "type": "City",
+	  "isPattern": "true",
+	  "id": ".*"
+	}
+	],
+	"restriction": {
+	"scopes": [
+	{
+	    "type" : "FIWARE::Location",
+	    "value" : {
+	      "circle": {
+		"centerLatitude": "40.418889",
+		"centerLongitude": "-3.691944",
+		"radius": "15000"
+	      }
+	      }
+	    }
+	    ]
+	  }
+	}
+      EOF
 Let's consider a query whose scope is outside a radius of 13.5 km (13500
 meters) centred in Madrid.
 
@@ -420,30 +415,29 @@ meters) centred in Madrid.
 We use the inverted element set to "true". The result of the query would
 be Alcobendas.
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                              {
-              <entityId type="City" isPattern="true">                                                                                 "type": "City",
-                <id>.*</id>                                                                                                           "isPattern": "true",
-              </entityId>                                                                                                             "id": ".*"
-        </entityIdList>                                                                                                             }
-        <attributeList>                                                                                                             ],
-        </attributeList>                                                                                                            "restriction": {
-        <restriction>                                                                                                                 "scopes": [
-          <scope>                                                                                                                     {
-            <operationScope>                                                                                                            "type" : "FIWARE::Location",
-              <scopeType>FIWARE::Location</scopeType>                                                                                   "value" : {
-              <scopeValue>                                                                                                                "circle": {
-                <circle>                                                                                                                    "centerLatitude": "40.418889",
-                  <centerLatitude>40.418889</centerLatitude>                                                                                "centerLongitude": "-3.691944",
-                  <centerLongitude>-3.691944</centerLongitude>                                                                              "radius": "13500",
-                  <radius>13500</radius>                                                                                                    "inverted": "true"
-                  <inverted>true</inverted>                                                                                               }
-                </circle>                                                                                                               }
-              </scopeValue>                                                                                                           }
-            </operationScope>                                                                                                         ]
-          </scope>                                                                                                                  }
-        </restriction>                                                                                                            }
-      </queryContextRequest>                                                                                                      EOF
-      EOF                                                                                                                     
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"entities": [
+	{
+	  "type": "City",
+	  "isPattern": "true",
+	  "id": ".*"
+	}
+	],
+	  "restriction": {
+	  "scopes": [
+	  {
+	    "type" : "FIWARE::Location",
+	    "value" : {
+	      "circle": {
+		"centerLatitude": "40.418889",
+		"centerLongitude": "-3.691944",
+		"radius": "13500",
+		"inverted": "true"
+	      }
+	    }
+	  }
+	  ]
+	}
+      }
+      EOF                                                                                                                   

--- a/doc/manuals/user/metadata.md
+++ b/doc/manuals/user/metadata.md
@@ -15,28 +15,28 @@ associate metadata "accuracy" to "temperature":
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"contextElements": [
-	{
-	  "type": "Room",
-	  "isPattern": "false",
-	  "id": "Room1",
-	    "attributes": [
-	    {
-	    "name": "temperature",
-	    "type": "float",
-	    "value": "26.5",
-	    "metadatas": [
-	    {
-	      "name": "accuracy",
-	      "type": "float",
-	      "value": "0.8"
-	    }
-	    ]
-	  }
-	  ]
-	}
-	],
-	"updateAction": "APPEND"
+	  "contextElements": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1",
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "26.5",
+			  "metadatas": [
+			      {
+				  "name": "accuracy",
+				  "type": "float",
+				  "value": "0.8"
+			      }
+			  ]
+		      }
+		  ]
+	      }
+	  ],
+	  "updateAction": "APPEND"
       }
       EOF                                                                                                                     
   
@@ -46,28 +46,28 @@ to 0.9 although the value of the temperature iself is still 26.5:
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"contextElements": [
-	{
-	  "type": "Room",
-	  "isPattern": "false",
-	  "id": "Room1",
-	  "attributes": [
-	  {
-	    "name": "temperature",
-	    "type": "float",
-	    "value": "26.5",
-	    "metadatas": [
-	    {
-	      "name": "accuracy",
-	      "type": "float",
-	      "value": "0.9"
-	    }
-	    ]
-	    }
-	  ]
-	}
-	],
-	"updateAction": "UPDATE"
+	  "contextElements": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1",
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "26.5",
+			  "metadatas": [
+			      {
+				  "name": "accuracy",
+				  "type": "float",
+				  "value": "0.9"
+			      }
+			  ]
+		      }
+		  ]
+	      }
+	  ],
+	  "updateAction": "UPDATE"
       }
       EOF                                                                                                                     
   
@@ -77,67 +77,67 @@ to add metadata "average" to "temperature" (in addition to the existing
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"contextElements": [
-	{
-	  "type": "Room",
-	  "isPattern": "false",
-	  "id": "Room1",
-	  "attributes": [
-	  {
-	    "name": "temperature",
-	    "type": "float",
-	    "value": "26.5",
-	    "metadatas": [
-	    {
-	      "name": "average",
-	      "type": "float",
-	      "value": "22.4"
-	    }
-	    ]
-	  }
-	  ]
-	}
-	],
-	"updateAction": "UPDATE"
+	  "contextElements": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1",
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "26.5",
+			  "metadatas": [
+			      {
+				  "name": "average",
+				  "type": "float",
+				  "value": "22.4"
+			      }
+			  ]
+		      }
+		  ]
+	      }
+	  ],
+	  "updateAction": "UPDATE"
       }
       EOF                                                                                                                      
   
 We can check that temperature includes both attributes
 
       curl localhost:1026/v1/contextEntities/Room1 -s -S --header 'Accept: application/json' | python -mjson.tool
-
       {
-	"contextElements": [
-	{
-	  "type": "Room",
-	  "isPattern": "false",
-	  "id": "Room1",
-	  "attributes": [
-	{
-	    "name": "temperature",
-	    "type": "float",
-	    "value": "26.5",
-	    "metadatas": [
-	    {
-	      "name": "average",
-	      "type": "float",
-	      "value": "22.4"
-	    },
-	    {
-	      "name": "accuracy",
-	      "type": "float",
-	      "value": "0.9"
-	    }
-	    ]
+	  "contextElements": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1",
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "26.5",
+			  "metadatas": [
+			      {
+				  "name": "average",
+				  "type": "float",
+				  "value": "22.4"
+			      },
+			      {
+				  "name": "accuracy",
+				  "type": "float",
+				  "value": "0.9"
+			      }
+			  ]
+		      }
+		  ]
+	      }
+	  ],
+	  "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
 	  }
-	  ]
-	}
-      ],
-	"statusCode": {
-	  "code": "200",
-	  "reasonPhrase": "OK"
-	}
       }
+
       
 Note that, from the point of view of [ONCHANGE
 subscription](#ONCHANGE "wikilink"), changing the metadata of a given
@@ -170,40 +170,40 @@ First, we create the Room1 entity:
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"contextElements": [
-	  {
-	    "type": "Room",
-	    "isPattern": "false",
-	    "id": "Room1",
-	    "attributes": [
+	  "contextElements": [
 	      {
-		"name": "temperature",
-		"type": "float",
-		"value": "23.5",
-		"metadatas": [
-		  {
-		    "name": "ID",
-		    "type": "string",
-		    "value": "ground"
-		  }
-		]
-	      },
-	    {
-		"name": "temperature",
-		"type": "float",
-		"value": "23.8",
-		"metadatas": [
-		{
-		  "name": "ID",
-		  "type": "string",
-		  "value": "wall"
-		}
-		]
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1",
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "23.5",
+			  "metadatas": [
+			      {
+				  "name": "ID",
+				  "type": "string",
+				  "value": "ground"
+			      }
+			  ]
+		      },
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "23.8",
+			  "metadatas": [
+			      {
+				  "name": "ID",
+				  "type": "string",
+				  "value": "wall"
+			      }
+			  ]
+		      }
+		  ]
 	      }
-	  ]
-	  }
-	],
-	"updateAction": "APPEND"
+	  ],
+	  "updateAction": "APPEND"
       }
       EOF                                                                                                                      
   
@@ -211,16 +211,16 @@ Now, we can query for temperature to get both instances:
 
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"entities": [
-	  {
-	    "type": "Room",
-	    "isPattern": "false",
-	    "id": "Room1"
-	  }
-	],
-	"attributes": [
-	  "temperature"
-	]
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      }
+	  ],
+	  "attributes": [
+	      "temperature"
+	  ]
       }
       EOF
   
@@ -229,30 +229,30 @@ untouched:
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"contextElements": [
-	  {
-	    "type": "Room",
-	    "isPattern": "false",
-	    "id": "Room1",
-	    "attributes": [
-	    {
-	      "name": "temperature",
-	      "type": "float",
-	      "value": "30",
-	      "metadatas": [
+	  "contextElements": [
 	      {
-		"name": "ID",
-		"type": "string",
-		"value": "ground"
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1",
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "30",
+			  "metadatas": [
+			      {
+				  "name": "ID",
+				  "type": "string",
+				  "value": "ground"
+			      }
+			  ]
+		      }
+		  ]
 	      }
-	      ]
-	    }
-	    ]
-	  }
 	  ],
-	"updateAction": "UPDATE"
-	}
-	EOF                                                                                                                     
+	  "updateAction": "UPDATE"
+      }
+      EOF                                                                                                                     
  
 Check it using again queryContext (ground has changed to 30ºC but wall
 has its initial value of 23.8º C).
@@ -260,46 +260,49 @@ has its initial value of 23.8º C).
 To avoid ambiguities, you cannot mix the same attribute with and without
 ID. The following entity creation will fail:
 
-	(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-	  {
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
 	  "contextElements": [
-	    {
-	      "type": "Room",
-	      "isPattern": "false",
-	      "id": "Room1",
-	      "attributes": [
-		{
-		"name": "temperature",
-		"type": "float",
-		 "value": "23.5",
-		"metadatas": [
-		  {
-		    "name": "ID",
-		    "type": "string",
-		    "value": "ground"
-		  }
-		]
-		},
-		{
-		"name": "temperature",
-		"type": "float",
-		"value": "23.8"
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1",
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "23.5",
+			  "metadatas": [
+			      {
+				  "name": "ID",
+				  "type": "string",
+				  "value": "ground"
+			      }
+			  ]
+		      },
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "23.8"
+		      }
+		  ]
 	      }
-	    ]
-	  }
 	  ],
 	  "updateAction": "APPEND"
-	}
-	EOF                                                                                                                     
+      }
+      EOF                                                                                                                     
 
-       ...                                                                                                 
-       "statusCode": {
-         "code": "472",
-         "details": "action: APPEND - entity: (Room1, Room) - offending attribute: temperature",
-         "reasonPhrase": "request parameter is invalid/not allowed"
-       }
-       ...                                                                                                 
-  Finally, you can use also the following convenience operations with
+      ...                                                                                                 
+      {
+	  "statusCode": {
+	      "code": "472",
+	      "details": "action: APPEND - entity: (Room1, Room) - offending attribute: temperature",
+	      "reasonPhrase": "request parameter is invalid/not allowed"
+	  }
+      }
+      ...    
+      
+Finally, you can use also the following convenience operations with
 attributes using ID metadata:
 
 -   GET /v1/contextEntities/Room1/attributes/temperature/ground: to get

--- a/doc/manuals/user/metadata.md
+++ b/doc/manuals/user/metadata.md
@@ -138,6 +138,7 @@ We can check that temperature includes both attributes
 	  "reasonPhrase": "OK"
 	}
       }
+      
 Note that, from the point of view of [ONCHANGE
 subscription](#ONCHANGE "wikilink"), changing the metadata of a given
 attribute or adding a new metadata element is considered a change even

--- a/doc/manuals/user/metadata.md
+++ b/doc/manuals/user/metadata.md
@@ -13,134 +13,131 @@ queryContext or notifyContext.
 For example, to create an entity Room1 with attribute "temperature", and
 associate metadata "accuracy" to "temperature":
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                          {
-          <contextElement>                                                                                                              "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                    "isPattern": "false",
-              <id>Room1</id>                                                                                                            "id": "Room1",
-            </entityId>                                                                                                                 "attributes": [
-            <contextAttributeList>                                                                                                      {
-              <contextAttribute>                                                                                                          "name": "temperature",
-                <name>temperature</name>                                                                                                  "type": "float",
-                <type>float</type>                                                                                                        "value": "26.5",
-                <contextValue>26.5</contextValue>                                                                                         "metadatas": [
-                <metadata>                                                                                                                {
-                  <contextMetadata>                                                                                                         "name": "accuracy",
-                    <name>accuracy</name>                                                                                                   "type": "float",
-                    <type>float</type>                                                                                                      "value": "0.8"
-                    <value>0.8</value>                                                                                                    }
-                  </contextMetadata>                                                                                                      ]
-                </metadata>                                                                                                             }
-              </contextAttribute>                                                                                                       ]
-            </contextAttributeList>                                                                                                   }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "APPEND"
-        <updateAction>APPEND</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+	{
+	  "type": "Room",
+	  "isPattern": "false",
+	  "id": "Room1",
+	    "attributes": [
+	    {
+	    "name": "temperature",
+	    "type": "float",
+	    "value": "26.5",
+	    "metadatas": [
+	    {
+	      "name": "accuracy",
+	      "type": "float",
+	      "value": "0.8"
+	    }
+	    ]
+	  }
+	  ]
+	}
+	],
+	"updateAction": "APPEND"
+      }
+      EOF                                                                                                                     
   
 Metadata can be updated regardless of the attribute value being updated
 or not. For example, next updateContext shows how "accuracy" is updated
 to 0.9 although the value of the temperature iself is still 26.5:
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                          {
-          <contextElement>                                                                                                              "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                    "isPattern": "false",
-              <id>Room1</id>                                                                                                            "id": "Room1",
-            </entityId>                                                                                                                 "attributes": [
-            <contextAttributeList>                                                                                                      {
-              <contextAttribute>                                                                                                          "name": "temperature",
-                <name>temperature</name>                                                                                                  "type": "float",
-                <type>float</type>                                                                                                        "value": "26.5",
-                <contextValue>26.5</contextValue>                                                                                         "metadatas": [
-                <metadata>                                                                                                                {
-                  <contextMetadata>                                                                                                         "name": "accuracy",
-                    <name>accuracy</name>                                                                                                   "type": "float",
-                    <type>float</type>                                                                                                      "value": "0.9"
-                    <value>0.9</value>                                                                                                    }
-                  </contextMetadata>                                                                                                      ]
-                </metadata>                                                                                                             }
-              </contextAttribute>                                                                                                       ]
-            </contextAttributeList>                                                                                                   }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "UPDATE"
-        <updateAction>UPDATE</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+	{
+	  "type": "Room",
+	  "isPattern": "false",
+	  "id": "Room1",
+	  "attributes": [
+	  {
+	    "name": "temperature",
+	    "type": "float",
+	    "value": "26.5",
+	    "metadatas": [
+	    {
+	      "name": "accuracy",
+	      "type": "float",
+	      "value": "0.9"
+	    }
+	    ]
+	    }
+	  ]
+	}
+	],
+	"updateAction": "UPDATE"
+      }
+      EOF                                                                                                                     
   
 Metadata can be added after attribute creation. For example, if we want
 to add metadata "average" to "temperature" (in addition to the existing
 "precision"):
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                          {
-          <contextElement>                                                                                                              "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                    "isPattern": "false",
-              <id>Room1</id>                                                                                                            "id": "Room1",
-            </entityId>                                                                                                                 "attributes": [
-            <contextAttributeList>                                                                                                      {
-              <contextAttribute>                                                                                                          "name": "temperature",
-                <name>temperature</name>                                                                                                  "type": "float",
-                <type>float</type>                                                                                                        "value": "26.5",
-                <contextValue>26.5</contextValue>                                                                                         "metadatas": [
-                <metadata>                                                                                                                {
-                  <contextMetadata>                                                                                                         "name": "average",
-                    <name>average</name>                                                                                                    "type": "float",
-                    <type>float</type>                                                                                                      "value": "22.4"
-                    <value>22.4</value>                                                                                                   }
-                  </contextMetadata>                                                                                                      ]
-                </metadata>                                                                                                             }
-              </contextAttribute>                                                                                                       ]
-            </contextAttributeList>                                                                                                   }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "UPDATE"
-        <updateAction>UPDATE</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+	{
+	  "type": "Room",
+	  "isPattern": "false",
+	  "id": "Room1",
+	  "attributes": [
+	  {
+	    "name": "temperature",
+	    "type": "float",
+	    "value": "26.5",
+	    "metadatas": [
+	    {
+	      "name": "average",
+	      "type": "float",
+	      "value": "22.4"
+	    }
+	    ]
+	  }
+	  ]
+	}
+	],
+	"updateAction": "UPDATE"
+      }
+      EOF                                                                                                                      
   
 We can check that temperature includes both attributes
 
-      curl localhost:1026/v1/contextEntities/Room1 -s -S | xmllint --format -       curl localhost:1026/v1/contextEntities/Room1 -s -S --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextEntities/Room1 -s -S --header 'Accept: application/json' | python -mjson.tool
 
-      <?xml version="1.0"?>                              {
-      <contextElementResponse>                             "contextElements": [
-        <contextElement>                                   {
-          <entityId type="Room" isPattern="false">           "type": "Room",
-            <id>Room1</id>                                   "isPattern": "false",
-          </entityId>                                        "id": "Room1",
-          <contextAttributeList>                             "attributes": [
-            <contextAttribute>                               {
-              <name>temperature</name>                         "name": "temperature",
-              <type>float</type>                               "type": "float",
-              <contextValue>26.5</contextValue>                "value": "26.5",
-              <metadata>                                       "metadatas": [
-                <contextMetadata>                              {
-                  <name>average</name>                           "name": "average",
-                  <type>float</type>                             "type": "float",
-                  <value>22.4</value>                            "value": "22.4"
-                </contextMetadata>                             },
-                <contextMetadata>                              {
-                  <name>accuracy</name>                          "name": "accuracy",
-                  <type>float</type>                             "type": "float",
-                  <value>0.9</value>                             "value": "0.9"
-                </contextMetadata>                             }
-              </metadata>                                      ]
-            </contextAttribute>                              }
-          </contextAttributeList>                            ]
-        </contextElement>                                  }
-        <statusCode>                                       ],
-          <code>200</code>                                 "statusCode": {
-          <reasonPhrase>OK</reasonPhrase>                    "code": "200",
-        </statusCode>                                        "reasonPhrase": "OK"
-      </contextElementResponse>                            }
-                                                         }
+      {
+	"contextElements": [
+	{
+	  "type": "Room",
+	  "isPattern": "false",
+	  "id": "Room1",
+	  "attributes": [
+	{
+	    "name": "temperature",
+	    "type": "float",
+	    "value": "26.5",
+	    "metadatas": [
+	    {
+	      "name": "average",
+	      "type": "float",
+	      "value": "22.4"
+	    },
+	    {
+	      "name": "accuracy",
+	      "type": "float",
+	      "value": "0.9"
+	    }
+	    ]
+	  }
+	  ]
+	}
+      ],
+	"statusCode": {
+	  "code": "200",
+	  "reasonPhrase": "OK"
+	}
+      }
 Note that, from the point of view of [ONCHANGE
 subscription](#ONCHANGE "wikilink"), changing the metadata of a given
 attribute or adding a new metadata element is considered a change even
@@ -170,93 +167,91 @@ use the metadata ID for this purpose. Let's illustrate with an example.
 
 First, we create the Room1 entity:
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                            {
-          <contextElement>                                                                                                                "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                      "isPattern": "false",
-              <id>Room1</id>                                                                                                              "id": "Room1",
-            </entityId>                                                                                                                   "attributes": [
-            <contextAttributeList>                                                                                                          {
-              <contextAttribute>                                                                                                              "name": "temperature",
-                <name>temperature</name>                                                                                                      "type": "float",
-                <type>float</type>                                                                                                            "value": "23.5",
-                <contextValue>23.5</contextValue>                                                                                             "metadatas": [
-                <metadata>                                                                                                                      {
-                   <contextMetadata>                                                                                                              "name": "ID",
-                      <name>ID</name>                                                                                                             "type": "string",
-                      <type>string</type>                                                                                                         "value": "ground"
-                      <value>ground</value>                                                                                                     }
-                   </contextMetadata>                                                                                                         ]
-                </metadata>                                                                                                                 },
-              </contextAttribute>                                                                                                           {
-              <contextAttribute>                                                                                                              "name": "temperature",
-                <name>temperature</name>                                                                                                      "type": "float",
-                <type>float</type>                                                                                                            "value": "23.8",
-                <contextValue>23.8</contextValue>                                                                                             "metadatas": [
-                <metadata>                                                                                                                    {
-                   <contextMetadata>                                                                                                            "name": "ID",
-                      <name>ID</name>                                                                                                           "type": "string",
-                      <type>string</type>                                                                                                       "value": "wall"
-                      <value>wall</value>                                                                                                     }
-                   </contextMetadata>                                                                                                         ]
-                </metadata>                                                                                                                 }
-              </contextAttribute>                                                                                                         ]
-            </contextAttributeList>                                                                                                     }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "APPEND"
-        <updateAction>APPEND</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+	  {
+	    "type": "Room",
+	    "isPattern": "false",
+	    "id": "Room1",
+	    "attributes": [
+	      {
+		"name": "temperature",
+		"type": "float",
+		"value": "23.5",
+		"metadatas": [
+		  {
+		    "name": "ID",
+		    "type": "string",
+		    "value": "ground"
+		  }
+		]
+	      },
+	    {
+		"name": "temperature",
+		"type": "float",
+		"value": "23.8",
+		"metadatas": [
+		{
+		  "name": "ID",
+		  "type": "string",
+		  "value": "wall"
+		}
+		]
+	      }
+	  ]
+	  }
+	],
+	"updateAction": "APPEND"
+      }
+      EOF                                                                                                                      
   
 Now, we can query for temperature to get both instances:
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                         "entities": [
-        <entityIdList>                                                                                                                {
-          <entityId type="Room" isPattern="false">                                                                                      "type": "Room",
-            <id>Room1</id>                                                                                                              "isPattern": "false",
-          </entityId>                                                                                                                   "id": "Room1"
-        </entityIdList>                                                                                                               }
-        <attributeList>                                                                                                             ],
-           <attribute>temperature</attribute>                                                                                       "attributes": [
-        </attributeList>                                                                                                              "temperature"
-      </queryContextRequest>                                                                                                        ]
-      EOF                                                                                                                         }
-                                                                                                                                  EOF
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"entities": [
+	  {
+	    "type": "Room",
+	    "isPattern": "false",
+	    "id": "Room1"
+	  }
+	],
+	"attributes": [
+	  "temperature"
+	]
+      }
+      EOF
   
 We can update an specific instance (e.g. ground), letting the other
 untouched:
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                            {
-          <contextElement>                                                                                                                "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                      "isPattern": "false",
-              <id>Room1</id>                                                                                                              "id": "Room1",
-            </entityId>                                                                                                                   "attributes": [
-            <contextAttributeList>                                                                                                        {
-              <contextAttribute>                                                                                                            "name": "temperature",
-                <name>temperature</name>                                                                                                    "type": "float",
-                <type>float</type>                                                                                                          "value": "30",
-                <contextValue>30</contextValue>                                                                                             "metadatas": [
-                <metadata>                                                                                                                  {
-                   <contextMetadata>                                                                                                          "name": "ID",
-                      <name>ID</name>                                                                                                         "type": "string",
-                      <type>string</type>                                                                                                     "value": "ground"
-                      <value>ground</value>                                                                                                 }
-                   </contextMetadata>                                                                                                       ]
-                </metadata>                                                                                                               }
-              </contextAttribute>                                                                                                         ]
-            </contextAttributeList>                                                                                                     }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "UPDATE"
-        <updateAction>UPDATE</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+	  {
+	    "type": "Room",
+	    "isPattern": "false",
+	    "id": "Room1",
+	    "attributes": [
+	    {
+	      "name": "temperature",
+	      "type": "float",
+	      "value": "30",
+	      "metadatas": [
+	      {
+		"name": "ID",
+		"type": "string",
+		"value": "ground"
+	      }
+	      ]
+	    }
+	    ]
+	  }
+	  ],
+	"updateAction": "UPDATE"
+	}
+	EOF                                                                                                                     
  
 Check it using again queryContext (ground has changed to 30ºC but wall
 has its initial value of 23.8º C).
@@ -264,46 +259,45 @@ has its initial value of 23.8º C).
 To avoid ambiguities, you cannot mix the same attribute with and without
 ID. The following entity creation will fail:
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                            {
-          <contextElement>                                                                                                                "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                      "isPattern": "false",
-              <id>Room2</id>                                                                                                              "id": "Room1",
-            </entityId>                                                                                                                   "attributes": [
-            <contextAttributeList>                                                                                                          {
-              <contextAttribute>                                                                                                              "name": "temperature",
-                <name>temperature</name>                                                                                                      "type": "float",
-                <type>float</type>                                                                                                            "value": "23.5",
-                <contextValue>23.5</contextValue>                                                                                             "metadatas": [
-                <metadata>                                                                                                                      {
-                   <contextMetadata>                                                                                                              "name": "ID",
-                      <name>ID</name>                                                                                                             "type": "string",
-                      <type>string</type>                                                                                                         "value": "ground"
-                      <value>ground</value>                                                                                                     }
-                   </contextMetadata>                                                                                                         ]
-                </metadata>                                                                                                                 },
-              </contextAttribute>                                                                                                           {
-              <contextAttribute>                                                                                                              "name": "temperature",
-                <name>temperature</name>                                                                                                      "type": "float",
-                <type>float</type>                                                                                                            "value": "23.8"
-                <contextValue>23.8</contextValue>                                                                                           }
-              </contextAttribute>                                                                                                         ]
-            </contextAttributeList>                                                                                                     }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "APPEND"
-        <updateAction>APPEND</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+	(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+	  {
+	  "contextElements": [
+	    {
+	      "type": "Room",
+	      "isPattern": "false",
+	      "id": "Room1",
+	      "attributes": [
+		{
+		"name": "temperature",
+		"type": "float",
+		 "value": "23.5",
+		"metadatas": [
+		  {
+		    "name": "ID",
+		    "type": "string",
+		    "value": "ground"
+		  }
+		]
+		},
+		{
+		"name": "temperature",
+		"type": "float",
+		"value": "23.8"
+	      }
+	    ]
+	  }
+	  ],
+	  "updateAction": "APPEND"
+	}
+	EOF                                                                                                                     
 
-       ...                                                                                                  ...
-       <statusCode>                                                                                         "statusCode": {
-         <code>472</code>                                                                                     "code": "472",
-         <reasonPhrase>request parameter is invalid/not allowed</reasonPhrase>                                "details": "action: APPEND - entity: (Room1, Room) - offending attribute: temperature",
-         <details>action: APPEND - entity: (Room1, Room) - offending attribute: temperature</details>         "reasonPhrase": "request parameter is invalid/not allowed"
-       </statusCode>                                                                                        }
-       ...                                                                                                  ...
+       ...                                                                                                 
+       "statusCode": {
+         "code": "472",
+         "details": "action: APPEND - entity: (Room1, Room) - offending attribute: temperature",
+         "reasonPhrase": "request parameter is invalid/not allowed"
+       }
+       ...                                                                                                 
   Finally, you can use also the following convenience operations with
 attributes using ID metadata:
 

--- a/doc/manuals/user/structured_attribute_valued.md
+++ b/doc/manuals/user/structured_attribute_valued.md
@@ -17,42 +17,52 @@ the value of attribute "A" to a vector and the value of attribute B to a
 key-map object (we use UPDATE as actionType, but this can be used at
 initial entity or attribute creation with APPEND).
 
-    (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-     {
-       "contextElements": [
-           {
-               "type": "T1",
-               "isPattern": "false",
-               "id": "E1",
-               "attributes": [
-               {
-                   "name": "A",
-                   "type": "T",
-                   "value": [ "22" , 
-                              {
-                                 "x": [ "x1", "x2"], 
-                                 "y": "3" 
-                              }, 
-                              [ "z1", "z2" ] 
-                            ]
-               },
-               {
-                   "name": "B",
-                   "type": "T",
-                   "value": {
-                      "x": { 
-                              "x1": "a", 
-                              "x2": "b" 
-                      },
-                      "y": [ "y1", "y2" ]
-                   }
-               }
-               ]
-           }
-       ],
-       "updateAction": "UPDATE"
-     }
-    EOF
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "contextElements": [
+	      {
+		  "type": "T1",
+		  "isPattern": "false",
+		  "id": "E1",
+		  "attributes": [
+		      {
+			  "name": "A",
+			  "type": "T",
+			  "value": [
+			      "22",
+			      {
+				  "x": [
+				      "x1",
+				      "x2"
+				  ],
+				  "y": "3"
+			      },
+			      [
+				  "z1",
+				  "z2"
+			      ]
+			  ]
+		      },
+		      {
+			  "name": "B",
+			  "type": "T",
+			  "value": {
+			      "x": {
+				  "x1": "a",
+				  "x2": "b"
+			      },
+			      "y": [
+				  "y1",
+				  "y2"
+			      ]
+			  }
+		      }
+		  ]
+	      }
+	  ],
+	  "updateAction": "UPDATE"
+      }
+      EOF
 
 
 The value of the attribute is stored internally by Orion Context Broker

--- a/doc/manuals/user/structured_attribute_valued.md
+++ b/doc/manuals/user/structured_attribute_valued.md
@@ -59,7 +59,7 @@ The value of the attribute is stored internally by Orion Context Broker
 in a format-independent representation. 
 
 Note that in order to align JSON representations, the final "leaf"
-elements of the structured attribute values after travesing all vectors
+elements of the structured attribute values after traversing all vectors
 and key-maps are always considered as strings.Thus, take into account that
 although you can use for instance a JSON integer as a field value in updates
 (such as {"x": 3 }),you will retrieve a string in queries and notifications 

--- a/doc/manuals/user/structured_attribute_valued.md
+++ b/doc/manuals/user/structured_attribute_valued.md
@@ -54,99 +54,13 @@ initial entity or attribute creation with APPEND).
      }
     EOF
 
-In the case of XML, the structure is a bit less "natural" than in JSON,
-but equivalent:
-
-    (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF
-    <?xml version="1.0" encoding="UTF-8"?>
-     <updateContextRequest>
-     <contextElementList>
-       <contextElement>
-         <entityId type="T1" isPattern="false">
-           <id>E1</id>
-         </entityId>
-         <contextAttributeList>
-           <contextAttribute>
-             <name>A</name>
-             <type>T</type>
-             <contextValue type="vector">
-                <item>22</item>
-                <item>
-                  <x type="vector">
-                    <item>x1</item>
-                    <item>x2</item>
-                  </x>
-                  <y>3</y>
-                </item>
-                <item type="vector">
-                  <item>z1</item>
-                  <item>z2</item>
-                </item>
-             </contextValue>
-           </contextAttribute>
-           <contextAttribute>
-             <name>B</name>
-             <type>T</type>
-             <contextValue>
-                <x>
-                  <x1>a</x1>
-                  <x2>b</x2>
-                </x>
-                <y type="vector">
-                   <item>y1</item>
-                   <item>y2</item>
-                </y>
-             </contextValue>
-           </contextAttribute>
-         </contextAttributeList>
-       </contextElement>
-     </contextElementList>
-     <updateAction>UPDATE</updateAction>
-     </updateContextRequest>
-    EOF
-
-The particular rules applied to XML format are the following ones:
-
--   Tags **not using** the "type" attribute equal to "vector" represent
-    key-map object, taking into account the following:
-    -   Each child tag is considered a key-map pair of the object, whose
-        key is the tag name and the value is the content of the tag. The
-        value can be either a string or a tag (which can represent
-        either a vector or a key-map object).
-    -   It is not allowed to have 2 child tags with the same name (a
-        parse error is generated in that case).
--   Tags **using** the "type" attribute equal to "vector" represent a
-    vector, taking into account the following:
-    -   Each child tag is considered a vector element, whose value is
-        the content of the tag. The value can be either a string or a
-        tag (which can represent either a vector or a key-map object).
-        The name of the tag is not taken into account (vector elements
-        have no name, otherwise the vector wouldn't be an actual vector,
-        but a key-map).
-    -   In updateContext, you can use whatever name you want for
-        child tags. However, all the child tags must have the same name
-        (otherwise a parse error is generated).
--   Except for "type", XML attributes are not allowed within the
-    sub-tree of an structured value (a parse error is generated as
-    a consequence).
 
 The value of the attribute is stored internally by Orion Context Broker
-in a format-independent representation. Thus, you can updateContext a
-structured attribute using JSON, then queryContext that attribute using
-XML (or vice-versa) and you get the equivalent result. The internal
-format-independent representation ignores the tag names for vector items
-set using XML (as described above), so the
-queryContextResponse/notifyContextRequest in XML uses always a
-predefined tag name for that: <item> (that may not match the tag name
-used in the updateContext operation setting that value; in fact, the
-updateContext operation could have been done with JSON, in which case
-the tag name for vector items has no sense at all).
+in a format-independent representation. 
 
-Note that in order to align XML/JSON representations, the final "leaf"
+Note that in order to align JSON representations, the final "leaf"
 elements of the structured attribute values after travesing all vectors
-and key-maps are always considered as strings. String is the "natural"
-type for elements in XML, but not in JSON (that allow other types, such
-as integer). Thus, take into account that although you can use for
-instance a JSON integer as a field value in updates (such as {"x": 3 }),
-you will retrieve a string in queries and notifications (i.e. { "x": "3"
-}).
+and key-maps are always considered as strings.Thus, take into account that
+although you can use for instance a JSON integer as a field value in updates
+(such as {"x": 3 }),you will retrieve a string in queries and notifications 
+(i.e. { "x": "3"}).

--- a/doc/manuals/user/updating_regs_and_subs.md
+++ b/doc/manuals/user/updating_regs_and_subs.md
@@ -5,11 +5,10 @@ The response to a register context request (both in
 [convenience](#Convenience_Register_Context "wikilink")) includes a
 registration ID (a 24 hexadecimal digit number):
 
-      <?xml version="1.0"?>                                             {
-      <registerContextResponse>                                             "duration": "PT24H",
-        <registrationId>51bf1e0ada053170df590f20</registrationId>           "registrationId": "51bf1e0ada053170df590f20"
-        <duration>PT24H</duration>                                      }
-      </registerContextResponse>                                    
+      {
+	"duration": "PT24H",
+        "registrationId": "51bf1e0ada053170df590f20"
+      }                                  
  
 This ID can be used to update the registration. There is no special
 operation to update a registration (in this sense, it is different from
@@ -18,31 +17,31 @@ updateContextSubscription and updateContextAvailabilitySubscription
 operations). The update is done issuing a new registerContextRequest,
 with the *registrationId* set:
 
-        (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                    {
-          <registerContextRequest>                                                                                                                 "contextRegistrations": [
-            <contextRegistrationList>                                                                                                                  {
-              <contextRegistration>                                                                                                                        "entities": [
-                <entityIdList>                                                                                                                                 {
-                  <entityId type="Room" isPattern="false">                                                                                                         "type": "Room",
-                    <id>Room8</id>                                                                                                                                 "isPattern": "false",
-                  </entityId>                                                                                                                                      "id": "Room8"
-                </entityIdList>                                                                                                                                }
-                <contextRegistrationAttributeList>                                                                                                         ],
-                  <contextRegistrationAttribute>                                                                                                           "attributes": [
-                    <name>humidity</name>                                                                                                                      {
-                    <type>percentage</type>                                                                                                                        "name": "humidity",
-                    <isDomain>false</isDomain>                                                                                                                     "type": "percentage",
-                  </contextRegistrationAttribute>                                                                                                                  "isDomain": "false"
-                </contextRegistrationAttributeList>                                                                                                            }
-                <providingApplication>http://mysensors.com/Rooms</providingApplication>                                                                    ],
-              </contextRegistration>                                                                                                                       "providingApplication": "http://mysensors.com/Rooms"
-            </contextRegistrationList>                                                                                                                 }
-            <duration>P1M</duration>                                                                                                               ],
-            <registrationId>51bf1e0ada053170df590f20</registrationId>                                                                              "duration": "P1M",
-          </registerContextRequest>                                                                                                                "registrationId": "51bf1e0ada053170df590f20"
-      EOF                                                                                                                                      }
-                                                                                                                                               EOF
+      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+	{
+	    "contextRegistrations": [
+	      {
+		  "entities": [
+		      {
+			  "type": "Room",
+			  "isPattern": "false",
+			  "id": "Room8"
+		      }
+		  ],
+		  "attributes": [
+		      {
+			  "name": "humidity",
+			  "type": "percentage",
+			  "isDomain": "false"
+		      }
+		  ],
+		  "providingApplication": "http://mysensors.com/Rooms"
+	      }
+	    ],
+	  "duration": "P1M",
+	  "registrationId": "51bf1e0ada053170df590f20"
+	}
+	EOF                                                                                                                                  
   
 This "update registration" replaces the existing registration associated
 to that ID with the new content, including [expiration

--- a/doc/manuals/user/updating_regs_and_subs.md
+++ b/doc/manuals/user/updating_regs_and_subs.md
@@ -18,8 +18,8 @@ operations). The update is done issuing a new registerContextRequest,
 with the *registrationId* set:
 
       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-	{
-	    "contextRegistrations": [
+      {
+	  "contextRegistrations": [
 	      {
 		  "entities": [
 		      {
@@ -37,11 +37,11 @@ with the *registrationId* set:
 		  ],
 		  "providingApplication": "http://mysensors.com/Rooms"
 	      }
-	    ],
+	  ],
 	  "duration": "P1M",
 	  "registrationId": "51bf1e0ada053170df590f20"
-	}
-	EOF                                                                                                                                  
+      }
+      EOF                                                                                                                                  
   
 This "update registration" replaces the existing registration associated
 to that ID with the new content, including [expiration

--- a/doc/manuals/user/walkthrough_apiv1.md
+++ b/doc/manuals/user/walkthrough_apiv1.md
@@ -625,7 +625,7 @@ Additional comments:
 
 <!-- -->
 
-    (curl 'localhost:1026/v1/queryContext?attributeFormat=object' -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      (curl 'localhost:1026/v1/queryContext?attributeFormat=object' -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "entities": [
 	      {
@@ -635,7 +635,7 @@ Additional comments:
 	      }
 	  ]
       }
-    EOF
+      EOF
 
 
 
@@ -1314,30 +1314,30 @@ Now, let's do the same with Room2:
 which response is:
 
       {
-	"contextResponses": [
-	  {
-	    "attributes": [
+	  "contextResponses": [
 	      {
-		"name": "temperature",
-		"type": "float",
-		"value": ""
-	      },
-	      {
-		"name": "pressure",
-		"type": "integer",
-		"value": ""
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": ""
+		      },
+		      {
+			  "name": "pressure",
+			  "type": "integer",
+			  "value": ""
+		      }
+		    ],
+		    "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
 	      }
-	    ],
-	    "statusCode": {
-	      "code": "200",
-	      "reasonPhrase": "OK"
-	    }
-	  }
-	],
-	"id": "Room2", 
-	"isPattern": "false", 
-	"type": ""
-      }          
+	  ],
+	  "id": "Room2",
+	  "isPattern": "false",
+	  "type": ""
+      }         
 
 You can also create an attribute (and the containing entity along the
 way) in the following way (additional attributes could be added after
@@ -1465,63 +1465,81 @@ differences:
     "Room1" by "/type/Room/id/Room1" in the URl to define the type (in
     general: "/type/<type>/id/<id>").
 
-You can also
-query by all the entities belonging to the same type, either all the
-attributes or a particular one, as shown below. First, create an couple
-of entities of type Car using standard updateContext APPEND operations
-(given that, as described in previous section, you cannot create
-entities with types using convenience operations):
+You can also query by all the entities belonging to the same type, either 
+all the attributes or a particular one, as shown below. First, create an 
+couple of entities of type Car using standard updateContext APPEND operations
+(given that, as described in previous section, you cannot create entities with
+types using convenience operations):
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"contextElements": [
-	  {
-	    "type": "Car",
-	    "isPattern": "false",
-	    "id": "Car1",
-	    "attributes": [
+	  "contextElements": [
 	    {
-	      "name": "speed",
-	      "type": "integer",
-	      "value": "75"
-	    },
-	    {
-	      "name": "fuel",
-	      "type": "float",
-	      "value": "12.5"
+	      "type": "Car",
+	      "isPattern": "false",
+	      "id": "Car1",
+	      "attributes": [
+	      {
+		"name": "speed",
+		"type": "integer",
+		"value": "75"
+	      },
+	      {
+		"name": "fuel",
+		"type": "float",
+		"value": "12.5"
+	      }
+	      ]
 	    }
-	    ]
-	  }
-	  ],
-	  "updateAction": "APPEND"
-	}
-	EOF                                                                                                                    
+	    ],
+	    "updateAction": "APPEND"
+      }
+      EOF                                                                                                                    
  
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"contextElements": [
-	  {
-	    "type": "Car",
-	    "isPattern": "false",
-	    "id": "Car2",
-	    "attributes": [
+	  "contextElements": [
 	    {
-	      "name": "speed",
-	      "type": "integer",
-	      "value": "90"
-	    },
-	    {
-	      "name": "fuel",
-	      "type": "float",
-	      "value": "25.7"
+	      "type": "Car",
+	      "isPattern": "false",
+	      "id": "Car2",
+	      "attributes": [
+	      {
+		"name": "speed",
+		"type": "integer",
+		"value": "90"
+	      },
+	      {
+		"name": "fuel",
+		"type": "float",
+		"value": "25.7"
+	      }
+	      ]
 	    }
-	    ]
-	  }
-	],
-	"updateAction": "APPEND"
-      }
+	  ],
+	  "updateAction": "APPEND"
+	}
       EOF                                                                         
-  
+        	"contextElements": [
+       	  {
+       	    "type": "Car",
+       	    "isPattern": "false",
+       	    "id": "Car1",
+       	    "attributes": [
+       	    {
+       	      "name": "speed",
+       	      "type": "integer",
+       	      "value": "75"
+       	    },
+       	    {
+       	      "name": "fuel",
+       	      "type": "float",
+       	      "value": "12.5"
+       	    }
+       	    ]
+       	  }
+       	  ],
+       	  "updateAction": "APPEND"
 Request to get all the attributes:
 
       curl localhost:1026/v1/contextEntityTypes/Car -s -S --header 'Accept: application/json' | python -mjson.tool
@@ -1560,7 +1578,7 @@ Response:
 		    }
 		},
 	      {
-		  "contextElement": {
+	  "contextElement": {
 		      "attributes": [
 			  {
 			      "name": "speed",
@@ -2220,17 +2238,17 @@ case, you have to set isPattern to "true" as shown below:
 
       (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	  "entities": [
-	      {
-		  "type": "Room",
-		  "isPattern": "true",
-		  "id": "Room.*"
-	      }
-	  ],
-	  "attributes": [
-	      "temperature"
-	  ]
-      }
+	    "entities": [
+		{
+		    "type": "Room",
+		    "isPattern": "true",
+		    "id": "Room.*"
+		}
+	    ],
+	    "attributes": [
+		"temperature"
+	    ]
+	}
       EOF
 This will produce the exact same response as the previous example.
 
@@ -2679,11 +2697,11 @@ The response is just an acknowledgement that the cancellation was
 successful.
   
       {
-      "statusCode": {
-        "code": "200",
-        "reasonPhrase": "OK"
-      },
-          "subscriptionId": "52a745e011f5816465943d59"
+	"statusCode": {
+	  "code": "200",
+	  "reasonPhrase": "OK"
+	},
+	    "subscriptionId": "52a745e011f5816465943d59"
       }                    
   ---------------------------------------------------------------------------------------------------------------------------------
 

--- a/doc/manuals/user/walkthrough_apiv1.md
+++ b/doc/manuals/user/walkthrough_apiv1.md
@@ -1015,9 +1015,9 @@ step) command:
 The response is very similar to the one for subscribeContext request:
 
       {
-	"subscribeResponse" : {
-	  "subscriptionId" : "51c04a21d714fb3b37d7d5a7",
-	}
+	  "subscribeResponse" : {
+	    "subscriptionId" : "51c04a21d714fb3b37d7d5a7",
+	  }
       }             
 
 You can check in accumulator-server.py that the notification frequency
@@ -1039,11 +1039,11 @@ The response is just an acknowledgement of that the cancellation was
 successful.
 
       {
-	  "statusCode": {
-	      "code": "200",
-	      "reasonPhrase": "OK"
-	  },
-	  "subscriptionId": "51c04a21d714fb3b37d7d5a7"
+	    "statusCode": {
+		"code": "200",
+		"reasonPhrase": "OK"
+	    },
+	    "subscriptionId": "51c04a21d714fb3b37d7d5a7"
       }                              
 
 You can have a look at accumulator-server.py to check that the
@@ -1764,7 +1764,6 @@ information of a given type (by the time being, that information consits
 of a list of all its attributes):
 
       curl localhost:1026/v1/contextTypes/Room -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
-
       {
         "attributes": [
           "hummidity",

--- a/doc/manuals/user/walkthrough_apiv1.md
+++ b/doc/manuals/user/walkthrough_apiv1.md
@@ -924,9 +924,8 @@ Let's examine in detail the different elements included in the payload:
 
 The response corresponding to that request contains a subscription ID (a
 24 hexadecimal number used for updating and cancelling the subscription
-- write it down because you will need it later in this tutorial) and a
+-Write it down because you will need it later in this tutorial) and a
 duration acknowledgement:
-
 
       {
 	  "subscribeResponse": {
@@ -1032,7 +1031,7 @@ step):
 
       (curl localhost:1026/v1/unsubscribeContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"subscriptionId": "51c04a21d714fb3b37d7d5a7"
+	  "subscriptionId": "51c04a21d714fb3b37d7d5a7"
       }
       EOF                                                                                                                          
 
@@ -1251,18 +1250,18 @@ its initial values)
 
       (curl localhost:1026/v1/contextEntities/Room1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X POST -d @- | python -mjson.tool) <<EOF
       {
-	"attributes" : [
-	  {
-	    "name" : "temperature",
-	    "type" : "float",
-	    "value" : "23"
-	  },
-	  {
-	    "name" : "pressure",
-	    "type" : "integer",
-	    "value" : "720"
-	  }
-	]
+	  "attributes": [
+	      {
+		  "name": "temperature",
+		  "type": "float",
+		  "value": "23"
+	      },
+	      {
+		  "name": "pressure",
+		  "type": "integer",
+		  "value": "720"
+	      }
+	  ]
       }
       EOF
 
@@ -1298,21 +1297,19 @@ Now, let's do the same with Room2:
 
       (curl localhost:1026/v1/contextEntities/Room2 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X POST -d @- | python -mjson.tool) <<EOF
       {
-	"attributes" : [
-	  {
-	    "name" : "temperature",
-	    "type" : "float",
-	    "value" : "21"
-	  },
-	  {
-	    "name" : "pressure",
-	    "type" : "integer",
-	    "value" : "711"
-	  }
-	]
+	  "attributes": [
+	      {
+		  "name": "temperature",
+		  "type": "float",
+		  "value": "21"
+	      },
+	      {
+		  "name": "pressure",
+		  "type": "integer",
+		  "value": "711"
+	      }
+	  ]
       }
-
-      EOF
       
 which response is:
 
@@ -1408,28 +1405,28 @@ e.g. Room1 attributes:
 which response is:
 
       {
-	"contextElement": {
-	  "attributes": [
-	  {
-	    "name": "temperature",
-	    "type": "float",
-	    "value": "23"
+	  "contextElement": {
+	      "attributes": [
+		  {
+		      "name": "temperature",
+		      "type": "float",
+		      "value": "23"
+		  },
+		  {
+		      "name": "pressure",
+		      "type": "integer",
+		      "value": "720"
+		  }
+	      ],
+	      "id": "Room1",
+	      "isPattern": "false",
+	      "type": "Room"
 	  },
-	  {
-	    "name": "pressure",
-	    "type": "integer",
-	    "value": "720"
+	  "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
 	  }
-	  ],
-	  "id": "Room1",
-	  "isPattern": "false",
-	  "type": "Room"
-	},
-	"statusCode": {
-	  "code": "200",
-	  "reasonPhrase": "OK"
-	}
-      }                     
+      }                 
 
 We can also query a single attribute of a given entity, e.g. Room2
 temperature:
@@ -1439,17 +1436,17 @@ temperature:
 which response is:
 
       {
-	"attributes": [
-	{
-	  "name": "temperature",
-	  "type": "float",
-	  "value": "21"
-	}
-	],
-	"statusCode": {
-	  "code": "200",
-	  "reasonPhrase": "OK"
-	}
+	  "attributes": [
+	      {
+		  "name": "temperature",
+		  "type": "float",
+		  "value": "21"
+	      }
+	  ],
+	  "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
+	  }
       }     
 
 Comparing to [standard queryContext
@@ -1862,7 +1859,7 @@ You can update a single attribute of a given entity in the following way:
 
       (curl localhost:1026/v1/contextEntities/Room2/attributes/temperature -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X PUT -d @- | python -mjson.tool) <<EOF
       {
-	"value" : "26.3"
+	    "value" : "26.3"
       }
       EOF                                                                                                                                                            
 
@@ -2056,7 +2053,7 @@ registrations for Room1 using:
 		  "id": "Room1"
 	      }
 	    ]
-	}
+      }
       EOF                                                                                                                                              
   
 This would produce the following response:
@@ -3008,7 +3005,7 @@ entities with types using convenience operations):
 			  "id": "Car2"
 		      }
 		  ],
-		  "attributes": [
+		  "attributes": [ 
 		      {
 			  "name": "fuel",
 			  "type": "float",

--- a/doc/manuals/user/walkthrough_apiv1.md
+++ b/doc/manuals/user/walkthrough_apiv1.md
@@ -246,26 +246,27 @@ creation time temperature and pressure of Room1 are 23 ºC and 720 mmHg
 respectively.
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF                                                                                    {                                                                          
-	    "contextElements": [
-          {
-            "type": "Room",
-            "isPattern": "false",
-            "id": "Room1",
-            "attributes": [
-              {
-                "name": "temperature",
-                "type": "float",
-                "value": "23"
-              },
-              {
-                "name": "pressure",
-                "type": "integer",
-                "value": "720"
-              }
-            ]
-          }
-        ],
-        "updateAction": "APPEND"
+      {
+	  "contextElements": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1",
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "23"
+		      },
+		      {
+			  "name": "pressure",
+			  "type": "integer",
+			  "value": "720"
+		      }
+		  ]
+	      }
+	  ],
+	  "updateAction": "APPEND"
       }
       EOF                                                                                                                         
 
@@ -289,31 +290,31 @@ internal database, set the values for its attributes and will response
 with the following:
 
       {
-      "contextResponses": [
-        {
-          "contextElement": {
-           "attributes": [
-              {
-                "name": "temperature",
-                "type": "float",
-                "value": ""
-              },
-              {
-                "name": "pressure",
-                "type": "integer",
-                "value": ""
-              }
-              ],
-                 "id": "Room1",
-                 "isPattern": "false",
-                 "type": "Room"
-              },
-	    "statusCode": {
-	      "code": "200",
-              "reasonPhrase": "OK"
-              }
-            }
-          ]
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": ""
+			  },
+			  {
+			      "name": "pressure",
+			      "type": "integer",
+			      "value": ""
+			  }
+		      ],
+		      "id": "Room1",
+		      "isPattern": "false",
+		      "type": "Room"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	    ]
       }
                            
 
@@ -328,24 +329,25 @@ temperature and pressure to 21 ºC and 711 mmHg respectively).
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool ) <<EOF
       {
-        "contextElements": [
-        {
-           "type": "Room",
-           "isPattern": "false",
-           "id": "Room2",
-           {
-              "name": "temperature",
-              "type": "float",
-              "value": "21"
-           },
-           {
-              "name": "pressure",
-              "type": "integer",
-              "value": "711"
-           }
-           ]
-        }
-        ],
+	  "contextElements": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room2",
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "21"
+		      },
+		      {
+			  "name": "pressure",
+			  "type": "integer",
+			  "value": "711"
+		      }
+		  ]
+	      }
+	  ],
 	  "updateAction": "APPEND"
       }
       EOF                                                                                                                       
@@ -353,32 +355,32 @@ temperature and pressure to 21 ºC and 711 mmHg respectively).
 The response to this request is:
 
       {
-	"contextResponses": [
-        {
-          "contextElement": {
-            "attributes": [
-            {
-                "name": "temperature",
-                "type": "float",
-                "value": ""
-            },
-            {
-                "name": "pressure",
-                "type": "integer",
-		"value": ""
-            }
-            ],
-                  "id": "Room2",
-                  "isPattern": "false",
-		  "type": "Room"
-            },
-            "statusCode": {
-            "code": "200",
-            "reasonPhrase": "OK"
-            }
-        }
-        ]
-      }                       
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": ""
+			  },
+			  {
+			      "name": "pressure",
+			      "type": "integer",
+			      "value": ""
+			  }
+		      ],
+		      "id": "Room2",
+		      "isPattern": "false",
+		      "type": "Room"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+		}
+	    ]
+      }	             
 
 Apart from simple values (i.e. strings) for attribute values, you can
 also use complex structures or custom metadata. These are advance
@@ -396,13 +398,13 @@ this case, e.g. to get context information for Room1:
 
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-      "entities": [
-       {
-          "type": "Room",
-          "isPattern": "false",
-          "id": "Room1"
-       }
-       ]
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      }
+	  ]
       }
       EOF
 
@@ -411,119 +413,52 @@ check that temperature and pressure have the values that we set at
 entity creation with updateContext (23ºC and 720 mmHg).
 
       {
-      "contextResponses": [
-        {
-          "contextElement": {
-            "attributes": [
-              {
-                "name": "temperature",
-		"type": "float",
-		"value": "23"
-              },
-              {
-                  "name": "pressure",
-                  "type": "integer",
-		  "value": "720"
-              }
-              ],
-                  "id": "Room1",
-                  "isPattern": "false",
-                  "type": "Room"
-              },
-            "statusCode": {
-		"code": "200",
-                "reasonPhrase": "OK"
-            }
-       }
-       ]
-     }
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": "23"
+			  },
+			  {
+			      "name": "pressure",
+			      "type": "integer",
+			      "value": "720"
+			  }
+		      ],
+		      "id": "Room1",
+		      "isPattern": "false",
+		      "type": "Room"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	  ]
+      }
                          
 
 If you use an empty attributes element in the request, the response will include all the attributes of the entity. If you include an actual list of attributes (e.g. temperature) only that are retrieved, as shown in the following request:
 
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-	"entities": [
-        {
-          "type": "Room",
-          "isPattern": "false",
-          "id": "Room1"
-        }
-        ],
-        "attributes" : [
-	    "temperature"
-	]
-      }
-      EOF
-
-which response is as follows:
-
-      {
-      "contextResponses": [
-       {
-          "contextElement": {
-            "attributes": [
-            {
-                "name": "temperature",
-		"type": "float",
-                "value": "23"
-            }
-            ],
-                  "id": "Room1",
-                  "isPattern": "false",
-                  "type": "Room"
-            },
-            "statusCode": {
-            "code": "200",
-            "reasonPhrase": "OK"
-            }
-            }
-          ]
-      }                          
-
-Moreover, a powerful feature of Orion Context Broker is that you can use
-a regular expression for the entity ID. For example, you can query
-entities which ID starts with "Room" using the regex "Room.\*". In this
-case, you have to set isPattern to "true" as shown below:
-
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      {
 	  "entities": [
-	  {
-	      "type": "Room",
-	      "isPattern": "false",
-	      "id": "Room1"
-	  },
-	  {
-	      "type": "Room",
-	      "isPattern": "false",
-	      "id": "Room2"
-	  }
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      }
 	  ],
-	  "attributes" : [
+	  "attributes": [
 	      "temperature"
 	  ]
       }
       EOF
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      {
-	  "entities": [
-	  {
-	      "type": "Room",
-	      "isPattern": "true",
-	      "id": "Room.*"
-	  }
-	  ],
-	  "attributes" : [
-	  "temperature"
-	  ]
-      }
-      EOF                                                                                                                       }
-                                                                                                                                  
-  
-
-Both produce the same response:
+which response is as follows:
 
       {
 	  "contextResponses": [
@@ -535,6 +470,73 @@ Both produce the same response:
 			      "type": "float",
 			      "value": "23"
 			  }
+		      ],
+		      "id": "Room1",
+		      "isPattern": "false",
+		      "type": "Room"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		    }
+	      }
+	  ]
+      }                       
+
+Moreover, a powerful feature of Orion Context Broker is that you can use
+a regular expression for the entity ID. For example, you can query
+entities which ID starts with "Room" using the regex "Room.\*". In this
+case, you have to set isPattern to "true" as shown below:
+
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      },
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room2"
+	      }
+	  ],
+	  "attributes": [
+	      "temperature"
+	  ]
+      }
+      EOF
+
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "true",
+		  "id": "Room.*"
+	      }
+	  ],
+	  "attributes": [
+	      "temperature"
+	  ]
+      }
+      EOF                                                                                                                       }
+                                                                                                                                  
+  
+
+Both produce the same response:
+
+      {
+	  "contextResponses": [
+	    {
+		"contextElement": {
+		      "attributes": [
+			{
+			      "name": "temperature",
+			      "type": "float",
+			      "value": "23"
+			}
 		      ],
 		      "id": "Room1",
 		      "isPattern": "false",
@@ -555,7 +557,7 @@ Both produce the same response:
 			  }
 		      ],
 		      "id": "Room2",
-		      "isPattern": "false",
+		      "isPattern": "false",	
 		      "type": "Room"
 		  },
 		  "statusCode": {
@@ -564,7 +566,7 @@ Both produce the same response:
 		  }
 	      }
 	  ]
-      }                         
+      }                        
 
 Finally, note that you will get an error in case you try to query a
 non-existing entity or attribute, as shown in the following cases below:
@@ -572,11 +574,11 @@ non-existing entity or attribute, as shown in the following cases below:
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "entities": [
-	  {
-	      "type": "Room",
-	      "isPattern": "false",
-	      "id": "Room5"
-	  }	
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room5"
+	      }
 	  ]
       }
       EOF                                                                                                                   
@@ -584,26 +586,26 @@ non-existing entity or attribute, as shown in the following cases below:
       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "entities": [
-	  {
-	      "type": "Room",
-	      "isPattern": "false",
-	      "id": "Room1"
-	  }
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      }
 	  ],
-	  "attributes" : [
+	  "attributes": [
 	      "humidity"
 	  ]
       }
-    EOF
+      EOF
 
 
 Both requests will produce the same error response:
 
       {
-      "errorCode": {
-        "code": "404",
-          "reasonPhrase": "No context elements found"
-         }
+	  "errorCode": {
+	      "code": "404",
+	      "reasonPhrase": "No context elements found"
+	  }
       }
                                           
 
@@ -624,42 +626,18 @@ Additional comments:
 <!-- -->
 
     (curl 'localhost:1026/v1/queryContext?attributeFormat=object' -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-    {
-        "entities": [
-           {
-               "type": "Room",
-               "isPattern": "false",
-               "id": "Room1"
-           }
-        ]
-    }
+      {
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      }
+	  ]
+      }
     EOF
 
-    {
-        "contextResponses": [
-            {
-                "contextElement": {
-                    "attributes": {
-                        "pressure": {
-                            "type": "integer",
-                            "value": "720"
-                        },
-                        "temperature": {
-                            "type": "float",
-                            "value": "23"
-                        }
-                    },
-                    "id": "Room1",
-                    "isPattern": "false",
-                    "type": "Room"
-                },
-                "statusCode": {
-                    "code": "200",
-                    "reasonPhrase": "OK"
-                }
-            }
-        ]
-    }
+
 
 #### Update context elements
 
@@ -676,27 +654,30 @@ given moment wants to set the temperature and pressure of Room1 to 26.5
 ºC and 763 mmHg respectively, so it issues the following request:
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-	{
-	  "contextElements": [
-	      {
-		  "type": "Room",
-		  "isPattern": "false",
-		  "id": "Room1",
-		  "attributes": [
-		  {
-		      "name": "temperature",
-		      "type": "float",
-		      "value": "26.5"
-		  },
-		  {
-		      "name": "pressure",
-		      "type": "integer",
-		      "value": "763"
+      {
+	  "contextResponses": [
+	    {
+		  "contextElement": {
+		      "attributes": {
+			  "pressure": {
+			      "type": "integer",
+			      "value": "720"
+			  },
+			  "temperature": {
+			      "type": "float",
+			      "value": "23"
+			  }
+		      },
+		      "id": "Room1",
+		      "isPattern": "false",
+		      "type": "Room"
+		    },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
 		  }
-		  ]
 	      }
-	  ],
-	  "updateAction": "UPDATE"
+	  ]
       }
       EOF                                                                                                                    
 
@@ -735,7 +716,7 @@ following:
 		  }
 	      }
 	  ]
-      }                         
+      }                     
 
 Again, the structure of the response is exactly the same one we used for
 [updateContext with APPEND for creating
@@ -756,22 +737,22 @@ entity in the updateContext, just the ones you want to update (the other
 attributes maintain their current value).
 
       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-	{
+      {
 	  "contextElements": [
 	      {
 		  "type": "Room",
 		  "isPattern": "false",
 		  "id": "Room2",
 		  "attributes": [
-		  {
-		      "name": "temperature",
-		      "type": "float",
-		      "value": "27.4"
-		  }
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": "27.4"
+		      }
 		  ]
 	      }
-	  ],
-	  "updateAction": "UPDATE"
+	    ],
+	    "updateAction": "UPDATE"
       }
       EOF                                                                                                                       
  
@@ -783,11 +764,11 @@ attributes maintain their current value).
 		  "isPattern": "false",
 		  "id": "Room2",
 		  "attributes": [
-		  {
-		      "name" : "pressure",
-		      "type" : "integer",
-		      "value" : "755"
-		  }
+		      {
+			  "name": "pressure",
+			  "type": "integer",
+			  "value": "755"
+		      }
 		  ]
 	      }
 	  ],
@@ -800,7 +781,7 @@ The responses for these requests are respectively:
       {
 	  "contextResponses": [
 	      {
-		  "contextElement": {
+		    "contextElement": {
 		      "attributes": [
 			  {
 			      "name": "temperature",
@@ -818,18 +799,20 @@ The responses for these requests are respectively:
 		  }
 	      }
 	  ]
-      }                   
+      }
+                 
   
+ 
       {
 	  "contextResponses": [
 	      {
 		  "contextElement": {
 		      "attributes": [
-			{
+			  {
 			      "name": "pressure",
 			      "type": "integer",
 			      "value": ""
-			}
+			  }
 		      ],
 		      "id": "Room2",
 		      "isPattern": "false",
@@ -841,7 +824,7 @@ The responses for these requests are respectively:
 		  }
 	      }
 	  ]
-      }                       
+      }
 
 Now, you can use queryContext operation [as previously
 described](#Query_Context_operation "wikilink") to check that Room1 and
@@ -964,29 +947,29 @@ that a message resembling the following one is received each 10 seconds:
       Content-Type: application/json
 
       {
-	"subscriptionId" : "51c04a21d714fb3b37d7d5a7",
-	"originator" : "localhost",
-	"contextResponses" : [
-	  {
-	    "contextElement" : {
-	      "attributes" : [
-		{
-		  "name" : "temperature",
-		  "type" : "float",
-		  "value" : "26.5"
-		}
-		],
-	      "type" : "Room",
-	      "isPattern" : "false",
-	      "id" : "Room1"
-	    },
-	    "statusCode" : {
-		"code" : "200",
-		"reasonPhrase" : "OK"
+	  "subscriptionId": "51c04a21d714fb3b37d7d5a7",
+	  "originator": "localhost",
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": "26.5"
+			  }
+		      ],
+		      "type": "Room",
+		      "isPattern": "false",
+		      "id": "Room1"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
 	      }
-	  }
-	]
-	} 
+	  ]
+      }
 
 Orion Context Broker notifies NGSI10 subscribeContext using the POST
 HTTP method (on the URL used as reference for the subscription) with a
@@ -1161,31 +1144,32 @@ notifyContextRequest, similar to this one:
       Host: localhost:1028
       Accept: application/xml, application/json
       Content-Type: application/json
-
-	{
-	  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
-	  "originator" : "localhost",
-	  "contextResponses" : [
-	  {
-	    "contextElement" : {
-	      "attributes" : [
+    
+      {
+	  "subscriptionId": "51c0ac9ed714fb3b37d7d5a8",
+	  "originator": "localhost",
+	  "contextResponses": [
 	      {
-		  "name" : "temperature",
-		  "type" : "float",
-		  "value" : "26.5"
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": "26.5"
+			  }
+		      ],
+		      "type": "Room",
+		      "isPattern": "false",
+		      "id": "Room1"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
 	      }
-	      ],
-	      "type" : "Room",
-	      "isPattern" : "false",
-	      "id" : "Room1"
-	  },
-	    "statusCode" : {
-	      "code" : "200",
-	      "reasonPhrase" : "OK"
-	    }
-	  }
-	]
+	  ]
       }
+
 
 You may wonder why accumulator-server.py is getting this message if you
 don't actually do any update. This is because the Orion Context Broker
@@ -1285,30 +1269,30 @@ its initial values)
 the response is:
 
       {
-	"contextResponses": [
-	  {
-	    "attributes": [
+	  "contextResponses": [
 	      {
-		"name": "temperature",
-		"type": "float",
-		"value": ""
-	      },
-	      {
-		"name": "pressure",
-		"type": "integer",
-		"value": ""
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": ""
+		      },
+		      {
+			  "name": "pressure",
+			  "type": "integer",
+			  "value": ""
+		      }
+		  ],
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
 	      }
-	      ],
-	    "statusCode": {
-	      "code": "200",
-	      "reasonPhrase": "OK"
-	    }
-	  }
-	], 
-	"id": "Room1", 
-	"isPattern": "false", 
-	"type": ""
-      }         
+	  ],
+	  "id": "Room1",
+	  "isPattern": "false",
+	  "type": ""
+      }        
 
 Now, let's do the same with Room2:
 
@@ -1546,56 +1530,6 @@ Request to get all the attributes:
       curl localhost:1026/v1/contextEntityTypes/Car -s -S --header 'Accept: application/json' | python -mjson.tool
 
 Response:
-      {
-	"contextResponses": [
-	{
-	  "contextElement": {
-	    "attributes": [
-	    {
-	      "name": "speed",
-	      "type": "integer",
-	      "value": "75"
-	    },
-	    {
-	      "name": "fuel",
-	      "type": "float",
-	      "value": "12.5"
-	    }
-	    ],
-	    "id": "Car1",
-	    "isPattern": "false",
-	    "type": "Car"
-	  },
-	  "statusCode": {
-	    "code": "200",
-	    "reasonPhrase": "OK"
-	  }
-	},
-	{
-	  "contextElement": {
-	    "attributes": [
-	    {
-	      "name": "speed",
-	      "type": "integer",
-	      "value": "90"
-	    },
-	    {
-	      "name": "fuel",
-	      "type": "float",
-	      "value": "25.7"
-	    }
-	    ],
-	    "id": "Car2",
-	    "isPattern": "false",
-	    "type": "Car"
-	  },
-	  "statusCode": {
-	    "code": "200",
-	    "reasonPhrase": "OK"
-	  }
-	}
-	]
-      }
 
 Request to get only one attribute (e.g. speed):
 
@@ -1604,45 +1538,55 @@ Request to get only one attribute (e.g. speed):
 Response:
 
       {
-	"contextResponses": [
-	{
-	  "contextElement": {
-	    "attributes": [
-	    {
-	      "name": "speed",
-	      "type": "integer",
-	      "value": "75"
-	    }
-	    ],
-	    "id": "Car1",
-	    "isPattern": "false",
-	    "type": "Car"
-	  },
-	  "statusCode": {
-	    "code": "200",
-	    "reasonPhrase": "OK"
-	  }
-	},
-	{
-	  "contextElement": {
-	    "attributes": [
-	    {
-	      "name": "speed",
-	      "type": "integer",
-	      "value": "90"
-	    }
-	    ],
-	    "id": "Car2",
-	    "isPattern": "false",
-	    "type": "Car"
-	  },
-	  "statusCode": {
-	    "code": "200",
-	    "reasonPhrase": "OK"
-	  }
-	}
-	]
-      }                         
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "speed",
+			      "type": "integer",
+			      "value": "75"
+			  },
+			  {
+			      "name": "fuel",
+			      "type": "float",
+			      "value": "12.5"
+			  }
+		      ],
+		      "id": "Car1",
+		      "isPattern": "false",
+		      "type": "Car"
+		    },
+		    "statusCode": {
+			"code": "200",
+			"reasonPhrase": "OK"
+		    }
+		},
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "speed",
+			      "type": "integer",
+			      "value": "90"
+			  },
+			  {
+			      "name": "fuel",
+			      "type": "float",
+			      "value": "25.7"
+			  }
+		      ],
+		      "id": "Car2",
+		      "isPattern": "false",
+		      "type": "Car"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	  ]
+      }                        
 
 Additional comments:
 
@@ -1830,87 +1774,88 @@ Let's set the Room1 temperature and pressure values:
 
       (curl localhost:1026/v1/contextEntities/Room1/attributes -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X PUT -d @- | python -mjson.tool) << EOF
       {
-	"attributes" : [
-	{
-	  "name" : "temperature",
-	  "type" : "float",
-	  "value" : "26.5"
-	},
-	{
-	  "name" : "pressure",
-	  "type" : "integer",
-	  "value" : "763"
-	}
-	]
+	  "attributes": [
+	      {
+		  "name": "temperature",
+		  "type": "float",
+		  "value": "26.5"
+	      },
+	      {
+		  "name": "pressure",
+		  "type": "integer",
+		  "value": "763"
+	      }
+	  ]
       }
       EOF                                                                                                                                                
 
 the response is:
 
       {
-	"contextResponses": [
-	{
-	  "attributes": [
-	  {
-	    "name": "temperature",
-	    "type": "float",
-	    "value": ""
-	  },
-	  {
-	    "name": "pressure",
-	    "type": "integer",
-	    "value": ""
-	  }
-	  ],
-	  "statusCode": {
-	    "code": "200",
-	    "reasonPhrase": "OK"
-	  }
-	}
-	]
+	  "contextResponses": [
+	      {
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": ""
+		      },
+		      {
+			  "name": "pressure",
+			  "type": "integer",
+			  "value": ""
+		      }
+		  ],
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	  ]
       }
+
 Now, let's do the same with Room2:
 
       (curl localhost:1026/v1/contextEntities/Room2/attributes -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X PUT -d @- | python -mjson.tool) << EOF
-      {
-	"attributes" : [
-	{
-	  "name" : "temperature",
-	  "type" : "float",
-	  "value" : "27.4"
-	},
-	{
-	  "name" : "pressure",
-	  "type" : "integer",
-	  "value" : "755"
-	}
-	]
+      {			
+	  "attributes": [
+	      {
+		  "name": "temperature",
+		  "type": "float",
+		  "value": "27.4"
+	      },
+	      {
+		  "name": "pressure",
+		  "type": "integer",
+		  "value": "755"
+	      }
+	  ]
       }
       EOF                                                                                                                                                 
  
 which response is:
 
       {
-	"contextResponses": [
-	{
-	  "attributes": [
-	  {
-	    "name": "temperature",
-	    "type": "float",
-	    "value": ""
-	  },
-	  {
-	    "name": "pressure",
-	    "type": "integer",
-	    "value": ""
-	  }
-	  ],
-	  "statusCode": {
-	    "code": "200",
-	    "reasonPhrase": "OK"
-	  }
-	}
-	]
+	  "contextResponses": [
+	      {
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "value": ""
+		      },
+		      {
+			  "name": "pressure",
+			  "type": "integer",
+			  "value": ""
+		      }
+		  ],
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	  ]
       }
 
 You can update a single attribute of a given entity in the following way:
@@ -2196,14 +2141,14 @@ a response telling so. Thus, the following request:
       (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "entities": [
-	  {
-	      "type": "Room",
-	      "isPattern": "false",
-	      "id": "Room1"
-	  }
+	      {
+		"type": "Room",
+		"isPattern": "false",
+		"id": "Room1"
+	      }
 	  ],
 	  "attributes": [
-	      "humidity"
+	    "humidity"
 	  ]
       }
       EOF
@@ -2223,20 +2168,20 @@ in both Room1 and Room2:
       (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "entities": [
-	  {
-	      "type": "Room",
-	      "isPattern": "false",
-	      "id": "Room1"
-	  },
-	  {
-	      "type": "Room",
-	      "isPattern": "false",
-	      "id": "Room2"
-	  }
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      },
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room2"
+	      }
 	  ],
 	  "attributes": [
-	  "temperature"
-	  ]
+	      "temperature"
+	]
       }
       EOF
 
@@ -2278,16 +2223,16 @@ case, you have to set isPattern to "true" as shown below:
 
       (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-        "entities": [
-        {
-            "type": "Room",
-            "isPattern": "true",
-            "id": "Room.*"
-        }
-        ],
-        "attributes": [
-	    "temperature"
-        ]
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "true",
+		  "id": "Room.*"
+	      }
+	  ],
+	  "attributes": [
+	      "temperature"
+	  ]
       }
       EOF
 This will produce the exact same response as the previous example.
@@ -2407,35 +2352,34 @@ notification:
       Content-Type: application/json
                                                                                         
       {
-        "subscriptionId" : "52a745e011f5816465943d59",
-        "contextRegistrationResponses" : [
-        {
-            "contextRegistration" : {
-              "entities" : [
-              {
-                  "type" : "Room",
-		  "isPattern" : "false",
-                  "id" : "Room1"
-              },
-              {
-              "type" : "Room",
-              "isPattern" : "false",
-              "id" : "Room2"
-              }
-              ],
-              "attributes" : [
-              {
-	           "name" : "temperature",
-                   "type" : "float",
-                  "isDomain" : "false"
+	  "subscriptionId": "52a745e011f5816465943d59",
+	  "contextRegistrationResponses": [
+	      {
+		  "contextRegistration": {
+		      "entities": [
+			  {
+			      "type": "Room",
+			      "isPattern": "false",
+			      "id": "Room1"
+			  },
+			  {
+			      "type": "Room",
+			      "isPattern": "false",
+			      "id": "Room2"
+			  }
+		      ],
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "isDomain": "false"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Rooms"
+		  }
 	      }
-	      ],
-	    "providingApplication" : "http://mysensors.com/Rooms"
-	    }
-        }
-        ]
-      }
-
+	  ]
+	}
 Orion Context Broker notifies NGSI9 subscribeContextAvailability using
 the POST HTTP method (on the URL used as reference for the subscription)
 with a notifyContextAvailabilityRequest payload. Apart from the
@@ -2469,31 +2413,31 @@ temperature and pressure:
 
       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-          "contextRegistrations": [
-          {
-              "entities": [
-               {
-                  "type": "Room",
-                  "isPattern": "false",
-                  "id": "Room3"
-               }
-               ],
-               "attributes": [
-               {
-                  "name": "temperature",
-                  "type": "float",
-                  "isDomain": "false"
-               },
-               {
-                  "name": "pressure",
-                  "type": "integer",
-                  "isDomain": "false"
-               }
-               ],
-               "providingApplication": "http://mysensors.com/Rooms"
-          }
-          ],
-	  "duration": "P1M"
+	  "contextRegistrations": [
+	      {
+		  "entities": [
+		      {
+			  "type": "Room",
+			  "isPattern": "false",
+			  "id": "Room3"
+		      }
+		  ],
+		    "attributes": [
+			{
+			  "name": "temperature",
+			  "type": "float",
+			  "isDomain": "false"
+			},
+			{
+			  "name": "pressure",
+			  "type": "integer",
+			  "isDomain": "false"
+			}
+			],
+		  "providingApplication": "http://mysensors.com/Rooms"
+	      }
+	    ],
+	    "duration": "P1M"
       }
       EOF
 
@@ -2507,31 +2451,31 @@ and pressure, only the first attribute is included in the notification.
       Host: localhost:1028
       Accept: application/xml, application/json
       Content-Type: application/json
-                                                                                        
+
       {
-        "subscriptionId" : "52a745e011f5816465943d59",
-        "contextRegistrationResponses" : [
-        {
-            "contextRegistration" : {
-              "entities" : [
-              {
-                  "type" : "Room",
-		  "isPattern" : "false",
-		  "id" : "Room3"
-              }
-              ],
-              "attributes" : [
-              {
-                  "name" : "temperature",
-                  "type" : "float",
-		  "isDomain" : "false"
-              }
-              ],
-            "providingApplication" : "http://mysensors.com/Rooms"
-           }
-        }
-        ]
-     }
+	  "subscriptionId": "52a745e011f5816465943d59",
+	  "contextRegistrationResponses": [
+	      {
+		  "contextRegistration": {
+		      "entities": [
+			  {
+			      "type": "Room",
+			      "isPattern": "false",
+			      "id": "Room3"
+			  }
+		      ],
+		    "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "isDomain": "false"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Rooms"
+		  }
+	      }
+	  ]
+      }
 
 We can also check that context registrations not matching the
 subscription doesn't trigger any notifications. For example, let's
@@ -2541,26 +2485,26 @@ subscription only includes temperature in attributeList).
   
       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-          "contextRegistrations": [
-          {
-              "entities": [
-              {
-                  "type": "Room",
-                  "isPattern": "false",
-                  "id": "Room4"
-              }
-              ],
-                  "attributes": [
-                  {
-                    "name": "pressure",
-                    "type": "integer",
-                    "isDomain": "false"
-                  }
-                  ],
-              "providingApplication": "http://mysensors.com/Rooms"
-          }
-          ],
-          "duration": "P1M"
+	  "contextRegistrations": [
+	      {
+		  "entities": [
+		      {
+			  "type": "Room",
+			  "isPattern": "false",
+			  "id": "Room4"
+		      }
+		  ],
+		  "attributes": [
+		      {
+			  "name": "pressure",
+			  "type": "integer",
+			  "isDomain": "false"
+		      }
+		  ],
+		  "providingApplication": "http://mysensors.com/Rooms"
+	      }
+	  ],
+	  "duration": "P1M"
       }
       EOF
   
@@ -2580,11 +2524,11 @@ subscribeContextAvailability response in the previous step).
       (curl localhost:1026/v1/registry/updateContextAvailabilitySubscription -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
 	  "entities": [
-	  {
-	      "type": "Car",
-	      "isPattern": "true",
-	      "id": ".*"
-	  }
+	      {
+		  "type": "Car",
+		  "isPattern": "true",
+		  "id": ".*"
+	      }
 	  ],
 	  "duration": "P1M",
 	  "subscriptionId": "52a745e011f5816465943d59"
@@ -2605,52 +2549,52 @@ receive any initial notification. So. let's register two cars: Car1 with
 an attribute named speed and Car2 with an attribute named location.
 
      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-     {
-          "contextRegistrations": [
-           {
-              "entities": [
-               {
-                  "type": "Car",
-                  "isPattern": "false",
-                  "id": "Car1"
-               }
-               ],
-                   "attributes": [
-                   {
-                     "name": "speed",
-                     "type": "integer",
-                     "isDomain": "false"
-                   }
-                  ],
-              "providingApplication": "http://mysensors.com/Cars"
-           }
-           ],
-          "duration": "P1M"
+      {
+	  "contextRegistrations": [
+	      {
+		  "entities": [
+		      {
+			  "type": "Car",
+			  "isPattern": "false",
+			  "id": "Car1"
+		      }
+		    ],
+		  "attributes": [
+		      {
+			  "name": "speed",
+			  "type": "integer",
+			  "isDomain": "false"
+		      }
+		    ],
+		      "providingApplication": "http://mysensors.com/Cars"
+	      }
+	  ],
+	  "duration": "P1M"
       }
       EOF
   
      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-     {
-          "contextRegistrations": [
-           {
-              "entities": [
-               {
-                  "type": "Car",
-                  "isPattern": "false",
-                  "id": "Car2"
-               }
-               ],
-                  "attributes": [
-                  {
-                    "name": "location",
-                    "type": "ISO6709",
-                    "isDomain": "false"
-                  }
-                  ],
-              "providingApplication": "http://mysensors.com/Cars"
-           }
-           ],
-          "duration": "P1M"
+      {
+	  "contextRegistrations": [
+	      {
+		    "entities": [
+		      {
+			  "type": "Car",
+			  "isPattern": "false",
+			  "id": "Car2"
+		      }
+		  ],
+		  "attributes": [
+		      {
+			  "name": "location",
+			  "type": "ISO6709",
+			  "isDomain": "false"
+		      }
+		  ],
+		  "providingApplication": "http://mysensors.com/Cars"
+	      }
+	  ],
+	    "duration": "P1M"
       }
       EOF
 As both registrations match the entityIdList and attributeList used in
@@ -2665,28 +2609,28 @@ for each car registration, as can be seen in accumulator-server.py:
       Content-Type: application/json
                                                                                        
       {
-        "subscriptionId" : "52a745e011f5816465943d59",
-        "contextRegistrationResponses" : [
-        {
-            "contextRegistration" : {
-              "entities" : [
-              {
-                  "type" : "Car",
-		  "isPattern" : "false",
-		  "id" : "Car1"
-              }
-              ],
-	      "attributes" : [
-              {
-		  "name" : "speed",
-		  "type" : "integer",
-		  "isDomain" : "false"
+	  "subscriptionId": "52a745e011f5816465943d59",
+	  "contextRegistrationResponses": [
+	      {
+		  "contextRegistration": {
+		      "entities": [
+			  {
+			      "type": "Car",
+			      "isPattern": "false",
+			      "id": "Car1"
+			  }
+		      ],
+		      "attributes": [
+			  {
+			      "name": "speed",
+			      "type": "integer",
+			      "isDomain": "false"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Cars"
+		  }
 	      }
-	      ],
-	    "providingApplication" : "http://mysensors.com/Cars"
-	    }
-	}
-        ]
+	  ]
       }
 
       POST http://localhost:1028/accumulate
@@ -2697,29 +2641,29 @@ for each car registration, as can be seen in accumulator-server.py:
       Content-Type: application/json
                                                                                        
       {
-        "subscriptionId" : "52a745e011f5816465943d59",
-        "contextRegistrationResponses" : [
-        {
-            "contextRegistration" : {
-              "entities" : [
-              {
-                  "type" : "Car",
-		  "isPattern" : "false",
-		  "id" : "Car2"
-              }
-              ],
-              "attributes" : [
-              {
-                  "name" : "location",
-		  "type" : "ISO6709",
-                  "isDomain" : "false"
-              }
-              ],
-       
-	    }
-        }
-        ]
-       }
+	  "subscriptionId": "52a745e011f5816465943d59",
+	  "contextRegistrationResponses": [
+	      {
+		  "contextRegistration": {
+		      "entities": [
+			  {
+			      "type": "Car",
+			      "isPattern": "false",
+			      "id": "Car2"
+			  }
+		      ],
+		      "attributes": [
+			  {
+			      "name": "location",
+			      "type": "ISO6709",
+			      "isDomain": "false"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Cars"
+		  }
+	      }
+	  ]
+      }
 
 Finally, you can cancel a subscription using the NGSI9
 unsubscribeContextAvailability operation, just using the subscriptionId
@@ -2935,48 +2879,7 @@ discover registrations for Room1 (no matter the attributes):
 
 which produces the following response:
 
-      {
-        "contextRegistrationResponses": [
-         {
-            "contextRegistration": {
-              "attributes": [
-              {
-                  "isDomain": "false",
-		  "name": "temperature",
-		  "type": ""
-              }
-              ],
-                  "entities": [
-                  {
-		      "id": "Room1",
-		      "isPattern": "false",
-		      "type": ""
-		  }
-		],
-	    "providingApplication": "http://mysensors.com/Rooms"
-	    }
-          },
-          {
-            "contextRegistration": {
-                "attributes": [
-                {
-		  "isDomain": "false",
-		  "name": "pressure",
-		  "type": ""
-               }
-               ],
-                  "entities": [
-                  {
-		      "id": "Room1",
-		      "isPattern": "false",
-		      "type": ""
-		  }
-		],
-	    "providingApplication": "http://mysensors.com/Rooms"
-	    }
-           }
-	   ]
-       }
+
 
 Now, let's discover registrations for Room2-temperature:
 
@@ -2985,28 +2888,47 @@ Now, let's discover registrations for Room2-temperature:
 The response is as follows:
 
       {
-      "contextRegistrationResponses": [
-      {
-          "contextRegistration": {
-            "attributes": [
-              {
-                "isDomain": "false",
-                "name": "temperature",
-                "type": ""
-              }
-              ],
-                "entities": [
-                {
-                  "id": "Room2",
-                  "isPattern": "false",
-		  "type": ""
-		}
-		],
-            "providingApplication": "http://mysensors.com/Rooms"
-          }
-        }
-      ]
-     }
+	  "contextRegistrationResponses": [
+	      {
+		  "contextRegistration": {
+		      "attributes": [
+			  {
+			      "isDomain": "false",
+			      "name": "temperature",
+			      "type": ""
+			  }
+		      ],
+		      "entities": [
+			  {
+			      "id": "Room1",
+			      "isPattern": "false",
+			      "type": ""
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Rooms"
+		  }
+	      },
+	      {
+		  "contextRegistration": {
+		      "attributes": [
+			  {
+			      "isDomain": "false",
+			      "name": "pressure",
+			      "type": ""
+			  }
+		      ],
+		      "entities": [
+			  {
+			      "id": "Room1",
+			      "isPattern": "false",
+			      "type": ""
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Rooms"
+		  }
+	      }
+	  ]
+      }
 
 Discovery of not registered elements (e.g. Room5 or the humidity of
 Room1) will produce an error. E.g. the following requests:
@@ -3052,51 +2974,51 @@ entities with types using convenience operations):
 
       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-          "contextRegistrations": [
-          {
-               "entities": [
-               {
-                  "type": "Car",
-                  "isPattern": "false",
-                  "id": "Car1"
-               }
-               ],
-		  "attributes": [
-		  {
-		      "name": "speed",
-		      "type": "integer",
-		      "isDomain": "false"
-		  }
+	  "contextRegistrations": [
+	      {
+		  "entities": [
+		      {
+			  "type": "Car",
+			  "isPattern": "false",
+			  "id": "Car1"
+		      }
 		  ],
-              "providingApplication": "http://mysensors.com/Cars"
-          }
-          ],
-          "duration": "P1M"
+		  "attributes": [
+		      {
+			  "name": "speed",
+			  "type": "integer",
+			  "isDomain": "false"
+		      }
+		  ],
+		  "providingApplication": "http://mysensors.com/Cars"
+	      }
+	  ],
+	  "duration": "P1M"
       }
       EOF
 
       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
       {
-          "contextRegistrations": [
-          {
-              "entities": [
-              {
-                  "type": "Car",
-                  "isPattern": "false",
-                  "id": "Car2"
-              }
-              ],
-              "attributes": [
-              {
-                  "name": "fuel",
-                  "type": "float",
-                  "isDomain": "false"
-              }
-              ],
-              "providingApplication": "http://mysensors.com/Cars"
-           }
-           ],     
-          "duration": "P1M"
+	  "contextRegistrations": [
+	      {
+		  "entities": [
+		      {
+			  "type": "Car",
+			  "isPattern": "false",
+			  "id": "Car2"
+		      }
+		  ],
+		  "attributes": [
+		      {
+			  "name": "fuel",
+			  "type": "float",
+			  "isDomain": "false"
+		      }
+		  ],
+		  "providingApplication": "http://mysensors.com/Cars"
+	      }
+	  ],
+	  "duration": "P1M"
       }
       EOF
                                                                                                                                          
@@ -3108,47 +3030,48 @@ Request without specifying attributes:
 Response:
 
       {
-      "contextRegistrationResponses": [
-        {
-          "contextRegistration": {
-            "attributes": [
-            {
-                "isDomain": "false",
-                "name": "speed",
-                "type": "integer"
-            }
-            ],
-                "entities": [
-                {
-                  "id": "Car1",
-                  "isPattern": "false",
-		  "type": "Car"
-                }
-               ],
-           "providingApplication": "http://mysensors.com/Cars"
-       }
-      },
-      {
-          "contextRegistration": {
-            "attributes": [
-            {
-                "isDomain": "false",
-		"name": "fuel",
-                "type": "float"
-            }
-            ],
-                "entities": [
-                {
-		  "id": "Car2",
-		  "isPattern": "false",
-		  "type": "Car"
-		}
-		],
-	    "providingApplication": "http://mysensors.com/Cars"
+	  "contextRegistrationResponses": [
+	      {
+		  "contextRegistration": {
+		      "attributes": [
+			  {
+			      "isDomain": "false",
+			      "name": "speed",
+			      "type": "integer"
+			  }
+		      ],
+		      "entities": [
+			  {
+			      "id": "Car1",
+			      "isPattern": "false",
+			      "type": "Car"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Cars"
+		  }
+	      },
+	      {
+		  "contextRegistration": {
+		      "attributes": [
+			  {
+			      "isDomain": "false",
+			      "name": "fuel",
+			      "type": "float"
+			  }
+		      ],
+		      "entities": [
+			  {
+			      "id": "Car2",
+			      "isPattern": "false",
+			      "type": "Car"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Cars"
+		  }
+	      }
+	  ]
       }
-      }
-      ]
-      }
+
 
 
 Request specifying one attribute (e.g. speed):
@@ -3157,29 +3080,30 @@ Request specifying one attribute (e.g. speed):
 
 Response:
 
-     {
-	"contextRegistrationResponses": [
-	{
-          "contextRegistration": {
-            "attributes": [
-            {
-		  "isDomain": "false",
-                  "name": "speed",
-		  "type": "integer"
-            }
-	    ],
-            "entities": [
-            {
-                  "id": "Car1",
-                  "isPattern": "false",
-		  "type": "Car"
-            }
-            ],
-	      "providingApplication": "http://mysensors.com/Cars"
-         }
-        }
-      ]
-     }
+      {
+	  "contextRegistrationResponses": [
+	      {
+		  "contextRegistration": {
+		      "attributes": [
+			  {
+			      "isDomain": "false",
+			      "name": "speed",
+			      "type": "integer"
+			  }
+		      ],
+		      "entities": [
+			  {
+			      "id": "Car1",
+			      "isPattern": "false",
+			      "type": "Car"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Cars"
+		  }
+	      }
+	  ]
+      }
+
 
 Note that by default only 20 registrations are returned (which is fine
 for this tutorial, but probably not for a real utilization scenario). In

--- a/doc/manuals/user/walkthrough_apiv1.md
+++ b/doc/manuals/user/walkthrough_apiv1.md
@@ -156,9 +156,7 @@ following:
 Regarding \[headers\] you have to include the following ones:
 
 -   Accept header to specify which payload format
-    you want to receive in the response. You should explicitly specify JSON,
-    as XML is the default (XML has been deprecated in Orion 0.23.0, but
-    the default has not been changed due to backward compability reasons).
+    you want to receive in the response. You should explicitly specify JSON.
 
 <!-- -->
 
@@ -175,8 +173,7 @@ Some additional remarks:
 
 -   We are using multi-line shell commands to provide the input to curl,
     using EOF to mark the beginning and the end of the multi-line block
-    (*here-documents*). An alternative to this is to put the XML in a
-    file (e.g. payload.xml), then use "--data-binary @payload.xml". In
+    (*here-documents*). In
     some cases (GET and DELETE) we omit "-d @-" as they don't
     use payload.
 -   In our examples we assume that the broker is listening on port 1026.
@@ -291,34 +288,34 @@ Upon receipt of this request, the broker will create the entity in its
 internal database, set the values for its attributes and will response
 with the following:
 
-      <?xml version="1.0"?>                                  {
-      <updateContextResponse>                                    "contextResponses": [
-        <contextResponseList>                                        {
-          <contextElementResponse>                                       "contextElement": {
-            <contextElement>                                                 "attributes": [
-              <entityId type="Room" isPattern="false">                           {
-                <id>Room1</id>                                                       "name": "temperature",
-              </entityId>                                                            "type": "float",
-              <contextAttributeList>                                                 "value": ""
-                <contextAttribute>                                               },
-                  <name>temperature</name>                                       {
-                  <type>float</type>                                                 "name": "pressure",
-                  <contextValue/>                                                    "type": "integer",
-                </contextAttribute>                                                  "value": ""
-                <contextAttribute>                                               }
-                  <name>pressure</name>                                      ],
-                  <type>integer</type>                                       "id": "Room1",
-                  <contextValue/>                                            "isPattern": "false",
-                </contextAttribute>                                          "type": "Room"
-              </contextAttributeList>                                    },
-            </contextElement>                                            "statusCode": {
-            <statusCode>                                                     "code": "200",
-              <code>200</code>                                               "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                            }
-            </statusCode>                                            }
-          </contextElementResponse>                              ]
-        </contextResponseList>                               }
-      </updateContextResponse>                           
+      {
+      "contextResponses": [
+        {
+          "contextElement": {
+           "attributes": [
+              {
+                "name": "temperature",
+                "type": "float",
+                "value": ""
+              },
+              {
+                "name": "pressure",
+                "type": "integer",
+                "value": ""
+              }
+              ],
+                 "id": "Room1",
+                 "isPattern": "false",
+                 "type": "Room"
+              },
+	    "statusCode": {
+	      "code": "200",
+              "reasonPhrase": "OK"
+              }
+            }
+          ]
+      }
+                           
 
 As you can see, it follows the same structure as the request, just to
 acknowledge that the request was correctly processed for these context
@@ -329,62 +326,59 @@ because you were the one to provide them in the request.
 Next, let's create Room2 in a similar way (in this case, setting
 temperature and pressure to 21 ºC and 711 mmHg respectively).
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool ) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                            "contextElements": [
-        <contextElementList>                                                                                                                {
-          <contextElement>                                                                                                                      "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                            "isPattern": "false",
-              <id>Room2</id>                                                                                                                    "id": "Room2",
-            </entityId>                                                                                                                         "attributes": [
-            <contextAttributeList>                                                                                                              {
-              <contextAttribute>                                                                                                                    "name": "temperature",
-                <name>temperature</name>                                                                                                            "type": "float",
-                <type>float</type>                                                                                                                  "value": "21"
-                <contextValue>21</contextValue>                                                                                                 },
-              </contextAttribute>                                                                                                               {
-              <contextAttribute>                                                                                                                    "name": "pressure",
-                <name>pressure</name>                                                                                                               "type": "integer",
-                <type>integer</type>                                                                                                                "value": "711"
-                <contextValue>711</contextValue>                                                                                                }
-              </contextAttribute>                                                                                                               ]
-            </contextAttributeList>                                                                                                         }
-          </contextElement>                                                                                                             ],
-        </contextElementList>                                                                                                           "updateAction": "APPEND"
-        <updateAction>APPEND</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool ) <<EOF
+      {
+        "contextElements": [
+        {
+           "type": "Room",
+           "isPattern": "false",
+           "id": "Room2",
+           {
+              "name": "temperature",
+              "type": "float",
+              "value": "21"
+           },
+           {
+              "name": "pressure",
+              "type": "integer",
+              "value": "711"
+           }
+           ]
+        }
+        ],
+	  "updateAction": "APPEND"
+      }
       EOF                                                                                                                       
   
 The response to this request is:
 
-      <?xml version="1.0"?>                                  {
-      <updateContextResponse>                                    "contextResponses": [
-        <contextResponseList>                                        {
-          <contextElementResponse>                                       "contextElement": {
-            <contextElement>                                                 "attributes": [
-              <entityId type="Room" isPattern="false">                           {
-                <id>Room2</id>                                                       "name": "temperature",
-              </entityId>                                                            "type": "float",
-              <contextAttributeList>                                                 "value": ""
-                <contextAttribute>                                               },
-                  <name>temperature</name>                                       {
-                  <type>float</type>                                                 "name": "pressure",
-                  <contextValue/>                                                    "type": "integer",
-                </contextAttribute>                                                  "value": ""
-                <contextAttribute>                                               }
-                  <name>pressure</name>                                      ],
-                  <type>integer</type>                                       "id": "Room2",
-                  <contextValue/>                                            "isPattern": "false",
-                </contextAttribute>                                          "type": "Room"
-              </contextAttributeList>                                    },
-            </contextElement>                                            "statusCode": {
-            <statusCode>                                                     "code": "200",
-              <code>200</code>                                               "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                            }
-            </statusCode>                                            }
-          </contextElementResponse>                              ]
-        </contextResponseList>                               }
-      </updateContextResponse>                           
+      {
+	"contextResponses": [
+        {
+          "contextElement": {
+            "attributes": [
+            {
+                "name": "temperature",
+                "type": "float",
+                "value": ""
+            },
+            {
+                "name": "pressure",
+                "type": "integer",
+		"value": ""
+            }
+            ],
+                  "id": "Room2",
+                  "isPattern": "false",
+		  "type": "Room"
+            },
+            "statusCode": {
+            "code": "200",
+            "reasonPhrase": "OK"
+            }
+        }
+        ]
+      }                       
 
 Apart from simple values (i.e. strings) for attribute values, you can
 also use complex structures or custom metadata. These are advance
@@ -400,219 +394,218 @@ interesting with it (e.g. show a graph with the room temperature in a
 graphical user interface). The NGSI10 queryContext request is used in
 this case, e.g. to get context information for Room1:
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                           "entities": [
-        <entityIdList>                                                                                                                    {
-          <entityId type="Room" isPattern="false">                                                                                            "type": "Room",
-            <id>Room1</id>                                                                                                                    "isPattern": "false",
-          </entityId>                                                                                                                         "id": "Room1"
-        </entityIdList>                                                                                                                   }
-        <attributeList/>                                                                                                              ]
-      </queryContextRequest>                                                                                                      }
-      EOF                                                                                                                         EOF
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+      "entities": [
+       {
+          "type": "Room",
+          "isPattern": "false",
+          "id": "Room1"
+       }
+       ]
+      }
+      EOF
 
 The response includes all the attributes belonging to Room1 and we can
 check that temperature and pressure have the values that we set at
 entity creation with updateContext (23ºC and 720 mmHg).
 
-      <?xml version="1.0"?>                                  {
-      <queryContextResponse>                                     "contextResponses": [
-        <contextResponseList>                                        {
-          <contextElementResponse>                                       "contextElement": {
-            <contextElement>                                                 "attributes": [
-              <entityId type="Room" isPattern="false">                           {
-                <id>Room1</id>                                                       "name": "temperature",
-              </entityId>                                                            "type": "float",
-              <contextAttributeList>                                                 "value": "23"
-                <contextAttribute>                                               },
-                  <name>temperature</name>                                       {
-                  <type>float</type>                                                 "name": "pressure",
-                  <contextValue>23</contextValue>                                    "type": "integer",
-                </contextAttribute>                                                  "value": "720"
-                <contextAttribute>                                               }
-                  <name>pressure</name>                                      ],
-                  <type>integer</type>                                       "id": "Room1",
-                  <contextValue>720</contextValue>                           "isPattern": "false",
-                </contextAttribute>                                          "type": "Room"
-              </contextAttributeList>                                    },
-            </contextElement>                                            "statusCode": {
-            <statusCode>                                                     "code": "200",
-              <code>200</code>                                               "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                            }
-            </statusCode>                                            }
-          </contextElementResponse>                              ]
-        </contextResponseList>                               }
-      </queryContextResponse>                            
+      {
+      "contextResponses": [
+        {
+          "contextElement": {
+            "attributes": [
+              {
+                "name": "temperature",
+		"type": "float",
+		"value": "23"
+              },
+              {
+                  "name": "pressure",
+                  "type": "integer",
+		  "value": "720"
+              }
+              ],
+                  "id": "Room1",
+                  "isPattern": "false",
+                  "type": "Room"
+              },
+            "statusCode": {
+		"code": "200",
+                "reasonPhrase": "OK"
+            }
+       }
+       ]
+     }
+                         
 
 If you use an empty attributes element in the request, the response will include all the attributes of the entity. If you include an actual list of attributes (e.g. temperature) only that are retrieved, as shown in the following request:
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                           "entities": [
-        <entityIdList>                                                                                                                {
-          <entityId type="Room" isPattern="false">                                                                                        "type": "Room",
-            <id>Room1</id>                                                                                                                "isPattern": "false",
-          </entityId>                                                                                                                     "id": "Room1"
-        </entityIdList>                                                                                                               }
-        <attributeList>                                                                                                               ],
-          <attribute>temperature</attribute>                                                                                          "attributes" : [
-        </attributeList>                                                                                                                  "temperature"
-      </queryContextRequest>                                                                                                          ]
-      EOF                                                                                                                         }
-                                                                                                                                  EOF
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"entities": [
+        {
+          "type": "Room",
+          "isPattern": "false",
+          "id": "Room1"
+        }
+        ],
+        "attributes" : [
+	    "temperature"
+	]
+      }
+      EOF
 
 which response is as follows:
 
-      <?xml version="1.0"?>                                  {
-      <queryContextResponse>                                     "contextResponses": [
-        <contextResponseList>                                        {
-          <contextElementResponse>                                       "contextElement": {
-            <contextElement>                                                 "attributes": [
-              <entityId type="Room" isPattern="false">                           {
-                <id>Room1</id>                                                       "name": "temperature",
-              </entityId>                                                            "type": "float",
-              <contextAttributeList>                                                 "value": "23"
-                <contextAttribute>                                               }
-                  <name>temperature</name>                                   ],
-                  <type>float</type>                                         "id": "Room1",
-                  <contextValue>23</contextValue>                            "isPattern": "false",
-                </contextAttribute>                                          "type": "Room"
-              </contextAttributeList>                                    },
-            </contextElement>                                            "statusCode": {
-            <statusCode>                                                     "code": "200",
-              <code>200</code>                                               "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                            }
-            </statusCode>                                            }
-          </contextElementResponse>                              ]
-        </contextResponseList>                               }
-      </queryContextResponse>                            
+      {
+      "contextResponses": [
+       {
+          "contextElement": {
+            "attributes": [
+            {
+                "name": "temperature",
+		"type": "float",
+                "value": "23"
+            }
+            ],
+                  "id": "Room1",
+                  "isPattern": "false",
+                  "type": "Room"
+            },
+            "statusCode": {
+            "code": "200",
+            "reasonPhrase": "OK"
+            }
+            }
+          ]
+      }                          
 
 Moreover, a powerful feature of Orion Context Broker is that you can use
 a regular expression for the entity ID. For example, you can query
 entities which ID starts with "Room" using the regex "Room.\*". In this
 case, you have to set isPattern to "true" as shown below:
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                           "entities": [
-        <entityIdList>                                                                                                                {
-          <entityId type="Room" isPattern="false">                                                                                        "type": "Room",
-            <id>Room1</id>                                                                                                                "isPattern": "false",
-          </entityId>                                                                                                                     "id": "Room1"
-          <entityId type="Room" isPattern="false">                                                                                    },
-            <id>Room2</id>                                                                                                            {
-          </entityId>                                                                                                                     "type": "Room",
-        </entityIdList>                                                                                                                   "isPattern": "false",
-        <attributeList>                                                                                                                   "id": "Room2"
-          <attribute>temperature</attribute>                                                                                          }
-        </attributeList>                                                                                                              ],
-      </queryContextRequest>                                                                                                          "attributes" : [
-      EOF                                                                                                                                 "temperature"
-                                                                                                                                      ]
-                                                                                                                                  }
-                                                                                                                                  EOF
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	  {
+	      "type": "Room",
+	      "isPattern": "false",
+	      "id": "Room1"
+	  },
+	  {
+	      "type": "Room",
+	      "isPattern": "false",
+	      "id": "Room2"
+	  }
+	  ],
+	  "attributes" : [
+	      "temperature"
+	  ]
+      }
+      EOF
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                           "entities": [
-        <entityIdList>                                                                                                                {
-          <entityId type="Room" isPattern="true">                                                                                         "type": "Room",
-            <id>Room.*</id>                                                                                                               "isPattern": "true",
-          </entityId>                                                                                                                     "id": "Room.*"
-        </entityIdList>                                                                                                               }
-        <attributeList>                                                                                                               ],
-          <attribute>temperature</attribute>                                                                                          "attributes" : [
-        </attributeList>                                                                                                              "temperature"
-      </queryContextRequest>                                                                                                          ]
-      EOF                                                                                                                         }
-                                                                                                                                  EOF
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	  {
+	      "type": "Room",
+	      "isPattern": "true",
+	      "id": "Room.*"
+	  }
+	  ],
+	  "attributes" : [
+	  "temperature"
+	  ]
+      }
+      EOF                                                                                                                       }
+                                                                                                                                  
   
 
 Both produce the same response:
 
-      <?xml version="1.0"?>                                  {
-      <queryContextResponse>                                     "contextResponses": [
-        <contextResponseList>                                        {
-          <contextElementResponse>                                       "contextElement": {
-            <contextElement>                                                 "attributes": [
-              <entityId type="Room" isPattern="false">                           {
-                <id>Room1</id>                                                       "name": "temperature",
-              </entityId>                                                            "type": "float",
-              <contextAttributeList>                                                 "value": "23"
-                <contextAttribute>                                               }
-                  <name>temperature</name>                                   ],
-                  <type>float</type>                                         "id": "Room1",
-                  <contextValue>23</contextValue>                            "isPattern": "false",
-                </contextAttribute>                                          "type": "Room"
-              </contextAttributeList>                                    },
-            </contextElement>                                            "statusCode": {
-            <statusCode>                                                     "code": "200",
-              <code>200</code>                                               "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                            }
-            </statusCode>                                            },
-          </contextElementResponse>                                  {
-          <contextElementResponse>                                       "contextElement": {
-            <contextElement>                                                 "attributes": [
-              <entityId type="Room" isPattern="false">                           {
-                <id>Room2</id>                                                       "name": "temperature",
-              </entityId>                                                            "type": "float",
-              <contextAttributeList>                                                 "value": "21"
-                <contextAttribute>                                               }
-                  <name>temperature</name>                                   ],
-                  <type>float</type>                                         "id": "Room2",
-                  <contextValue>21</contextValue>                            "isPattern": "false",
-                </contextAttribute>                                          "type": "Room"
-              </contextAttributeList>                                    },
-            </contextElement>                                            "statusCode": {
-            <statusCode>                                                     "code": "200",
-              <code>200</code>                                               "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                            }
-            </statusCode>                                            }
-          </contextElementResponse>                              ]
-        </contextResponseList>                               }
-      </queryContextResponse>                            
+      {
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": "23"
+			  }
+		      ],
+		      "id": "Room1",
+		      "isPattern": "false",
+		      "type": "Room"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      },
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": "21"
+			  }
+		      ],
+		      "id": "Room2",
+		      "isPattern": "false",
+		      "type": "Room"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	  ]
+      }                         
 
 Finally, note that you will get an error in case you try to query a
 non-existing entity or attribute, as shown in the following cases below:
 
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                           "entities": [
-        <entityIdList>                                                                                                                {
-          <entityId type="Room" isPattern="false">                                                                                        "type": "Room",
-            <id>Room5</id>                                                                                                                "isPattern": "false",
-          </entityId>                                                                                                                     "id": "Room5"
-        </entityIdList>                                                                                                               }
-        <attributeList/>                                                                                                              ]
-      </queryContextRequest>                                                                                                      }
-      EOF                                                                                                                         EOF
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	  {
+	      "type": "Room",
+	      "isPattern": "false",
+	      "id": "Room5"
+	  }	
+	  ]
+      }
+      EOF                                                                                                                   
   
-      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                      {
-      <queryContextRequest>                                                                                                           "entities": [
-        <entityIdList>                                                                                                                {
-          <entityId type="Room" isPattern="false">                                                                                        "type": "Room",
-            <id>Room1</id>                                                                                                                "isPattern": "false",
-          </entityId>                                                                                                                     "id": "Room1"
-        </entityIdList>                                                                                                               }
-        <attributeList>                                                                                                               ],
-          <attribute>humidity</attribute>                                                                                             "attributes" : [
-        </attributeList>                                                                                                                  "humidity"
-      </queryContextRequest>                                                                                                          ]
-      EOF                                                                                                                         }
-                                                                                                                                  EOF
+      (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	  {
+	      "type": "Room",
+	      "isPattern": "false",
+	      "id": "Room1"
+	  }
+	  ],
+	  "attributes" : [
+	      "humidity"
+	  ]
+      }
+    EOF
 
 
 Both requests will produce the same error response:
 
-      <?xml version="1.0"?>                                            {
-      <queryContextResponse>                                               "errorCode": {
-        <errorCode>                                                            "code": "404",
-          <code>404</code>                                                     "reasonPhrase": "No context elements found"
-          <reasonPhrase>No context elements found</reasonPhrase>           }
-        </errorCode>                                                   }
-      </queryContextResponse>                                      
+      {
+      "errorCode": {
+        "code": "404",
+          "reasonPhrase": "No context elements found"
+         }
+      }
+                                          
 
 Additional comments:
 
@@ -682,31 +675,30 @@ source of context information. Let's assume that this application in a
 given moment wants to set the temperature and pressure of Room1 to 26.5
 ºC and 763 mmHg respectively, so it issues the following request:
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                            "contextElements": [
-        <contextElementList>                                                                                                                {
-          <contextElement>                                                                                                                      "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                            "isPattern": "false",
-              <id>Room1</id>                                                                                                                    "id": "Room1",
-            </entityId>                                                                                                                         "attributes": [
-            <contextAttributeList>                                                                                                              {
-              <contextAttribute>                                                                                                                    "name": "temperature",
-                <name>temperature</name>                                                                                                            "type": "float",
-                <type>float</type>                                                                                                                  "value": "26.5"
-                <contextValue>26.5</contextValue>                                                                                               },
-              </contextAttribute>                                                                                                               {
-              <contextAttribute>                                                                                                                    "name": "pressure",
-                <name>pressure</name>                                                                                                               "type": "integer",
-                <type>integer</type>                                                                                                                "value": "763"
-                <contextValue>763</contextValue>                                                                                                }
-              </contextAttribute>                                                                                                               ]
-            </contextAttributeList>                                                                                                         }
-          </contextElement>                                                                                                             ],
-        </contextElementList>                                                                                                           "updateAction": "UPDATE"
-        <updateAction>UPDATE</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+	{
+	  "contextElements": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1",
+		  "attributes": [
+		  {
+		      "name": "temperature",
+		      "type": "float",
+		      "value": "26.5"
+		  },
+		  {
+		      "name": "pressure",
+		      "type": "integer",
+		      "value": "763"
+		  }
+		  ]
+	      }
+	  ],
+	  "updateAction": "UPDATE"
+      }
+      EOF                                                                                                                    
 
 As you can see, the structure of the request is exactly the same we used
 for [updateContext with APPEND for creating
@@ -717,34 +709,33 @@ Upon receipt of this request, the broker will update the values for the
 entity attributes in its internal database and will response with the
 following:
 
-      <?xml version="1.0"?>                                  {
-      <updateContextResponse>                                    "contextResponses": [
-        <contextResponseList>                                        {
-          <contextElementResponse>                                       "contextElement": {
-            <contextElement>                                                 "attributes": [
-              <entityId type="Room" isPattern="false">                           {
-                <id>Room1</id>                                                       "name": "temperature",
-              </entityId>                                                            "type": "float",
-              <contextAttributeList>                                                 "value": ""
-                <contextAttribute>                                               },
-                  <name>temperature</name>                                       {
-                  <type>float</type>                                                 "name": "pressure",
-                  <contextValue/>                                                    "type": "integer",
-                </contextAttribute>                                                  "value": ""
-                <contextAttribute>                                               }
-                  <name>pressure</name>                                      ],
-                  <type>integer</type>                                       "id": "Room1",
-                  <contextValue/>                                            "isPattern": "false",
-                </contextAttribute>                                          "type": "Room"
-              </contextAttributeList>                                    },
-            </contextElement>                                            "statusCode": {
-            <statusCode>                                                     "code": "200",
-              <code>200</code>                                               "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                            }
-            </statusCode>                                            }
-          </contextElementResponse>                              ]
-        </contextResponseList>                               }
-      </updateContextResponse>                           
+      {
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": ""
+			  },
+			  {
+			      "name": "pressure",
+			      "type": "integer",
+			      "value": ""
+			  }
+		      ],
+		      "id": "Room1",
+		      "isPattern": "false",
+		      "type": "Room"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	  ]
+      }                         
 
 Again, the structure of the response is exactly the same one we used for
 [updateContext with APPEND for creating
@@ -764,97 +755,93 @@ also illustrates that you don't need to include all the attributes of an
 entity in the updateContext, just the ones you want to update (the other
 attributes maintain their current value).
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                            "contextElements": [
-        <contextElementList>                                                                                                                {
-          <contextElement>                                                                                                                      "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                            "isPattern": "false",
-              <id>Room2</id>                                                                                                                    "id": "Room2",
-            </entityId>                                                                                                                         "attributes": [
-            <contextAttributeList>                                                                                                              {
-              <contextAttribute>                                                                                                                    "name": "temperature",
-                <name>temperature</name>                                                                                                            "type": "float",
-                <type>float</type>                                                                                                                  "value": "27.4"
-                <contextValue>27.4</contextValue>                                                                                               }
-              </contextAttribute>                                                                                                               ]
-            </contextAttributeList>                                                                                                         }
-          </contextElement>                                                                                                             ],
-        </contextElementList>                                                                                                           "updateAction": "UPDATE"
-        <updateAction>UPDATE</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+	{
+	  "contextElements": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room2",
+		  "attributes": [
+		  {
+		      "name": "temperature",
+		      "type": "float",
+		      "value": "27.4"
+		  }
+		  ]
+	      }
+	  ],
+	  "updateAction": "UPDATE"
+      }
       EOF                                                                                                                       
  
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                            "contextElements": [
-        <contextElementList>                                                                                                                {
-          <contextElement>                                                                                                                      "type": "Room",
-            <entityId type="Room" isPattern="false">                                                                                            "isPattern": "false",
-              <id>Room2</id>                                                                                                                    "id": "Room2",
-            </entityId>                                                                                                                         "attributes": [
-            <contextAttributeList>                                                                                                              {
-              <contextAttribute>                                                                                                                    "name" : "pressure",
-                <name>pressure</name>                                                                                                               "type" : "integer",
-                <type>integer</type>                                                                                                                "value" : "755"
-                <contextValue>755</contextValue>                                                                                                }
-              </contextAttribute>                                                                                                               ]
-            </contextAttributeList>                                                                                                         }
-          </contextElement>                                                                                                             ],
-        </contextElementList>                                                                                                           "updateAction": "UPDATE"
-        <updateAction>UPDATE</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "contextElements": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room2",
+		  "attributes": [
+		  {
+		      "name" : "pressure",
+		      "type" : "integer",
+		      "value" : "755"
+		  }
+		  ]
+	      }
+	  ],
+	  "updateAction": "UPDATE"
+      }
+      EOF                                                                                                                
   
 The responses for these requests are respectively:
 
-      <?xml version="1.0"?>                                  {
-      <updateContextResponse>                                    "contextResponses": [
-        <contextResponseList>                                        {
-          <contextElementResponse>                                       "contextElement": {
-            <contextElement>                                                 "attributes": [
-              <entityId type="Room" isPattern="false">                           {
-                <id>Room2</id>                                                       "name": "temperature",
-              </entityId>                                                            "type": "float",
-              <contextAttributeList>                                                 "value": ""
-                <contextAttribute>                                               }
-                  <name>temperature</name>                                   ],
-                  <type>float</type>                                         "id": "Room2",
-                  <contextValue/>                                            "isPattern": "false",
-                </contextAttribute>                                          "type": "Room"
-              </contextAttributeList>                                    },
-            </contextElement>                                            "statusCode": {
-            <statusCode>                                                     "code": "200",
-              <code>200</code>                                               "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                            }
-            </statusCode>                                            }
-          </contextElementResponse>                              ]
-        </contextResponseList>                               }
-      </updateContextResponse>                           
+      {
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			  {
+			      "name": "temperature",
+			      "type": "float",
+			      "value": ""
+			  }
+		      ],
+		      "id": "Room2",
+		      "isPattern": "false",
+		      "type": "Room"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	  ]
+      }                   
   
-      <?xml version="1.0"?>                                  {
-      <updateContextResponse>                                    "contextResponses": [
-        <contextResponseList>                                        {
-          <contextElementResponse>                                       "contextElement": {
-            <contextElement>                                                 "attributes": [
-              <entityId type="Room" isPattern="false">                           {
-                <id>Room2</id>                                                       "name": "pressure",
-              </entityId>                                                            "type": "integer",
-              <contextAttributeList>                                                 "value": ""
-                <contextAttribute>                                               }
-                  <name>pressure</name>                                      ],
-                  <type>integer</type>                                       "id": "Room2",
-                  <contextValue/>                                            "isPattern": "false",
-                </contextAttribute>                                          "type": "Room"
-              </contextAttributeList>                                    },
-            </contextElement>                                            "statusCode": {
-            <statusCode>                                                     "code": "200",
-              <code>200</code>                                               "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                            }
-            </statusCode>                                            }
-          </contextElementResponse>                              ]
-        </contextResponseList>                               }
-      </updateContextResponse>                           
+      {
+	  "contextResponses": [
+	      {
+		  "contextElement": {
+		      "attributes": [
+			{
+			      "name": "pressure",
+			      "type": "integer",
+			      "value": ""
+			}
+		      ],
+		      "id": "Room2",
+		      "isPattern": "false",
+		      "type": "Room"
+		  },
+		  "statusCode": {
+		      "code": "200",
+		      "reasonPhrase": "OK"
+		  }
+	      }
+	  ]
+      }                       
 
 Now, you can use queryContext operation [as previously
 described](#Query_Context_operation "wikilink") to check that Room1 and
@@ -892,40 +879,38 @@ current version of the Orion Context Broker doesn't support it.
 The following is the request corresponding to an ONTIMEINTERVAL
 subscription:
 
-      (curl localhost:1026/v1/subscribeContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/subscribeContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                           {
-      <subscribeContextRequest>                                                                                                           "entities": [
-        <entityIdList>                                                                                                                        {
-          <entityId type="Room" isPattern="false">                                                                                                "type": "Room",
-            <id>Room1</id>                                                                                                                        "isPattern": "false",
-          </entityId>                                                                                                                             "id": "Room1"
-        </entityIdList>                                                                                                                       }
-        <attributeList>                                                                                                                   ],
-          <attribute>temperature</attribute>                                                                                              "attributes": [
-        </attributeList>                                                                                                                      "temperature"
-        <reference>http://localhost:1028/accumulate</reference>                                                                           ],
-        <duration>P1M</duration>                                                                                                          "reference": "http://localhost:1028/accumulate",
-        <notifyConditions>                                                                                                                "duration": "P1M",
-          <notifyCondition>                                                                                                               "notifyConditions": [
-            <type>ONTIMEINTERVAL</type>                                                                                                       {
-            <condValueList>                                                                                                                       "type": "ONTIMEINTERVAL",
-              <condValue>PT10S</condValue>                                                                                                        "condValues": [
-            </condValueList>                                                                                                                          "PT10S"
-          </notifyCondition>                                                                                                                      ]
-        </notifyConditions>                                                                                                                   }
-      </subscribeContextRequest>                                                                                                          ]
-      EOF                                                                                                                             }
-                                                                                                                                      EOF
+      (curl localhost:1026/v1/subscribeContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      }
+	  ],
+	  "attributes": [
+	      "temperature"
+	  ],
+	  "reference": "http://localhost:1028/accumulate",
+	  "duration": "P1M",
+	  "notifyConditions": [
+	      {
+		  "type": "ONTIMEINTERVAL",
+		  "condValues": [
+		      "PT10S"
+		    ]
+	      }
+	  ]
+      }
+      EOF
+
 Let's examine in detail the different elements included in the payload:
 
 -   entityIdList and attributeList ('entities' and 'attributes' for
     short, in JSON) define which context elements will be included in
-    the notification message. They work the same way as the XML elements
-    with the same name in [queryContext
-    request](#Query_Context_operation "wikilink"). You can even include
-    lists or patterns to specify entities. In this example, we are
-    specifying that the notification has to include the temperature
-    attribute for entity Room1.
+    the notification message. 
+    In this example, we are specifying that the notification has to include 
+    the temperature attribute for entity Room1.
 -   The callback URL to send notifications is defined with the
     reference element. We are using the URL of the accumulator-server.py
     program started before. Only one reference can be included per
@@ -960,49 +945,48 @@ The response corresponding to that request contains a subscription ID (a
 duration acknowledgement:
 
 
-      <?xml version="1.0"?>                                               {
-      <subscribeContextResponse>                                              "subscribeResponse": {
-        <subscribeResponse>                                                       "duration": "P1M",
-          <subscriptionId>51c04a21d714fb3b37d7d5a7</subscriptionId>               "subscriptionId": "51c04a21d714fb3b37d7d5a7"
-          <duration>P1M</duration>                                            }
-        </subscribeResponse>                                              }
-      </subscribeContextResponse>                                       
+      {
+	  "subscribeResponse": {
+	      "duration": "P1M",
+	      "subscriptionId": "51c04a21d714fb3b37d7d5a7"
+	  }
+      }                                   
 
 If you look at the accumulator-script.py terminal window, you will see
 that a message resembling the following one is received each 10 seconds:
 
 
-      POST http://localhost:1028/accumulate                             POST http://localhost:1028/accumulate
-      Content-Length: 739                                               Content-Length: 492
-      User-Agent: orion/0.9.0                                           User-Agent: orion/0.9.0
-      Host: localhost:1028                                              Host: localhost:1028
-      Accept: application/xml, application/json                         Accept: application/xml, application/json
-      Content-Type: application/xml                                     Content-Type: application/json
-                                                                    
-      <notifyContextRequest>                                            {
-        <subscriptionId>51c04a21d714fb3b37d7d5a7</subscriptionId>         "subscriptionId" : "51c04a21d714fb3b37d7d5a7",
-        <originator>localhost</originator>                                "originator" : "localhost",
-        <contextResponseList>                                             "contextResponses" : [
-          <contextElementResponse>                                          {
-            <contextElement>                                                  "contextElement" : {
-              <entityId type="Room" isPattern="false">                          "attributes" : [
-                <id>Room1</id>                                                    {
-              </entityId>                                                           "name" : "temperature",
-              <contextAttributeList>                                                "type" : "float",
-                <contextAttribute>                                                  "value" : "26.5"
-                  <name>temperature</name>                                        }
-                  <type>float</type>                                            ],
-                  <contextValue>26.5</contextValue>                             "type" : "Room",
-                </contextAttribute>                                             "isPattern" : "false",
-              </contextAttributeList>                                           "id" : "Room1"
-            </contextElement>                                                 },
-            <statusCode>                                                      "statusCode" : {
-              <code>200</code>                                                  "code" : "200",
-              <reasonPhrase>OK</reasonPhrase>                                   "reasonPhrase" : "OK"
-            </statusCode>                                                     }
-          </contextElementResponse>                                         }
-        </contextResponseList>                                            ]
-      </notifyContextRequest>                                           }  
+      POST http://localhost:1028/accumulate
+      Content-Length: 492
+      User-Agent: orion/0.9.0
+      Host: localhost:1028
+      Accept: application/xml, application/json
+      Content-Type: application/json
+
+      {
+	"subscriptionId" : "51c04a21d714fb3b37d7d5a7",
+	"originator" : "localhost",
+	"contextResponses" : [
+	  {
+	    "contextElement" : {
+	      "attributes" : [
+		{
+		  "name" : "temperature",
+		  "type" : "float",
+		  "value" : "26.5"
+		}
+		],
+	      "type" : "Room",
+	      "isPattern" : "false",
+	      "id" : "Room1"
+	    },
+	    "statusCode" : {
+		"code" : "200",
+		"reasonPhrase" : "OK"
+	      }
+	  }
+	]
+	} 
 
 Orion Context Broker notifies NGSI10 subscribeContext using the POST
 HTTP method (on the URL used as reference for the subscription) with a
@@ -1032,30 +1016,27 @@ change the notification interval to 5 seconds we will use the following
 one that you have got in the subscribeContext response in the previous
 step) command:
 
-      (curl localhost:1026/v1/updateContextSubscription -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContextSubscription -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                     {
-      <updateContextSubscriptionRequest>                                                                                                            "subscriptionId": "51c04a21d714fb3b37d7d5a7",
-        <subscriptionId>51c04a21d714fb3b37d7d5a7</subscriptionId>                                                                                   "notifyConditions": [
-        <notifyConditions>                                                                                                                              {
-          <notifyCondition>                                                                                                                                 "type": "ONTIMEINTERVAL",
-            <type>ONTIMEINTERVAL</type>                                                                                                                     "condValues": [
-            <condValueList>                                                                                                                                     "PT5S"
-              <condValue>PT5S</condValue>                                                                                                                   ]
-            </condValueList>                                                                                                                            }
-          </notifyCondition>                                                                                                                        ]
-        </notifyConditions>                                                                                                                     }
-      </updateContextSubscriptionRequest>                                                                                                       EOF
-      EOF                                                                                                                                   
+      (curl localhost:1026/v1/updateContextSubscription -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "subscriptionId": "51c04a21d714fb3b37d7d5a7",
+	  "notifyConditions": [
+	      {
+		  "type": "ONTIMEINTERVAL",
+		  "condValues": [
+		      "PT5S"
+		  ]
+	      }
+	  ]
+      }
+      EOF                                                                                                                                 
   
 The response is very similar to the one for subscribeContext request:
 
-
-      <?xml version="1.0"?>                                               {
-      <updateContextSubscriptionResponse>                                   "subscribeResponse" : {
-        <subscribeResponse>                                                   "subscriptionId" : "51c04a21d714fb3b37d7d5a7",
-          <subscriptionId>51c04a21d714fb3b37d7d5a7</subscriptionId>         }
-        </subscribeResponse>                                              }
-      </updateContextSubscriptionResponse>                            
+      {
+	"subscribeResponse" : {
+	  "subscriptionId" : "51c04a21d714fb3b37d7d5a7",
+	}
+      }             
 
 You can check in accumulator-server.py that the notification frequency
 has changed to 5 seconds.
@@ -1066,24 +1047,22 @@ request payload (replace the subscriptionId value after copy-paste with
 the one that you get in the subscribeContext response in the previous
 step):
 
-      (curl localhost:1026/v1/unsubscribeContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/unsubscribeContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                              {
-      <unsubscribeContextRequest>                                                                                                          "subscriptionId": "51c04a21d714fb3b37d7d5a7"
-        <subscriptionId>51c04a21d714fb3b37d7d5a7</subscriptionId>                                                                        }
-      </unsubscribeContextRequest>                                                                                                       EOF
-      EOF                                                                                                                            
+      (curl localhost:1026/v1/unsubscribeContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"subscriptionId": "51c04a21d714fb3b37d7d5a7"
+      }
+      EOF                                                                                                                          
 
 The response is just an acknowledgement of that the cancellation was
 successful.
 
-      <?xml version="1.0"?>                                             {
-      <unsubscribeContextResponse>                                          "statusCode": {
-        <subscriptionId>51c04a21d714fb3b37d7d5a7</subscriptionId>               "code": "200",
-        <statusCode>                                                            "reasonPhrase": "OK"
-          <code>200</code>                                                  },
-          <reasonPhrase>OK</reasonPhrase>                                   "subscriptionId": "51c04a21d714fb3b37d7d5a7"
-        </statusCode>                                                   }
-      </unsubscribeContextResponse>                                 
+      {
+	  "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
+	  },
+	  "subscriptionId": "51c04a21d714fb3b37d7d5a7"
+      }                              
 
 You can have a look at accumulator-server.py to check that the
 notification flow has stopped.
@@ -1098,31 +1077,31 @@ ONCHANGE subscriptions are used when you want to be notified not when a
 given time interval has passed but when some attribute changes. Let's
 consider the following example:
 
-      (curl localhost:1026/v1/subscribeContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/subscribeContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                           {
-      <subscribeContextRequest>                                                                                                           "entities": [
-        <entityIdList>                                                                                                                        {
-          <entityId type="Room" isPattern="false">                                                                                                "type": "Room",
-            <id>Room1</id>                                                                                                                        "isPattern": "false",
-          </entityId>                                                                                                                             "id": "Room1"
-        </entityIdList>                                                                                                                       }
-        <attributeList>                                                                                                                   ],
-          <attribute>temperature</attribute>                                                                                              "attributes": [
-        </attributeList>                                                                                                                      "temperature"
-        <reference>http://localhost:1028/accumulate</reference>                                                                           ],
-        <duration>P1M</duration>                                                                                                          "reference": "http://localhost:1028/accumulate",
-        <notifyConditions>                                                                                                                "duration": "P1M",
-          <notifyCondition>                                                                                                               "notifyConditions": [
-            <type>ONCHANGE</type>                                                                                                             {
-            <condValueList>                                                                                                                       "type": "ONCHANGE",
-              <condValue>pressure</condValue>                                                                                                     "condValues": [
-            </condValueList>                                                                                                                          "pressure"
-          </notifyCondition>                                                                                                                      ]
-        </notifyConditions>                                                                                                                   }
-        <throttling>PT5S</throttling>                                                                                                     ],
-      </subscribeContextRequest>                                                                                                          "throttling": "PT5S"
-      EOF                                                                                                                             }
-                                                                                                                                      EOF
+      (curl localhost:1026/v1/subscribeContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      }
+	  ],
+	  "attributes": [
+	      "temperature"
+	  ],
+	  "reference": "http://localhost:1028/accumulate",
+	  "duration": "P1M",
+	  "notifyConditions": [
+	      {
+		  "type": "ONCHANGE",
+		  "condValues": [
+		      "pressure"
+		  ]
+	      }
+	  ],
+	  "throttling": "PT5S"
+      }
+      EOF
 
 
 Having a look at the payload we can check that it is very similar to the
@@ -1164,50 +1143,49 @@ As in ONTIMEINTERVAL subscriptions, the response consists of a
 subscription ID, a duration acknowledgement and (given that we used
 throttling in the request) a throttling acknowledgement:
 
-      <?xml version="1.0"?>                                               {
-      <subscribeContextResponse>                                              "subscribeResponse": {
-        <subscribeResponse>                                                       "duration": "P1M",
-          <subscriptionId>51c0ac9ed714fb3b37d7d5a8</subscriptionId>               "subscriptionId": "51c0ac9ed714fb3b37d7d5a8",
-          <duration>P1M</duration>                                                "throttling": "PT5S"
-          <throttling>PT5S</throttling>                                       }
-        </subscribeResponse>                                              }
-      </subscribeContextResponse>                                     
+      {
+	  "subscribeResponse": {
+	      "duration": "P1M",
+	      "subscriptionId": "51c0ac9ed714fb3b37d7d5a8",
+	      "throttling": "PT5S"
+	  }
+      }                                    
 
 Let's have a look now at accumulator-server.py. We will see one (and
 just one by the moment, no matter how much you wait)
 notifyContextRequest, similar to this one:
 
-      POST http://localhost:1028/accumulate                             POST http://localhost:1028/accumulate
-      Content-Length: 739                                               Content-Length: 492
-      User-Agent: orion/0.9.0                                           User-Agent: orion/0.9.0
-      Host: localhost:1028                                              Host: localhost:1028
-      Accept: application/xml, application/json                         Accept: application/xml, application/json
-      Content-Type: application/xml                                     Content-Type: application/json
-                                                                    
-      <notifyContextRequest>                                            {
-        <subscriptionId>51c0ac9ed714fb3b37d7d5a8</subscriptionId>         "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
-        <originator>localhost</originator>                                "originator" : "localhost",
-        <contextResponseList>                                             "contextResponses" : [
-          <contextElementResponse>                                          {
-            <contextElement>                                                  "contextElement" : {
-              <entityId type="Room" isPattern="false">                          "attributes" : [
-                <id>Room1</id>                                                    {
-              </entityId>                                                           "name" : "temperature",
-              <contextAttributeList>                                                "type" : "float",
-                <contextAttribute>                                                  "value" : "26.5"
-                  <name>temperature</name>                                        }
-                  <type>float</type>                                            ],
-                  <contextValue>26.5</contextValue>                             "type" : "Room",
-                </contextAttribute>                                             "isPattern" : "false",
-              </contextAttributeList>                                           "id" : "Room1"
-            </contextElement>                                                 },
-            <statusCode>                                                      "statusCode" : {
-              <code>200</code>                                                  "code" : "200",
-              <reasonPhrase>OK</reasonPhrase>                                   "reasonPhrase" : "OK"
-            </statusCode>                                                     }
-          </contextElementResponse>                                         }
-        </contextResponseList>                                            ]
-      </notifyContextRequest>                                           }
+      POST http://localhost:1028/accumulate
+      Content-Length: 492
+      User-Agent: orion/0.9.0
+      Host: localhost:1028
+      Accept: application/xml, application/json
+      Content-Type: application/json
+
+	{
+	  "subscriptionId" : "51c0ac9ed714fb3b37d7d5a8",
+	  "originator" : "localhost",
+	  "contextResponses" : [
+	  {
+	    "contextElement" : {
+	      "attributes" : [
+	      {
+		  "name" : "temperature",
+		  "type" : "float",
+		  "value" : "26.5"
+	      }
+	      ],
+	      "type" : "Room",
+	      "isPattern" : "false",
+	      "id" : "Room1"
+	  },
+	    "statusCode" : {
+	      "code" : "200",
+	      "reasonPhrase" : "OK"
+	    }
+	  }
+	]
+      }
 
 You may wonder why accumulator-server.py is getting this message if you
 don't actually do any update. This is because the Orion Context Broker
@@ -1287,112 +1265,108 @@ need to make it aware of the existence of certain entities. Thus, let's
 first create Room1 entity with temperature and pressure attributes (with
 its initial values)
 
-      (curl localhost:1026/v1/contextEntities/Room1 -s -S --header 'Content-Type: application/xml' -X POST -d @- | xmllint --format - ) << EOF       (curl localhost:1026/v1/contextEntities/Room1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X POST -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                                         {
-      <appendContextElementRequest>                                                                                                                    "attributes" : [
-        <contextAttributeList>                                                                                                                           {
-          <contextAttribute>                                                                                                                               "name" : "temperature",
-            <name>temperature</name>                                                                                                                       "type" : "float",
-            <type>float</type>                                                                                                                             "value" : "23"
-            <contextValue>23</contextValue>                                                                                                              },
-          </contextAttribute>                                                                                                                            {
-          <contextAttribute>                                                                                                                               "name" : "pressure",
-            <name>pressure</name>                                                                                                                          "type" : "integer",
-            <type>integer</type>                                                                                                                           "value" : "720"
-            <contextValue>720</contextValue>                                                                                                             }
-          </contextAttribute>                                                                                                                          ]
-        </contextAttributeList>                                                                                                                      }
-      </appendContextElementRequest>                                                                                                                 EOF
-      EOF                                                                                                                                        
-  
+      (curl localhost:1026/v1/contextEntities/Room1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X POST -d @- | python -mjson.tool) <<EOF
+      {
+	"attributes" : [
+	  {
+	    "name" : "temperature",
+	    "type" : "float",
+	    "value" : "23"
+	  },
+	  {
+	    "name" : "pressure",
+	    "type" : "integer",
+	    "value" : "720"
+	  }
+	]
+      }
+      EOF
+
 the response is:
 
-      <?xml version="1.0"?>                         {
-      <appendContextElementResponse>                  "contextResponses": [
-        <entityId type="" isPattern="false">            {
-          <id>Room1</id>                                  "attributes": [
-        </entityId>                                         {
-        <contextResponseList>                                 "name": "temperature",
-          <contextAttributeResponse>                          "type": "float",
-            <contextAttributeList>                            "value": ""
-              <contextAttribute>                            },
-                <name>temperature</name>                    {
-                <type>float</type>                            "name": "pressure",
-                <contextValue/>                               "type": "integer",
-              </contextAttribute>                             "value": ""
-              <contextAttribute>                            }
-                <name>pressure</name>                     ],
-                <type>integer</type>                      "statusCode": {
-                <contextValue/>                             "code": "200",
-              </contextAttribute>                           "reasonPhrase": "OK"
-            </contextAttributeList>                       }
-            <statusCode>                                }
-              <code>200</code>                        ], 
-              <reasonPhrase>OK</reasonPhrase>         "id": "Room1", 
-            </statusCode>                             "isPattern": "false", 
-          </contextAttributeResponse>                 "type": ""
-        </contextResponseList>                      }
-      </appendContextElementResponse>           
+      {
+	"contextResponses": [
+	  {
+	    "attributes": [
+	      {
+		"name": "temperature",
+		"type": "float",
+		"value": ""
+	      },
+	      {
+		"name": "pressure",
+		"type": "integer",
+		"value": ""
+	      }
+	      ],
+	    "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
+	    }
+	  }
+	], 
+	"id": "Room1", 
+	"isPattern": "false", 
+	"type": ""
+      }         
 
 Now, let's do the same with Room2:
 
-      (curl localhost:1026/v1/contextEntities/Room2 -s -S --header 'Content-Type: application/xml' -X POST -d @- | xmllint --format - ) << EOF       (curl localhost:1026/v1/contextEntities/Room2 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X POST -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                                         {
-      <appendContextElementRequest>                                                                                                                    "attributes" : [
-        <contextAttributeList>                                                                                                                           {
-          <contextAttribute>                                                                                                                               "name" : "temperature",
-            <name>temperature</name>                                                                                                                       "type" : "float",
-            <type>float</type>                                                                                                                             "value" : "21"
-            <contextValue>21</contextValue>                                                                                                              },
-          </contextAttribute>                                                                                                                            {
-          <contextAttribute>                                                                                                                               "name" : "pressure",
-            <name>pressure</name>                                                                                                                          "type" : "integer",
-            <type>integer</type>                                                                                                                           "value" : "711"
-            <contextValue>711</contextValue>                                                                                                             }
-          </contextAttribute>                                                                                                                          ]
-        </contextAttributeList>                                                                                                                      }
-      </appendContextElementRequest>                                                                                                             
-      EOF                                                                                                                                            EOF
+      (curl localhost:1026/v1/contextEntities/Room2 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X POST -d @- | python -mjson.tool) <<EOF
+      {
+	"attributes" : [
+	  {
+	    "name" : "temperature",
+	    "type" : "float",
+	    "value" : "21"
+	  },
+	  {
+	    "name" : "pressure",
+	    "type" : "integer",
+	    "value" : "711"
+	  }
+	]
+      }
 
+      EOF
+      
 which response is:
 
-      <?xml version="1.0"?>                         {
-      <appendContextElementResponse>                  "contextResponses": [
-        <entityId type="" isPattern="false">            {
-          <id>Room2</id>                                  "attributes": [
-        </entityId>                                         {
-        <contextResponseList>                                 "name": "temperature",
-          <contextAttributeResponse>                          "type": "float",
-            <contextAttributeList>                            "value": ""
-              <contextAttribute>                            },
-                <name>temperature</name>                    {
-                <type>float</type>                            "name": "pressure",
-                <contextValue/>                               "type": "integer",
-              </contextAttribute>                             "value": ""
-              <contextAttribute>                            }
-                <name>pressure</name>                     ],
-                <type>integer</type>                      "statusCode": {
-                <contextValue/>                             "code": "200",
-              </contextAttribute>                           "reasonPhrase": "OK"
-            </contextAttributeList>                       }
-            <statusCode>                                }
-              <code>200</code>                        ],
-              <reasonPhrase>OK</reasonPhrase>         "id": "Room2", 
-            </statusCode>                             "isPattern": "false", 
-          </contextAttributeResponse>                 "type": ""
-        </contextResponseList>                      }
-      </appendContextElementResponse>           
+      {
+	"contextResponses": [
+	  {
+	    "attributes": [
+	      {
+		"name": "temperature",
+		"type": "float",
+		"value": ""
+	      },
+	      {
+		"name": "pressure",
+		"type": "integer",
+		"value": ""
+	      }
+	    ],
+	    "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
+	    }
+	  }
+	],
+	"id": "Room2", 
+	"isPattern": "false", 
+	"type": ""
+      }          
 
 You can also create an attribute (and the containing entity along the
 way) in the following way (additional attributes could be added after
 that, as described in [this
 section](#Adding_and_removing_attributes_with_APPEND_and_DELETE_in_updateContext "wikilink")):
 
-      (curl localhost:1026/v1/contextEntities/Room3/attributes/temperature -s -S --header 'Content-Type: application/xml' -X POST -d @- | xmllint --format - ) << EOF       (curl localhost:1026/v1/contextEntities/Room3/attributes/temperature -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X POST -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                                                                {
-      <updateContextAttributeRequest>                                                                                                                                          "value" : "21"
-         <contextValue>21</contextValue>                                                                                                                                    }
-      </updateContextAttributeRequest>                                                                                                                                      EOF
+      (curl localhost:1026/v1/contextEntities/Room3/attributes/temperature -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X POST -d @- | python -mjson.tool) <<EOF
+      {
+	  "value" : "21"
+      }
       EOF                                                                                                                                                               
  
 Compared to [entity creation based on standard
@@ -1445,56 +1419,54 @@ Finally, let's describe convenience operations for querying context
 information. We can query all the attribute values of a given entity,
 e.g. Room1 attributes:
 
-      curl localhost:1026/v1/contextEntities/Room1 -s -S | xmllint --format -       curl localhost:1026/v1/contextEntities/Room1 -s -S --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextEntities/Room1 -s -S --header 'Accept: application/json' | python -mjson.tool
 
 which response is:
 
-      <?xml version="1.0"?>                              {
-      <contextElementResponse>                             "contextElement": {
-        <contextElement>                                     "attributes": [
-          <entityId type="Room" isPattern="false">           {
-            <id>Room1</id>                                     "name": "temperature",
-          </entityId>                                          "type": "float",
-          <contextAttributeList>                               "value": "23"
-            <contextAttribute>                               },
-              <name>temperature</name>                       {
-              <type>float</type>                               "name": "pressure",
-              <contextValue>23</contextValue>                  "type": "integer",
-            </contextAttribute>                                "value": "720"
-            <contextAttribute>                               }
-              <name>pressure</name>                          ],
-              <type>integer</type>                           "id": "Room1",
-              <contextValue>720</contextValue>               "isPattern": "false",
-            </contextAttribute>                              "type": "Room"
-          </contextAttributeList>                          },
-        </contextElement>                                  "statusCode": {
-        <statusCode>                                         "code": "200",
-          <code>200</code>                                   "reasonPhrase": "OK"
-          <reasonPhrase>OK</reasonPhrase>                  }
-        </statusCode>                                    }
-      </contextElementResponse>                      
+      {
+	"contextElement": {
+	  "attributes": [
+	  {
+	    "name": "temperature",
+	    "type": "float",
+	    "value": "23"
+	  },
+	  {
+	    "name": "pressure",
+	    "type": "integer",
+	    "value": "720"
+	  }
+	  ],
+	  "id": "Room1",
+	  "isPattern": "false",
+	  "type": "Room"
+	},
+	"statusCode": {
+	  "code": "200",
+	  "reasonPhrase": "OK"
+	}
+      }                     
 
 We can also query a single attribute of a given entity, e.g. Room2
 temperature:
 
-      curl localhost:1026/v1/contextEntities/Room2/attributes/temperature -s -S | xmllint --format -       curl localhost:1026/v1/contextEntities/Room2/attributes/temperature -s -S --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextEntities/Room2/attributes/temperature -s -S --header 'Accept: application/json' | python -mjson.tool
 
 which response is:
 
-      <?xml version="1.0"?>                       {
-      <contextAttributeResponse>                    "attributes": [
-        <contextAttributeList>                      {
-          <contextAttribute>                          "name": "temperature",
-            <name>temperature</name>                  "type": "float",
-            <type>float</type>                        "value": "21"
-            <contextValue>21</contextValue>         }
-          </contextAttribute>                       ],
-        </contextAttributeList>                     "statusCode": {
-        <statusCode>                                  "code": "200",
-          <code>200</code>                            "reasonPhrase": "OK"
-          <reasonPhrase>OK</reasonPhrase>           }
-        </statusCode>                             }
-      </contextAttributeResponse>             
+      {
+	"attributes": [
+	{
+	  "name": "temperature",
+	  "type": "float",
+	  "value": "21"
+	}
+	],
+	"statusCode": {
+	  "code": "200",
+	  "reasonPhrase": "OK"
+	}
+      }     
 
 Comparing to [standard queryContext
 operation](#Query_Context_operation "wikilink") we observe the following
@@ -1519,164 +1491,158 @@ of entities of type Car using standard updateContext APPEND operations
 (given that, as described in previous section, you cannot create
 entities with types using convenience operations):
 
-      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                        {
-      <updateContextRequest>                                                                                                          "contextElements": [
-        <contextElementList>                                                                                                            {
-          <contextElement>                                                                                                                "type": "Car",
-            <entityId type="Car" isPattern="false">                                                                                       "isPattern": "false",
-              <id>Car1</id>                                                                                                               "id": "Car1",
-            </entityId>                                                                                                                   "attributes": [
-            <contextAttributeList>                                                                                                        {
-              <contextAttribute>                                                                                                            "name": "speed",
-                <name>speed</name>                                                                                                          "type": "integer",
-                <type>integer</type>                                                                                                        "value": "75"
-                <contextValue>75</contextValue>                                                                                           },
-              </contextAttribute>                                                                                                         {
-              <contextAttribute>                                                                                                            "name": "fuel",
-                <name>fuel</name>                                                                                                           "type": "float",
-                <type>float</type>                                                                                                          "value": "12.5"
-                <contextValue>12.5</contextValue>                                                                                         }
-              </contextAttribute>                                                                                                         ]
-            </contextAttributeList>                                                                                                     }
-          </contextElement>                                                                                                           ],
-        </contextElementList>                                                                                                         "updateAction": "APPEND"
-        <updateAction>APPEND</updateAction>                                                                                         }
-      </updateContextRequest>                                                                                                       EOF
-      EOF                                                                                                                       
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+	  {
+	    "type": "Car",
+	    "isPattern": "false",
+	    "id": "Car1",
+	    "attributes": [
+	    {
+	      "name": "speed",
+	      "type": "integer",
+	      "value": "75"
+	    },
+	    {
+	      "name": "fuel",
+	      "type": "float",
+	      "value": "12.5"
+	    }
+	    ]
+	  }
+	  ],
+	  "updateAction": "APPEND"
+	}
+	EOF                                                                                                                    
  
-      (curl localhost:1026/v1/updateContext -s -S -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                               {
-      <updateContextRequest>                                                                 "contextElements": [
-        <contextElementList>                                                                   {
-          <contextElement>                                                                       "type": "Car",
-            <entityId type="Car" isPattern="false">                                              "isPattern": "false",
-              <id>Car2</id>                                                                      "id": "Car2",
-            </entityId>                                                                          "attributes": [
-            <contextAttributeList>                                                               {
-              <contextAttribute>                                                                   "name": "speed",
-                <name>speed</name>                                                                 "type": "integer",
-                <type>integer</type>                                                               "value": "90"
-                <contextValue>90</contextValue>                                                  },
-              </contextAttribute>                                                                {
-              <contextAttribute>                                                                   "name": "fuel",
-                <name>fuel</name>                                                                  "type": "float",
-                <type>float</type>                                                                 "value": "25.7"
-                <contextValue>25.7</contextValue>                                                }
-              </contextAttribute>                                                                ]
-            </contextAttributeList>                                                            }
-          </contextElement>                                                                  ],
-        </contextElementList>                                                                "updateAction": "APPEND"
-        <updateAction>APPEND</updateAction>                                                }
-      </updateContextRequest>                                                              EOF
-      EOF                                                                              
+      (curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	"contextElements": [
+	  {
+	    "type": "Car",
+	    "isPattern": "false",
+	    "id": "Car2",
+	    "attributes": [
+	    {
+	      "name": "speed",
+	      "type": "integer",
+	      "value": "90"
+	    },
+	    {
+	      "name": "fuel",
+	      "type": "float",
+	      "value": "25.7"
+	    }
+	    ]
+	  }
+	],
+	"updateAction": "APPEND"
+      }
+      EOF                                                                         
   
 Request to get all the attributes:
 
-      curl localhost:1026/v1/contextEntityTypes/Car -s -S | xmllint --format -       curl localhost:1026/v1/contextEntityTypes/Car -s -S --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextEntityTypes/Car -s -S --header 'Accept: application/json' | python -mjson.tool
 
 Response:
-
-      <?xml version="1.0"?>                                 {
-      <?xml version="1.0"?>                                   "contextResponses": [
-      <queryContextResponse>                                  {
-        <contextResponseList>                                   "contextElement": {
-          <contextElementResponse>                                "attributes": [
-            <contextElement>                                      {
-              <entityId type="Car" isPattern="false">               "name": "speed",
-                <id>Car1</id>                                       "type": "integer",
-              </entityId>                                           "value": "75"
-              <contextAttributeList>                              },
-                <contextAttribute>                                {
-                  <name>speed</name>                                "name": "fuel",
-                  <type>integer</type>                              "type": "float",
-                  <contextValue>75</contextValue>                   "value": "12.5"
-                </contextAttribute>                               }
-                <contextAttribute>                                ],
-                  <name>fuel</name>                               "id": "Car1",
-                  <type>float</type>                              "isPattern": "false",
-                  <contextValue>12.5</contextValue>               "type": "Car"
-                </contextAttribute>                             },
-              </contextAttributeList>                           "statusCode": {
-            </contextElement>                                     "code": "200",
-            <statusCode>                                          "reasonPhrase": "OK"
-              <code>200</code>                                  }
-              <reasonPhrase>OK</reasonPhrase>                 },
-            </statusCode>                                     {
-          </contextElementResponse>                             "contextElement": {
-          <contextElementResponse>                                "attributes": [
-            <contextElement>                                      {
-              <entityId type="Car" isPattern="false">               "name": "speed",
-                <id>Car2</id>                                       "type": "integer",
-              </entityId>                                           "value": "90"
-              <contextAttributeList>                              },
-                <contextAttribute>                                {
-                  <name>speed</name>                                "name": "fuel",
-                  <type>integer</type>                              "type": "float",
-                  <contextValue>90</contextValue>                   "value": "25.7"
-                </contextAttribute>                               }
-                <contextAttribute>                                ],
-                  <name>fuel</name>                               "id": "Car2",
-                  <type>float</type>                              "isPattern": "false",
-                  <contextValue>25.7</contextValue>               "type": "Car"
-                </contextAttribute>                             },
-              </contextAttributeList>                           "statusCode": {
-            </contextElement>                                     "code": "200",
-            <statusCode>                                          "reasonPhrase": "OK"
-              <code>200</code>                                  }
-              <reasonPhrase>OK</reasonPhrase>                 }
-            </statusCode>                                     ]
-          </contextElementResponse>                         }
-        </contextResponseList>                          
-      </queryContextResponse>                             
+      {
+	"contextResponses": [
+	{
+	  "contextElement": {
+	    "attributes": [
+	    {
+	      "name": "speed",
+	      "type": "integer",
+	      "value": "75"
+	    },
+	    {
+	      "name": "fuel",
+	      "type": "float",
+	      "value": "12.5"
+	    }
+	    ],
+	    "id": "Car1",
+	    "isPattern": "false",
+	    "type": "Car"
+	  },
+	  "statusCode": {
+	    "code": "200",
+	    "reasonPhrase": "OK"
+	  }
+	},
+	{
+	  "contextElement": {
+	    "attributes": [
+	    {
+	      "name": "speed",
+	      "type": "integer",
+	      "value": "90"
+	    },
+	    {
+	      "name": "fuel",
+	      "type": "float",
+	      "value": "25.7"
+	    }
+	    ],
+	    "id": "Car2",
+	    "isPattern": "false",
+	    "type": "Car"
+	  },
+	  "statusCode": {
+	    "code": "200",
+	    "reasonPhrase": "OK"
+	  }
+	}
+	]
+      }
 
 Request to get only one attribute (e.g. speed):
 
-      curl localhost:1026/v1/contextEntityTypes/Car/attributes/speed -s -S | xmllint --format -       curl localhost:1026/v1/contextEntityTypes/Car/attributes/speed -s -S --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextEntityTypes/Car/attributes/speed -s -S --header 'Accept: application/json' | python -mjson.tool
 
 Response:
 
-      <?xml version="1.0"?>                                 {
-      <queryContextResponse>                                  "contextResponses": [
-        <contextResponseList>                                 {
-          <contextElementResponse>                              "contextElement": {
-            <contextElement>                                      "attributes": [
-              <entityId type="Car" isPattern="false">             {
-                <id>Car1</id>                                       "name": "speed",
-              </entityId>                                           "type": "integer",
-              <contextAttributeList>                                "value": "75"
-                <contextAttribute>                                }
-                  <name>speed</name>                              ],
-                  <type>integer</type>                            "id": "Car1",
-                  <contextValue>75</contextValue>                 "isPattern": "false",
-                </contextAttribute>                               "type": "Car"
-              </contextAttributeList>                           },
-            </contextElement>                                   "statusCode": {
-            <statusCode>                                          "code": "200",
-              <code>200</code>                                    "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                   }
-            </statusCode>                                     },
-          </contextElementResponse>                           {
-          <contextElementResponse>                              "contextElement": {
-            <contextElement>                                      "attributes": [
-              <entityId type="Car" isPattern="false">             {
-                <id>Car2</id>                                       "name": "speed",
-              </entityId>                                           "type": "integer",
-              <contextAttributeList>                                "value": "90"
-                <contextAttribute>                                }
-                  <name>speed</name>                              ],
-                  <type>integer</type>                            "id": "Car2",
-                  <contextValue>90</contextValue>                 "isPattern": "false",
-                </contextAttribute>                               "type": "Car"
-              </contextAttributeList>                           },
-            </contextElement>                                   "statusCode": {
-            <statusCode>                                          "code": "200",
-              <code>200</code>                                    "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>                   }
-            </statusCode>                                     }
-          </contextElementResponse>                           ]
-        </contextResponseList>                              }
-      </queryContextResponse>                           
+      {
+	"contextResponses": [
+	{
+	  "contextElement": {
+	    "attributes": [
+	    {
+	      "name": "speed",
+	      "type": "integer",
+	      "value": "75"
+	    }
+	    ],
+	    "id": "Car1",
+	    "isPattern": "false",
+	    "type": "Car"
+	  },
+	  "statusCode": {
+	    "code": "200",
+	    "reasonPhrase": "OK"
+	  }
+	},
+	{
+	  "contextElement": {
+	    "attributes": [
+	    {
+	      "name": "speed",
+	      "type": "integer",
+	      "value": "90"
+	    }
+	    ],
+	    "id": "Car2",
+	    "isPattern": "false",
+	    "type": "Car"
+	  },
+	  "statusCode": {
+	    "code": "200",
+	    "reasonPhrase": "OK"
+	  }
+	}
+	]
+      }                         
 
 Additional comments:
 
@@ -1796,32 +1762,32 @@ Additional comments:
 The following operation can be used to get a list of all entity types
 existing at Orion Context Broker in a given moment:
 
-      curl localhost:1026/v1/contextTypes -s -S --header 'Content-Type: application/xml'  | xmllint --format -       curl localhost:1026/v1/contextTypes -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextTypes -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
-      <entityTypesResponse>                     {
-        <typeEntities>                              "statusCode": {
-          <entityType>                                  "code": "200",
-            <name>Car</name>                            "reasonPhrase": "OK"
-            <contextAttributeList>                  },
-              <name>speed</name>                    "types": [
-              <name>fuel</name>                         {
-              <name>temperature</name>                      "attributes": [
-            </contextAttributeList>                             "speed",
-          </entityType>                                         "fuel",
-          <entityType>                                          "temperature"
-            <name>Room</name>                               ],
-            <contextAttributeList>                          "name": "Car"
-              <name>pressure</name>                     },
-              <name>hummidity</name>                    {
-              <name>temperature</name>                      "attributes": [
-            </contextAttributeList>                             "pressure",
-          </entityType>                                         "hummidity",
-        </typeEntities>                                         "temperature"
-        <statusCode>                                        ],
-          <code>200</code>                                  "name": "Room"
-          <reasonPhrase>OK</reasonPhrase>               }
-        </statusCode>                               ]
-      </entityTypesResponse>                    }
+      {
+	  "statusCode": {
+	      "code": "200",
+	      "reasonPhrase": "OK"
+	  },
+	  "types": [
+	      {
+		  "attributes": [
+		      "speed",
+		      "fuel",
+		      "temperature"
+		  ],
+		  "name": "Car"
+	      },
+	      {
+		  "attributes": [
+		      "pressure",
+		      "hummidity",
+		      "temperature"
+		  ],
+		  "name": "Room"
+	      }
+	  ]
+      }
 
 As you can see, attribute information for each type is provided. Some
 important remarks:
@@ -1838,23 +1804,21 @@ In addition, you can use the following operation to get detailed
 information of a given type (by the time being, that information consits
 of a list of all its attributes):
 
-      curl localhost:1026/v1/contextTypes/Room -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -       curl localhost:1026/v1/contextTypes/Room -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/contextTypes/Room -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
-      entityTypeAttributesResponse>             {
-        <entityType>                                "attributes": [
-          <name>Room</name>                             "hummidity",
-          <contextAttributeList>                        "pressure",
-            <name>hummidity</name>                      "temperature"
-            <name>pressure</name>                   ],
-            <name>temperature</name>                "name": "Room",
-          </contextAttributeList>                   "statusCode": {
-        </entityType>                                   "code": "200",
-        <statusCode>                                    "reasonPhrase": "OK"
-          <code>200</code>                          }
-          <reasonPhrase>OK</reasonPhrase>       }
-        </statusCode>                       
-      </entityTypeAttributesResponse>       
-
+      {
+        "attributes": [
+          "hummidity",
+          "pressure",
+          "temperature"
+        ],
+           "name": "Room",
+	    "statusCode": {
+		"code": "200",
+		"reasonPhrase": "OK"
+	    }
+      }
+       
 Note that [pagination mechanism](#Pagination "wikilink") also works in
 the operations described above.
 
@@ -1864,104 +1828,98 @@ In addition, note that this convenience operation doesn't have any standard oper
 
 Let's set the Room1 temperature and pressure values:
 
-      (curl localhost:1026/v1/contextEntities/Room1/attributes -s -S --header 'Content-Type: application/xml' -X PUT -d @- | xmllint --format - ) << EOF       (curl localhost:1026/v1/contextEntities/Room1/attributes -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X PUT -d @- | python -mjson.tool) << EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                                                   {
-      <updateContextElementRequest>                                                                                                                              "attributes" : [
-        <contextAttributeList>                                                                                                                                   {
-          <contextAttribute>                                                                                                                                       "name" : "temperature",
-            <name>temperature</name>                                                                                                                               "type" : "float",
-            <type>float</type>                                                                                                                                     "value" : "26.5"
-            <contextValue>26.5</contextValue>                                                                                                                    },
-          </contextAttribute>                                                                                                                                    {
-          <contextAttribute>                                                                                                                                       "name" : "pressure",
-            <name>pressure</name>                                                                                                                                  "type" : "integer",
-            <type>integer</name>                                                                                                                                   "value" : "763"
-            <contextValue>763</contextValue>                                                                                                                     }
-          </contextAttribute>                                                                                                                                    ]
-        </contextAttributeList>                                                                                                                                }
-      </updateContextElementRequest>                                                                                                                           EOF
-      EOF                                                                                                                                                  
+      (curl localhost:1026/v1/contextEntities/Room1/attributes -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X PUT -d @- | python -mjson.tool) << EOF
+      {
+	"attributes" : [
+	{
+	  "name" : "temperature",
+	  "type" : "float",
+	  "value" : "26.5"
+	},
+	{
+	  "name" : "pressure",
+	  "type" : "integer",
+	  "value" : "763"
+	}
+	]
+      }
+      EOF                                                                                                                                                
 
 the response is:
 
-      <?xml version="1.0"?>                         {
-      <updateContextElementResponse>                  "contextResponses": [
-        <contextResponseList>                         {
-          <contextAttributeResponse>                    "attributes": [
-            <contextAttributeList>                      {
-              <contextAttribute>                          "name": "temperature",
-                <name>temperature</name>                  "type": "float",
-                <type>float</type>                        "value": ""
-                <contextValue/>                         },
-              </contextAttribute>                       {
-              <contextAttribute>                          "name": "pressure",
-                <name>pressure</name>                     "type": "integer",
-                <type>integer</type>                      "value": ""
-                <contextValue/>                         }
-              </contextAttribute>                       ],
-            </contextAttributeList>                     "statusCode": {
-            <statusCode>                                  "code": "200",
-              <code>200</code>                            "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>           }
-            </statusCode>                             }
-          </contextAttributeResponse>                 ]
-        </contextResponseList>                      }
-      </updateContextElementResponse>           
-
+      {
+	"contextResponses": [
+	{
+	  "attributes": [
+	  {
+	    "name": "temperature",
+	    "type": "float",
+	    "value": ""
+	  },
+	  {
+	    "name": "pressure",
+	    "type": "integer",
+	    "value": ""
+	  }
+	  ],
+	  "statusCode": {
+	    "code": "200",
+	    "reasonPhrase": "OK"
+	  }
+	}
+	]
+      }
 Now, let's do the same with Room2:
 
-      (curl localhost:1026/v1/contextEntities/Room2/attributes -s -S --header 'Content-Type: application/xml' -X PUT -d @- | xmllint --format - ) << EOF       (curl localhost:1026/v1/contextEntities/Room2/attributes -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X PUT -d @- | python -mjson.tool) << EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                                                   {
-      <updateContextElementRequest>                                                                                                                              "attributes" : [
-        <contextAttributeList>                                                                                                                                   {
-          <contextAttribute>                                                                                                                                       "name" : "temperature",
-            <name>temperature</name>                                                                                                                               "type" : "float",
-            <type>float</type>                                                                                                                                     "value" : "27.4"
-            <contextValue>27.4</contextValue>                                                                                                                    },
-          </contextAttribute>                                                                                                                                    {
-          <contextAttribute>                                                                                                                                       "name" : "pressure",
-            <name>pressure</name>                                                                                                                                  "type" : "integer",
-            <type>integer</type>                                                                                                                                   "value" : "755"
-            <contextValue>755</contextValue>                                                                                                                     }
-          </contextAttribute>                                                                                                                                    ]
-        </contextAttributeList>                                                                                                                                }
-      </updateContextElementRequest>                                                                                                                           EOF
-      EOF                                                                                                                                                  
+      (curl localhost:1026/v1/contextEntities/Room2/attributes -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X PUT -d @- | python -mjson.tool) << EOF
+      {
+	"attributes" : [
+	{
+	  "name" : "temperature",
+	  "type" : "float",
+	  "value" : "27.4"
+	},
+	{
+	  "name" : "pressure",
+	  "type" : "integer",
+	  "value" : "755"
+	}
+	]
+      }
+      EOF                                                                                                                                                 
  
 which response is:
 
-      <?xml version="1.0"?>                         {
-      <updateContextElementResponse>                  "contextResponses": [
-        <contextResponseList>                         {
-          <contextAttributeResponse>                    "attributes": [
-            <contextAttributeList>                      {
-              <contextAttribute>                          "name": "temperature",
-                <name>temperature</name>                  "type": "float",
-                <type>float</type>                        "value": ""
-                <contextValue/>                         },
-              </contextAttribute>                       {
-              <contextAttribute>                          "name": "pressure",
-                <name>pressure</name>                     "type": "integer",
-                <type>integer</type>                      "value": ""
-                <contextValue/>                         }
-              </contextAttribute>                       ],
-            </contextAttributeList>                     "statusCode": {
-            <statusCode>                                  "code": "200",
-              <code>200</code>                            "reasonPhrase": "OK"
-              <reasonPhrase>OK</reasonPhrase>           }
-            </statusCode>                             }
-          </contextAttributeResponse>                 ]
-        </contextResponseList>                      }
-      </updateContextElementResponse>           
+      {
+	"contextResponses": [
+	{
+	  "attributes": [
+	  {
+	    "name": "temperature",
+	    "type": "float",
+	    "value": ""
+	  },
+	  {
+	    "name": "pressure",
+	    "type": "integer",
+	    "value": ""
+	  }
+	  ],
+	  "statusCode": {
+	    "code": "200",
+	    "reasonPhrase": "OK"
+	  }
+	}
+	]
+      }
 
 You can update a single attribute of a given entity in the following way:
 
-      (curl localhost:1026/v1/contextEntities/Room2/attributes/temperature -s -S --header 'Content-Type: application/xml' -X PUT -d @- | xmllint --format - ) << EOF       (curl localhost:1026/v1/contextEntities/Room2/attributes/temperature -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X PUT -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0" encoding="UTF-8"?>                                                                                                                               {
-      <updateContextAttributeRequest>                                                                                                                                         "value" : "26.3"
-         <contextValue>26.3</contextValue>                                                                                                                                 }
-      </updateContextAttributeRequest>                                                                                                                                     EOF
-      EOF                                                                                                                                                              
+      (curl localhost:1026/v1/contextEntities/Room2/attributes/temperature -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -X PUT -d @- | python -mjson.tool) <<EOF
+      {
+	"value" : "26.3"
+      }
+      EOF                                                                                                                                                            
 
 Comparing to [standard updateContext
 operation](#Update_context_elements "wikilink") we observe the following
@@ -2042,40 +2000,40 @@ Broker with NGSI9 standard operations:
 First of all you have to register Room1 and Room2. In order to do so, we
 use the following NGSI9 registerContext operation:
 
-      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                    {
-      <registerContextRequest>                                                                                                                     "contextRegistrations": [
-        <contextRegistrationList>                                                                                                                      {
-          <contextRegistration>                                                                                                                            "entities": [
-            <entityIdList>                                                                                                                                     {
-              <entityId type="Room" isPattern="false">                                                                                                             "type": "Room",
-                <id>Room1</id>                                                                                                                                     "isPattern": "false",
-              </entityId>                                                                                                                                          "id": "Room1"
-              <entityId type="Room" isPattern="false">                                                                                                         },
-                <id>Room2</id>                                                                                                                                 {
-              </entityId>                                                                                                                                          "type": "Room",
-            </entityIdList>                                                                                                                                        "isPattern": "false",
-            <contextRegistrationAttributeList>                                                                                                                     "id": "Room2"
-              <contextRegistrationAttribute>                                                                                                                   }
-                <name>temperature</name>                                                                                                                   ],
-                <type>float</type>                                                                                                                         "attributes": [
-                <isDomain>false</isDomain>                                                                                                                     {
-              </contextRegistrationAttribute>                                                                                                                      "name": "temperature",
-              <contextRegistrationAttribute>                                                                                                                       "type": "float",
-                <name>pressure</name>                                                                                                                              "isDomain": "false"
-                <type>integer</type>                                                                                                                           },
-                <isDomain>false</isDomain>                                                                                                                     {
-              </contextRegistrationAttribute>                                                                                                                      "name": "pressure",
-            </contextRegistrationAttributeList>                                                                                                                    "type": "integer",
-            <providingApplication>http://mysensors.com/Rooms</providingApplication>                                                                                "isDomain": "false"
-        </contextRegistration>                                                                                                                                 }
-        </contextRegistrationList>                                                                                                                         ],
-        <duration>P1M</duration>                                                                                                                           "providingApplication": "http://mysensors.com/Rooms"
-      </registerContextRequest>                                                                                                                        }
-      EOF                                                                                                                                          ],
-                                                                                                                                                   "duration": "P1M"
-                                                                                                                                               }
-                                                                                                                                               EOF
+      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "contextRegistrations": [
+	      {
+		  "entities": [
+		      {
+			  "type": "Room",
+			  "isPattern": "false",
+			   "id": "Room1"
+		      },
+		      {
+			  "type": "Room",
+			  "isPattern": "false",
+			  "id": "Room2"
+		      }
+		  ],
+		  "attributes": [
+		      {
+			  "name": "temperature",
+			  "type": "float",
+			  "isDomain": "false"
+		      },
+		      {
+			  "name": "pressure",
+			  "type": "integer",
+			  "isDomain": "false"
+		      }
+		  ],
+		  "providingApplication": "http://mysensors.com/Rooms"
+	      }
+	    ],
+	  "duration": "P1M"
+      }
+      EOF
 
 The payload includes a list of contextRegistration elements, each one
 with the following information:
@@ -2123,14 +2081,13 @@ standard](http://www.wikipedia.org/wiki/ISO_8601) for duration format.
 We are using "P1M" which means "one month" (a very large amount,
 probably enough time to complete this tutorial :).
 
-We will get the following response (XML case):
+We will get the following response :
 
 
-      <?xml version="1.0"?>                                             {
-      <registerContextResponse>                                           "duration" : "P1M",
-        <duration>P1M</duration>                                          "registrationId" : "52a744b011f5816465943d58"
-        <registrationId>52a744b011f5816465943d58</registrationId>       }
-      </registerContextResponse>                                    
+      {
+      "duration" : "P1M",
+        "registrationId" : "52a744b011f5816465943d58"
+      }                                 
 
 The registrationId (whose value will be different when you run the
 request, as it is generated using the timestamp of the current time :)
@@ -2145,193 +2102,194 @@ How can we access that information? Using the NGSI9
 discoverContextAvailability operation. For example, we can discover
 registrations for Room1 using:
 
-      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                                {
-      <discoverContextAvailabilityRequest>                                                                                                                     "entities": [
-        <entityIdList>                                                                                                                                             {
-          <entityId type="Room" isPattern="false">                                                                                                                     "type": "Room",
-            <id>Room1</id>                                                                                                                                             "isPattern": "false",
-          </entityId>                                                                                                                                                  "id": "Room1"
-        </entityIdList>                                                                                                                                            }
-        <attributeList/>                                                                                                                                       ]
-      </discoverContextAvailabilityRequest>                                                                                                                }
-      EOF                                                                                                                                                  EOF
+      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      }
+	    ]
+	}
+      EOF                                                                                                                                              
   
 This would produce the following response:
 
-      <?xml version="1.0"?>                                                                 {
-      <discoverContextAvailabilityResponse>                                                     "contextRegistrationResponses": [
-        <contextRegistrationResponseList>                                                           {
-          <contextRegistrationResponse>                                                                 "contextRegistration": {
-            <contextRegistration>                                                                           "attributes": [
-              <entityIdList>                                                                                    {
-                <entityId type="Room" isPattern="false">                                                            "isDomain": "false",
-                  <id>Room1</id>                                                                                    "name": "temperature",
-                </entityId>                                                                                         "type": "float"
-              </entityIdList>                                                                                   },
-              <contextRegistrationAttributeList>                                                                {
-                <contextRegistrationAttribute>                                                                      "isDomain": "false",
-                  <name>temperature</name>                                                                          "name": "pressure",
-                  <type>float</type>                                                                                "type": "integer"
-                  <isDomain>false</isDomain>                                                                    }
-                </contextRegistrationAttribute>                                                             ],
-                <contextRegistrationAttribute>                                                              "entities": [
-                  <name>pressure</name>                                                                         {
-                  <type>integer</type>                                                                              "id": "Room1",
-                  <isDomain>false</isDomain>                                                                        "isPattern": "false",
-                </contextRegistrationAttribute>                                                                     "type": "Room"
-              </contextRegistrationAttributeList>                                                               }
-              <providingApplication>http://mysensors.com/Rooms</providingApplication>                       ],
-            </contextRegistration>                                                                          "providingApplication": "http://mysensors.com/Rooms"
-          </contextRegistrationResponse>                                                                }
-        </contextRegistrationResponseList>                                                          }
-      </discoverContextAvailabilityResponse>                                                    ]                                                                                            
-
+      {
+	  "contextRegistrationResponses": [
+	      {
+		"contextRegistration": {
+		      "attributes": [
+			  {
+			      "isDomain": "false",
+			      "name": "temperature",
+			      "type": "float"
+			  },
+			  {
+			      "isDomain": "false",
+			      "name": "pressure",
+			      "type": "integer"
+			  }
+		      ],
+		      "entities": [
+			  {
+			      "id": "Room1",
+			      "isPattern": "false",
+			      "type": "Room"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Rooms"
+		  }
+	      }
+	  ]
+      }
+      
 Note that we used an empty attributes in the request. Doing so, the discover searches for Room1, no
 matter which attributes have been registered. If we want to be more
 precise, we can include the name of an attribute to search for:
 
-      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                                {
-        <discoverContextAvailabilityRequest>                                                                                                                   "entities": [
-          <entityIdList>                                                                                                                                           {
-            <entityId type="Room" isPattern="false">                                                                                                                   "type": "Room",
-              <id>Room1</id>                                                                                                                                           "isPattern": "false",
-            </entityId>                                                                                                                                                "id": "Room1"
-          </entityIdList>                                                                                                                                          }
-          <attributeList>                                                                                                                                      ],
-            <attribute>temperature</attribute>                                                                                                                 "attributes": [
-          </attributeList>                                                                                                                                         "temperature"
-        </discoverContextAvailabilityRequest>                                                                                                                  ]
-      EOF                                                                                                                                                  }
-                                                                                                                                                           EOF
+      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	      {
+		  "type": "Room",
+		  "isPattern": "false",
+		  "id": "Room1"
+	      }
+	  ],
+	  "attributes": [
+	      "temperature"
+	  ]
+      }
+      EOF                                                                                                                                                   
 
 which produces the following response:
 
-      <?xml version="1.0"?>                                                                 {
-      <discoverContextAvailabilityResponse>                                                     "contextRegistrationResponses": [
-        <contextRegistrationResponseList>                                                           {
-          <contextRegistrationResponse>                                                                 "contextRegistration": {
-            <contextRegistration>                                                                           "attributes": [
-              <entityIdList>                                                                                    {
-                <entityId type="Room" isPattern="false">                                                            "isDomain": "false",
-                  <id>Room1</id>                                                                                    "name": "temperature",
-                </entityId>                                                                                         "type": "float"
-              </entityIdList>                                                                                   }
-              <contextRegistrationAttributeList>                                                            ],
-                <contextRegistrationAttribute>                                                              "entities": [
-                  <name>temperature</name>                                                                      {
-                  <type>float</type>                                                                                "id": "Room1",
-                  <isDomain>false</isDomain>                                                                        "isPattern": "false",
-                </contextRegistrationAttribute>                                                                     "type": "Room"
-              </contextRegistrationAttributeList>                                                               }
-              <providingApplication>http://mysensors.com/Rooms</providingApplication>                       ],
-            </contextRegistration>                                                                          "providingApplication": "http://mysensors.com/Rooms"
-          </contextRegistrationResponse>                                                                }
-        </contextRegistrationResponseList>                                                          }
-      </discoverContextAvailabilityResponse>                                                    ]
-                                                                                            }
+      {
+	  "contextRegistrationResponses": [
+	      {
+		  "contextRegistration": {
+		      "attributes": [
+			  {
+			      "isDomain": "false",
+			      "name": "temperature",
+			      "type": "float"
+			  }
+		      ],
+		      "entities": [
+			  {
+			      "id": "Room1",
+			      "isPattern": "false",
+			      "type": "Room"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Rooms"
+		    }
+	      }
+	  ]
+      }
 
 If the broker doesn't have any registration information, it will return
 a response telling so. Thus, the following request:
 
-      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                                {
-        <discoverContextAvailabilityRequest>                                                                                                                   "entities": [
-          <entityIdList>                                                                                                                                       {
-            <entityId type="Room" isPattern="false">                                                                                                               "type": "Room",
-              <id>Room1</id>                                                                                                                                       "isPattern": "false",
-            </entityId>                                                                                                                                            "id": "Room1"
-          </entityIdList>                                                                                                                                      }
-          <attributeList>                                                                                                                                      ],
-            <attribute>humidity</attribute>                                                                                                                    "attributes": [
-          </attributeList>                                                                                                                                         "humidity"
-        </discoverContextAvailabilityRequest>                                                                                                                  ]
-      EOF                                                                                                                                                  }
-                                                                                                                                                           EOF
+      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	  {
+	      "type": "Room",
+	      "isPattern": "false",
+	      "id": "Room1"
+	  }
+	  ],
+	  "attributes": [
+	      "humidity"
+	  ]
+      }
+      EOF
+
 would produce the following response:
 
-      <?xml version="1.0"?>                                                         {
-      <discoverContextAvailabilityResponse>                                             "errorCode": {
-        <errorCode>                                                                         "code": "404",
-          <code>404</code>                                                                  "reasonPhrase": "No context element registrations found"
-          <reasonPhrase>No context element registrations found</reasonPhrase>           }
-        </errorCode>                                                                }
-      </discoverContextAvailabilityResponse>                                    
+      {
+	  "errorCode": {
+	      "code": "404",
+	      "reasonPhrase": "No context element registrations found"
+	  }
+      }                    
 
 You can also search for a list of entities, e.g. to discover temperature
 in both Room1 and Room2:
 
-      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                                {
-        <discoverContextAvailabilityRequest>                                                                                                                   "entities": [
-          <entityIdList>                                                                                                                                       {
-            <entityId type="Room" isPattern="false">                                                                                                               "type": "Room",
-              <id>Room1</id>                                                                                                                                       "isPattern": "false",
-            </entityId>                                                                                                                                            "id": "Room1"
-            <entityId type="Room" isPattern="false">                                                                                                           },
-              <id>Room2</id>                                                                                                                                   {
-            </entityId>                                                                                                                                            "type": "Room",
-          </entityIdList>                                                                                                                                          "isPattern": "false",
-          <attributeList>                                                                                                                                          "id": "Room2"
-            <attribute>temperature</attribute>                                                                                                                 }
-          </attributeList>                                                                                                                                     ],
-        </discoverContextAvailabilityRequest>                                                                                                                  "attributes": [
-      EOF                                                                                                                                                      "temperature"
-                                                                                                                                                               ]
-                                                                                                                                                           }
-                                                                                                                                                           EOF
+      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	  {
+	      "type": "Room",
+	      "isPattern": "false",
+	      "id": "Room1"
+	  },
+	  {
+	      "type": "Room",
+	      "isPattern": "false",
+	      "id": "Room2"
+	  }
+	  ],
+	  "attributes": [
+	  "temperature"
+	  ]
+      }
+      EOF
 
 which will produce the following response:
 
-      <?xml version="1.0"?>                                                                 {
-      <discoverContextAvailabilityResponse>                                                     "contextRegistrationResponses": [
-        <contextRegistrationResponseList>                                                           {
-          <contextRegistrationResponse>                                                                 "contextRegistration": {
-            <contextRegistration>                                                                           "attributes": [
-              <entityIdList>                                                                                    {
-                <entityId type="Room" isPattern="false">                                                            "isDomain": "false",
-                  <id>Room1</id>                                                                                    "name": "temperature",
-                </entityId>                                                                                         "type": "float"
-                <entityId type="Room" isPattern="false">                                                        }
-                  <id>Room2</id>                                                                            ],
-                </entityId>                                                                                 "entities": [
-              </entityIdList>                                                                                   {
-              <contextRegistrationAttributeList>                                                                    "id": "Room1",
-                <contextRegistrationAttribute>                                                                      "isPattern": "false",
-                  <name>temperature</name>                                                                          "type": "Room"
-                  <type>float</type>                                                                            },
-                  <isDomain>false</isDomain>                                                                    {
-                </contextRegistrationAttribute>                                                                     "id": "Room2",
-              </contextRegistrationAttributeList>                                                                   "isPattern": "false",
-              <providingApplication>http://mysensors.com/Rooms</providingApplication>                               "type": "Room"
-            </contextRegistration>                                                                              }
-          </contextRegistrationResponse>                                                                    ],
-        </contextRegistrationResponseList>                                                                  "providingApplication": "http://mysensors.com/Rooms"
-      </discoverContextAvailabilityResponse>                                                            }
-                                                                                                    }
-                                                                                                ]
-                                                                                            }
+      {
+	  "contextRegistrationResponses": [
+	      {
+		  "contextRegistration": {
+		      "attributes": [
+			  {
+			      "isDomain": "false",
+			      "name": "temperature",
+			      "type": "float"
+			  }
+		      ],
+		      "entities": [
+			  {
+			      "id": "Room1",
+			      "isPattern": "false",
+			      "type": "Room"
+			  },
+			  {
+			      "id": "Room2",
+			      "isPattern": "false",
+			      "type": "Room"
+			  }
+		      ],
+		      "providingApplication": "http://mysensors.com/Rooms"
+		  }
+	      }
+	  ]
+      }
 
 Finally, a powerful feature of Orion Context Broker is that you can use
 a regular expression for the entity ID. For example, you can discover
 entities whose ID starts with "Room" using the regex "Room.\*". In this
 case, you have to set isPattern to "true" as shown below:
 
-      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                                {
-        <discoverContextAvailabilityRequest>                                                                                                                   "entities": [
-          <entityIdList>                                                                                                                                       {
-            <entityId type="Room" isPattern="true">                                                                                                                "type": "Room",
-              <id>Room.*</id>                                                                                                                                      "isPattern": "true",
-            </entityId>                                                                                                                                            "id": "Room.*"
-          </entityIdList>                                                                                                                                      }
-          <attributeList>                                                                                                                                      ],
-            <attribute>temperature</attribute>                                                                                                                 "attributes": [
-          </attributeList>                                                                                                                                     "temperature"
-        </discoverContextAvailabilityRequest>                                                                                                                  ]
-      EOF                                                                                                                                                  }
-                                                                                                                                                           EOF
+      (curl localhost:1026/v1/registry/discoverContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+        "entities": [
+        {
+            "type": "Room",
+            "isPattern": "true",
+            "id": "Room.*"
+        }
+        ],
+        "attributes": [
+	    "temperature"
+        ]
+      }
+      EOF
 This will produce the exact same response as the previous example.
 
 Note that by default only 20 registrations are returned (which is fine
@@ -2373,22 +2331,22 @@ able to send notifications.
 In order to configure this behavior, we use the following NGSI9
 subscribeContextAvailability request:
 
-      (curl localhost:1026/v1/registry/subscribeContextAvailability -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format -) <<EOF       (curl localhost:1026/v1/registry/subscribeContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                                {
-      <subscribeContextAvailabilityRequest>                                                                                                                    "entities": [
-        <entityIdList>                                                                                                                                         {
-          <entityId type="Room" isPattern="true">                                                                                                                  "type": "Room",
-            <id>.*</id>                                                                                                                                            "isPattern": "true",
-          </entityId>                                                                                                                                              "id": ".*"
-        </entityIdList>                                                                                                                                        }
-        <attributeList>                                                                                                                                        ],
-          <attribute>temperature</attribute>                                                                                                                   "attributes": [
-        </attributeList>                                                                                                                                       "temperature"
-        <reference>http://localhost:1028/accumulate</reference>                                                                                                ],
-        <duration>P1M</duration>                                                                                                                               "reference": "http://localhost:1028/accumulate",
-      </subscribeContextAvailabilityRequest>                                                                                                                   "duration": "P1M"
-      EOF                                                                                                                                                  }
-                                                                                                                                                           EOF
+     (curl localhost:1026/v1/registry/subscribeContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+     {
+	"entities": [
+        {
+             "type": "Room",
+             "isPattern": "true",
+             "id": ".*"
+        }
+        ],
+        "attributes": [
+	     "temperature"
+        ],
+        "reference": "http://localhost:1028/accumulate",
+        "duration": "P1M"
+     }
+     EOF
 
 
 The payload has the following elements:
@@ -2396,10 +2354,8 @@ The payload has the following elements:
 -   entityIdList and attributeList ('entities' and 'attributes' for
     short, in JSON) define which context availability information we are
     interested in. They are used to select the context registrations to
-    include in the notifications. They work in the same way as the XML
-    elements with the same name in [discoverContextAvailability
-    request](#Discover_Context_Availability_operation "wikilink"). In
-    this case, we are stating that we are interested in context
+    include in the notifications.
+    In this case, we are stating that we are interested in context
     availability about "temperature" attribute in any entity of type
     "Room" ("any" is represented by the ".\*" pattern, which is a
     regular expression that matches any string).
@@ -2434,51 +2390,51 @@ cancelling the subscription - write it down because you will need it in
 later steps of this tutorial) and a duration acknowledgement. Again,
 pretty similar to a subscribeContext.
 
-      <?xml version="1.0"?>                                             {
-      <subscribeContextAvailabilityResponse>                                "duration": "P1M",
-        <subscriptionId>52a745e011f5816465943d59</subscriptionId>           "subscriptionId": "52a745e011f5816465943d59"
-        <duration>P1M</duration>                                        }
-      </subscribeContextAvailabilityResponse>                       
+      {
+      "duration": "P1M",
+        "subscriptionId": "52a745e011f5816465943d59"
+      }
+             
 
 Looking at accumulator-server.py, we will see the following initial
 notification:
 
-      POST http://localhost:1028/accumulate                                                 POST http://localhost:1028/accumulate
-      Content-Length: 940                                                                   Content-Length: 638
-      User-Agent: orion/0.9.0                                                               User-Agent: orion/0.9.0
-      Host: localhost:1028                                                                  Host: localhost:1028
-      Accept: application/xml, application/json                                             Accept: application/xml, application/json
-      Content-Type: application/xml                                                         Content-Type: application/json
+      POST http://localhost:1028/accumulate
+      Content-Length: 638
+      User-Agent: orion/0.9.0
+      Host: localhost:1028
+      Accept: application/xml, application/json
+      Content-Type: application/json
                                                                                         
-      <notifyContextAvailabilityRequest>                                                    {
-        <subscriptionId>52a745e011f5816465943d59</subscriptionId>                             "subscriptionId" : "52a745e011f5816465943d59",
-        <contextRegistrationResponseList>                                                     "contextRegistrationResponses" : [
-          <contextRegistrationResponse>                                                         {
-            <contextRegistration>                                                                 "contextRegistration" : {
-              <entityIdList>                                                                        "entities" : [
-                <entityId type="Room" isPattern="false">                                              {
-                  <id>Room1</id>                                                                        "type" : "Room",
-                </entityId>                                                                             "isPattern" : "false",
-                <entityId type="Room" isPattern="false">                                                "id" : "Room1"
-                  <id>Room2</id>                                                                      },
-                </entityId>                                                                           {
-              </entityIdList>                                                                           "type" : "Room",
-              <contextRegistrationAttributeList>                                                        "isPattern" : "false",
-                <contextRegistrationAttribute>                                                          "id" : "Room2"
-                  <name>temperature</name>                                                            }
-                  <type>float</type>                                                                ],
-                  <isDomain>false</isDomain>                                                        "attributes" : [
-                </contextRegistrationAttribute>                                                       {
-              </contextRegistrationAttributeList>                                                       "name" : "temperature",
-              <providingApplication>http://mysensors.com/Rooms</providingApplication>                   "type" : "float",
-            </contextRegistration>                                                                      "isDomain" : "false"
-          </contextRegistrationResponse>                                                              }
-        </contextRegistrationResponseList>                                                          ],
-      </notifyContextAvailabilityRequest>                                                           "providingApplication" : "http://mysensors.com/Rooms"
-                                                                                                  }
-                                                                                                }
-                                                                                              ]
-                                                                                            }
+      {
+        "subscriptionId" : "52a745e011f5816465943d59",
+        "contextRegistrationResponses" : [
+        {
+            "contextRegistration" : {
+              "entities" : [
+              {
+                  "type" : "Room",
+		  "isPattern" : "false",
+                  "id" : "Room1"
+              },
+              {
+              "type" : "Room",
+              "isPattern" : "false",
+              "id" : "Room2"
+              }
+              ],
+              "attributes" : [
+              {
+	           "name" : "temperature",
+                   "type" : "float",
+                  "isDomain" : "false"
+	      }
+	      ],
+	    "providingApplication" : "http://mysensors.com/Rooms"
+	    }
+        }
+        ]
+      }
 
 Orion Context Broker notifies NGSI9 subscribeContextAvailability using
 the POST HTTP method (on the URL used as reference for the subscription)
@@ -2511,71 +2467,71 @@ could be changed in a later version. What is your opinion? :)
 Let's see what happens when we register a new room (Room3) with
 temperature and pressure:
 
-      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                    {
-          <registerContextRequest>                                                                                                                 "contextRegistrations": [
-            <contextRegistrationList>                                                                                                              {
-              <contextRegistration>                                                                                                                    "entities": [
-                <entityIdList>                                                                                                                         {
-                  <entityId type="Room" isPattern="false">                                                                                                 "type": "Room",
-                    <id>Room3</id>                                                                                                                         "isPattern": "false",
-                  </entityId>                                                                                                                              "id": "Room3"
-                </entityIdList>                                                                                                                        }
-                <contextRegistrationAttributeList>                                                                                                     ],
-                  <contextRegistrationAttribute>                                                                                                       "attributes": [
-                    <name>temperature</name>                                                                                                           {
-                    <type>float</type>                                                                                                                     "name": "temperature",
-                    <isDomain>false</isDomain>                                                                                                             "type": "float",
-                  </contextRegistrationAttribute>                                                                                                          "isDomain": "false"
-                  <contextRegistrationAttribute>                                                                                                       },
-                    <name>pressure</name>                                                                                                              {
-                    <type>integer</type>                                                                                                                   "name": "pressure",
-                    <isDomain>false</isDomain>                                                                                                             "type": "integer",
-                  </contextRegistrationAttribute>                                                                                                          "isDomain": "false"
-                </contextRegistrationAttributeList>                                                                                                    }
-                <providingApplication>http://mysensors.com/Rooms</providingApplication>                                                                ],
-              </contextRegistration>                                                                                                                   "providingApplication": "http://mysensors.com/Rooms"
-            </contextRegistrationList>                                                                                                             }
-            <duration>P1M</duration>                                                                                                               ],
-          </registerContextRequest>                                                                                                                "duration": "P1M"
-      EOF                                                                                                                                      }
-                                                                                                                                               EOF
+      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+          "contextRegistrations": [
+          {
+              "entities": [
+               {
+                  "type": "Room",
+                  "isPattern": "false",
+                  "id": "Room3"
+               }
+               ],
+               "attributes": [
+               {
+                  "name": "temperature",
+                  "type": "float",
+                  "isDomain": "false"
+               },
+               {
+                  "name": "pressure",
+                  "type": "integer",
+                  "isDomain": "false"
+               }
+               ],
+               "providingApplication": "http://mysensors.com/Rooms"
+          }
+          ],
+	  "duration": "P1M"
+      }
+      EOF
 
 As expected, the accumulator-server.py will be notified of the new
 registration. Again, although Room3 registration includes temperature
 and pressure, only the first attribute is included in the notification.
 
-      POST http://localhost:1028/accumulate                                                 POST http://localhost:1028/accumulate
-      Content-Length: 840                                                                   Content-Length: 522
-      User-Agent: orion/0.9.0                                                               User-Agent: orion/0.9.0
-      Host: localhost:1028                                                                  Host: localhost:1028
-      Accept: application/xml, application/json                                             Accept: application/xml, application/json
-      Content-Type: application/xml                                                         Content-Type: application/json
+      POST http://localhost:1028/accumulate
+      Content-Length: 522
+      User-Agent: orion/0.9.0
+      Host: localhost:1028
+      Accept: application/xml, application/json
+      Content-Type: application/json
                                                                                         
-      <notifyContextAvailabilityRequest>                                                    {
-        <subscriptionId>52a745e011f5816465943d59</subscriptionId>                             "subscriptionId" : "52a745e011f5816465943d59",
-        <contextRegistrationResponseList>                                                     "contextRegistrationResponses" : [
-          <contextRegistrationResponse>                                                         {
-            <contextRegistration>                                                                 "contextRegistration" : {
-              <entityIdList>                                                                        "entities" : [
-                <entityId type="Room" isPattern="false">                                              {
-                  <id>Room3</id>                                                                        "type" : "Room",
-                </entityId>                                                                             "isPattern" : "false",
-              </entityIdList>                                                                           "id" : "Room3"
-              <contextRegistrationAttributeList>                                                      }
-                <contextRegistrationAttribute>                                                      ],
-                  <name>temperature</name>                                                          "attributes" : [
-                  <type>float</type>                                                                  {
-                  <isDomain>false</isDomain>                                                            "name" : "temperature",
-                </contextRegistrationAttribute>                                                         "type" : "float",
-              </contextRegistrationAttributeList>                                                       "isDomain" : "false"
-              <providingApplication>http://mysensors.com/Rooms</providingApplication>                 }
-            </contextRegistration>                                                                  ],
-          </contextRegistrationResponse>                                                            "providingApplication" : "http://mysensors.com/Rooms"
-        </contextRegistrationResponseList>                                                        }
-      </notifyContextAvailabilityRequest>                                                       }
-                                                                                              ]
-                                                                                            }
+      {
+        "subscriptionId" : "52a745e011f5816465943d59",
+        "contextRegistrationResponses" : [
+        {
+            "contextRegistration" : {
+              "entities" : [
+              {
+                  "type" : "Room",
+		  "isPattern" : "false",
+		  "id" : "Room3"
+              }
+              ],
+              "attributes" : [
+              {
+                  "name" : "temperature",
+                  "type" : "float",
+		  "isDomain" : "false"
+              }
+              ],
+            "providingApplication" : "http://mysensors.com/Rooms"
+           }
+        }
+        ]
+     }
 
 We can also check that context registrations not matching the
 subscription doesn't trigger any notifications. For example, let's
@@ -2583,30 +2539,30 @@ register a room (Room4) with only attribute pressure (remember that the
 subscription only includes temperature in attributeList).
 
   
-      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                    {
-          <registerContextRequest>                                                                                                                 "contextRegistrations": [
-            <contextRegistrationList>                                                                                                              {
-              <contextRegistration>                                                                                                                    "entities": [
-                <entityIdList>                                                                                                                         {
-                  <entityId type="Room" isPattern="false">                                                                                                 "type": "Room",
-                    <id>Room4</id>                                                                                                                         "isPattern": "false",
-                  </entityId>                                                                                                                              "id": "Room4"
-                </entityIdList>                                                                                                                        }
-                <contextRegistrationAttributeList>                                                                                                     ],
-                  <contextRegistrationAttribute>                                                                                                       "attributes": [
-                    <name>pressure</name>                                                                                                              {
-                    <type>integer</type>                                                                                                                   "name": "pressure",
-                    <isDomain>false</isDomain>                                                                                                             "type": "integer",
-                  </contextRegistrationAttribute>                                                                                                          "isDomain": "false"
-                </contextRegistrationAttributeList>                                                                                                    }
-                <providingApplication>http://mysensors.com/Rooms</providingApplication>                                                                ],
-              </contextRegistration>                                                                                                                   "providingApplication": "http://mysensors.com/Rooms"
-            </contextRegistrationList>                                                                                                             }
-            <duration>P1M</duration>                                                                                                               ],
-          </registerContextRequest>                                                                                                                "duration": "P1M"
-      EOF                                                                                                                                      }
-                                                                                                                                               EOF
+      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+          "contextRegistrations": [
+          {
+              "entities": [
+              {
+                  "type": "Room",
+                  "isPattern": "false",
+                  "id": "Room4"
+              }
+              ],
+                  "attributes": [
+                  {
+                    "name": "pressure",
+                    "type": "integer",
+                    "isDomain": "false"
+                  }
+                  ],
+              "providingApplication": "http://mysensors.com/Rooms"
+          }
+          ],
+          "duration": "P1M"
+      }
+      EOF
   
 You can now check that no new notification arrives to
 accumulator-server.py.
@@ -2621,151 +2577,149 @@ element). As always you have to replace the *subscriptionId* value after
 copy-pasting with the value you got from the
 subscribeContextAvailability response in the previous step).
 
-      (curl localhost:1026/v1/registry/updateContextAvailabilitySubscription -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/updateContextAvailabilitySubscription -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                                          {
-      <updateContextAvailabilitySubscriptionRequest>                                                                                                                     "entities": [
-        <entityIdList>                                                                                                                                                   {
-          <entityId type="Car" isPattern="true">                                                                                                                             "type": "Car",
-            <id>.*</id>                                                                                                                                                      "isPattern": "true",
-          </entityId>                                                                                                                                                        "id": ".*"
-        </entityIdList>                                                                                                                                                  }
-        <attributeList/>                                                                                                                                                 ],
-        <duration>P1M</duration>                                                                                                                                         "duration": "P1M",
-        <subscriptionId>52a745e011f5816465943d59</subscriptionId>                                                                                                        "subscriptionId": "52a745e011f5816465943d59"
-      </updateContextAvailabilitySubscriptionRequest>                                                                                                                }
-      EOF                                                                                                                                                            EOF
+      (curl localhost:1026/v1/registry/updateContextAvailabilitySubscription -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+	  "entities": [
+	  {
+	      "type": "Car",
+	      "isPattern": "true",
+	      "id": ".*"
+	  }
+	  ],
+	  "duration": "P1M",
+	  "subscriptionId": "52a745e011f5816465943d59"
+      }
+      EOF                                                                                                                                                           EOF
  
 The response is very similar to the one for subscribeContextAvailability
 request:
 
-      <?xml version="1.0"?>                                             {
-      <updateContextAvailabilitySubscriptionResponse>                       "duration": "P1M",
-        <subscriptionId>52a745e011f5816465943d59</subscriptionId>           "subscriptionId": "52a745e011f5816465943d59"
-        <duration>P1M</duration>                                        }
-      </updateContextAvailabilitySubscriptionResponse>              
+      {
+      "duration": "P1M",
+        "subscriptionId": "52a745e011f5816465943d59"
+      }
+           
 
 Given that there are currently no car entities registered, you will not
 receive any initial notification. So. let's register two cars: Car1 with
-an attribute named speed and Car2 with an attribute named location
-(don't worry about the [ISO6709](http://www.wikipedia.org/wiki/ISO_6709)
-reference in the XML, it's just standard for geo-location and nothing
-significant for this tutorial).
+an attribute named speed and Car2 with an attribute named location.
 
-      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                    {
-          <registerContextRequest>                                                                                                                 "contextRegistrations": [
-            <contextRegistrationList>                                                                                                              {
-              <contextRegistration>                                                                                                                    "entities": [
-                <entityIdList>                                                                                                                         {
-                  <entityId type="Car" isPattern="false">                                                                                                  "type": "Car",
-                    <id>Car1</id>                                                                                                                          "isPattern": "false",
-                  </entityId>                                                                                                                              "id": "Car1"
-                </entityIdList>                                                                                                                        }
-                <contextRegistrationAttributeList>                                                                                                     ],
-                  <contextRegistrationAttribute>                                                                                                       "attributes": [
-                    <name>speed</name>                                                                                                                 {
-                    <type>integer</type>                                                                                                                   "name": "speed",
-                    <isDomain>false</isDomain>                                                                                                             "type": "integer",
-                  </contextRegistrationAttribute>                                                                                                          "isDomain": "false"
-                </contextRegistrationAttributeList>                                                                                                    }
-                <providingApplication>http://mysensors.com/Cars</providingApplication>                                                                 ],
-              </contextRegistration>                                                                                                                   "providingApplication": "http://mysensors.com/Cars"
-            </contextRegistrationList>                                                                                                             }
-            <duration>P1M</duration>                                                                                                               ],
-          </registerContextRequest>                                                                                                                "duration": "P1M"
-      EOF                                                                                                                                      }
-                                                                                                                                               EOF
+     (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+     {
+          "contextRegistrations": [
+           {
+              "entities": [
+               {
+                  "type": "Car",
+                  "isPattern": "false",
+                  "id": "Car1"
+               }
+               ],
+                   "attributes": [
+                   {
+                     "name": "speed",
+                     "type": "integer",
+                     "isDomain": "false"
+                   }
+                  ],
+              "providingApplication": "http://mysensors.com/Cars"
+           }
+           ],
+          "duration": "P1M"
+      }
+      EOF
   
-      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                    {
-          <registerContextRequest>                                                                                                                 "contextRegistrations": [
-            <contextRegistrationList>                                                                                                              {
-              <contextRegistration>                                                                                                                    "entities": [
-                <entityIdList>                                                                                                                         {
-                  <entityId type="Car" isPattern="false">                                                                                                  "type": "Car",
-                    <id>Car2</id>                                                                                                                          "isPattern": "false",
-                  </entityId>                                                                                                                              "id": "Car2"
-                </entityIdList>                                                                                                                        }
-                <contextRegistrationAttributeList>                                                                                                     ],
-                  <contextRegistrationAttribute>                                                                                                       "attributes": [
-                    <name>location</name>                                                                                                              {
-                    <type>ISO6709</type>                                                                                                                   "name": "location",
-                    <isDomain>false</isDomain>                                                                                                             "type": "ISO6709",
-                  </contextRegistrationAttribute>                                                                                                          "isDomain": "false"
-                </contextRegistrationAttributeList>                                                                                                    }
-                <providingApplication>http://mysensors.com/Cars</providingApplication>                                                                 ],
-              </contextRegistration>                                                                                                                   "providingApplication": "http://mysensors.com/Cars"
-            </contextRegistrationList>                                                                                                             }
-            <duration>P1M</duration>                                                                                                               ],
-          </registerContextRequest>                                                                                                                "duration": "P1M"
-      EOF                                                                                                                                      }
-                                                                                                                                               EOF
+     (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+     {
+          "contextRegistrations": [
+           {
+              "entities": [
+               {
+                  "type": "Car",
+                  "isPattern": "false",
+                  "id": "Car2"
+               }
+               ],
+                  "attributes": [
+                  {
+                    "name": "location",
+                    "type": "ISO6709",
+                    "isDomain": "false"
+                  }
+                  ],
+              "providingApplication": "http://mysensors.com/Cars"
+           }
+           ],
+          "duration": "P1M"
+      }
+      EOF
 As both registrations match the entityIdList and attributeList used in
 the updateContextAvailabilitySubscription, we will get a notification
 for each car registration, as can be seen in accumulator-server.py:
 
-      POST http://localhost:1028/accumulate                                                POST http://localhost:1028/accumulate
-      Content-Length: 825                                                                  Content-Length: 529
-      User-Agent: orion/0.9.0                                                              User-Agent: orion/0.9.0
-      Host: localhost:1028                                                                 Host: localhost:1028
-      Accept: application/xml, application/json                                            Accept: application/xml, application/json
-      Content-Type: application/xml                                                        Content-Type: application/json
+      POST http://localhost:1028/accumulate
+      Content-Length: 529
+      User-Agent: orion/0.9.0
+      Host: localhost:1028
+      Accept: application/xml, application/json
+      Content-Type: application/json
                                                                                        
-      <notifyContextAvailabilityRequest>                                                   {
-        <subscriptionId>52a745e011f5816465943d59</subscriptionId>                            "subscriptionId" : "52a745e011f5816465943d59",
-        <contextRegistrationResponseList>                                                    "contextRegistrationResponses" : [
-          <contextRegistrationResponse>                                                        {
-            <contextRegistration>                                                                "contextRegistration" : {
-              <entityIdList>                                                                       "entities" : [
-                <entityId type="Car" isPattern="false">                                              {
-                  <id>Car1</id>                                                                        "type" : "Car",
-                </entityId>                                                                            "isPattern" : "false",
-              </entityIdList>                                                                          "id" : "Car1"
-              <contextRegistrationAttributeList>                                                     }
-                <contextRegistrationAttribute>                                                     ],
-                  <name>speed</name>                                                               "attributes" : [
-                  <type>integer</type>                                                               {
-                  <isDomain>false</isDomain>                                                           "name" : "speed",
-                </contextRegistrationAttribute>                                                        "type" : "integer",
-              </contextRegistrationAttributeList>                                                      "isDomain" : "false"
-              <providingApplication>http://mysensors.com/Cars</providingApplication>                 }
-            </contextRegistration>                                                                 ],
-          </contextRegistrationResponse>                                                           "providingApplication" : "http://mysensors.com/Cars"
-        </contextRegistrationResponseList>                                                       }
-      </notifyContextAvailabilityRequest>                                                      }
-                                                                                             ]
+      {
+        "subscriptionId" : "52a745e011f5816465943d59",
+        "contextRegistrationResponses" : [
+        {
+            "contextRegistration" : {
+              "entities" : [
+              {
+                  "type" : "Car",
+		  "isPattern" : "false",
+		  "id" : "Car1"
+              }
+              ],
+	      "attributes" : [
+              {
+		  "name" : "speed",
+		  "type" : "integer",
+		  "isDomain" : "false"
+	      }
+	      ],
+	    "providingApplication" : "http://mysensors.com/Cars"
+	    }
+	}
+        ]
+      }
 
-      POST http://localhost:1028/accumulate                                                POST http://localhost:1028/accumulate
-      Content-Length: 831                                                                  Content-Length: 535
-      User-Agent: orion/0.9.0                                                              User-Agent: orion/0.9.0
-      Host: localhost:1028                                                                 Host: localhost:1028
-      Accept: application/xml, application/json                                            Accept: application/xml, application/json
-      Content-Type: application/xml                                                        Content-Type: application/json
+      POST http://localhost:1028/accumulate
+      Content-Length: 535
+      User-Agent: orion/0.9.0
+      Host: localhost:1028
+      Accept: application/xml, application/json
+      Content-Type: application/json
                                                                                        
-      <notifyContextAvailabilityRequest>                                                   {
-        <subscriptionId>52a745e011f5816465943d59</subscriptionId>                            "subscriptionId" : "52a745e011f5816465943d59",
-        <contextRegistrationResponseList>                                                    "contextRegistrationResponses" : [
-          <contextRegistrationResponse>                                                        {
-            <contextRegistration>                                                                "contextRegistration" : {
-              <entityIdList>                                                                       "entities" : [
-                <entityId type="Car" isPattern="false">                                              {
-                  <id>Car2</id>                                                                        "type" : "Car",
-                </entityId>                                                                            "isPattern" : "false",
-              </entityIdList>                                                                          "id" : "Car2"
-              <contextRegistrationAttributeList>                                                     }
-                <contextRegistrationAttribute>                                                     ],
-                  <name>location</name>                                                            "attributes" : [
-                  <type>ISO6709</type>                                                               {
-                  <isDomain>false</isDomain>                                                           "name" : "location",
-                </contextRegistrationAttribute>                                                        "type" : "ISO6709",
-              </contextRegistrationAttributeList>                                                      "isDomain" : "false"
-              <providingApplication>http://mysensors.com/Cars</providingApplication>                 }
-            </contextRegistration>                                                                 ],
-          </contextRegistrationResponse>                                                           "providingApplication" : "http://mysensors.com/Cars"
-        </contextRegistrationResponseList>                                                       }
-      </notifyContextAvailabilityRequest>                                                      }
-                                                                                             ]
-                                                                                           }
+      {
+        "subscriptionId" : "52a745e011f5816465943d59",
+        "contextRegistrationResponses" : [
+        {
+            "contextRegistration" : {
+              "entities" : [
+              {
+                  "type" : "Car",
+		  "isPattern" : "false",
+		  "id" : "Car2"
+              }
+              ],
+              "attributes" : [
+              {
+                  "name" : "location",
+		  "type" : "ISO6709",
+                  "isDomain" : "false"
+              }
+              ],
+       
+	    }
+        }
+        ]
+       }
 
 Finally, you can cancel a subscription using the NGSI9
 unsubscribeContextAvailability operation, just using the subscriptionId
@@ -2773,24 +2727,23 @@ in the request payload (replace the subscriptionId value after
 copy-pasting with the one you received in the
 subscribeContextAvailability response in the previous step).
 
-      (curl localhost:1026/v1/registry/unsubscribeContextAvailability -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/unsubscribeContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                                   {
-      <unsubscribeContextAvailabilityRequest>                                                                                                                     "subscriptionId": "52a745e011f5816465943d59"
-        <subscriptionId>52a745e011f5816465943d59</subscriptionId>                                                                                             }
-      </unsubscribeContextAvailabilityRequest>                                                                                                                EOF
-      EOF                                                                                                                                                 
+      (curl localhost:1026/v1/registry/unsubscribeContextAvailability -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+            "subscriptionId": "52a745e011f5816465943d59"
+      }
+      EOF
+                                                                                                                                                  
  
 The response is just an acknowledgement that the cancellation was
 successful.
   
-      <?xml version="1.0"?>                                             {
-      <unsubscribeContextAvailabilityResponse>                              "statusCode": {
-        <subscriptionId>52a745e011f5816465943d59</subscriptionId>               "code": "200",
-        <statusCode>                                                            "reasonPhrase": "OK"
-          <code>200</code>                                                  },
-          <reasonPhrase>OK</reasonPhrase>                                   "subscriptionId": "52a745e011f5816465943d59"
-        </statusCode>                                                   }
-      </unsubscribeContextAvailabilityResponse>                     
+      {
+      "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+      },
+          "subscriptionId": "52a745e011f5816465943d59"
+      }                    
   ---------------------------------------------------------------------------------------------------------------------------------
 
 After cancelling, you can try to register a new car (e.g. Car3) to check
@@ -2892,11 +2845,11 @@ The response to each of these requests is the same as the response to a
 standard registerContext (one response for each of the four requests,
 with a different ID):
 
-      <?xml version="1.0"?>                                             {
-      <registerContextResponse>                                           "duration": "P1M",
-        <registrationId>51c1f5c31612797e4fe6b6b6</registrationId>         "registrationId": "51c1f5c31612797e4fe6b6b6"
-        <duration>P1M</duration>                                        }
-      </registerContextResponse>                                    
+      {
+      "duration": "P1M",
+        "registrationId": "51c1f5c31612797e4fe6b6b6"
+      }
+                                
 
 #### Only-type entity registrations using convenience operations
 
@@ -2978,108 +2931,106 @@ Using convenience operations you can discover registration information
 for a single entity or for an entity-attribute pair. For example, to
 discover registrations for Room1 (no matter the attributes):
 
-      curl localhost:1026/v1/registry/contextEntities/Room1 -s -S --header 'Content-Type: application/xml' | xmllint --format -       curl localhost:1026/v1/registry/contextEntities/Room1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/registry/contextEntities/Room1 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
 which produces the following response:
 
-      <discoverContextAvailabilityResponse>                                                 {
-        <contextRegistrationResponseList>                                                     "contextRegistrationResponses": [
-          <contextRegistrationResponse>                                                       {
-            <contextRegistration>                                                               "contextRegistration": {
-              <entityIdList>                                                                      "attributes": [
-                <entityId type="" isPattern="false">                                              {
-                  <id>Room1</id>                                                                    "isDomain": "false",
-                </entityId>                                                                         "name": "temperature",
-              </entityIdList>                                                                       "type": ""
-              <contextRegistrationAttributeList>                                                  }
-                <contextRegistrationAttribute>                                                    ],
-                  <name>temperature</name>                                                        "entities": [
-                  <type/>                                                                         {
-                  <isDomain>false</isDomain>                                                        "id": "Room1",
-                </contextRegistrationAttribute>                                                     "isPattern": "false",
-              </contextRegistrationAttributeList>                                                   "type": ""
-              <providingApplication>http://mysensors.com/Rooms</providingApplication>             }
-            </contextRegistration>                                                                ],
-          </contextRegistrationResponse>                                                          "providingApplication": "http://mysensors.com/Rooms"
-          <contextRegistrationResponse>                                                         }
-            <contextRegistration>                                                             },
-              <entityIdList>                                                                  {
-                <entityId type="" isPattern="false">                                            "contextRegistration": {
-                  <id>Room1</id>                                                                  "attributes": [
-                </entityId>                                                                       {
-              </entityIdList>                                                                       "isDomain": "false",
-              <contextRegistrationAttributeList>                                                    "name": "pressure",
-                <contextRegistrationAttribute>                                                      "type": ""
-                  <name>pressure</name>                                                           }
-                  <type/>                                                                         ],
-                  <isDomain>false</isDomain>                                                      "entities": [
-                </contextRegistrationAttribute>                                                   {
-              </contextRegistrationAttributeList>                                                   "id": "Room1",
-              <providingApplication>http://mysensors.com/Rooms</providingApplication>               "isPattern": "false",
-            </contextRegistration>                                                                  "type": ""
-          </contextRegistrationResponse>                                                          }
-        </contextRegistrationResponseList>                                                        ],
-      </discoverContextAvailabilityResponse>                                                      "providingApplication": "http://mysensors.com/Rooms"
-                                                                                                }
-                                                                                              }
-                                                                                              ]
-                                                                                            }
+      {
+        "contextRegistrationResponses": [
+         {
+            "contextRegistration": {
+              "attributes": [
+              {
+                  "isDomain": "false",
+		  "name": "temperature",
+		  "type": ""
+              }
+              ],
+                  "entities": [
+                  {
+		      "id": "Room1",
+		      "isPattern": "false",
+		      "type": ""
+		  }
+		],
+	    "providingApplication": "http://mysensors.com/Rooms"
+	    }
+          },
+          {
+            "contextRegistration": {
+                "attributes": [
+                {
+		  "isDomain": "false",
+		  "name": "pressure",
+		  "type": ""
+               }
+               ],
+                  "entities": [
+                  {
+		      "id": "Room1",
+		      "isPattern": "false",
+		      "type": ""
+		  }
+		],
+	    "providingApplication": "http://mysensors.com/Rooms"
+	    }
+           }
+	   ]
+       }
 
 Now, let's discover registrations for Room2-temperature:
 
-      curl localhost:1026/v1/registry/contextEntities/Room2/attributes/temperature -s -S --header 'Content-Type: application/xml' | xmllint --format -       curl localhost:1026/v1/registry/contextEntities/Room2/attributes/temperature -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+     curl localhost:1026/v1/registry/contextEntities/Room2/attributes/temperature -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
 The response is as follows:
 
-      <?xml version="1.0"?>                                                                 {
-      <discoverContextAvailabilityResponse>                                                   "contextRegistrationResponses": [
-        <contextRegistrationResponseList>                                                     {
-          <contextRegistrationResponse>                                                         "contextRegistration": {
-            <contextRegistration>                                                                 "attributes": [
-              <entityIdList>                                                                      {
-                <entityId type="" isPattern="false">                                                "isDomain": "false",
-                  <id>Room2</id>                                                                    "name": "temperature",
-                </entityId>                                                                         "type": ""
-              </entityIdList>                                                                     }
-              <contextRegistrationAttributeList>                                                  ],
-                <contextRegistrationAttribute>                                                    "entities": [
-                  <name>temperature</name>                                                        {
-                  <type/>                                                                           "id": "Room2",
-                  <isDomain>false</isDomain>                                                        "isPattern": "false",
-                </contextRegistrationAttribute>                                                     "type": ""
-              </contextRegistrationAttributeList>                                                 }
-              <providingApplication>http://mysensors.com/Rooms</providingApplication>             ],
-            </contextRegistration>                                                                "providingApplication": "http://mysensors.com/Rooms"
-          </contextRegistrationResponse>                                                        }
-        </contextRegistrationResponseList>                                                    }
-      </discoverContextAvailabilityResponse>                                                  ]
-                                                                                            }
+      {
+      "contextRegistrationResponses": [
+      {
+          "contextRegistration": {
+            "attributes": [
+              {
+                "isDomain": "false",
+                "name": "temperature",
+                "type": ""
+              }
+              ],
+                "entities": [
+                {
+                  "id": "Room2",
+                  "isPattern": "false",
+		  "type": ""
+		}
+		],
+            "providingApplication": "http://mysensors.com/Rooms"
+          }
+        }
+      ]
+     }
 
 Discovery of not registered elements (e.g. Room5 or the humidity of
 Room1) will produce an error. E.g. the following requests:
 
 
-      curl localhost:1026/v1/registry/contextEntities/Room3 -s -S --header 'Content-Type: application/xml' | xmllint --format -       curl localhost:1026/v1/registry/contextEntities/Room3 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/registry/contextEntities/Room3 -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
-      curl localhost:1026/v1/registry/contextEntities/Room2/attributes/humidity -s -S --header 'Content-Type: application/xml' | xmllint --format -       curl localhost:1026/v1/registry/contextEntities/Room2/attributes/humidity -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+      curl localhost:1026/v1/registry/contextEntities/Room2/attributes/humidity -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
 will produce the following error response:
 
-      <?xml version="1.0"?>                                           {
-      <discoverContextAvailabilityResponse>                             "errorCode": {
-        <errorCode>                                                       "code": "404",
-          <code>404</code>                                                "reasonPhrase": "No context element found"
-          <reasonPhrase>No context element found</reasonPhrase>         }
-        </errorCode>                                                  }
-      </discoverContextAvailabilityResponse>                      
+      {
+	"errorCode": {
+	  "code": "404",
+	   "reasonPhrase": "No context element found"
+         }
+      }
+                     
 
 Compared to [standard discoverContextAvailability
 operation](#Discover_Context_Availability_operation "wikilink"):
 
 -   Convenience operations use the GET method without needing any
-    payload in the request (simpler than the standard operation)
--   The structure of the response XML (i.e.
-    discoverContextAvailabilityResponse) is the same in both cases.
+    payload in the request (simpler than the standard operation).
     However, there are two differences in the content. First, each
     attribute always comes in a different contextRegistrationResponse
     element (as each attribute corresponds to a different registration,
@@ -3099,135 +3050,136 @@ couple of entities of type Car using standard registerContext operations
 (given that, as described in previous section, you cannot register
 entities with types using convenience operations):
 
-      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                    {
-          <registerContextRequest>                                                                                                               "contextRegistrations": [
-            <contextRegistrationList>                                                                                                            {
-              <contextRegistration>                                                                                                                "entities": [
-                <entityIdList>                                                                                                                     {
-                  <entityId type="Car" isPattern="false">                                                                                            "type": "Car",
-                    <id>Car1</id>                                                                                                                    "isPattern": "false",
-                  </entityId>                                                                                                                        "id": "Car1"
-                </entityIdList>                                                                                                                    }
-                <contextRegistrationAttributeList>                                                                                                 ],
-                  <contextRegistrationAttribute>                                                                                                   "attributes": [
-                    <name>speed</name>                                                                                                             {
-                    <type>integer</type>                                                                                                             "name": "speed",
-                    <isDomain>false</isDomain>                                                                                                       "type": "integer",
-                  </contextRegistrationAttribute>                                                                                                    "isDomain": "false"
-                </contextRegistrationAttributeList>                                                                                                }
-                <providingApplication>http://mysensors.com/Cars</providingApplication>                                                             ],
-              </contextRegistration>                                                                                                               "providingApplication": "http://mysensors.com/Cars"
-            </contextRegistrationList>                                                                                                           }
-            <duration>P1M</duration>                                                                                                             ],
-          </registerContextRequest>                                                                                                              "duration": "P1M"
-      EOF                                                                                                                                      }
-                                                                                                                                               EOF
+      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+          "contextRegistrations": [
+          {
+               "entities": [
+               {
+                  "type": "Car",
+                  "isPattern": "false",
+                  "id": "Car1"
+               }
+               ],
+		  "attributes": [
+		  {
+		      "name": "speed",
+		      "type": "integer",
+		      "isDomain": "false"
+		  }
+		  ],
+              "providingApplication": "http://mysensors.com/Cars"
+          }
+          ],
+          "duration": "P1M"
+      }
+      EOF
 
-      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/xml' -d @- | xmllint --format - ) <<EOF       (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-      <?xml version="1.0"?>                                                                                                                    {
-          <registerContextRequest>                                                                                                               "contextRegistrations": [
-            <contextRegistrationList>                                                                                                            {
-              <contextRegistration>                                                                                                                "entities": [
-                <entityIdList>                                                                                                                     {
-                  <entityId type="Car" isPattern="false">                                                                                            "type": "Car",
-                    <id>Car2</id>                                                                                                                    "isPattern": "false",
-                  </entityId>                                                                                                                        "id": "Car2"
-                </entityIdList>                                                                                                                    }
-                <contextRegistrationAttributeList>                                                                                                 ],
-                  <contextRegistrationAttribute>                                                                                                   "attributes": [
-                    <name>fuel</name>                                                                                                              {
-                    <type>float</type>                                                                                                               "name": "fuel",
-                    <isDomain>false</isDomain>                                                                                                       "type": "float",
-                  </contextRegistrationAttribute>                                                                                                    "isDomain": "false"
-                </contextRegistrationAttributeList>                                                                                                }
-                <providingApplication>http://mysensors.com/Cars</providingApplication>                                                             ],
-              </contextRegistration>                                                                                                               "providingApplication": "http://mysensors.com/Cars"
-            </contextRegistrationList>                                                                                                           }
-            <duration>P1M</duration>                                                                                                             ],
-          </registerContextRequest>                                                                                                              "duration": "P1M"
-      EOF                                                                                                                                      }
-                                                                                                                                               EOF
+      (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+      {
+          "contextRegistrations": [
+          {
+              "entities": [
+              {
+                  "type": "Car",
+                  "isPattern": "false",
+                  "id": "Car2"
+              }
+              ],
+              "attributes": [
+              {
+                  "name": "fuel",
+                  "type": "float",
+                  "isDomain": "false"
+              }
+              ],
+              "providingApplication": "http://mysensors.com/Cars"
+           }
+           ],     
+          "duration": "P1M"
+      }
+      EOF
+                                                                                                                                         
 
 Request without specifying attributes:
 
-      curl localhost:1026/v1/registry/contextEntityTypes/Car -s -S --header 'Content-Type: application/xml' | xmllint --format -       curl localhost:1026/v1/registry/contextEntityTypes/Car -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+     curl localhost:1026/v1/registry/contextEntityTypes/Car -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
 Response:
 
-      <?xml version="1.0"?>                                                                {
-      <discoverContextAvailabilityResponse>                                                  "contextRegistrationResponses": [
-        <contextRegistrationResponseList>                                                    {
-          <contextRegistrationResponse>                                                        "contextRegistration": {
-            <contextRegistration>                                                                "attributes": [
-              <entityIdList>                                                                     {
-                <entityId type="Car" isPattern="false">                                            "isDomain": "false",
-                  <id>Car1</id>                                                                    "name": "speed",
-                </entityId>                                                                        "type": "integer"
-              </entityIdList>                                                                    }
-              <contextRegistrationAttributeList>                                                 ],
-                <contextRegistrationAttribute>                                                   "entities": [
-                  <name>speed</name>                                                             {
-                  <type>integer</type>                                                             "id": "Car1",
-                  <isDomain>false</isDomain>                                                       "isPattern": "false",
-                </contextRegistrationAttribute>                                                    "type": "Car"
-              </contextRegistrationAttributeList>                                                }
-              <providingApplication>http://mysensors.com/Cars</providingApplication>             ],
-            </contextRegistration>                                                               "providingApplication": "http://mysensors.com/Cars"
-          </contextRegistrationResponse>                                                       }
-          <contextRegistrationResponse>                                                      },
-            <contextRegistration>                                                            {
-              <entityIdList>                                                                   "contextRegistration": {
-                <entityId type="Car" isPattern="false">                                          "attributes": [
-                  <id>Car2</id>                                                                  {
-                </entityId>                                                                        "isDomain": "false",
-              </entityIdList>                                                                      "name": "fuel",
-              <contextRegistrationAttributeList>                                                   "type": "float"
-                <contextRegistrationAttribute>                                                   }
-                  <name>fuel</name>                                                              ],
-                  <type>liter</type>                                                             "entities": [
-                  <isDomain>false</isDomain>                                                     {
-                </contextRegistrationAttribute>                                                    "id": "Car2",
-              </contextRegistrationAttributeList>                                                  "isPattern": "false",
-              <providingApplication>http://mysensors.com/Cars</providingApplication>               "type": "Car"
-            </contextRegistration>                                                               }
-          </contextRegistrationResponse>                                                         ],
-        </contextRegistrationResponseList>                                                       "providingApplication": "http://mysensors.com/Cars"
-      </discoverContextAvailabilityResponse>                                                   }
-                                                                                             }
-                                                                                             ]
-                                                                                           }
+      {
+      "contextRegistrationResponses": [
+        {
+          "contextRegistration": {
+            "attributes": [
+            {
+                "isDomain": "false",
+                "name": "speed",
+                "type": "integer"
+            }
+            ],
+                "entities": [
+                {
+                  "id": "Car1",
+                  "isPattern": "false",
+		  "type": "Car"
+                }
+               ],
+           "providingApplication": "http://mysensors.com/Cars"
+       }
+      },
+      {
+          "contextRegistration": {
+            "attributes": [
+            {
+                "isDomain": "false",
+		"name": "fuel",
+                "type": "float"
+            }
+            ],
+                "entities": [
+                {
+		  "id": "Car2",
+		  "isPattern": "false",
+		  "type": "Car"
+		}
+		],
+	    "providingApplication": "http://mysensors.com/Cars"
+      }
+      }
+      ]
+      }
 
 
 Request specifying one attribute (e.g. speed):
 
-      curl localhost:1026/v1/registry/contextEntityTypes/Car/attributes/speed -s -S --header 'Content-Type: application/xml' | xmllint --format -       curl localhost:1026/v1/registry/contextEntityTypes/Car/attributes/speed -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
+     curl localhost:1026/v1/registry/contextEntityTypes/Car/attributes/speed -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' | python -mjson.tool
 
 Response:
 
-      <?xml version="1.0"?>                                                                {
-      <discoverContextAvailabilityResponse>                                                  "contextRegistrationResponses": [
-        <contextRegistrationResponseList>                                                    {
-          <contextRegistrationResponse>                                                        "contextRegistration": {
-            <contextRegistration>                                                                "attributes": [
-              <entityIdList>                                                                     {
-                <entityId type="Car" isPattern="false">                                            "isDomain": "false",
-                  <id>Car1</id>                                                                    "name": "speed",
-                </entityId>                                                                        "type": "integer"
-              </entityIdList>                                                                    }
-              <contextRegistrationAttributeList>                                                 ],
-                <contextRegistrationAttribute>                                                   "entities": [
-                  <name>speed</name>                                                             {
-                  <type>integer</type>                                                             "id": "Car1",
-                  <isDomain>false</isDomain>                                                       "isPattern": "false",
-                </contextRegistrationAttribute>                                                    "type": "Car"
-              </contextRegistrationAttributeList>                                                }
-              <providingApplication>http://mysensors.com/Cars</providingApplication>             ],
-            </contextRegistration>                                                               "providingApplication": "http://mysensors.com/Cars"
-          </contextRegistrationResponse>                                                       }
-        </contextRegistrationResponseList>                                                   }
-      </discoverContextAvailabilityResponse>                                                 ]
-                                                                                           }
+     {
+	"contextRegistrationResponses": [
+	{
+          "contextRegistration": {
+            "attributes": [
+            {
+		  "isDomain": "false",
+                  "name": "speed",
+		  "type": "integer"
+            }
+	    ],
+            "entities": [
+            {
+                  "id": "Car1",
+                  "isPattern": "false",
+		  "type": "Car"
+            }
+            ],
+	      "providingApplication": "http://mysensors.com/Cars"
+         }
+        }
+      ]
+     }
 
 Note that by default only 20 registrations are returned (which is fine
 for this tutorial, but probably not for a real utilization scenario). In


### PR DESCRIPTION
It has been removed the XML format from these files : 
-/doc/manuals/user/ append_and_delete.md duration.md structured_attribute_valued.md updating_regs_and_subs.md geolocation.md metadata.md context_providers.md filtering.md
-/doc/manuals/admin/database_model.md.

There are also other files that contains some XML formats: 
--In the files: code_contributions.md, federation.md, http_and_gsi.md, known_limitations.md, multitenancy.md, pagination.md,empty_types.md
--In the file /doc/manuals/walkthrough_apiv1.md , in :
#### Convenience Register Context
All the examples implemented.
#### Only-type entity registrations using convenience operations
It is the Funny example (/v1/registry/contextEntityTypes/Funny ).
