### PR TITLE
FIX docker compose scripts resersing mongo/orion startup order 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,12 +13,13 @@ WORKDIR /opt
 
 RUN \
     # Install dependencies
+    yum -y install epel-release && \
     yum -y install \
       boost-devel \
       bzip2 \
       cmake \
       clang \
-      CUnit-devel && \
+      CUnit-devel \
       epel-release \
       libcurl-devel \
       libmicrohttpd-devel \
@@ -28,7 +29,7 @@ RUN \
       gcc-c++ \
       scons \
       tar \
-      which \
+      which && \
     # Install mongodb driver from source
     curl -kOL https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.0.2.tar.gz && \
     tar xfz legacy-1.0.2.tar.gz && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,7 +21,11 @@ You are using this [docker-compose.yml](docker-compose.yml) file. This will inst
 
 ### Run a container pulling an image from the cloud (recommended)
 
-If you do not have or want to download the Orion repository, you can create a file called `docker-compose.yml` in a directory of your choice and fill it with the following content
+If you do not have or want to download the Orion repository, you can create a file called `docker-compose.yml` in a directory of your choice and fill it with the following content (uncomment the `--smallfiles` line if you host doesn't have too much free space)
+
+	mongo:
+	  image: mongo:2.6
+      #command: --smallfiles
 
 	orion:
 	  image: fiware/orion
@@ -30,9 +34,6 @@ If you do not have or want to download the Orion repository, you can create a fi
 	  ports:
 	    - "1026:1026"
 	  command: -dbhost mongo
-
-	mongo:
-	  image: mongo:2.6
 
 Then run
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,12 @@
+# Note that mongo container is started before Orion, as Orion needs it
+# as dependency and reserve the order has been found problematic in some
+# low resource hosts
+
+# Uncomment the --smallfiles line if you host doesn't have too much free space
+mongo:
+  image: mongo:2.6
+  #command: --smallfiles
+
 orion:
   build: .
   links:
@@ -6,5 +15,4 @@ orion:
     - "1026:1026"
   command: -dbhost mongo
 
-mongo:
-  image: mongo:2.6
+


### PR DESCRIPTION
And adding the --smallfiles option (as comment)