### PR TITLE
FIX tenant in wrong places in subscription cache code

### DIFF
--- a/src/lib/cache/Subscription.cpp
+++ b/src/lib/cache/Subscription.cpp
@@ -269,7 +269,7 @@ bool Subscription::match
   const std::string&  attributeName
 )
 {
-  if (composeDatabaseName(_tenant) != composeDatabaseName(tenant))
+  if (_tenant != tenant)
   {
     return false;
   }

--- a/src/lib/cache/SubscriptionCache.cpp
+++ b/src/lib/cache/SubscriptionCache.cpp
@@ -80,7 +80,7 @@ void subCacheMutexWaitingTimeGet(char* buf, int bufLen)
 */
 SubscriptionCache::SubscriptionCache()
 {
-  tenant = "";
+  dbPrefix = "";
 }
 
 
@@ -89,9 +89,9 @@ SubscriptionCache::SubscriptionCache()
 *
 * SubscriptionCache::SubscriptionCache - 
 */
-SubscriptionCache::SubscriptionCache(std::string _tenant)
+SubscriptionCache::SubscriptionCache(std::string _dbPrefix)
 {
-  tenant = _tenant;
+  dbPrefix = _dbPrefix;
 }
 
 
@@ -246,18 +246,18 @@ void SubscriptionCache::init(void)
 */
 void SubscriptionCache::fillFromDb(void)
 {
-  std::vector<std::string> tenantV;
+  std::vector<std::string> databases;
 
-  getOrionDatabases(tenantV);
+  getOrionDatabases(databases);
 
   //
   // Add the 'default tenant'
   //
-  tenantV.push_back(tenant);
+  databases.push_back(dbPrefix);
 
-  for (unsigned int ix = 0; ix < tenantV.size(); ++ix)
+  for (unsigned int ix = 0; ix < databases.size(); ++ix)
   {
-    subscriptionsTreat(tenantV[ix], subToCache);
+    subscriptionsTreat(databases[ix], subToCache);
   }
 }
 

--- a/src/lib/cache/SubscriptionCache.h
+++ b/src/lib/cache/SubscriptionCache.h
@@ -70,13 +70,13 @@ class SubscriptionCache
 {
 private:
   std::vector<Subscription*>  subs;
-  std::string                 tenant;
+  std::string                 dbPrefix;
   sem_t                       mutex;
   pthread_t                   mutexOwner;
 
 public:
   SubscriptionCache();
-  SubscriptionCache(std::string _tenant);
+  SubscriptionCache(std::string _dbPrefix);
 
   void           init(void);
   void           fillFromDb(void);

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -295,6 +295,34 @@ extern void getOrionDatabases(std::vector<std::string>& dbs)
   }
 }
 
+/*****************************************************************************
+*
+* tenantFromDb -
+*
+* Given a database name as an argument (e.g. orion-myservice1) it returns the
+* corresponding tenant name as result (myservice1) or "" if the string doesn't
+* start with the database prefix
+*/
+std::string tenantFromDb(std::string& database)
+{
+  std::string r;
+  std::string prefix  = dbPrefix + "-";
+  if (strncmp(prefix.c_str(), database.c_str(), strlen(prefix.c_str())) == 0)
+  {
+    char tenant[MAX_SERVICE_NAME_LEN];
+    strcpy(tenant, prefix.c_str() + strlen(prefix.c_str()));
+    r = std::string(tenant);
+  }
+  else
+  {
+    r = "";
+  }
+
+  LM_T(LmtMongo, ("DB -> tenant: <%s> -> <%s>", database.c_str(), r.c_str()));
+  return r;
+
+}
+
 
 /*****************************************************************************
 *
@@ -2832,12 +2860,13 @@ std::string dbDotDecode(std::string s)
 *
 * Lookup all subscriptions in the database and call a treat function for each
 */
-void subscriptionsTreat(std::string tenant, MongoTreatFunction treatFunction)
+void subscriptionsTreat(std::string database, MongoTreatFunction treatFunction)
 {
   BSONObj                   query;
   DBClientBase*             connection = getMongoConnection();
   auto_ptr<DBClientCursor>  cursor;
 
+  std::string tenant = tenantFromDb(database);
   try
   {
     cursor = connection->query(getSubscribeContextCollectionName(tenant).c_str(), query);

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -228,6 +228,12 @@ extern void getOrionDatabases(std::vector<std::string>& dbs);
 
 /*****************************************************************************
 *
+* tenantFromDb -
+*/
+extern std::string tenantFromDb(std::string& database);
+
+/*****************************************************************************
+*
 * setEntitiesCollectionName -
 */
 extern void setEntitiesCollectionName(std::string name);


### PR DESCRIPTION
Fixes #1186 

Note that no entry is included in CNR file, as this bug was introduced by the cache subscription feature and it is not a bug in previous Orion version.