### PR TITLE
FIX CB crashes when DB stops due to cache refresh

### DIFF
--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -223,8 +223,11 @@ extern void setDbPrefix(std::string dbPrefix);
 * Note that the DB belonging to the default service is not included in the
 * returned list
 *
+* Function return value is false in the case of problems accessing database,
+* true otherwise.
+*
 */
-extern void getOrionDatabases(std::vector<std::string>& dbs);
+extern bool getOrionDatabases(std::vector<std::string>& dbs);
 
 /*****************************************************************************
 *


### PR DESCRIPTION
Fixes #1210.

CNR entry not needed, as the fix is on functionality developed in the current version (subscriptions cache).

Manually tested.