### PR TITLE
Hardening/removing whitespace after

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ How to run Orion Context Broker can be found at [the corresponding section of th
 In order to create an entity (Room1) with two attributes (temperature and pressure):
 
 ``` 
-(curl <orion_host>:1026/v1/contextEntities/Room1 -s -S --header 'Content-Type: application/json' \ 
+(curl <orion_host>:1026/v1/contextEntities/Room1 -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -X POST -d @- | python -mjson.tool) <<EOF
 {
     "attributes": [

--- a/doc/manuals/admin/install.md
+++ b/doc/manuals/admin/install.md
@@ -53,10 +53,10 @@ rpm -i contextBroker-X.Y.Z-1.x86_64.rpm
 
 ### Optional packages
 
-Apart from the mandatory RPM described above, you can install the contextBroker-test package, which contain utility tools:
+Apart from the mandatory RPM described above, you can install the contextBroker-tests package, which contain utility tools:
 
 ```
-yum install contextBroker-test
+yum install contextBroker-tests
 ```
 
 or

--- a/doc/manuals/user/append_and_delete.md
+++ b/doc/manuals/user/append_and_delete.md
@@ -7,15 +7,15 @@ with an example.
 
 We start creating a simple entity 'E1' with one attribute named 'A':
 ```
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
-```                                                                                                                    
+```                                                                                                                  
 
 Now, in order to append a new attribute (let's name it 'B') we use
 updateContext APPEND with an entityId matching 'E1':
 
 ```
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -40,7 +40,7 @@ Now we can check with a query to that entity that both attributes A and
 B are there:
 
 ``` 
-(curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' | python -mjson.tool)<<EOF
 {
     "contextElement": {
@@ -135,7 +135,7 @@ add and delete attributes. Try the following:
 Add a new attribute 'C' and 'D':
 
 ```
-(curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "attributes": [
@@ -157,13 +157,13 @@ EOF
 Remove attribute 'B':
 ```
 curl localhost:1026/v1/contextEntities/E1/attribute/B -s -S \
-   --header 'Content-Type: application/json'  -X DELETE  \ 
-   --header 'Accept: application/json'  | python -mjson.tool
+    --header 'Content-Type: application/json'  -X DELETE  \
+    --header 'Accept: application/json'  | python -mjson.tool
 ```
 Query entity (should see 'C' and 'D', but not 'B'):
 
 ```
-(curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/contextEntities/E1 -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' | python -mjson.tool) <<EOF
 {
     "contextElement": {
@@ -202,7 +202,7 @@ operation is used, with DELETE as actionType and with an empty
 attributeList, as in the following example:
 
 ```
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -219,8 +219,8 @@ EOF
  
 You can also use the following equivalent convenience operation:
 ``` 
-curl localhost:1026/v1/contextEntities/E1 -s -S \ 
-   --header 'Content-Type: application/json' \ 
-   --header 'Accept: application/json' -X DELETE
+curl localhost:1026/v1/contextEntities/E1 -s -S \
+    --header 'Content-Type: application/json' \ 
+    --header 'Accept: application/json' -X DELETE
 ``` 
 

--- a/doc/manuals/user/context_providers.md
+++ b/doc/manuals/user/context_providers.md
@@ -33,7 +33,7 @@ Let's illustrate this with an example.
       its API on <http://sensor48.mycity.com/ngsi10>
       
 ```
-(curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextRegistrations": [
@@ -66,7 +66,7 @@ EOF
 
       
 ``` 
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [

--- a/doc/manuals/user/filtering.md
+++ b/doc/manuals/user/filtering.md
@@ -17,7 +17,7 @@ As a general rule, filters used in standard operation use a scope
 element:
 
 ``` 
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -43,7 +43,7 @@ while filters in convenience operations are included as parameters in
 the URL:
 
 ``` 
-curl localhost:1026/v1/contextEntities?filter=value -s -S  --header 'Content-Type: application/json'  \ 
+curl localhost:1026/v1/contextEntities?filter=value -s -S  --header 'Content-Type: application/json'  \
     --header 'Accept: application/json' | python -mjson.tool
 ``` 
 Filters are cumulative. In other words, you can use several scopes in

--- a/doc/manuals/user/geolocation.md
+++ b/doc/manuals/user/geolocation.md
@@ -15,7 +15,7 @@ example, the following updateContext request creates the entity "Madrid"
 (of type "City") with attribute "position" defined as location.
 
 ``` 
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -105,7 +105,7 @@ longitude) that provide the coordinates of the vertex. The result of the
 query would be A and B.
 
 ``` 
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -156,7 +156,7 @@ defined by coordinates (3, 3), (3, 8), (11, 8) and (11, 3).
 The result of the query would be B and C.
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -205,7 +205,7 @@ to the area external to the polygon we include the inverted element set
 to "true".
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -257,7 +257,7 @@ defined by coordinates (0, 0), (0, 6) and (6, 0).
 The result of the query would be A.
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -301,7 +301,7 @@ However, if we consider the query to the external area to that triangle
 would be B and C.
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -364,7 +364,7 @@ center), centerLongitude (the longitude of the circle center) and radius
 (in meters). The result of the query would be Madrid and Leganes.
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -400,7 +400,7 @@ meters) centred in Madrid.
 The result of the query would be Madrid, Leganes and Alcobendas.
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -436,7 +436,7 @@ We use the inverted element set to "true". The result of the query would
 be Alcobendas.
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [

--- a/doc/manuals/user/metadata.md
+++ b/doc/manuals/user/metadata.md
@@ -13,7 +13,7 @@ For example, to create an entity Room1 with attribute "temperature", and
 associate metadata "accuracy" to "temperature":
 
 ``` 
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -47,7 +47,7 @@ or not. For example, next updateContext shows how "accuracy" is updated
 to 0.9 although the value of the temperature iself is still 26.5:
 
 ``` 
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -81,7 +81,7 @@ to add metadata "average" to "temperature" (in addition to the existing
 "precision"):
 
 ``` 
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -112,7 +112,7 @@ EOF
 We can check that temperature includes both attributes
 
 ``` 
-(curl localhost:1026/v1/contextEntities/Room1 -s -S \ 
+(curl localhost:1026/v1/contextEntities/Room1 -s -S \
     --header 'Accept: application/json' | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -178,7 +178,7 @@ use the metadata ID for this purpose. Let's illustrate with an example.
 First, we create the Room1 entity:
 
 ``` 
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -222,7 +222,7 @@ EOF
 Now, we can query for temperature to get both instances:
 
 ``` 
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -243,7 +243,7 @@ We can update an specific instance (e.g. ground), letting the other
 untouched:
 
 ``` 
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [
@@ -279,7 +279,7 @@ To avoid ambiguities, you cannot mix the same attribute with and without
 ID. The following entity creation will fail:
 
 ``` 
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [

--- a/doc/manuals/user/structured_attribute_valued.md
+++ b/doc/manuals/user/structured_attribute_valued.md
@@ -18,7 +18,7 @@ key-map object (we use UPDATE as actionType, but this can be used at
 initial entity or attribute creation with APPEND).
 
 ``` 
-(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextElements": [

--- a/doc/manuals/user/updating_regs_and_subs.md
+++ b/doc/manuals/user/updating_regs_and_subs.md
@@ -20,7 +20,7 @@ operations). The update is done issuing a new registerContextRequest,
 with the *registrationId* set:
 
 ``` 
-(curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextRegistrations": [

--- a/doc/manuals/user/walkthrough_apiv1.md
+++ b/doc/manuals/user/walkthrough_apiv1.md
@@ -450,7 +450,7 @@ graphical user interface). The NGSI10 queryContext request is used in
 this case, e.g. to get context information for Room1:
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -501,7 +501,7 @@ entity creation with updateContext (23ºC and 720 mmHg).
 If you use an empty attributes element in the request, the response will include all the attributes of the entity. If you include an actual list of attributes (e.g. temperature) only that are retrieved, as shown in the following request:
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -551,7 +551,7 @@ entities which ID starts with "Room" using the regex "Room.\*". In this
 case, you have to set isPattern to "true" as shown below:
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -573,7 +573,7 @@ case, you have to set isPattern to "true" as shown below:
 EOF
 ```
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -640,7 +640,7 @@ Finally, note that you will get an error in case you try to query a
 non-existing entity or attribute, as shown in the following cases below:
 
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -654,7 +654,7 @@ non-existing entity or attribute, as shown in the following cases below:
 EOF
 ```
 ```
-(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/queryContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -1100,7 +1100,7 @@ one that you have got in the subscribeContext response in the previous
 step) command:
 
 ```
-(curl localhost:1026/v1/updateContextSubscription -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/updateContextSubscription -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "subscriptionId": "51c04a21d714fb3b37d7d5a7",
@@ -1477,8 +1477,8 @@ that, as described in [this
 section](append_and_delete.md#adding-and-removing-attributes-with-append-and-delete-in-updatecontext)):
 
 ```
-(curl localhost:1026/v1/contextEntities/Room3/attributes/temperature -s -S \ 
-    --header 'Content-Type: application/json' --header 'Accept: application/json' \ 
+(curl localhost:1026/v1/contextEntities/Room3/attributes/temperature -s -S \
+    --header 'Content-Type: application/json' --header 'Accept: application/json' \
     -X POST -d @- | python -mjson.tool) <<EOF
 {
     "value" : "21"
@@ -1809,7 +1809,7 @@ Additional comments:
     a vector (default behaviour):
 
 ``` 
-curl localhost:1026/v1/contextEntities/Room1?attributeFormat=object -s -S \ 
+curl localhost:1026/v1/contextEntities/Room1?attributeFormat=object -s -S \
     --header 'Accept: application/json' | python -mjson.tool
 
 ```
@@ -1850,9 +1850,10 @@ curl localhost:1026/v1/contextEntities/Room1?attributeFormat=object -s -S \
 
 You can get all the entities using the following convenience operation:
 
-    curl localhost:1026/v1/contextEntities -s -S --header 'Content-Type: application/json' \
-        --header 'Accept: application/json' | python -mjson.tool
-
+```
+curl localhost:1026/v1/contextEntities -s -S --header 'Content-Type: application/json' \
+    --header 'Accept: application/json' | python -mjson.tool
+```
 In our case, it will return both Room1 and Room2:
 
 ``` 
@@ -1931,7 +1932,7 @@ The following operation can be used to get a list of all entity types
 existing at Orion Context Broker in a given moment:
 
 ``` 
-curl localhost:1026/v1/contextTypes -s -S --header 'Content-Type: application/json' \ 
+curl localhost:1026/v1/contextTypes -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' | python -mjson.tool
 ``` 
 
@@ -1979,7 +1980,7 @@ information of a given type (by the time being, that information consits
 of a list of all its attributes):
 
 ``` 
-curl localhost:1026/v1/contextTypes/Room -s -S --header 'Content-Type: application/json' \ 
+curl localhost:1026/v1/contextTypes/Room -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' | python -mjson.tool
 ``` 
 
@@ -2012,8 +2013,8 @@ In addition, note that this convenience operation doesn't have any standard oper
 Let's set the Room1 temperature and pressure values:
 
 ``` 
-(curl localhost:1026/v1/contextEntities/Room1/attributes -s -S \ 
-    --header 'Content-Type: application/json'  --header 'Accept: application/json' \ 
+(curl localhost:1026/v1/contextEntities/Room1/attributes -s -S \
+    --header 'Content-Type: application/json'  --header 'Accept: application/json' \
     -X PUT -d @- | python -mjson.tool) << EOF
 {
     "attributes": [
@@ -2062,8 +2063,8 @@ the response is:
 Now, let's do the same with Room2:
 
 ``` 
-(curl localhost:1026/v1/contextEntities/Room2/attributes -s -S \ 
-    --header 'Content-Type: application/json'  --header 'Accept: application/json' \ 
+(curl localhost:1026/v1/contextEntities/Room2/attributes -s -S \
+    --header 'Content-Type: application/json'  --header 'Accept: application/json' \
     -X PUT -d @- | python -mjson.tool) << EOF
 {
     "attributes": [
@@ -2369,7 +2370,7 @@ precise, we can include the name of an attribute to search for:
 
 ``` 
 (curl localhost:1026/v1/registry/discoverContextAvailability -s -S \
-    --header  'Content-Type: application/json' --header 'Accept: application/json' \ 
+    --header  'Content-Type: application/json' --header 'Accept: application/json' \
     -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -2418,8 +2419,8 @@ If the broker doesn't have any registration information, it will return
 a response telling so. Thus, the following request:
 
 ``` 
-(curl localhost:1026/v1/registry/discoverContextAvailability -s -S \ 
-    --header 'Content-Type: application/json' --header 'Accept: application/json' \ 
+(curl localhost:1026/v1/registry/discoverContextAvailability -s -S \
+    --header 'Content-Type: application/json' --header 'Accept: application/json' \
     -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -2513,8 +2514,8 @@ entities whose ID starts with "Room" using the regex "Room.\*". In this
 case, you have to set isPattern to "true" as shown below:
 
 ``` 
-(curl localhost:1026/v1/registry/discoverContextAvailability -s -S \ 
-    --header 'Content-Type: application/json' --header 'Accept: application/json' \ 
+(curl localhost:1026/v1/registry/discoverContextAvailability -s -S \
+    --header 'Content-Type: application/json' --header 'Accept: application/json' \
     -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -2575,8 +2576,8 @@ In order to configure this behavior, we use the following NGSI9
 subscribeContextAvailability request:
 
 ``` 
-(curl localhost:1026/v1/registry/subscribeContextAvailability -s -S \ 
-    --header 'Content-Type: application/json' --header 'Accept: application/json' \ 
+(curl localhost:1026/v1/registry/subscribeContextAvailability -s -S \
+    --header 'Content-Type: application/json' --header 'Accept: application/json' \
     -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -2835,7 +2836,7 @@ subscribeContextAvailability response in the previous step).
 
 ```
 (curl localhost:1026/v1/registry/updateContextAvailabilitySubscription -s -S \
-    --header 'Content-Type: application/json' --header 'Accept: application/json' \ 
+    --header 'Content-Type: application/json' --header 'Accept: application/json' \
     -d @- | python -mjson.tool) <<EOF
 {
     "entities": [
@@ -3422,7 +3423,7 @@ entities with types using convenience operations):
 EOF
 ``` 
 ``` 
-(curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' \ 
+(curl localhost:1026/v1/registry/registerContext -s -S --header 'Content-Type: application/json' \
     --header 'Accept: application/json' -d @- | python -mjson.tool) <<EOF
 {
     "contextRegistrations": [


### PR DESCRIPTION
Fixes #1221 

It has been removed whitespace after '\' from the corresponding files: 
-append_and_delete.md,context_providers.md,filtering.md,geolocation.md,metadata.md,structured_attribute_valued.md,updating_regs_and_subs.md and walkthrough_apiv1.md
