### PR TITLE
REFACTOR README.md sections into admin manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,20 @@
 #<a name="top"></a>Orion Context Broker
 
 * [Introduction](#introduction)
-    * [GEi overall description](#gei-overall-description)
-    * [Build and Install](#build-and-install)
-	  * [Requirements](#requirements)
-	  * [Installation](#installation)
-		* [Using yum (recommended)](#using-yum-(recommended))
-		* [Using RPM file](#using-rpm-file)
-		* [Optional packages](#optional-packages)
-	  * [Upgrading from a previous version](#upgrading-from-a-previous-version)
-		* [Upgrading MongoDB version](#upgrading-mongodb-version)
-		* [Migrating the data stored in DB](#migrating-the-data-stored-in-db)
-		* [Standard upgrade](#standard-upgrade)
-    * [Running](#running)
-	  * [Configuration file](#configuration-file)
-	  * [Checking status](#checking-status)
-    * [API Overview](#api-overview)
-    * [API Walkthrough](#api-walkthrough)
-    * [API Reference Documentation](#api-reference-documentation)
-    * [Testing](#testing)
-	  * [Ent-to-end tests](#ent-to-end-tests)
-	  * [Unit Tests](#unit-tests)
-    * [Advanced topics](#advanced-topics)
-    * [License](#license)
-    * [Support](#support)
-	  
+* [GEi overall description](#gei-overall-description)
+* [Build and Install](#build-and-install)
+* [Running](#running)
+* [API Overview](#api-overview)
+* [API Walkthrough](#api-walkthrough)
+* [API Reference Documentation](#api-reference-documentation)
+* [Testing](#testing)
+    * [Ent-to-end tests](#ent-to-end-tests)
+    * [Unit Tests](#unit-tests)
+* [Advanced topics](#advanced-topics)
+* [License](#license)
+* [Support](#support)
 		  
-# Introduction
+## Introduction
 
 This is the code repository for the Orion Context Broker, the reference implementation of the Publish/Subscribe Context Broker GE.
 
@@ -56,209 +44,13 @@ If this is your first contact with the Orion Context Broker, it is highly recomm
 
 ## Build and Install
 
-The recommended procedure is to install using RPM packages in CentOS 6.x. If you are interested in
-building from sources, check [this document](doc/manuals/admin/build_source.md).
-
-### Requirements
-
-* System resources: see [these recommendations](doc/manuals/admin/resources.md#resources-recommendations)
-* Operating system: CentOS/RedHat. The reference operating system is CentOS 6.3  
-but it should work also in any later CentOS/RedHat 6.x version.
-* Database: MongoDB is required to run either in the same host where Orion Context Broker is to be installed or in a different host accessible through the network. The recommended MongoDB version is 2.6.9 (although it should work with later MongoDB 2.6.x and 3.0.x versions). It is not recommended using MongoDB 2.4.x., as some [geolocated queries](doc/manuals/user/geolocation.md) may not work.
-    * Note that the officially supported MongoDB version is 2.6. In the case of using MongoDB 3.0 with its new authentication mechanism
-      (SCRAM_SHA1) you may need to compile from sources using special switches for the MongoDB driver. See [this issue](https://github.com/telefonicaid/fiware-orion/issues/1061) for details.
-* RPM dependencies (some of these packages could not be in the official CentOS/RedHat repository but in EPEL, in which case you have to configure EPEL repositories, see <http://fedoraproject.org/wiki/EPEL>):
-    * The contextBroker package (mandatory) depends on the following packages: boost-filesystem, boost-thread, libmicrohttpd, logrotate, libcurl and boost-regex.
-    * The contextBroker-test package (optional) depends on the following packages: python, python-flask, python-jinja2, curl, libxml2, libxslt, nc, mongo-10gen and contextBroker. The mongo-10gen dependency needs to configure MongoDB repository, check [this piece of documentation about that](http://docs.mongodb.org/manual/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux/).
-
-[Top](#top)
-
-### Installation
-
-#### Using yum (recommended)
-
-Configure the FIWARE yum repository ([as described in this post](http://stackoverflow.com/questions/24331330/how-to-configure-system-to-use-the-fi-ware-yum-repository/24510985#24510985)). Then you can install doing (as root):
-
-    yum install contextBroker
-
-Sometimes the above commands fails due to yum cache. In that case, run
-`yum clean all` and try again.
-
-#### Using RPM file
-
-Download the package from the [FIWARE Files area](https://forge.fiware.org/frs/?group_id=7). Look for the "DATA-OrionContextBroker" entry.
-
-Next, install the package using the rpm command (as root):
-
-    rpm -i contextBroker-X.Y.Z-1.x86_64.rpm
-
-#### Optional packages
-
-Apart from the mandatory RPM described above, you can install the contextBroker-test package, which contain utility tools:
-
-    yum install contextBroker-test
-
-or
-
-    rpm -i contextBroker-test-X.Y.Z-1.x86_64.rpm
-
-[Top](#top)
-
-### Upgrading from a previous version
-
-Upgrade procedure depends on whether the *upgrade path* (i.e. from the installed Orion version to the target one to upgrade) crosses a version number that requires:
-
-* Upgrading MongoDB version
-* Migrating the data stored in DB (due to a change in the DB data model).
-
-#### Upgrading MongoDB version
-
-You only need to pay attention to this if your upgrade path crosses 0.11.0 or 0.22.0. Otherwise, you can skip this section.
-
-* Orion versions previous to 0.11.0 recommend MongoDB 2.2
-* Orion version from 0.11.0 to 0.20.0 recommend MongoDB 2.4. Check [the 2.4 upgrade procedure in the oficial MongoDB documentation.](http://docs.mongodb.org/master/release-notes/2.4-upgrade/)
-* Orion version from 0.21.0 on recommend MongoDB 2.6 o 3.0. check [the 2.6 upgrade procedure](http://docs.mongodb.org/master/release-notes/2.6-upgrade/) or
-[the 3.0 upgrade procedure](http://docs.mongodb.org/master/release-notes/3.0-upgrade/) in the oficial MongoDB documentation.  
-
-#### Migrating the data stored in DB
-
-You only need to pay attention to this if your upgrade path crosses 0.14.1, 0.19.0 or 0.21.0. Otherwise, you can skip this section. You can also skip this section if your DB are not valuable (e.g. debug/testing environments) and you can flush your DB before upgrading.
-
-* [Upgrading to 0.14.1 and beyond from a pre-0.14.1 version](doc/manuals/admin/upgrading_crossing_0-14-1.md)
-* [Upgrading to 0.19.0 and beyond from a pre-0.19.0 version](doc/manuals/admin/upgrading_crossing_0-19-0.md)
-* [Upgrading to 0.21.0 and beyond from a pre-0.21.0 version](doc/manuals/admin/upgrading_crossing_0-21-0.md)
-
-If your upgrade cover several segments (e.g. you are using 0.13.0 and
-want to upgrade to 0.19.0, so both "upgrading to 0.14.1 and beyond from
-a pre-0.14.1 version" and "upgrading to 0.19.0 and beyond from a
-pre-0.19.0 version" applies to the case) you need to execute the
-segments in sequence (the common part are done only one time, i.e. stop
-CB, remove package, install package, start CB). In the case of doubt,
-please [ask using StackOverflow](http://stackoverflow.com/questions/ask)
-(remember to include the "fiware-orion" tag in your questions).
-
-#### Standard upgrade 
-
-If you are using yum, then you can upgrade doing (as root):
-
-` yum install contextBroker`
-
-Sometimes the above commands fails due to yum cache. In that case, run
-`yum clean all` and try again.
-
-If you are upgrading using the RPM file, then first download the new package from the [FIWARE Files area](https://forge.fiware.org/frs/?group_id=7). Look for the "DATA-OrionContextBroker" entry.
-
-Then upgrade the package using the rpm command (as root):
-
-    rpm -U contextBroker-X.Y.Z-1.x86_64.rpm
+Build and Install documentation for Orion Context Broker can be found at [the corresponding section of the Admin Manual](doc/manuals/admin/install.md).
 
 [Top](#top)
 
 ## Running
 
-Once installed, there are two ways of running Orion Context Broker: manually from the command line or as a system service (the later only available if Orion was installed as RPM package). It is not recommended to mix both ways (e.g. start the context broker from the command line, then use `/etc/init.d/contextBroker status` to check its status). This section assumes you are running Orion as system service. From command line alternative, check [this document](doc/md/admin/cli.md).
-
-You will typically need superuser privileges to use Orion Context Broker
-as a system service, so the following commands need to be run as root or
-using the sudo command.
-
-In order to start the broker service, run:
-
-    /etc/init.d/contextBroker start
-
-Then, to stop the context broker, run:
-
-    /etc/init.d/contextBroker stop
-
-To restart, run:
-
-    /etc/init.d/contextBroker restart
-
-You can use chkconfig command to make contextBroker automatically
-start/stop when your system boots/shutdowns (see [chkconfig
-documentation](http://www.centos.org/docs/5/html/Deployment_Guide-en-US/s1-services-chkconfig.html)
-for details).
-
-[Top](#top)
-
-### Configuration file
-
-The configuration used by the contextBroker service is stored in the
-/etc/sysconfig/contextBroker file, which typical content is:
-
-    # BROKER_USER - What user to run orion-broker as
-    BROKER_USER=orion
-    
-    # BROKER_PORT - the port/socket where orion-broker will listen for connections
-    BROKER_PORT=1026
-    
-    # BROKER_LOG_DIR - Where to log to
-    BROKER_LOG_DIR=/var/log/contextBroker
-    
-    # BROKER_PID_FILE - Where to store the pid for orion-broker
-    BROKER_PID_FILE=/var/log/contextBroker/contextBroker.pid
-    
-    ## Database configuration for orion-broker
-    BROKER_DATABASE_HOST=localhost
-    BROKER_DATABASE_NAME=orion
-    
-    ## Replica set configuration. Note that if you set this parameter, the BROKER_DATBASE_HOST
-    ## is interpreted as the list of host (or host:port) separated by commas to use as
-    ## replica set seed list (single element lists are also allowed). If BROKER_DATABASE_RPL_SET
-    ## parameter is unset, Orion CB assumes that the BROKER_DATABASE_HOST is an stand-alone
-    ## mongod instance
-    #BROKER_DATABASE_RPLSET=orion_rs
-    
-    # Database authentication (not needed if MongoDB doesn't use --auth)
-    #BROKER_DATABASE_USER=orion
-    #BROKER_DATABASE_PASSWORD=orion
-    
-    # Use the following variable if you need extra command line options
-    #BROKER_EXTRA_OPS="-t 0-255"
-
-All the fields except BROKER\_USER and BROKER\_EXTRA\_OPS map to *one*
-of the options described in [command line
-options](#Command_line_options), as follows:
-
--   BROKER\_PORT maps to -port
--   BROKER\_LOG\_DIR maps to -logDir
--   BROKER\_PID\_FILE maps to -pidpath
--   BROKER\_DATABASE\_HOST maps to -dbhost
--   BROKER\_DATABASE\_NAME maps to -db
--   BROKER\_DATABASE\_RPLSET maps to -rplSet
--   BROKER\_DATABASE\_USER maps to -dbuser
--   BROKER\_DATABASE\_PASSWORD maps to -dbpwd
-
-Regarding BROKER\_EXTRA\_OPS, it is used to specify other options not
-covered by the fields above, as a string that is appended to the broker
-command line at starting time. Note that this string is "blindly"
-appended, i.e. the service script doesn't do any check so be careful
-using this, ensuring that you are providing valid options here and you
-are not duplicating any option in other BROKER\_\* field (e.g. not set
-BROKER\_EXTRA\_OPS="-port 1026" as BROKER\_PORT is used for that).
-
-Regarding BROKER\_USER, it is the user that will own the contextBroker
-process upon launching it. By default, the RPM installation creates a
-user named 'orion'. Note that if you want to run the broker in a
-privileged port (i.e. 1024 or below) you will need to use 'root' as
-BROKER\_USER.
-
-[Top](#top)
-
-### Checking status
-
-In order to check the status of the broker, use the following command
-with superuser privileges (using the root user or the sudo command):
-
-    /etc/init.d/contextBroker status
-
-If broker is running you will get:
-
-    Checking contextBroker...                         Running
-
-If broker is not running you will get:
-
-    Checking contextBroker...                         Service not running
+How to run Orion Context Broker can be found at [the corresponding section of the Admin Manual](doc/manuals/admin/running.md).
 
 [Top](#top)
 

--- a/doc/manuals/admin/README.md
+++ b/doc/manuals/admin/README.md
@@ -5,7 +5,9 @@ Orion Context Broker: Administration Guide.
 
 ## Table of Contents
 
+* [Installing Orion](install.md)
 * [Building from sources](build_source.md)
+* [Running Orion as system service](running.md)
 * [Running Orion from command line](cli.md)
 * [Database administration](database_admin.md)
 * [Logs](logs.md)

--- a/doc/manuals/admin/cli.md
+++ b/doc/manuals/admin/cli.md
@@ -12,15 +12,14 @@ Orion Context Broker listens, using the -port option:
 
     contextBroker -port 5057
 
-To know all the possible options, have a look at the [command line
-options](#Command_line_options "wikilink") section.
+To know all the possible options, have a look at the next section.
 
 ## Command line options
 
-Command line options can be used directly (in the case of running [from
-the command line](#From_the_command_line "wikilink")) or indirectly
+Command line options can be used directly (in the case of running from
+the command line) or indirectly
 through the different fields in /etc/sysconfig/contextBroker (in the
-case of running [as a system service](../../../README.md#as-system-service) )
+case of running [as a system service](running.md)).
 To obtain a list of available options, use:
 
     contextBroker -u

--- a/doc/manuals/admin/database_admin.md
+++ b/doc/manuals/admin/database_admin.md
@@ -1,19 +1,18 @@
 #<a name="top"></a>Database administration 
 
 * [Introduction](#introduction)
-    * [Backup](#backup)
-    * [Restore](#restore)
-    * [Database authorization](#database-authorization)
-    * [Multiservice/multitenant database separation](#multiservicemultitenant-database-separation)
-    * [Delete complete database](#delete-complete-database)
-    * [Setting indexes](#setting-indexes)
-	  * [Analysis](#analysis)
-    * [Database management scripts](#database-management-scripts)
-	  * [Deleting expired documents](#deleting-expired-documents)
-	  * [Latest updated document](#latest-updated-document)
+* [Backup](#backup)
+* [Restore](#restore)
+* [Database authorization](#database-authorization)
+* [Multiservice/multitenant database separation](#multiservicemultitenant-database-separation)
+* [Delete complete database](#delete-complete-database)
+* [Setting indexes](#setting-indexes)
+    * [Analysis](#analysis)
+* [Database management scripts](#database-management-scripts)
+    * [Deleting expired documents](#deleting-expired-documents)
+    * [Latest updated document](#latest-updated-document)
 	  
-	  
-# Introduction 
+## Introduction
 
 We assume that the system administrator has knowledge of MongoDB (there
 are very good and free courses at [MongoDB education

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -1,12 +1,12 @@
 #<a name="top"></a>Data model
 
 * [Introduction](#introduction)
-    * [entities collection](#entities-collection)
-    * [registrations collection](#registrations-collection)
-    * [csubs collection](#csubs-collection)
-    * [casubs collection](#casubs-collection)
+* [entities collection](#entities-collection)
+* [registrations collection](#registrations-collection)
+* [csubs collection](#csubs-collection)
+* [casubs collection](#casubs-collection)
 
-# Introduction
+## Introduction
 
 Normally you don't need to access MongoDB directly as Orion Contex
 Broker uses it transparently. However, for some operations (e.g. backup,

--- a/doc/manuals/admin/diagnosis.md
+++ b/doc/manuals/admin/diagnosis.md
@@ -1,15 +1,15 @@
 #<a name="top"></a>Problem diagnosis procedures
 
 * [Introduction](#introduction)
-    * [Sanity check procedures](#sanity-check-procedures)
-	  * [Checking Orion is up and running](#checking-orion-is-up-and-running)
-	  * [List of Running Processes](#list-of-running-processes)
-	  * [Network interfaces Up & Open](#network-interfaces-up--open)
-	  * [Database server](#database-server)
-    * [Diagnose database connection problems](#diagnose-database-connection-problems)
-    * [Diagnose spontaneous binary corruption problems**](#diagnose-spontaneous-binary-corruption-problems**)
+* [Sanity check procedures](#sanity-check-procedures)
+    * [Checking Orion is up and running](#checking-orion-is-up-and-running)
+    * [List of Running Processes](#list-of-running-processes)
+    * [Network interfaces Up & Open](#network-interfaces-up--open)
+    * [Database server](#database-server)
+* [Diagnose database connection problems](#diagnose-database-connection-problems)
+* [Diagnose spontaneous binary corruption problems**](#diagnose-spontaneous-binary-corruption-problems**)
 	  
-# Introduction
+## Introduction
 
 The Diagnosis Procedures are the first steps that a System Administrator
 will take to locate the source of an error in Orion. Once the nature of

--- a/doc/manuals/admin/install.md
+++ b/doc/manuals/admin/install.md
@@ -1,0 +1,118 @@
+# Installing Orion
+
+* [Introduction](#introduction)
+* [Requirements](#requirements)
+* [Installation](#installation)
+    * [Using yum (recommended)](#using-yum-(recommended))
+    * [Using RPM file](#using-rpm-file)
+    * [Optional packages](#optional-packages)
+* [Upgrading from a previous version](#upgrading-from-a-previous-version)
+    * [Upgrading MongoDB version](#upgrading-mongodb-version)
+    * [Migrating the data stored in DB](#migrating-the-data-stored-in-db)
+    * [Standard upgrade](#standard-upgrade)
+
+## Introduction
+
+The recommended procedure is to install using RPM packages in CentOS 6.x. If you are interested in
+building from sources, check [this document](build_source.md).
+
+## Requirements
+
+* System resources: see [these recommendations](resources.md#resources-recommendations)
+* Operating system: CentOS/RedHat. The reference operating system is CentOS 6.3
+but it should work also in any later CentOS/RedHat 6.x version.
+* Database: MongoDB is required to run either in the same host where Orion Context Broker is to be installed or in a different host accessible through the network. The recommended MongoDB version is 2.6.9 (although it should work with later MongoDB 2.6.x and 3.0.x versions). It is not recommended using MongoDB 2.4.x., as some [geolocated queries](../user/geolocation.md) may not work.
+    * Note that the officially supported MongoDB version is 2.6. In the case of using MongoDB 3.0 with its new authentication mechanism
+      (SCRAM_SHA1) you may need to compile from sources using special switches for the MongoDB driver. See [this issue](https://github.com/telefonicaid/fiware-orion/issues/1061) for details.
+* RPM dependencies (some of these packages could not be in the official CentOS/RedHat repository but in EPEL, in which case you have to configure EPEL repositories, see <http://fedoraproject.org/wiki/EPEL>):
+    * The contextBroker package (mandatory) depends on the following packages: boost-filesystem, boost-thread, libmicrohttpd, logrotate, libcurl and boost-regex.
+    * The contextBroker-test package (optional) depends on the following packages: python, python-flask, python-jinja2, curl, libxml2, libxslt, nc, mongo-10gen and contextBroker. The mongo-10gen dependency needs to configure MongoDB repository, check [this piece of documentation about that](http://docs.mongodb.org/manual/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux/).
+
+## Installation
+
+### Using yum (recommended)
+
+Configure the FIWARE yum repository ([as described in this post](http://stackoverflow.com/questions/24331330/how-to-configure-system-to-use-the-fi-ware-yum-repository/24510985#24510985)). Then you can install doing (as root):
+
+```
+yum install contextBroker
+```
+
+Sometimes the above commands fails due to yum cache. In that case, run
+`yum clean all` and try again.
+
+### Using RPM file
+
+Download the package from the [FIWARE Files area](https://forge.fiware.org/frs/?group_id=7). Look for the "DATA-OrionContextBroker" entry.
+
+Next, install the package using the rpm command (as root):
+
+```
+rpm -i contextBroker-X.Y.Z-1.x86_64.rpm
+```
+
+### Optional packages
+
+Apart from the mandatory RPM described above, you can install the contextBroker-test package, which contain utility tools:
+
+```
+yum install contextBroker-test
+```
+
+or
+
+```
+rpm -i contextBroker-test-X.Y.Z-1.x86_64.rpm
+```
+
+## Upgrading from a previous version
+
+Upgrade procedure depends on whether the *upgrade path* (i.e. from the installed Orion version to the target one to upgrade) crosses a version number that requires:
+
+* Upgrading MongoDB version
+* Migrating the data stored in DB (due to a change in the DB data model).
+
+### Upgrading MongoDB version
+
+You only need to pay attention to this if your upgrade path crosses 0.11.0 or 0.22.0. Otherwise, you can skip this section.
+
+* Orion versions previous to 0.11.0 recommend MongoDB 2.2
+* Orion version from 0.11.0 to 0.20.0 recommend MongoDB 2.4. Check [the 2.4 upgrade procedure in the oficial MongoDB documentation.](http://docs.mongodb.org/master/release-notes/2.4-upgrade/)
+* Orion version from 0.21.0 on recommend MongoDB 2.6 o 3.0. check [the 2.6 upgrade procedure](http://docs.mongodb.org/master/release-notes/2.6-upgrade/) or
+[the 3.0 upgrade procedure](http://docs.mongodb.org/master/release-notes/3.0-upgrade/) in the oficial MongoDB documentation.
+
+### Migrating the data stored in DB
+
+You only need to pay attention to this if your upgrade path crosses 0.14.1, 0.19.0 or 0.21.0. Otherwise, you can skip this section. You can also skip this section if your DB are not valuable (e.g. debug/testing environments) and you can flush your DB before upgrading.
+
+* [Upgrading to 0.14.1 and beyond from a pre-0.14.1 version](upgrading_crossing_0-14-1.md)
+* [Upgrading to 0.19.0 and beyond from a pre-0.19.0 version](ugrading_crossing_0-19-0.md)
+* [Upgrading to 0.21.0 and beyond from a pre-0.21.0 version](upgrading_crossing_0-21-0.md)
+
+If your upgrade cover several segments (e.g. you are using 0.13.0 and
+want to upgrade to 0.19.0, so both "upgrading to 0.14.1 and beyond from
+a pre-0.14.1 version" and "upgrading to 0.19.0 and beyond from a
+pre-0.19.0 version" applies to the case) you need to execute the
+segments in sequence (the common part are done only one time, i.e. stop
+CB, remove package, install package, start CB). In the case of doubt,
+please [ask using StackOverflow](http://stackoverflow.com/questions/ask)
+(remember to include the "fiware-orion" tag in your questions).
+
+### Standard upgrade
+
+If you are using yum, then you can upgrade doing (as root):
+
+```
+yum install contextBroker
+```
+
+Sometimes the above commands fails due to yum cache. In that case, run
+`yum clean all` and try again.
+
+If you are upgrading using the RPM file, then first download the new package from the [FIWARE Files area](https://forge.fiware.org/frs/?group_id=7). Look for the "DATA-OrionContextBroker" entry.
+
+Then upgrade the package using the rpm command (as root):
+
+```
+rpm -U contextBroker-X.Y.Z-1.x86_64.rpm
+```

--- a/doc/manuals/admin/logs.md
+++ b/doc/manuals/admin/logs.md
@@ -1,12 +1,12 @@
 #<a name="top"></a>Logs
 
 * [Introduction](#introduction)
-    * [Log file](#log-file)
-    * [Log format](#log-format)
-    * [Error and warning types](#error-and-warning-types)
-    * [Log rotation](#log-rotation)
+* [Log file](#log-file)
+* [Log format](#log-format)
+* [Error and warning types](#error-and-warning-types)
+* [Log rotation](#log-rotation)
 
-# Introduction
+## Introduction
 
 The log system has been re-worked in deep in release 0.14.1. This
 section describes its main characteristics.

--- a/doc/manuals/admin/running.md
+++ b/doc/manuals/admin/running.md
@@ -1,0 +1,115 @@
+# Running Orion as system service
+
+Once installed, there are two ways of running Orion Context Broker: manually from the command line or as a system service (the later only available if Orion was installed as RPM package). It is not recommended to mix both ways (e.g. start the context broker from the command line, then use `/etc/init.d/contextBroker status` to check its status). This section assumes you are running Orion as system service. From command line alternative, check [this document](cli.md).
+
+You will typically need superuser privileges to use Orion Context Broker
+as a system service, so the following commands need to be run as root or
+using the sudo command.
+
+In order to start the broker service, run:
+
+```
+/etc/init.d/contextBroker start
+```
+
+Then, to stop the context broker, run:
+
+```
+/etc/init.d/contextBroker stop
+```
+
+To restart, run:
+
+```
+/etc/init.d/contextBroker restart
+```
+
+You can use chkconfig command to make contextBroker automatically
+start/stop when your system boots/shutdowns (see [chkconfig
+documentation](http://www.centos.org/docs/5/html/Deployment_Guide-en-US/s1-services-chkconfig.html)
+for details).
+
+## Configuration file
+
+The configuration used by the contextBroker service is stored in the
+/etc/sysconfig/contextBroker file, which typical content is:
+
+```
+# BROKER_USER - What user to run orion-broker as
+BROKER_USER=orion
+
+# BROKER_PORT - the port/socket where orion-broker will listen for connections
+BROKER_PORT=1026
+
+# BROKER_LOG_DIR - Where to log to
+BROKER_LOG_DIR=/var/log/contextBroker
+
+# BROKER_PID_FILE - Where to store the pid for orion-broker
+BROKER_PID_FILE=/var/log/contextBroker/contextBroker.pid
+
+## Database configuration for orion-broker
+BROKER_DATABASE_HOST=localhost
+BROKER_DATABASE_NAME=orion
+
+## Replica set configuration. Note that if you set this parameter, the BROKER_DATBASE_HOST
+## is interpreted as the list of host (or host:port) separated by commas to use as
+## replica set seed list (single element lists are also allowed). If BROKER_DATABASE_RPL_SET
+## parameter is unset, Orion CB assumes that the BROKER_DATABASE_HOST is an stand-alone
+## mongod instance
+#BROKER_DATABASE_RPLSET=orion_rs
+
+# Database authentication (not needed if MongoDB doesn't use --auth)
+#BROKER_DATABASE_USER=orion
+#BROKER_DATABASE_PASSWORD=orion
+
+# Use the following variable if you need extra command line options
+#BROKER_EXTRA_OPS="-t 0-255"
+```
+
+All the fields except BROKER\_USER and BROKER\_EXTRA\_OPS map to *one*
+of the options described in [command line
+options](cli.md#command-line-options), as follows:
+
+-   BROKER\_PORT maps to -port
+-   BROKER\_LOG\_DIR maps to -logDir
+-   BROKER\_PID\_FILE maps to -pidpath
+-   BROKER\_DATABASE\_HOST maps to -dbhost
+-   BROKER\_DATABASE\_NAME maps to -db
+-   BROKER\_DATABASE\_RPLSET maps to -rplSet
+-   BROKER\_DATABASE\_USER maps to -dbuser
+-   BROKER\_DATABASE\_PASSWORD maps to -dbpwd
+
+Regarding BROKER\_EXTRA\_OPS, it is used to specify other options not
+covered by the fields above, as a string that is appended to the broker
+command line at starting time. Note that this string is "blindly"
+appended, i.e. the service script doesn't do any check so be careful
+using this, ensuring that you are providing valid options here and you
+are not duplicating any option in other BROKER\_\* field (e.g. not set
+BROKER\_EXTRA\_OPS="-port 1026" as BROKER\_PORT is used for that).
+
+Regarding BROKER\_USER, it is the user that will own the contextBroker
+process upon launching it. By default, the RPM installation creates a
+user named 'orion'. Note that if you want to run the broker in a
+privileged port (i.e. 1024 or below) you will need to use 'root' as
+BROKER\_USER.
+
+## Checking status
+
+In order to check the status of the broker, use the following command
+with superuser privileges (using the root user or the sudo command):
+
+```
+/etc/init.d/contextBroker status
+```
+
+If broker is running you will get:
+
+```
+Checking contextBroker...                         Running
+```
+
+If broker is not running you will get:
+
+```
+Checking contextBroker...                         Service not running
+```

--- a/doc/manuals/user/filtering.md
+++ b/doc/manuals/user/filtering.md
@@ -1,13 +1,13 @@
 #<a name="top"></a>Filtering results
 
 * [Introduction](#introduction)
-    * [Existence type filter](#existence-type-filter)
-    * [No-Existence type filter](#no-existence-type-filter)
-    * [Entity type filter](#entity-type-filter)
-    * [Geo-location filter](#geo-location-filter)
-    * [String query filter](#string-filter)
+* [Existence type filter](#existence-type-filter)
+* [No-Existence type filter](#no-existence-type-filter)
+* [Entity type filter](#entity-type-filter)
+* [Geo-location filter](#geo-location-filter)
+* [String query filter](#string-filter)
     
-# Introduction
+## Introduction
 
 Orion Context Broker implements several filters
 that can be used to filter the results in NGSI10 query operations. These

--- a/doc/manuals/user/walkthrough_apiv1.md
+++ b/doc/manuals/user/walkthrough_apiv1.md
@@ -37,7 +37,7 @@
 	  * [Convenience operations for context availability subscriptions](#convenience-operations-for-context-availability-subscriptions)
 	  * [Summary of NGSI9 convenience operations URLs](#summary-of-ngsi9-convenience-operations-urls) 
 
-# Introduction
+## Introduction
 
 This walkthrough adopts a practical approach that we hope will help our
 readers to get familiar with the Orion Context Broker and have some fun

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,9 @@ pages:
       - 'Considerations on NGSIv1 and NGSIv2 coexistence': 'user/v1_v2_coexistence.md'
   - 'Admin Guide':
       - 'Introduction': 'admin/index.md'
+      - 'Installing Orion': 'admin/install.md'
       - 'Building from Sources': 'admin/build_source.md'
+      - 'Running Orion as system service': 'admin/running.md'
       - 'Running Orion from command line': 'admin/cli.md'
       - 'Database administration': 'admin/database_admin.md'
       - 'Data model': 'admin/database_model.md'


### PR DESCRIPTION
Sections related Installing and Running Orion has been moved from master README.md to administration manual, in order they get included in the readthedocs manuals. README.md now include links to the admin manual .md documents in those places.

In addition, this PR fixes the ToC problems described in issue #1136