### PR TITLE
FIX remove XML leftovers from manuals

### DIFF
--- a/doc/manuals/admin/cli.md
+++ b/doc/manuals/admin/cli.md
@@ -42,8 +42,8 @@ The list of available options is the following:
 -   **-ipv6**. Runs broker in IPv6 only mode (by default, the broker
     runs in both IPv4 and IPv6). Cannot be used at the same time
     that -ipv4.
--   **-rush <host:port>**. Use <b>rush</b> in <i>host</i> and
-    <i>port</i>. Default behavior is to <i>not</i> use Rush. See section
+-   **-rush <host:port>**. Use **rush** in *host* and
+    *port*. Default behavior is to *not* use Rush. See section
     on [using Rush relayer](rush.md).
 -   **-multiservice**. Enables multiservice/multitenant mode (see [multi
     service tenant section](../user/multitenancy.md)).

--- a/doc/manuals/admin/diagnosis.md
+++ b/doc/manuals/admin/diagnosis.md
@@ -36,22 +36,25 @@ tests and user validation.
 -   Run the following command
 
 ```
-curl localhost:1026/version
+curl --header 'Accept: application/json' localhost:1026/version
 ```
 
 -   Check that you get the version number as output (along with uptime
     information and compilation environment information):
 
 ```
-<orion>
-  <version>0.22.0-next</version>
-  <uptime>0 d, 1 h, 34 m, 25 s</uptime>
-  <git_hash>6e2aca5ebe287083efa306fc84d213fa24309a63</git_hash>
-  <compile_time>Fri Jun 19 10:34:41 CEST 2015</compile_time>
-  <compiled_by>fermin</compiled_by>
-  <compiled_in>debvm</compiled_in>
-</orion>
+{
+  "orion" : {
+    "version" : "0.23.0-next",
+    "uptime" : "0 d, 0 h, 2 m, 30 s",
+    "git_hash" : "c49692a996fb8d23cb2e78992094e26b1ca45dac",
+    "compile_time" : "Tue Sep 8 16:56:16 CEST 2015",
+    "compiled_by" : "fermin",
+    "compiled_in" : "debvm"
+  }
+}
 ```
+
 [Top](#top)
 
 ### List of Running Processes
@@ -112,40 +115,42 @@ The symptoms of a database connection problem are the following ones:
 ` X@08:04:45 main[313]: MongoDB error`
 
 -   During broker operation. Error message like the following ones
-    appear in the responses sent by the broker.
+    appear in the responses sent by the broker.   
 
 ```
-      ...
-      <errorCode>
-        <code>500</code>
-        <reasonPhrase>Database Error</reasonPhrase>
-        <details>collection: ... - exception: Null cursor</details>
-      </errorCode>
-      ...
 
-      ...
-      <errorCode>
-        <code>500</code>
-        <reasonPhrase>Database Error</reasonPhrase>
-        <details>collection: ... - exception: socket exception [CONNECT_ERROR] for localhost:27017</details>
-      </errorCode>
-      ...
+    ...
+    "errorCode": {
+        "code": "500",
+        "reasonPhrase": "Database Error",
+        "details": "collection: ... - exception: Null cursor"
+    }
+    ...
 
-      ...
-      <errorCode>
-        <code>500</code>
-        <reasonPhrase>Database Error</reasonPhrase>
-        <details>collection: ... - exception: socket exception [FAILED_STATE] for localhost:27017</details
-      </errorCode>
-      ...
+    ...
+    "errorCode": {
+        "code": "500",
+        "reasonPhrase": "Database Error",
+        "details": "collection: ... - exception: socket exception [CONNECT_ERROR] for localhost:27017"
+    }
+    ...
 
-      ...
-      <errorCode>
-        <code>500</code>
-        <reasonPhrase>Database Error</reasonPhrase>
-        <details>collection: ... - exception: DBClientBase::findN: transport error: localhost:27017 ns: orion.$cmd query: { .. }</details>
-      </errorCode>
-      ...
+    ...
+    "errorCode": {
+        "code": "500",
+        "reasonPhrase": "Database Error",
+        "details": "collection: ... - exception: socket exception [FAILED_STATE] for localhost:27017"
+    }
+    ...
+
+    ...
+    "errorCode": {
+        "code": "500",
+        "reasonPhrase": "Database Error",
+        "details": "collection: ... - exception: DBClientBase::findN: transport error: localhost:27017 ns: orion.$cmd query: { .. }"
+    }
+    ...
+
 ```
 
 In both cases, check that the connection to MonogDB is correctly

--- a/doc/manuals/admin/management_api.md
+++ b/doc/manuals/admin/management_api.md
@@ -7,14 +7,15 @@ API for management that allows to change the trace and verbosity levels
 In order to manage the trace level:
 
 ```
-curl --request DELETE <host>:<port>/log/trace
-curl --request DELETE <host>:<port>/log/trace/t1
-curl --request DELETE <host>:<port>/log/trace/t1-t2
-curl --request DELETE <host>:<port>/log/trace/t1-t2,t3-t4
-curl --request GET <host>:<port>/log/trace
-curl --request PUT <host>:<port>/log/trace/t1
-curl --request PUT <host>:<port>/log/trace/t1-t2
-curl --request PUT <host>:<port>/log/trace/t1-t2,t3-t4
+curl --request DELETE <host>:<port>/log/trace
+curl --request DELETE <host>:<port>/log/trace/t1
+curl --request DELETE <host>:<port>/log/trace/t1-t2
+curl --request DELETE <host>:<port>/log/trace/t1-t2,t3-t4
+curl --request GET <host>:<port>/log/trace
+curl --request PUT <host>:<port>/log/trace/t1
+curl --request PUT <host>:<port>/log/trace/t1-t2
+curl --request PUT <host>:<port>/log/trace/t1-t2,t3-t4
+```
 
 'PUT-requests' overwrites the previous log settings. So, in order to ADD
 a trace level, a GET /log/trace must be issued first and after that the
@@ -25,31 +26,40 @@ complete trace string to be sent in the PUT request can be assembled.
 The Orion context broker maintains a set of counters for the incoming
 messages and such. The information is accessed via REST, of course:
 
-` curl `<host>`:`<port>`/statistics`
+```
+curl --header 'Accept: application/json' <host>:<port>/statistics
+```
 
-A sample <i>statistics</i> response:
+A sample *statistics* response:
 
 ```
- <orion>
-   <jsonRequests>1</jsonRequests>
-   <registrations>5</registrations>
-   <discoveries>10</discoveries>
-   <statisticsRequests>2</statisticsRequests>
- </orion>
+{
+  "orion" : {
+    "jsonRequests" : "13",
+    "updates" : "13",
+    "versionRequests" : "1",
+    "statisticsRequests" : "2",
+    "subCacheLookups" : "1",
+    "uptime_in_secs" : "14470",
+    "measuring_interval_in_secs" : "14470"
+  }
+}
 ```
 
 To reset the statistics, the verb DELETE is used:
 
 ```
-curl -X DELETE `<host>`:`<port>`/statistics
+curl -X DELETE --header 'Accept: application/json' <host>:<port>/statistics
 ```
 
 Resetting the statistics counters yields the following response:
 
 ```
-<orion>
-  <message>All statistics counter reset</message>
-</orion>
+{
+  "orion" : {
+    "message" : "All statistics counter reset"
+  }
+}
 ```
 
 There are a lot of counters, but only those that have been used since
@@ -59,7 +69,14 @@ REST request.
 The `-mutexTimeStat` CLI parameter activates recording of waiting time in the different internal semaphores, e.g:
 
 ```
-      <requestSemaphoreWaitingTime>0.000000000</requestSemaphoreWaitingTime>
-      <dbConnectionPoolWaitingTime>0.000000230</dbConnectionPoolWaitingTime>
-      <transactionSemaphoreWaitingTime>0.000001050</transactionSemaphoreWaitingTime>
+{
+  "orion" : {
+    ...
+    "requestSemaphoreWaitingTime" : "0.000000000",
+    "dbConnectionPoolWaitingTime" : "0.000000611",
+    "transactionSemaphoreWaitingTime" : "0.000000930",
+    "curlContextMutexWaitingTime" : "0.000000000",
+    ...
+  }
+}
 ```

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -32,7 +32,6 @@ Let's illustrate this with an example.
       Street4 temperature. Let's assume that the Context Provider exposes
       its API on <http://sensor48.mycity.com/ngsi10>
       
-<!-- -->
 ```
 (curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' \ 
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
@@ -66,7 +65,6 @@ EOF
       (message number 2).
 
       
-<!-- -->
 ``` 
 (curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
@@ -95,7 +93,6 @@ EOF
       "/queryContext" operation).
 
 
-<!-- -->
 ``` 
 {
     "entities": [
@@ -115,7 +112,6 @@ EOF
 -     The Context Provider at <http://sensor48.mycity.com/ngsi10> responds
       with the data (message number 4).
 
-<!-- -->
 ``` 
 {
     "contextResponses": [
@@ -149,7 +145,6 @@ EOF
       (or ignore) that information. Orion doesn't store the
       Street4 temperature.
  
-<!-- --> 
 ``` 
 {
     "contextResponses": [

--- a/doc/manuals/user/empty_types.md
+++ b/doc/manuals/user/empty_types.md
@@ -21,13 +21,17 @@ Context Broker:
 
 A discoveryContextAvailability/querycontext using:
 
-        ...
-        <entityIdList>
-          <entityId type="" isPattern="false">
-            <id>Room1</id>
-          </entityId>
-        </entityIdList>
-        ...
+```
+  ...
+  "entities": [
+      {
+          "type": "",
+          "isPattern": "false",
+          "id": "Room1"
+      }
+  ]
+  ...
+```
 
 will match both Entity 1 and Entity 2.
 

--- a/doc/manuals/user/federation.md
+++ b/doc/manuals/user/federation.md
@@ -33,123 +33,135 @@ Next, let's send a subscribeContext to A (to make B subscribe to updates
 made in A). Note that the URL used in the reference has to be
 "/v1/notifyContext":
 
-    (curl localhost:1030/v1/subscribeContext -s -S --header 'Content-Type: application/xml' \ 
-       -d @- | xmllint --format -) <<EOF
-    <?xml version="1.0"?>
-    <subscribeContextRequest>
-      <entityIdList>
-        <entityId type="Room" isPattern="false">
-          <id>Room1</id>
-        </entityId>
-      </entityIdList>
-      <reference>http://localhost:1031/v1/notifyContext</reference>
-      <duration>P1M</duration>
-      <notifyConditions>
-        <notifyCondition>
-          <type>ONCHANGE</type>
-          <condValueList>
-            <condValue>temperature</condValue>
-          </condValueList>
-        </notifyCondition>
-      </notifyConditions>
-      <throttling>PT5S</throttling>
-    </subscribeContextRequest>
-    EOF
+```
+(curl localhost:1030/v1/subscribeContext -s -S --header 'Content-Type: application/json' \
+    --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+{
+    "entities": [
+        {
+            "type": "Room",
+            "isPattern": "false",
+            "id": "Room1"
+        }
+    ],
+    "reference": "http://localhost:1031/v1/notifyContext",
+    "duration": "P1M",
+    "notifyConditions": [
+        {
+            "type": "ONCHANGE",
+            "condValues": [
+                "temperature"
+            ]
+        }
+    ],
+    "throttling": "PT5S"
+}
+EOF
+```
 
 Next, let's send a subscribeContext to B (to make C subscribe to updates
 made in B). The subscription is basically the same, only the port in the
 curl line and reference elements are different.
+
 ```
-(curl localhost:1031/v1/subscribeContext -s -S --header 'Content-Type: application/xml' \ 
-    -d @- | xmllint --format -) <<EOF
-    <?xml version="1.0"?>
-    <subscribeContextRequest>
-      <entityIdList>
-        <entityId type="Room" isPattern="false">
-          <id>Room1</id>
-        </entityId>
-      </entityIdList>
-      <reference>http://localhost:1032/v1/notifyContext</reference>
-      <duration>P1M</duration>
-      <notifyConditions>
-        <notifyCondition>
-          <type>ONCHANGE</type>
-          <condValueList>
-            <condValue>temperature</condValue>
-          </condValueList>
-        </notifyCondition>
-      </notifyConditions>
-      <throttling>PT5S</throttling>
-    </subscribeContextRequest>
-    EOF
+(curl localhost:1031/v1/subscribeContext -s -S --header 'Content-Type: application/json' \
+    --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+{
+    "entities": [
+        {
+            "type": "Room",
+            "isPattern": "false",
+            "id": "Room1"
+        }
+    ],
+    "reference": "http://localhost:1032/v1/notifyContext",
+    "duration": "P1M",
+    "notifyConditions": [
+        {
+            "type": "ONCHANGE",
+            "condValues": [
+                "temperature"
+            ]
+        }
+    ],
+    "throttling": "PT5S"
+}
+EOF
 ```
+
 Now, let's create an entity in context broker A.
+
 ```
-(curl localhost:1030/v1/updateContext -s -S --header 'Content-Type: application/xml' \ 
-    -d @- | xmllint --format - ) <<EOF
-    <?xml version="1.0" encoding="UTF-8"?>
-    <updateContextRequest>
-      <contextElementList>
-        <contextElement>
-          <entityId type="Room" isPattern="false">
-            <id>Room1</id>
-          </entityId>
-          <contextAttributeList>
-            <contextAttribute>
-              <name>temperature</name>
-              <type>float</type>
-              <contextValue>23</contextValue>
-            </contextAttribute>
-          </contextAttributeList>
-        </contextElement>
-      </contextElementList>
-      <updateAction>APPEND</updateAction>
-    </updateContextRequest>
-    EOF
+(curl localhost:1030/v1/updateContext -s -S --header 'Content-Type: application/json' \
+    --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+{
+    "contextElements": [
+        {
+            "type": "Room",
+            "isPattern": "false",
+            "id": "Room1",
+            "attributes": [
+                {
+                    "name": "temperature",
+                    "type": "float",
+                    "value": "23"
+                }
+            ]
+        }
+    ],
+    "updateAction": "APPEND"
+}
+EOF
 ```
+
 Given the subscriptions in place, a notifyContextRequest is
 automatically sent from A to B. That event at B causes in sequence a
 notifyContextRequest to be sent to C. So, at the end, the creation of an
 entity in A causes the creation of the same entity (with the same
 attribute values) in C. You can check it by doing a queryContext to C:
-```
-(curl localhost:1032/v1/queryContext -s -S --header 'Content-Type: application/xml' \ 
-    -d @- | xmllint --format -) <<EOF
-    <?xml version="1.0" encoding="UTF-8"?>
-    <queryContextRequest>
-      <entityIdList>
-        <entityId type="Room" isPattern="false">
-          <id>Room1</id>
-        </entityId>
-      </entityIdList>
-      <attributeList/>
-    </queryContextRequest>
-    EOF
 
-    <?xml version="1.0"?>
-    <queryContextResponse>
-      <contextResponseList>
-        <contextElementResponse>
-          <contextElement>
-            <entityId type="Room" isPattern="false">
-              <id>Room1</id>
-            </entityId>
-            <contextAttributeList>
-              <contextAttribute>
-                <name>temperature</name>
-                <type>float</type>
-                <contextValue>23</contextValue>
-              </contextAttribute>
-            </contextAttributeList>
-          </contextElement>
-          <statusCode>
-            <code>200</code>
-            <reasonPhrase>OK</reasonPhrase>
-          </statusCode>
-        </contextElementResponse>
-      </contextResponseList>
-    </queryContextResponse>
 ```
+(curl localhost:1032/v1/queryContext -s -S --header 'Content-Type: application/json' \
+    --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
+{
+    "entities": [
+        {
+            "type": "Room",
+            "isPattern": "false",
+            "id": "Room1"
+        }
+    ]
+}
+EOF
+```
+
+which response is:
+
+```
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "temperature",
+                        "type": "float",
+                        "value": "23"
+                    }
+                ],
+                "id": "Room1",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+```
+
 In the current context broker version, the semantics of
 nofityContextRequest are the same that [updateContext
 APPEND  or, if the context element already

--- a/doc/manuals/user/forbidden_characters.md
+++ b/doc/manuals/user/forbidden_characters.md
@@ -1,7 +1,5 @@
 ### Forbidden characters
 
-<span style="color:red">**Since 0.17.0**</span>
-
 In order to avoid script injections attack in some circustances (e.g.
 cross domain to co-located web servers in the same hot that CB) the
 following characters are forbidden in any request:

--- a/doc/manuals/user/http_and_ngsi_sc.md
+++ b/doc/manuals/user/http_and_ngsi_sc.md
@@ -13,37 +13,38 @@ entity (e.g. "foo"). Note the -v flag in the curl command, in order to
 print the HTTP response codes and headers:
 
 ```
-# curl localhost:1026/v1/contextEntities/foo -s -S --header 'Content-Type: application/xml' -v | xmllint --format -
+# curl localhost:1026/v1/contextEntities/foo -s -S --header 'Accept: application/json' -v | python -mjson.tool
 * About to connect() to localhost port 1026 (#0)
-*   Trying ::1... connected
+*   Trying ::1...
+* connected
 * Connected to localhost (::1) port 1026 (#0)
 > GET /v1/contextEntities/foo HTTP/1.1
-> User-Agent: curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.13.1.0 zlib/1.2.3 libidn/1.18 libssh2/1.2.2
+> User-Agent: curl/7.26.0
 > Host: localhost:1026
-> Accept: */*
-> Content-Type: application/xml
+> Accept: application/json
 >
+* additional stuff not fine transfer.c:1037: 0 0
+* HTTP 1.1 or later with persistent connection, pipelining supported
 < HTTP/1.1 200 OK
-< Content-Length: 316
-< Content-Type: application/xml
-< Date: Mon, 31 Mar 2014 10:13:45 GMT
+< Content-Length: 220
+< Content-Type: application/json
+< Date: Thu, 10 Sep 2015 18:40:37 GMT
 <
 { [data not shown]
 * Connection #0 to host localhost left intact
 * Closing connection #0
-<?xml version="1.0"?>
-<contextElementResponse>
-  <contextElement>
-    <entityId type="" isPattern="false">
-      <id>foo</id>
-    </entityId>
-  </contextElement>
-  <statusCode>
-    <code>404</code>
-    <reasonPhrase>No context element found</reasonPhrase>
-    <details>Entity id: 'foo'</details>
-  </statusCode>
-</contextElementResponse>
+{
+    "contextElement": {
+        "id": "foo",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "404",
+        "details": "Entity id: /foo/",
+        "reasonPhrase": "No context element found"
+    }
+}
 ```
 Note that in this case the NGSI response code is "404 No context element
 found" while the HTTP is "200 OK". Thus, in other words, the
@@ -52,32 +53,27 @@ entity doesn't exist in Orion Context Broker database) happened at the
 NGSI level.
 
 The following example shows a case of an HTTP level problem, due to a
-client attempting to get the response in a MIME type not supported by
-Orion (in this case "text/plain"). In this case, an HTTP response code
-"406 Not Acceptable" is generated.
+client attempting to use a HTTP verb that is not allowed. In this case,
+an HTTP response code "405 Method Not Allowed" is generated.
 
 ```
-# curl localhost:1026/v1/contextEntities/foo -s -S --header 'Accept: text/plain' -v | xmllint --format -
+curl -X PATCH localhost:1026/v1/contextEntities/foo -s -S --header 'Accept: application/json' -v
 * About to connect() to localhost port 1026 (#0)
-*   Trying ::1... connected
+*   Trying ::1...
+* connected
 * Connected to localhost (::1) port 1026 (#0)
-> GET /v1/contextEntities/foo HTTP/1.1
-> User-Agent: curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.13.1.0 zlib/1.2.3 libidn/1.18 libssh2/1.2.2
+> PATCH /v1/contextEntities/foo HTTP/1.1
+> User-Agent: curl/7.26.0
 > Host: localhost:1026
-> Accept: text/plain
+> Accept: application/json
 >
-< HTTP/1.1 406 Not Acceptable
-< Content-Length: 196
-< Content-Type: application/xml
-< Date: Mon, 31 Mar 2014 10:16:16 GMT
+* additional stuff not fine transfer.c:1037: 0 0
+* HTTP 1.1 or later with persistent connection, pipelining supported
+< HTTP/1.1 405 Method Not Allowed
+< Content-Length: 0
+< Allow: POST, GET, PUT, DELETE
+< Date: Thu, 10 Sep 2015 18:42:38 GMT
 <
-{ [data not shown]
 * Connection #0 to host localhost left intact
 * Closing connection #0
-<?xml version="1.0"?>
-<orionError>
-  <code>406</code>
-  <reasonPhrase>Not Acceptable</reasonPhrase>
-  <details>acceptable types: 'application/xml' but Accept header in request was: 'text/plain'</details>
-</orionError>
 ```

--- a/doc/manuals/user/known_limitations.md
+++ b/doc/manuals/user/known_limitations.md
@@ -8,14 +8,15 @@ avoids denial of service due to too large requests. If you don't take
 this limitation into account, you will get messages such the following
 ones:
 
-    <?xml version="1.0"?>
-    <queryContextResponse>
-      <errorCode>
-        <code>413</code>
-        <reasonPhrase>Payload Too Large</reasonPhrase>
-        <details>payload size: 1500748</details>
-      </errorCode>
-    </queryContextResponse>
+```
+{
+  "errorCode" : {
+    "code" : "413",
+    "reasonPhrase" : "Request Entity Too Large",
+    "details" : "payload size: 1500000, max size supported: 1048576"
+  }
+}
+```
 
 Or, if you are sending a huge request, this one:
 

--- a/doc/manuals/user/multitenancy.md
+++ b/doc/manuals/user/multitenancy.md
@@ -30,11 +30,11 @@ which case the header is not present), e.g.:
     Host: 127.0.0.1:9977
     Accept: application/xml, application/json
     Fiware-Service: t_02
-    Content-Type: application/xml
+    Content-Type: application/json
 
-    <notifyContextRequest>
+    {
     ...
-    <notifyContextRequest>
+    }
 
 Regarding service/tenant name syntax, it must be a string of
 alphanumeric characters (and the "\_" symbol). Maximum length is 50

--- a/doc/manuals/user/pagination.md
+++ b/doc/manuals/user/pagination.md
@@ -15,12 +15,8 @@ allow pagination. The mechanism is based on three URI parameters:
     discoverContextAvailability respectively) (default is 20, maximun
     allowed is 1000).
 
-<!-- -->
-
 -   **offset**, in order to skip a given number of elements at the
     beginning (default is 0)
-
-<!-- -->
 
 -   **details** (allowed values are “on” and “off”, default is “off”),
     in order to get a global errorCode for the response including a
@@ -48,11 +44,11 @@ included, for the sake of completeness).
     which allows the client to know how many entities are in sum and, therefore, the number of 
     subsequence queries to do)
 
-      <errorCode>
-        <code>200</code>
-        <reasonPhrase>OK</reasonPhrase>
-        <details>Count: 322</details>
-      </errorCode>
+      "errorCode": {
+        "code": "200",
+        "reasonPhrase": "OK",
+        "details": "Count: 322"
+      }
 
     POST <orion_host>:1026/v1/queryContext?offset=100&limit=100
     ...
@@ -69,12 +65,14 @@ included, for the sake of completeness).
 Note that if the request uses an “out of bound” offset you will get a
 404 NGSI error, as shown below:
 
-    POST <orion_host>:1026/v1/queryContext?offset=1000&limit=100
-    ...
-    <queryContextResponse>
-      <errorCode>
-        <code>404</code>
-        <reasonPhrase>No context element found</reasonPhrase>
-        <details>Number of matching entities: 5. Offset is 1000</details>
-      </errorCode>
-    </queryContextResponse>
+```
+POST <orion_host>:1026/v1/queryContext?offset=1000&limit=100
+...
+{
+    "errorCode": {
+        "code": "404",
+        "reasonPhrase": "No context element found",
+        "details": "Number of matching entities: 5. Offset is 1000"
+    }
+}
+```

--- a/doc/manuals/user/security.md
+++ b/doc/manuals/user/security.md
@@ -35,11 +35,11 @@ notifications. In order to do so:
     element in subscribeContext or subscribeContextAvailability
     subscriptions, e.g.
 
-<!-- -->
-
-    ...
-        <reference>https://mymachime.example.com:1028/notify</reference>
-    ...
+```
+  ...
+  "reference": "https://mymachime.example.com:1028/notify"
+  ...
+```
 
 -   You have to use Rush as relayer (as the HTTPS encoding is
     implemented in Rush). See [how to run Orion using

--- a/doc/manuals/user/service_path.md
+++ b/doc/manuals/user/service_path.md
@@ -50,16 +50,12 @@ Some additional remarks:
         query Fiware-ServicePath header (no more than 1 scope path in
         update Fiware-ServicePath header)
 
-<!-- -->
-
 -   Fiware-ServicePath is an optional header. It is assumed that all the
     entities created without Fiware-ServicePath (or that don't include
     service path information in the database) belongs to a root scope
     "/" implicitely. All the queries without using Fiware-ServicePath
     are on "/\#" implicitely. This behavior ensures backward
     compatibility to pre-0.14.0 versions.
-
-<!-- -->
 
 -   It is possible to have an entity with the same ID and type in
     different Scopes. E.g. we can create entity ID "Tree1" of type
@@ -71,16 +67,10 @@ Some additional remarks:
     queryContextResponse, making hard to distinguish to which scope
     belongs each one)
 
-<!-- -->
-
 -   Entities belongs to one (and only one) scope.
-
-<!-- -->
 
 -   Fiware-ServicePath
     header is included in NGSI10 notifyContext requests sent by Orion.
-
-<!-- -->
 
 -   The scopes entities can be combined orthogonally with the
     [multi-service/multi-tenant

--- a/doc/manuals/user/walkthrough_apiv1.md
+++ b/doc/manuals/user/walkthrough_apiv1.md
@@ -6,7 +6,6 @@
     * [Starting the broker for the tutorials](#starting-the-broker-for-the-tutorials)
     * [Starting accumulator server](#starting-accumulator-server)
     * [Issuing commands to the broker](#issuing-commands-to-the-broker)
-    * [Text colour convention](#text-colour-convention)
 * [Context management using NGSI10](#context-management-using-ngsi10)
     * [NGSI10 standard operations](#ngsi10-standard-operations)
 	  * [Entity Creation](#entity-creation)
@@ -176,47 +175,47 @@ following:
 
 -   For POST:
 
-<!-- -->
-
-    curl localhost:1026/<operation_url> -s -S [headers]' -d @- <<EOF
-    [payload]
-    EOF
+```
+curl localhost:1026/<operation_url> -s -S [headers]' -d @- <<EOF
+[payload]
+EOF
+```
 
 -   For PUT:
 
-<!-- -->
-
-    (curl localhost:1026/<operation_url> -s -S [headers] -X PUT -d @- <<EOF
-    [payload]
-    EOF
+```
+(curl localhost:1026/<operation_url> -s -S [headers] -X PUT -d @- <<EOF
+[payload]
+EOF
+```
 
 -   For GET:
 
-<!-- -->
-
-    curl localhost:1026/<operation_url> -s -S [headers]' 
+```
+curl localhost:1026/<operation_url> -s -S [headers]
+```
 
 -   For DELETE:
 
-<!-- -->
-
-    curl localhost:1026/<operation_url> -s -S [headers] -X DELETE
+```
+curl localhost:1026/<operation_url> -s -S [headers] -X DELETE
+```
 
 Regarding \[headers\] you have to include the following ones:
 
 -   Accept header to specify which payload format
     you want to receive in the response. You should explicitly specify JSON.
 
-<!-- -->
-
-    curl ... --header 'Accept: application/json' ...
+```
+curl ... --header 'Accept: application/json' ...
+```
 
 -   Only in the case of using payload in the request (i.e. POST or PUT),
     you have to use Context-Type header to specify the format (JSON).
 
-<!-- -->
-
-    curl ... --header 'Content-Type: application/json' ...
+```
+curl ... --header 'Content-Type: application/json' ...
+```
 
 Some additional remarks:
 
@@ -225,6 +224,7 @@ Some additional remarks:
     (*here-documents*). In
     some cases (GET and DELETE) we omit "-d @-" as they don't
     use payload.
+
 -   In our examples we assume that the broker is listening on port 1026.
     Adjust this in the curl command line if you are using a
     different setting.
@@ -232,28 +232,17 @@ Some additional remarks:
 -   In order to pretty-print JSON in responses, you can use Python with
     msjon.tool (examples along with tutorial are using this style):
 
-<!-- -->
-
-    (curl ... | python -mjson.tool) <<EOF
-    ...
-    EOF
+```
+(curl ... | python -mjson.tool) <<EOF
+...
+EOF
+```
 
 -   Check that curl is installed in your system using:
 
 ```
 # which curl
 ```
-
-[Top](#top)
-
-### Text colour convention
-
-This document assumes the following convention for text colour in JSON
-fragments:
-
--   <span style="color:darkblue">Blue</span>: request messages
--   <span style="color:darkgreen">Green</span>: response messages
--   <span style="color:purple">Purple</span>: notification messages
 
 [Top](#top)
 
@@ -299,7 +288,7 @@ creation time temperature and pressure of Room1 are 23 ºC and 720 mmHg
 respectively.
 
 ```
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -707,7 +696,6 @@ Additional comments:
     to get attributes as a JSON object (i.e. key-values map) instead of
     a vector (default behaviour):
 
-<!-- -->
 ```
 (curl 'localhost:1026/v1/queryContext?attributeFormat=object' -s -S \
     --header  'Content-Type: application/json' --header 'Accept: application/json' \
@@ -1819,8 +1807,6 @@ Additional comments:
 -   You can use the *?attributeFormat=object* URI parameter
     to get attributes as a JSON object (i.e. key-values map) instead of
     a vector (default behaviour):
-
-<!-- -->
 
 ``` 
 curl localhost:1026/v1/contextEntities/Room1?attributeFormat=object -s -S \ 
@@ -3166,34 +3152,41 @@ any entity ID):
 
 ```
 (curl localhost:1026/v1/registry/contextEntityTypes/Funny -s -S \
-    --header 'Content-Type: application/xml' -d @- | xmllint --format - ) << EOF
-<?xml version="1.0"?>
-<registerProviderRequest>
-  <duration>P1M</duration>
-      <providingApplication>http://mysensors.com/Funny</providingApplication>
-</registerProviderRequest>
+    --header 'Content-Type: application/json' --header 'Accept: application/json' \
+    -d @- | python -mjson.tool) << EOF
+{
+  "duration": "P1M",
+  "providingApplication": "http://mysensors.com/Funny"
+}
 EOF
 ```
+
 Now, let's discover on that type:
 
 ```
 curl localhost:1026/v1/registry/contextEntityTypes/Funny -s -S \
-    --header 'Content-Type: application/xml' | xmllint --format -
+    --header 'Accept: application/json' | python -mjson.tool
+```
 
-<discoverContextAvailabilityResponse>
-  <contextRegistrationResponseList>
-    <contextRegistrationResponse>
-      <contextRegistration>
-        <entityIdList>
-          <entityId type="Funny" isPattern="false">
-            <id/>
-          </entityId>
-        </entityIdList>
-        <providingApplication>http://mysensors.com/Funny</providingApplication>
-      </contextRegistration>
-    </contextRegistrationResponse>
-  </contextRegistrationResponseList>
-</discoverContextAvailabilityResponse>
+which response is:
+
+```
+{
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "entities": [
+                    {
+                        "id": "",
+                        "isPattern": "false",
+                        "type": "Funny"
+                    }
+                ],
+                "providingApplication": "http://mysensors.com/Funny"
+            }
+        }
+    ]
+}
 ```
 
 As you can see, the ID element is empty (it makes sense, as we didn't
@@ -3203,41 +3196,44 @@ Moreover, you can register attributes in these registrations, e.g:
 
 ```
 (curl localhost:1026/v1/registry/contextEntityTypes/MoreFunny/attributes/ATT -s -S \
-    --header 'Content-Type: application/xml' -d @- | xmllint --format - ) << EOF
-<?xml version="1.0"?>
-<registerProviderRequest>
-   <duration>P1M</duration>
-   <providingApplication>http://mysensors.com/Funny</providingApplication>
-</registerProviderRequest>
+    --header 'Content-Type: application/json' --header 'Accept: application/json' \
+    -d @- | python -mjson.tool) << EOF
+{
+  "duration": "P1M",
+  "providingApplication": "http://mysensors.com/Funny"
+}
 EOF
 ```
+
 ```
-curl localhost:1026/v1/registry/contextEntityTypes/MoreFunny -s -S \
-    --header 'Content-Type: application/xml' | xmllint --format -
+curl localhost:1026/v1/registry/contextEntityTypes/MoreFunny/attributes/ATT -s -S \
+    --header 'Accept: application/json' | python -mjson.tool
 ```
+
 ```
-<?xml version="1.0"?>
-<discoverContextAvailabilityResponse>
-  <contextRegistrationResponseList>
-    <contextRegistrationResponse>
-      <contextRegistration>
-        <entityIdList>
-          <entityId type="MoreFunny" isPattern="false">
-            <id/>
-          </entityId>
-        </entityIdList>
-        <contextRegistrationAttributeList>
-          <contextRegistrationAttribute>
-            <name>ATT</name>
-            <type/>
-            <isDomain>false</isDomain>
-          </contextRegistrationAttribute>
-        </contextRegistrationAttributeList>
-        <providingApplication>http://mysensors.com/Funny</providingApplication>
-      </contextRegistration>
-    </contextRegistrationResponse>
-  </contextRegistrationResponseList>
-</discoverContextAvailabilityResponse>
+{
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "ATT",
+                        "type": ""
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "",
+                        "isPattern": "false",
+                        "type": "MoreFunny"
+                    }
+                ],
+                "providingApplication": "http://mysensors.com/Funny"
+            }
+        }
+    ]
+}
 ```
 
 [Top](#top)


### PR DESCRIPTION
Removing XML leftovers in the manual, yet pending until now.

After this PR, the `grep '</' -R *` run in doc/manuals show only the following ocurrences:

* code_contributions.md. They are verbatim contributions from users, done in the past, so it means sense to have XML there.
* `<a name="top">` marks. They are not rendered, used for intra-page navigation. No problem.
* known_limitations.md. A cite to the HTML error that libmicrohttp generates for huge requests. It ok to have it as is, as is a text generated by the library.

So, after merging this PR, documentation is XML-free finally :)