### PR TITLE
Feature/1169 uri param options map

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -30,3 +30,4 @@ Add:  APPEND_STRICT action type for POST /v1/updateContext operation
 Add:  REPLACE action type for POST /v1/updateContext operation
 Fix:  Removed the check of forbidden characters for the values of the URI parameter 'idPattern'
 Add:  GET /v2/types (Issue #1027)
+Fix:  Made broker respond with 400 Bad Request on encountering invalid items in URI parameter 'options' (Issue #1169)

--- a/src/lib/rest/CMakeLists.txt
+++ b/src/lib/rest/CMakeLists.txt
@@ -29,6 +29,7 @@ SET (SOURCES
     orionReply.cpp
     OrionError.cpp
     HttpStatusCode.cpp
+    ConnectionInfo.cpp
 )
 
 SET (HEADERS

--- a/src/lib/rest/ConnectionInfo.cpp
+++ b/src/lib/rest/ConnectionInfo.cpp
@@ -1,0 +1,91 @@
+/*
+*
+* Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Ken Zangelin
+*/
+#include <string>
+#include <map>
+
+#include "common/string.h"
+#include "rest/ConnectionInfo.h"
+
+
+
+/* ****************************************************************************
+*
+* validOptions - 
+*/
+static const char* validOptions[] = 
+{
+  "count",
+  "normalized",
+  "values",
+  "text"
+};
+
+
+
+/* ****************************************************************************
+*
+* isValidOption - 
+*/
+static bool isValidOption(std::string item)
+{
+  for (unsigned int ix = 0; ix < sizeof(validOptions) / sizeof(validOptions[0]); ++ix)
+  {
+    if (item == validOptions[ix])
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
+
+/* ****************************************************************************
+*
+* uriParamOptionsParse - 
+*
+* FIXME P5: We could maintain a vector of 'allowed' option valuess and if a call is made with 
+*           any other value we could return an error.
+*           It would be fairly easy and it would make life easier for our users ...
+*/
+int uriParamOptionsParse(ConnectionInfo* ciP, const char* value)
+{
+  std::vector<std::string> vec;
+
+  stringSplit(value, ',', vec);
+
+  for (unsigned int ix = 0; ix < vec.size(); ++ix)
+  {
+    if (!isValidOption(vec[ix]))
+    {
+      return -1;
+    }
+
+    ciP->uriParamOptions[vec[ix]] = true;
+  }
+
+  return 0;
+}

--- a/src/lib/rest/ConnectionInfo.cpp
+++ b/src/lib/rest/ConnectionInfo.cpp
@@ -65,11 +65,11 @@ static bool isValidOption(std::string item)
 
 /* ****************************************************************************
 *
-* uriParamOptionsParse - 
+* uriParamOptionsParse - parse the URI param 'options' into uriParamOptions map
 *
-* FIXME P5: We could maintain a vector of 'allowed' option valuess and if a call is made with 
-*           any other value we could return an error.
-*           It would be fairly easy and it would make life easier for our users ...
+* RETURN VALUE
+*  0  on success
+* <0  on error
 */
 int uriParamOptionsParse(ConnectionInfo* ciP, const char* value)
 {

--- a/src/lib/rest/ConnectionInfo.h
+++ b/src/lib/rest/ConnectionInfo.h
@@ -152,6 +152,7 @@ public:
   std::string                apiVersion;
 
   std::map<std::string, std::string>   uriParam;
+  std::map<std::string, bool>          uriParamOptions;
 
   bool                       inCompoundValue;
   orion::CompoundValueNode*  compoundValueP;    // Points to current node in the tree
@@ -163,5 +164,13 @@ public:
   std::vector<std::string>  httpHeader;
   std::vector<std::string>  httpHeaderValue;
 };
+
+
+
+/* ****************************************************************************
+*
+* uriParamOptionsParse - 
+*/
+extern int uriParamOptionsParse(ConnectionInfo* ciP, const char* value);
 
 #endif

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -183,6 +183,18 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
     // If URI_PARAM_ATTRIBUTE_FORMAT used, set URI_PARAM_ATTRIBUTES_FORMAT as well
     ciP->uriParam[URI_PARAM_ATTRIBUTES_FORMAT] = value;
   }
+  else if (key == URI_PARAM_OPTIONS)
+  {
+    ciP->uriParam[URI_PARAM_OPTIONS] = value;
+
+    if (uriParamOptionsParse(ciP, val) != 0)
+    {
+      OrionError error(SccBadRequest, "Invalid value for URI param /options/");
+
+      ciP->httpStatusCode = SccBadRequest;
+      ciP->answer         = error.render(ciP, "");
+    }
+  }
   else
     LM_T(LmtUriParams, ("Received unrecognized URI parameter: '%s'", key.c_str()));
 

--- a/src/lib/rest/uriParamNames.h
+++ b/src/lib/rest/uriParamNames.h
@@ -43,6 +43,7 @@
 #define URI_PARAM_EXIST                   "exist"
 #define URI_PARAM_ATTRIBUTES_FORMAT       "attributesFormat"
 #define URI_PARAM_ATTRIBUTE_FORMAT        "attributeFormat"
+#define URI_PARAM_OPTIONS                 "options"
 
 
 

--- a/test/functionalTest/cases/1169_uri_param_options_map/uri_param_options_map.test
+++ b/test/functionalTest/cases/1169_uri_param_options_map/uri_param_options_map.test
@@ -75,7 +75,7 @@ echo
 
 echo "06. Error: Test an arbitrary API v2 path"
 echo "========================================"
-orionCurl --url /v2/type?options=BAD --json
+orionCurl --url /v2/types?options=BAD --json
 echo
 echo
 

--- a/test/functionalTest/cases/1169_uri_param_options_map/uri_param_options_map.test
+++ b/test/functionalTest/cases/1169_uri_param_options_map/uri_param_options_map.test
@@ -30,148 +30,77 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. OK: Send a /version request with one valid option (count)
-# 02. OK: Send a /version request with two valid options (count + normalized)
-# 03. Error: Send a /version request with one invalid option (canonical)
-# 04. OK: Send a /version request with ALL valid options (count, normalized, values & text)
-# 05. Error: Send a /version request with ALL valid options and ONE invalid
+# 01. OK: Send a request with one valid option (count)
+# 02. OK: Send a request with two valid options (count + normalized)
+# 03. Error: Send a request with one invalid option (canonical)
+# 04. OK: Send a request with ALL valid options (count, normalized, values & text)
+# 05. Error: Send a request with ALL valid options and ONE invalid
 # 06. Error: Test an arbitrary API v2 path
 #
 
-echo "01. OK: Send a /version request with one valid option (count)"
+echo "01. OK: Send a request with one valid option (count)"
+echo "===================================================="
+orionCurl --url /v2/entities?options=count --json --payload '{ "id": "ID", "type": "type" }'
+echo
+echo
+
+
+echo "02. OK: Send a request with two valid options (count + normalized)"
+echo "=================================================================="
+orionCurl --url /v2/entities?options=count,normalized --json --payload '{ "id": "ID2", "type": "type" }'
+echo
+echo
+
+
+echo "03. Error: Send a request with one invalid option (canonical)"
 echo "============================================================="
-orionCurl --url /version?options=count --json
+orionCurl --url /v2/entities?options=canonical --json --payload '{ "id": "ID3", "type": "type" }'
 echo
 echo
 
 
-echo "02. OK: Send a /version request with two valid options (count + normalized)"
-echo "==========================================================================="
-orionCurl --url /version?options=count,normalized --json
+echo "04. OK: Send a request with ALL valid options (count, normalized, values & text)"
+echo "================================================================================"
+orionCurl --url '/v2/entities?options=count,normalized,values,text' --json --payload '{ "id": "ID4", "type": "type" }'
 echo
 echo
 
 
-echo "03. Error: Send a /version request with one invalid option (canonical)"
-echo "======================================================================"
-orionCurl --url /version?options=canonical --json
+echo "05. Error: Send a request with ALL valid options and ONE invalid"
+echo "================================================================"
+orionCurl --url '/v2/entities?options=count,normalized,values,text,BAD' --json --payload '{ "id": "ID5", "type": "type" }'
 echo
 echo
 
 
-echo "04. OK: Send a /version request with ALL valid options (count, normalized, values & text)"
-echo "========================================================================================="
-orionCurl --url /version?options=count,normalized,values,text --json
-echo
-echo
-
-
-echo "05. Error: Send a /version request with ALL valid options and ONE invalid"
-echo "========================================================================="
-orionCurl --url /version?options=count,normalized,values,text,BAD --json
-echo
-echo
-
-
-echo "06. Error: Test an arbitrary API v2 path"
+echo "06. Error: Test an arbitrary API v1 path"
 echo "========================================"
-orionCurl --url /v2/types?options=BAD --json
+orionCurl --url /ngsi10/updateContextSubscription?options=BAD --json --payload '{ "subscriptionId": "000000000000000000000000" }'
 echo
 echo
 
 
 --REGEXPECT--
-01. OK: Send a /version request with one valid option (count)
+01. OK: Send a request with one valid option (count)
+====================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/ID
+Date: REGEX(.*)
+
+
+
+02. OK: Send a request with two valid options (count + normalized)
+==================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/ID2
+Date: REGEX(.*)
+
+
+
+03. Error: Send a request with one invalid option (canonical)
 =============================================================
-HTTP/1.1 200 OK
-Content-Length: REGEX(\d+)
-Content-Type: application/json
-Date: REGEX(.*)
-
-{
-    "orion": {
-        "compile_time": "REGEX(.*)",
-        "compiled_by": "REGEX(.*)",
-        "compiled_in": "REGEX(.*)",
-        "git_hash": "REGEX(([0-9a-f]{40}|nogitversion))",
-        "uptime": "REGEX(.*)",
-        "version": "REGEX(.*)"
-    }
-}
-
-
-02. OK: Send a /version request with two valid options (count + normalized)
-===========================================================================
-HTTP/1.1 200 OK
-Content-Length: REGEX(\d+)
-Content-Type: application/json
-Date: REGEX(.*)
-
-{
-    "orion": {
-        "compile_time": "REGEX(.*)",
-        "compiled_by": "REGEX(.*)",
-        "compiled_in": "REGEX(.*)",
-        "git_hash": "REGEX(([0-9a-f]{40}|nogitversion))",
-        "uptime": "REGEX(.*)",
-        "version": "REGEX(.*)"
-    }
-}
-
-
-03. Error: Send a /version request with one invalid option (canonical)
-======================================================================
-HTTP/1.1 400 Bad Request
-Content-Length: 139
-Content-Type: application/json
-Date: REGEX(.*)
-
-{
-    "orionError": {
-        "code": "400",
-        "details": "Invalid value for URI param /options/",
-        "reasonPhrase": "Bad Request"
-    }
-}
-
-
-04. OK: Send a /version request with ALL valid options (count, normalized, values & text)
-=========================================================================================
-HTTP/1.1 200 OK
-Content-Length: REGEX(\d+)
-Content-Type: application/json
-Date: REGEX(.*)
-
-{
-    "orion": {
-        "compile_time": "REGEX(.*)",
-        "compiled_by": "REGEX(.*)",
-        "compiled_in": "REGEX(.*)",
-        "git_hash": "REGEX(([0-9a-f]{40}|nogitversion))",
-        "uptime": "REGEX(.*)",
-        "version": "REGEX(.*)"
-    }
-}
-
-
-05. Error: Send a /version request with ALL valid options and ONE invalid
-=========================================================================
-HTTP/1.1 400 Bad Request
-Content-Length: 139
-Content-Type: application/json
-Date: REGEX(.*)
-
-{
-    "orionError": {
-        "code": "400",
-        "details": "Invalid value for URI param /options/",
-        "reasonPhrase": "Bad Request"
-    }
-}
-
-
-06. Error: Test an arbitrary API v2 path
-========================================
 HTTP/1.1 400 Bad Request
 Content-Length: 76
 Content-Type: application/json
@@ -180,6 +109,44 @@ Date: REGEX(.*)
 {
     "description": "Invalid value for URI param /options/",
     "error": "BadRequest"
+}
+
+
+04. OK: Send a request with ALL valid options (count, normalized, values & text)
+================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/ID4
+Date: REGEX(.*)
+
+
+
+05. Error: Send a request with ALL valid options and ONE invalid
+================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 76
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "Invalid value for URI param /options/",
+    "error": "BadRequest"
+}
+
+
+06. Error: Test an arbitrary API v1 path
+========================================
+HTTP/1.1 400 Bad Request
+Content-Length: 139
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "orionError": {
+        "code": "400",
+        "details": "Invalid value for URI param /options/",
+        "reasonPhrase": "Bad Request"
+    }
 }
 
 

--- a/test/functionalTest/cases/1169_uri_param_options_map/uri_param_options_map.test
+++ b/test/functionalTest/cases/1169_uri_param_options_map/uri_param_options_map.test
@@ -1,0 +1,188 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+URI Param OPTIONS
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. OK: Send a /version request with one valid option (count)
+# 02. OK: Send a /version request with two valid options (count + normalized)
+# 03. Error: Send a /version request with one invalid option (canonical)
+# 04. OK: Send a /version request with ALL valid options (count, normalized, values & text)
+# 05. Error: Send a /version request with ALL valid options and ONE invalid
+# 06. Error: Test an arbitrary API v2 path
+#
+
+echo "01. OK: Send a /version request with one valid option (count)"
+echo "============================================================="
+orionCurl --url /version?options=count --json
+echo
+echo
+
+
+echo "02. OK: Send a /version request with two valid options (count + normalized)"
+echo "==========================================================================="
+orionCurl --url /version?options=count,normalized --json
+echo
+echo
+
+
+echo "03. Error: Send a /version request with one invalid option (canonical)"
+echo "======================================================================"
+orionCurl --url /version?options=canonical --json
+echo
+echo
+
+
+echo "04. OK: Send a /version request with ALL valid options (count, normalized, values & text)"
+echo "========================================================================================="
+orionCurl --url /version?options=count,normalized,values,text --json
+echo
+echo
+
+
+echo "05. Error: Send a /version request with ALL valid options and ONE invalid"
+echo "========================================================================="
+orionCurl --url /version?options=count,normalized,values,text,BAD --json
+echo
+echo
+
+
+echo "06. Error: Test an arbitrary API v2 path"
+echo "========================================"
+orionCurl --url /v2/type?options=BAD --json
+echo
+echo
+
+
+--REGEXPECT--
+01. OK: Send a /version request with one valid option (count)
+=============================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "orion": {
+        "compile_time": "REGEX(.*)",
+        "compiled_by": "REGEX(.*)",
+        "compiled_in": "REGEX(.*)",
+        "git_hash": "REGEX(([0-9a-f]{40}|nogitversion))",
+        "uptime": "REGEX(.*)",
+        "version": "REGEX(.*)"
+    }
+}
+
+
+02. OK: Send a /version request with two valid options (count + normalized)
+===========================================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "orion": {
+        "compile_time": "REGEX(.*)",
+        "compiled_by": "REGEX(.*)",
+        "compiled_in": "REGEX(.*)",
+        "git_hash": "REGEX(([0-9a-f]{40}|nogitversion))",
+        "uptime": "REGEX(.*)",
+        "version": "REGEX(.*)"
+    }
+}
+
+
+03. Error: Send a /version request with one invalid option (canonical)
+======================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 139
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "orionError": {
+        "code": "400",
+        "details": "Invalid value for URI param /options/",
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+04. OK: Send a /version request with ALL valid options (count, normalized, values & text)
+=========================================================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "orion": {
+        "compile_time": "REGEX(.*)",
+        "compiled_by": "REGEX(.*)",
+        "compiled_in": "REGEX(.*)",
+        "git_hash": "REGEX(([0-9a-f]{40}|nogitversion))",
+        "uptime": "REGEX(.*)",
+        "version": "REGEX(.*)"
+    }
+}
+
+
+05. Error: Send a /version request with ALL valid options and ONE invalid
+=========================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 139
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "orionError": {
+        "code": "400",
+        "details": "Invalid value for URI param /options/",
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+06. Error: Test an arbitrary API v2 path
+========================================
+HTTP/1.1 400 Bad Request
+Content-Length: 76
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "Invalid value for URI param /options/",
+    "error": "BadRequest"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
The broker now detects invalid items in URI parameter 'options' and returns **400 Bad Request** if necessary.
Also (implementation), all the items in URI parameter 'options' are saved in a map <string, bool> and can be looked up in ConnectionInfo::uriParamOptions:

    if (ciP->uriParamOptions["text"] == true)
    {
        ...
    }