### PR TITLE
3.2999999999998 => 3.3 - new python version fixes the problem

### DIFF
--- a/test/functionalTest/cases/0970_create_entity/creation_with_attribute_as_object.test
+++ b/test/functionalTest/cases/0970_create_entity/creation_with_attribute_as_object.test
@@ -90,7 +90,7 @@ Date: REGEX(.*)
 {
     "attr01": "1", 
     "attr02": 2.0, 
-    "attr03": 3.2999999999999998, 
+    "attr03": 3.3, 
     "attr04": true, 
     "attr05": false, 
     "attr06": "06", 

--- a/test/functionalTest/cases/0970_create_entity/simple_creation.test
+++ b/test/functionalTest/cases/0970_create_entity/simple_creation.test
@@ -77,7 +77,7 @@ Date: REGEX(.*)
 {
     "attr01": "1", 
     "attr02": 2.0, 
-    "attr03": 3.2999999999999998, 
+    "attr03": 3.3, 
     "attr04": true, 
     "attr05": false, 
     "id": "E1", 


### PR DESCRIPTION
I installed a newer version of python (2.7.10) and my CentOS now works just like Jenkins.