### PR TITLE
Add docker support based on CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ If this is your first approach with Orion Context Broker, it is highly recommend
 The recommended procedure is to install using RPM packages in CentOS 6.x. If you are interested in
 building from sources, check [this document](doc/md/admin/build_source.md).
 
+If you want to build using docker containers, please refer to [this document](docker/dev/centos/README.md) for instructions on how to build an image for building from source. This image is based on CentOS 6.
+
 ### Requirements
 
 * System resources: see [these recommendations](doc/md/admin/resources.md#resources-recommendations)

--- a/docker/dev/centos/Dockerfile
+++ b/docker/dev/centos/Dockerfile
@@ -1,0 +1,33 @@
+FROM centos:centos6
+
+MAINTAINER FIWARE Orion Context Broker Team. Telefónica I+D
+
+WORKDIR /root
+
+# Install dependencies for building
+RUN \
+	yum -y install git make cmake gcc-c++ scons libmicrohttpd-devel boost-devel libcurl-devel tar wget bzip2
+
+# Install MongoDB C++ Driver
+RUN \
+    curl -kOL https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.0.2.tar.gz && \
+    tar xfz legacy-1.0.2.tar.gz && \
+    cd mongo-cxx-driver-legacy-1.0.2 && \
+    scons install --prefix=/usr/local && \
+    cd .. && \
+    rm legacy-1.0.2.tar.gz && \
+    rm -rf mongo-cxx-driver-legacy-1.0.2
+
+# Testing tools
+RUN \
+    wget http://googlemock.googlecode.com/files/gmock-1.5.0.tar.bz2 && \
+    tar xfvj gmock-1.5.0.tar.bz2 && \
+    cd gmock-1.5.0 && \
+    ./configure && \
+    make && \
+    make install && \
+    ldconfig && \
+    cd .. && \
+    rm gmock-1.5.0.tar.bz2 && \
+    rm -rf gmock-1.5.0
+

--- a/docker/dev/centos/README.md
+++ b/docker/dev/centos/README.md
@@ -12,11 +12,11 @@ You only need to do this once.
     
 ## Run the container
 
-This assumes that there is another docker running with name $mongodb$. If you don't, type this:
+This assumes that there is another docker running with name *mongodb*. If you don't, type this:
 
     docker run -d --name mongodb mongo
 
-The following line will run the container exposing port 1026, give it a name -in this case $orionDev$-, link it to the mongodb docker, and present a bash prompt. Keep in mind that /path/to/orion/source is the path to your Orion Context Broker code in the host, not the container. 
+The following line will run the container exposing port 1026, give it a name -in this case *orionDev*-, link it to the mongodb docker, and present a bash prompt. Keep in mind that /path/to/orion/source is the path to your Orion Context Broker code in the host, not the container. 
 
     docker run -p 1026:1026 --name orionDev -v /path/to/orion/source:/root/src --link mongodb:mongodb -t -i orion-dev:centos6 /bin/bash
 

--- a/docker/dev/centos/README.md
+++ b/docker/dev/centos/README.md
@@ -1,0 +1,46 @@
+# How to use this Dockerfile
+
+This image is intended for development of Orion Context Broker. This will create an environment on which Orion can compile and be run based on CentOS 6.
+
+If you are only interested in running Orion Context Broker in a container this image is not what you are looking for. 
+
+## Build the image
+
+You only need to do this once.
+
+    docker build -t orion-dev:centos6 .
+    
+## Run the container
+
+This assumes that there is another docker running with name $mongodb$. If you don't, type this:
+
+    docker run -d --name mongodb mongo
+
+The following line will run the container exposing port 1026, give it a name -in this case $orionDev$-, link it to the mongodb docker, and present a bash prompt. Keep in mind that /path/to/orion/source is the path to your Orion Context Broker code in the host, not the container. 
+
+    docker run -p 1026:1026 --name orionDev -v ~/src/fiware-orion:/root/src --link mongodb:mongodb -t -i orion-dev:centos6 /bin/bash
+
+## Compile Orion
+
+Before you compile you must disable proxyCoap (not supported in this docker image):
+
+    sed -i '/proxyCoap/s/^/#/' /root/src/CMakeLists.txt    
+
+Now you can compile Orion Context Broker:
+
+    cd /root/src
+    make
+    make install
+
+## Run Orion
+
+To run orion you can do it interactively:
+
+    contextBroker -fg -t 0-255
+
+Or as on the background
+    
+    contextBroker -t 0-255
+
+Take a look a the [documentation](http://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/Publish/Subscribe_Broker_-_Orion_Context_Broker_-_Installation_and_Administration_Guide#Command_line_options) for all command-line options.
+

--- a/docker/dev/centos/README.md
+++ b/docker/dev/centos/README.md
@@ -12,11 +12,11 @@ You only need to do this once.
     
 ## Run the container
 
-This assumes that there is another docker running with name *mongodb*. If you don't, type this:
+This assumes that there is another docker running with name `mongodb`. If you don't, type this:
 
     docker run -d --name mongodb mongo
 
-The following line will run the container exposing port 1026, give it a name -in this case *orionDev*-, link it to the mongodb docker, and present a bash prompt. Keep in mind that /path/to/orion/source is the path to your Orion Context Broker code in the host, not the container. 
+The following line will run the container exposing port 1026, give it a name -in this case `orionDev`-, link it to the mongodb docker, and present a bash prompt. Keep in mind that /path/to/orion/source is the path to your Orion Context Broker code in the host, not the container. 
 
     docker run -p 1026:1026 --name orionDev -v /path/to/orion/source:/root/src --link mongodb:mongodb -t -i orion-dev:centos6 /bin/bash
 

--- a/docker/dev/centos/README.md
+++ b/docker/dev/centos/README.md
@@ -1,8 +1,8 @@
 # How to use this Dockerfile
 
-This image is intended for development of Orion Context Broker. This will create an environment on which Orion can compile and be run based on CentOS 6.
+This image is intended for **development** of Orion Context Broker. This will create an environment on which Orion can compile and be run based on CentOS 6.
 
-If you are only interested in running Orion Context Broker in a container this image is not what you are looking for. 
+If you are only interested in **running** Orion Context Broker in a container this image is not what you are looking for. 
 
 ## Build the image
 
@@ -16,13 +16,13 @@ This assumes that there is another docker running with name `mongodb`. If you do
 
     docker run -d --name mongodb mongo
 
-The following line will run the container exposing port 1026, give it a name -in this case `orionDev`-, link it to the mongodb docker, and present a bash prompt. Keep in mind that /path/to/orion/source is the path to your Orion Context Broker code in the host, not the container. 
+The following line will run the container exposing port 1026, give it a name -in this case `orionDev`-, link it to the mongodb docker just created, and present a bash prompt. Keep in mind that /path/to/orion/source is the path to your Orion Context Broker code in the host, not the container. 
 
     docker run -p 1026:1026 --name orionDev -v /path/to/orion/source:/root/src --link mongodb:mongodb -t -i orion-dev:centos6 /bin/bash
 
 ## Compile Orion
 
-Before you compile you must disable proxyCoap (not supported in this docker image):
+Now you are in the docker container running a shell. Before you compile you must disable proxyCoap (not supported in this docker image):
 
     sed -i '/proxyCoap/s/^/#/' /root/src/CMakeLists.txt    
 
@@ -36,11 +36,11 @@ Now you can compile Orion Context Broker:
 
 To run orion you can do it interactively:
 
-    contextBroker -fg -t 0-255
+    contextBroker -fg -t 0-255 --dbhost mongodb
 
-Or as on the background
+Or on the background
     
-    contextBroker -t 0-255
+    contextBroker -t 0-255 --dbhost mongodb
 
 Take a look a the [documentation](../.../.../doc/admin/cli.md) for all command-line options.
 

--- a/docker/dev/centos/README.md
+++ b/docker/dev/centos/README.md
@@ -18,7 +18,7 @@ This assumes that there is another docker running with name $mongodb$. If you do
 
 The following line will run the container exposing port 1026, give it a name -in this case $orionDev$-, link it to the mongodb docker, and present a bash prompt. Keep in mind that /path/to/orion/source is the path to your Orion Context Broker code in the host, not the container. 
 
-    docker run -p 1026:1026 --name orionDev -v ~/src/fiware-orion:/root/src --link mongodb:mongodb -t -i orion-dev:centos6 /bin/bash
+    docker run -p 1026:1026 --name orionDev -v /path/to/orion/source:/root/src --link mongodb:mongodb -t -i orion-dev:centos6 /bin/bash
 
 ## Compile Orion
 
@@ -42,5 +42,5 @@ Or as on the background
     
     contextBroker -t 0-255
 
-Take a look a the [documentation](http://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/Publish/Subscribe_Broker_-_Orion_Context_Broker_-_Installation_and_Administration_Guide#Command_line_options) for all command-line options.
+Take a look a the [documentation](../.../.../doc/admin/cli.md) for all command-line options.
 


### PR DESCRIPTION
**DO NOT MERGE**

This PR is waiting for https://github.com/telefonicaid/fiware-orion/pull/1057 to be merged. Then the tests can be run against this one.

This creates a docker image based on CentOS for development purposes, along with instructions on how  to use it.