### PR TITLE
Task/no illegal char for FIWARE::StringQuery scope in payload

### DIFF
--- a/src/lib/jsonParse/jsonParse.cpp
+++ b/src/lib/jsonParse/jsonParse.cpp
@@ -109,6 +109,33 @@ static bool isCompoundPath(const char* path)
 
 /* ****************************************************************************
 *
+* isScopeValue - 
+*
+* A path is a scope value if the path ends with /scopes/scope/value
+*/
+static bool isScopeValue(const char* path)
+{
+  int          slen   = strlen(path);
+  const char*  end    = "/scopes/scope/value";
+  int          start  = slen - strlen(end);
+
+  if (start < 0)
+  {
+    return false;
+  }
+
+  if (strcmp(&path[start], end) == 0)
+  {
+    return true;
+  }
+
+  return false;
+}
+
+
+
+/* ****************************************************************************
+*
 * treat -
 */
 static bool treat
@@ -127,14 +154,18 @@ static bool treat
     //
     // Before treating a node, a check is made that the value of the node has no forbidden
     // characters.
-    // However, if the the node has attributes, then the values of the attributes are checked instead
+    // 
+    // For scopes, the check for forbiddenChars is postponed to the check() method of scope
     //
-    if (forbiddenChars(value.c_str()) == true)
+    if (!isScopeValue(path.c_str()))
     {
-      LM_W(("Bad Input (found a forbidden value in '%s')", value.c_str()));
-      ciP->httpStatusCode = SccBadRequest;
-      ciP->answer = std::string("Illegal value for JSON field");
-      return false;
+      if (forbiddenChars(value.c_str()) == true)
+      {
+        LM_W(("Bad Input (found a forbidden value in '%s')", value.c_str()));
+        ciP->httpStatusCode = SccBadRequest;
+        ciP->answer = std::string("Illegal value for JSON field");
+        return false;
+      }
     }
 
     if (path == parseVector[ix].path)

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -96,6 +96,22 @@ std::string Scope::check
   int                 counter
 )
 {
+  //
+  // Check for forbidden characters
+  //
+  if (forbiddenChars(type.c_str()))
+  {
+    return "illegal chars in scope type";
+  }
+
+  if (type != SCOPE_TYPE_SIMPLE_QUERY)
+  {
+    if (forbiddenChars(value.c_str()))
+    {
+      return "illegal chars in scope";
+    }
+  }
+
   if (type == FIWARE_LOCATION || type == FIWARE_LOCATION_DEPRECATED)
   {
     if (areaType == orion::CircleType)
@@ -189,15 +205,8 @@ std::string Scope::check
       }
     }
   }
-  else if (type != SCOPE_TYPE_SIMPLE_QUERY)
-  {
-    if (forbiddenChars(value.c_str()))
-    {
-      return "illegal chars in scope";
-    }
-  }
 
-  if ((type != FIWARE_LOCATION) && (type == FIWARE_LOCATION_DEPRECATED))
+  if ((type != FIWARE_LOCATION) && (type != FIWARE_LOCATION_DEPRECATED))
   {
     if (type == "")
     {

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -31,6 +31,7 @@
 #include "common/tag.h"
 #include "ngsi/Scope.h"
 #include "common/Format.h"
+#include "parse/forbiddenChars.h"
 
 
 
@@ -188,7 +189,15 @@ std::string Scope::check
       }
     }
   }
-  else
+  else if (type != SCOPE_TYPE_SIMPLE_QUERY)
+  {
+    if (forbiddenChars(value.c_str()))
+    {
+      return "illegal chars in scope";
+    }
+  }
+
+  if ((type != FIWARE_LOCATION) && (type == FIWARE_LOCATION_DEPRECATED))
   {
     if (type == "")
     {

--- a/src/lib/xmlParse/xmlParse.cpp
+++ b/src/lib/xmlParse/xmlParse.cpp
@@ -118,12 +118,21 @@ static bool treat(ConnectionInfo* ciP, xml_node<>* node, const std::string& path
       //
       if (node->first_attribute() == NULL)
       {
-        if (forbiddenChars(node->value()) == true)
+        //
+        // If we're in a Scope, no forbiddenChars check made.
+        // We still don't know the type of the Scope, so the forbiddenChars check
+        // will have to be postponed until we know both the type and the value.
+        // For example, the 'check' method can take care of trhis
+        //
+        if (strcasecmp(node->name(), "scopeValue") == 0)
         {
-          LM_E(("Found a forbidden value in '%s'", node->value()));
-          ciP->httpStatusCode = SccBadRequest;
-          ciP->answer = std::string("Illegal value for XML attribute");
-          return true;
+          if (forbiddenChars(node->value()) == true)
+          {
+            LM_E(("Found a forbidden value in '%s'", node->value()));
+            ciP->httpStatusCode = SccBadRequest;
+            ciP->answer = std::string("Illegal value for XML attribute");
+            return true;
+          }
         }
       }
       else

--- a/src/lib/xmlParse/xmlParse.cpp
+++ b/src/lib/xmlParse/xmlParse.cpp
@@ -122,9 +122,9 @@ static bool treat(ConnectionInfo* ciP, xml_node<>* node, const std::string& path
         // If we're in a Scope, no forbiddenChars check made.
         // We still don't know the type of the Scope, so the forbiddenChars check
         // will have to be postponed until we know both the type and the value.
-        // For example, the 'check' method can take care of trhis
+        // For example, the 'check' method can take care of this
         //
-        if (strcasecmp(node->name(), "scopeValue") == 0)
+        if (strcasecmp(node->name(), "scopeValue") != 0)
         {
           if (forbiddenChars(node->value()) == true)
           {

--- a/test/functionalTest/cases/0619_forbidden_characters_in_payload/input.test
+++ b/test/functionalTest/cases/0619_forbidden_characters_in_payload/input.test
@@ -700,14 +700,14 @@ Date: REGEX(.*)
 15. JSON: Intent to query an entity with  ';' as part of a scopeType
 ====================================================================
 HTTP/1.1 200 OK
-Content-Length: 129
+Content-Length: 128
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "errorCode": {
         "code": "400", 
-        "details": "Illegal value for JSON field", 
+        "details": "illegal chars in scope type", 
         "reasonPhrase": "Bad Request"
     }
 }

--- a/test/functionalTest/cases/0864_filter_string_scope/filter_string_scope.test
+++ b/test/functionalTest/cases/0864_filter_string_scope/filter_string_scope.test
@@ -118,7 +118,7 @@ payload='{
   "restriction": {
       "scopes": [
           {
-              "type": "FIWARE::StringFilter",
+              "type": "FIWARE::StringQuery",
               "value": "temperature<60;humidity==83..61;status==ERR"
           }
       ]
@@ -178,24 +178,16 @@ Date: REGEX(.*)
 06. v1 Query: temperature<60;humidity==83..61;status==ERR -> E2
 ===============================================================
 HTTP/1.1 200 OK
-Content-Length: 129
+Content-Length: 94
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-   <Needs to be adjusted before merging this into develop. A solution
-    is on the way, based on doing an exception for the illegal characters
-    checking in the following cases:
-    * q= parameters
-    * "value" of an "scope" if the scope falue is SCOPE_TYPE_SIMPLE_QUERY
-    >
     "errorCode": {
-        "code": "400",
-        "details": "Illegal value for JSON field",
-        "reasonPhrase": "Bad Request"
+        "code": "404",
+        "reasonPhrase": "No context element found"
     }
 }
-
 
 
 --TEARDOWN--


### PR DESCRIPTION
Not checking for illegal characters in payload inside 'scope-values' if their scope-type is FIWARE::StringQuery