### PR TITLE
All functests but coap_basic now work again under valgrind

### DIFF
--- a/test/functionalTest/cases/0000_statistics_operation/statistics.test
+++ b/test/functionalTest/cases/0000_statistics_operation/statistics.test
@@ -50,7 +50,7 @@ Date: REGEX(.*)
 <?xml version="1.0"?>
 <orion>
   <xmlRequests>REGEX((1|2))</xmlRequests>
-  <versionRequests>0</versionRequests>
+  <versionRequests>REGEX((0|1))</versionRequests>
   <statisticsRequests>1</statisticsRequests>
   <uptime_in_secs>REGEX(1?\d)</uptime_in_secs>
   <measuring_interval_in_secs>REGEX(1?\d)</measuring_interval_in_secs>
@@ -69,7 +69,7 @@ Date: REGEX(.*)
         "measuring_interval_in_secs": "REGEX(1?\d)", 
         "statisticsRequests": "2", 
         "uptime_in_secs": "REGEX(1?\d)", 
-        "versionRequests": "0", 
+        "versionRequests": "REGEX((0|1))", 
         "xmlRequests": "REGEX((1|2))"
     }
 }

--- a/test/functionalTest/cases/0000_statistics_operation/statistics_with_semaphores.test
+++ b/test/functionalTest/cases/0000_statistics_operation/statistics_with_semaphores.test
@@ -50,7 +50,7 @@ Date: REGEX(.*)
 <?xml version="1.0"?>
 <orion>
   <xmlRequests>REGEX((1|2))</xmlRequests>
-  <versionRequests>0</versionRequests>
+  <versionRequests>REGEX((0|1))</versionRequests>
   <statisticsRequests>1</statisticsRequests>
   <requestSemaphoreWaitingTime>REGEX(\d+.\d+)</requestSemaphoreWaitingTime>
   <dbConnectionPoolWaitingTime>REGEX(\d+.\d+)</dbConnectionPoolWaitingTime>
@@ -79,7 +79,7 @@ Date: REGEX(.*)
         "subCacheMutexWaitingTime": "REGEX(\d+.\d+)", 
         "transactionSemaphoreWaitingTime": "REGEX(\d+.\d+)", 
         "uptime_in_secs": "REGEX(1?\d)", 
-        "versionRequests": "0", 
+        "versionRequests": "REGEX((0|1))", 
         "xmlRequests": "REGEX((1|2))"
     }
 }

--- a/test/functionalTest/cases/0392_service_path_update_and_query/service_path_http_header.test
+++ b/test/functionalTest/cases/0392_service_path_update_and_query/service_path_http_header.test
@@ -67,6 +67,13 @@ echo
 echo "+++++ 5: four service paths"
 orionCurl --url /v1/queryContext --payload "$payload" --servicePath '/home/kz/1, /home/kz/2, /home/kz/3, /home/kz/4'
 echo
+
+
+#
+# When started under valgrind, a "GET /version" is issued to make sure the broker is running, and this gives us ONE EXTRA
+# Request found in the log-file. The Service Path is '/#' for this GET /version request and it is removed from the diff by
+# the final grep -v '/#', to make this functional test work both as normal functest and under the valgrind suite.
+#
 echo "+++++ 6: service paths from log file"
 grep servicePathSplit /tmp/contextBroker.log | awk -F\| '{ print $6 }' | awk -F: '{ printf "%s:%s\n", $2, $3 }' | grep -v '/#'
 echo

--- a/test/functionalTest/cases/0392_service_path_update_and_query/service_path_http_header.test
+++ b/test/functionalTest/cases/0392_service_path_update_and_query/service_path_http_header.test
@@ -68,7 +68,7 @@ echo "+++++ 5: four service paths"
 orionCurl --url /v1/queryContext --payload "$payload" --servicePath '/home/kz/1, /home/kz/2, /home/kz/3, /home/kz/4'
 echo
 echo "+++++ 6: service paths from log file"
-grep servicePathSplit /tmp/contextBroker.log | awk -F\| '{ print $6 }' | awk -F: '{ printf "%s:%s\n", $2, $3 }'
+grep servicePathSplit /tmp/contextBroker.log | awk -F\| '{ print $6 }' | awk -F: '{ printf "%s:%s\n", $2, $3 }' | grep -v '/#'
 echo
 
 

--- a/test/functionalTest/cases/0563_ngsi10_get_list_of_all_entities/all_entities_no_filter.test
+++ b/test/functionalTest/cases/0563_ngsi10_get_list_of_all_entities/all_entities_no_filter.test
@@ -318,7 +318,7 @@ Date: REGEX(.*)
   <xmlRequests>REGEX((6|7))</xmlRequests>
   <updates>3</updates>
   <allContextEntitiesRequests>2</allContextEntitiesRequests>
-  <versionRequests>0</versionRequests>
+  <versionRequests>REGEX((0|1))</versionRequests>
   <statisticsRequests>1</statisticsRequests>
   <subCacheLookups>3</subCacheLookups>
   <uptime_in_secs>REGEX(\d+)</uptime_in_secs>

--- a/test/functionalTest/cases/0581_include_type_in_convops/v1_registry_contextEntities_enType_ENTYPE_enId_ENID_attribute_attrName.test
+++ b/test/functionalTest/cases/0581_include_type_in_convops/v1_registry_contextEntities_enType_ENTYPE_enId_ENID_attribute_attrName.test
@@ -233,7 +233,7 @@ Date: REGEX(.*)
         "measuring_interval_in_secs": "REGEX(\d+)", 
         "statisticsRequests": "1", 
         "uptime_in_secs": "REGEX(\d+)", 
-        "versionRequests": "0",
+        "versionRequests": "REGEX((0|1))",
         "xmlRequests": "REGEX((2|3))"
     }
 }

--- a/test/functionalTest/cases/1048_subscription_cache/cache_population_at_init.test
+++ b/test/functionalTest/cases/1048_subscription_cache/cache_population_at_init.test
@@ -237,7 +237,7 @@ Date: REGEX(.*)
 <?xml version="1.0"?>
 <orion>
   <xmlRequests>REGEX((1|2))</xmlRequests>
-  <versionRequests>0</versionRequests>
+  <versionRequests>REGEX((0|1))</versionRequests>
   <statisticsRequests>1</statisticsRequests>
   <subCacheEntries>3</subCacheEntries>
   <uptime_in_secs>REGEX(\d)</uptime_in_secs>
@@ -259,7 +259,7 @@ Date: REGEX(.*)
         "statisticsRequests": "2",
         "subCacheEntries": "3",
         "uptime_in_secs": "REGEX(\d)",
-        "versionRequests": "0",
+        "versionRequests": "REGEX((0|1))",
         "xmlRequests": "REGEX((1|2))"
     }
 }

--- a/test/functionalTest/cases/1048_subscription_cache/three_subscriptions.test
+++ b/test/functionalTest/cases/1048_subscription_cache/three_subscriptions.test
@@ -32,6 +32,7 @@ accumulatorStart
 
 #
 # 00. Making sure only ONE ftest database exists
+# 00. Making sure counters are RESET
 # 01. Subscribe to E1/A1 (no pattern)
 # 02. Subscribe to E2.*/A1
 # 03. Subscribe to E3.*/A1
@@ -46,6 +47,13 @@ accumulatorStart
 echo "00. Making sure only ONE ftest database exists"
 echo "=============================================="
 dbList ftest*
+echo
+echo
+
+
+echo "00. Making sure counters are RESET"
+echo "=================================="
+orionCurl --url /statistics -X DELETE --json
 echo
 echo
 
@@ -191,6 +199,20 @@ echo
 ftest
 
 
+00. Making sure counters are RESET
+==================================
+HTTP/1.1 200 OK
+Content-Length: 69
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "orion": {
+        "message": "All statistics counter reset"
+    }
+}
+
+
 01. Subscribe to E1/A1 (no pattern)
 ===================================
 HTTP/1.1 200 OK
@@ -259,7 +281,7 @@ Date: REGEX(.*)
         "subscriptions": "3",
         "transactionSemaphoreWaitingTime": "REGEX(\d+.\d+)",
         "uptime_in_secs": "REGEX(\d+)",
-        "versionRequests": "0"
+        "versionRequests": "REGEX((0|1))"
     }
 }
 
@@ -301,7 +323,7 @@ Date: REGEX(.*)
         "transactionSemaphoreWaitingTime": "REGEX(\d+.\d+)", 
         "unsubscriptions": "1", 
         "uptime_in_secs": "REGEX(\d+)",
-        "versionRequests": "0"
+        "versionRequests": "REGEX((0|1))"
     }
 }
 
@@ -344,7 +366,7 @@ Date: REGEX(.*)
         "transactionSemaphoreWaitingTime": "REGEX(\d+.\d+)", 
         "unsubscriptions": "2", 
         "uptime_in_secs": "REGEX(\d+)",
-        "versionRequests": "0"
+        "versionRequests": "REGEX((0|1))"
     }
 }
 


### PR DESCRIPTION
Made the last changes (there was no time to include this in the release 0.24.0) to fix the failing functests under the valgrind suite.

Now only coap_basic fails under valgrind.