### PR TITLE
No forbiddenChars check for URI param idPattern

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -28,3 +28,4 @@ Add:  PUT /v2/entities/<entityId>/attrs/<attrName> (Issue #991)
 Add:  GET /v2/types/<type> (Issue #1028)
 Add:  APPEND_STRICT action type for POST /v1/updateContext operation
 Add:  REPLACE action type for POST /v1/updateContext operation
+Fix:  Removed the check of forbidden characters for the values of the URI parameter 'idPattern'

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -195,9 +195,9 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
 
   //
   // Now check the URI param has no invalid characters
-  // Except for the URI param 'q' that is not to be checked for invalid characters
+  // Except for the URI params 'q' and 'idPattern' that are not to be checked for invalid characters
   //
-  if (key != "q")
+  if ((key != "q") && (key != "idPattern"))
   {
     if (forbiddenChars(ckey) || forbiddenChars(val))
     {


### PR DESCRIPTION
Removed the check of forbidden characters for the value of the URI param **idPattern**