### PR TITLE
Bug/1200 parse error in description string

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 Fix:  Detail message for HTTP Content-Lenght required error (Issue #1203)
+Fix:  Changed the description text for parse errors in v2 json requests (Issue #1200)

--- a/src/lib/jsonParseV2/jsonRequestTreat.cpp
+++ b/src/lib/jsonParseV2/jsonRequestTreat.cpp
@@ -56,7 +56,7 @@ std::string jsonRequestTreat(ConnectionInfo* ciP, ParseData* parseDataP, Request
 
     if ((answer = parseDataP->ent.res.check(ciP, EntitiesRequest)) != "OK")
     {
-      OrionError error(SccBadRequest, "Parse Error (" + answer + ")");
+      OrionError error(SccBadRequest, answer);
       return error.render(ciP, "");
     }
     break;
@@ -71,7 +71,7 @@ std::string jsonRequestTreat(ConnectionInfo* ciP, ParseData* parseDataP, Request
 
     if ((answer = parseDataP->ent.res.check(ciP, EntityRequest)) != "OK")
     {
-      OrionError error(SccBadRequest, "Parse Error (" + answer + ")");
+      OrionError error(SccBadRequest, answer);
       return error.render(ciP, "");
     }
     break;

--- a/test/functionalTest/cases/1200_parse_error_in_description_string/parse_error_in_description_string.test
+++ b/test/functionalTest/cases/1200_parse_error_in_description_string/parse_error_in_description_string.test
@@ -1,0 +1,64 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Parse Error In Description String
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. POST /v2/entities with JSON parse error
+#
+
+echo "01. POST /v2/entities with JSON parse error"
+echo "==========================================="
+payload='{
+  "type":"T1",
+  "id": "E1",
+  "temp": "a<1>"
+}'
+orionCurl --url /v2/entities --payload "$payload" --json
+echo
+echo
+
+
+--REGEXPECT--
+01. POST /v2/entities with JSON parse error
+===========================================
+HTTP/1.1 400 Bad Request
+Content-Length: 76
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "Invalid characters in attribute value",
+    "error": "BadRequest"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Just changed the description text for v2 JSON parse errors.
New very simple functest covering this (one case only - 'Behave' tests cover the rest of the cases). 

Implements #1200
