### PR TITLE
Rename types to make code clearer

### DIFF
--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -85,7 +85,7 @@
 #include "common/Timer.h"
 #include "common/compileInfo.h"
 
-#include "orionTypes/EntityTypesResponse.h"
+#include "orionTypes/EntityTypeVectorResponse.h"
 #include "ngsi/ParseData.h"
 #include "ngsiNotify/onTimeIntervalThread.h"
 #include "serviceRoutines/logTraceTreat.h"

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -156,7 +156,7 @@ static long long countEntities(const std::string& tenant, const std::vector<std:
 */
 HttpStatusCode mongoEntityTypes
 (
-  EntityTypesResponse*                  responseP,
+  EntityTypeVectorResponse*                  responseP,
   const std::string&                    tenant,
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams
@@ -300,7 +300,7 @@ HttpStatusCode mongoEntityTypes
   for (unsigned int ix = offset; ix < MIN(resultsArray.size(), offset + limit); ++ix)
   {
     BSONObj                   resultItem  = resultsArray[ix].embeddedObject();
-    TypeEntity*               entityType  = new TypeEntity(resultItem.getStringField("_id"));
+    EntityType*               entityType  = new EntityType(resultItem.getStringField("_id"));
     std::vector<BSONElement>  attrsArray  = resultItem.getField("attrs").Array();
 
     entityType->count = countEntities(tenant, servicePathV, entityType->type);
@@ -324,11 +324,11 @@ HttpStatusCode mongoEntityTypes
       }
     }
 
-    responseP->typeEntityVector.push_back(entityType);
+    responseP->entityTypeVector.push_back(entityType);
   }
 
   char detailsMsg[256];
-  if (responseP->typeEntityVector.size() > 0)
+  if (responseP->entityTypeVector.size() > 0)
   {
     if (details)
     {
@@ -367,7 +367,7 @@ HttpStatusCode mongoEntityTypes
 HttpStatusCode mongoAttributesForEntityType
 (
   std::string                           entityType,
-  EntityTypeAttributesResponse*         responseP,
+  EntityTypeResponse*         responseP,
   const std::string&                    tenant,
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams

--- a/src/lib/mongoBackend/mongoQueryTypes.h
+++ b/src/lib/mongoBackend/mongoQueryTypes.h
@@ -29,8 +29,8 @@
 #include <string>
 #include <map>
 
-#include "orionTypes/EntityTypesResponse.h"
-#include "orionTypes/EntityTypeAttributesResponse.h"
+#include "orionTypes/EntityTypeVectorResponse.h"
+#include "orionTypes/EntityTypeResponse.h"
 
 #include "mongoBackend/MongoGlobal.h"
 
@@ -50,7 +50,7 @@ const std::string S_ATTRNAMES      = std::string("$") + ENT_ATTRNAMES;
 */
 extern HttpStatusCode mongoEntityTypes
 (
-  EntityTypesResponse*                  responseP,
+  EntityTypeVectorResponse*                  responseP,
   const std::string&                    tenant,
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams
@@ -63,7 +63,7 @@ extern HttpStatusCode mongoEntityTypes
 extern HttpStatusCode mongoAttributesForEntityType
 (
   std::string                           entityType,
-  EntityTypeAttributesResponse*         responseP,
+  EntityTypeResponse*         responseP,
   const std::string&                    tenant,
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams

--- a/src/lib/orionTypes/CMakeLists.txt
+++ b/src/lib/orionTypes/CMakeLists.txt
@@ -22,10 +22,10 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
 SET (SOURCES
     areas.cpp
-    TypeEntity.cpp
-    TypeEntityVector.cpp
-    EntityTypesResponse.cpp
-    EntityTypeAttributesResponse.cpp
+    EntityType.cpp
+    EntityTypeVector.cpp
+    EntityTypeVectorResponse.cpp
+    EntityTypeResponse.cpp
     QueryContextRequestVector.cpp
     QueryContextResponseVector.cpp
     UpdateContextRequestVector.cpp
@@ -34,10 +34,10 @@ SET (SOURCES
 
 SET (HEADERS
     areas.h
-    TypeEntity.h
-    TypeEntityVector.h
-    EntityTypesResponse.h
-    EntityTypeAttributesResponse.h
+    EntityType.h
+    EntityTypeVector.h
+    EntityTypeVectorResponse.h
+    EntityTypeResponse.h
     QueryContextRequestVector.h
     QueryContextResponseVector.h
     UpdateContextRequestVector.h

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -30,15 +30,15 @@
 #include "common/tag.h"
 #include "ngsi/Request.h"
 #include "rest/uriParamNames.h"
-#include "orionTypes/TypeEntity.h"
+#include "orionTypes/EntityType.h"
 
 
 
 /* ****************************************************************************
 *
-* TypeEntity::TypeEntity -
+* EntityType::EntityType -
 */
-TypeEntity::TypeEntity()
+EntityType::EntityType()
 {
   type = "";
 }
@@ -47,9 +47,9 @@ TypeEntity::TypeEntity()
 
 /* ****************************************************************************
 *
-* TypeEntity::TypeEntity -
+* EntityType::EntityType -
 */
-TypeEntity::TypeEntity(std::string  _type)
+EntityType::EntityType(std::string  _type)
 {
   type = _type;
 }
@@ -57,15 +57,15 @@ TypeEntity::TypeEntity(std::string  _type)
 
 /* ****************************************************************************
 *
-* TypeEntity::render -
+* EntityType::render -
 *
 * This method is used by:
-*   o TypeEntityVector
-*   o EntityTypeAttributesResponse
+*   o EntityTypeVector
+*   o EntityTypeResponse
 *
-* 'typeNameBefore' is set to TRUE when called from EntityTypeAttributesResponse
+* 'typeNameBefore' is set to TRUE when called from EntityTypeResponse
 */
-std::string TypeEntity::render
+std::string EntityType::render
 (
   ConnectionInfo*     ciP,
   const std::string&  indent,
@@ -106,9 +106,9 @@ std::string TypeEntity::render
 
 /* ****************************************************************************
 *
-* TypeEntity::check -
+* EntityType::check -
 */
-std::string TypeEntity::check
+std::string EntityType::check
 (
   ConnectionInfo*     ciP,
   const std::string&  indent,
@@ -131,9 +131,9 @@ std::string TypeEntity::check
 
 /* ****************************************************************************
 *
-* TypeEntity::present -
+* EntityType::present -
 */
-void TypeEntity::present(const std::string& indent)
+void EntityType::present(const std::string& indent)
 {
   LM_F(("%stype:   %s", indent.c_str(), type.c_str()));
   contextAttributeVector.present(indent);
@@ -143,9 +143,9 @@ void TypeEntity::present(const std::string& indent)
 
 /* ****************************************************************************
 *
-* TypeEntity::release -
+* EntityType::release -
 */
-void TypeEntity::release(void)
+void EntityType::release(void)
 {
   contextAttributeVector.release();
 }
@@ -154,9 +154,9 @@ void TypeEntity::release(void)
 
 /* ****************************************************************************
 *
-* TypeEntity::toJson -
+* EntityType::toJson -
 */
-std::string TypeEntity::toJson(ConnectionInfo* ciP)
+std::string EntityType::toJson(ConnectionInfo* ciP)
 {
   std::string  out = "{";
   char         countV[16];

--- a/src/lib/orionTypes/EntityType.h
+++ b/src/lib/orionTypes/EntityType.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_UTILITY_TYPEENTITYVECTOR_H_
-#define SRC_LIB_UTILITY_TYPEENTITYVECTOR_H_
+#ifndef SRC_LIB_UTILITY_ENTITYTYPE_H_
+#define SRC_LIB_UTILITY_ENTITYTYPE_H_
 
 /*
 *
@@ -26,40 +26,31 @@
 * Author: Ken Zangelin
 */
 #include <string>
-#include <vector>
 
-#include "orionTypes/TypeEntity.h"
+#include "ngsi/ContextAttributeVector.h"
+#include "rest/ConnectionInfo.h"
 
 
 
 /* ****************************************************************************
 *
-* TypeEntityVector - 
+* EntityType -
 */
-class TypeEntityVector
+class EntityType
 {
  public:
-  std::vector<TypeEntity*> vec;
+  std::string              type;
+  ContextAttributeVector   contextAttributeVector;
+  long long                count;
 
-  TypeEntityVector();
+  EntityType();
+  explicit EntityType(std::string _type);
 
-  void          present(const std::string& indent);
-  void          push_back(TypeEntity* item);
-  unsigned int  size(void);
-  TypeEntity*   get(unsigned int ix);
-  void          release(void);
   std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
-  std::string   render(ConnectionInfo* ciP, const std::string& indent, bool comma = false);  
-
-  TypeEntity*   operator[](unsigned int ix)
-  {
-    if (ix < vec.size())
-    {
-      return vec[ix];
-    }
-
-    return NULL;
-  }
+  std::string   render(ConnectionInfo* ciP, const std::string& indent, bool comma = false, bool typeNameBefore = false);  
+  void          present(const std::string& indent);
+  void          release(void);
+  std::string   toJson(ConnectionInfo* ciP);
 };
 
-#endif  // SRC_LIB_UTILITY_TYPEENTITYVECTOR_H_
+#endif  // SRC_LIB_UTILITY_ENTITYTYPE_H_

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -32,18 +32,18 @@
 #include "common/tag.h"
 #include "ngsi/Request.h"
 #include "rest/uriParamNames.h"
-#include "orionTypes/EntityTypeAttributesResponse.h"
+#include "orionTypes/EntityTypeResponse.h"
 
 
 
 /* ****************************************************************************
 *
-* EntityTypeAttributesResponse::render -
+* EntityTypeResponse::render -
 */
-std::string EntityTypeAttributesResponse::render(ConnectionInfo* ciP, const std::string& indent)
+std::string EntityTypeResponse::render(ConnectionInfo* ciP, const std::string& indent)
 {
   std::string out                 = "";
-  std::string tag                 = "entityTypeAttributesResponse";
+  std::string tag                 = "entityTypeResponse";
 
   out += startTag(indent, tag, ciP->outFormat, false);
 
@@ -59,9 +59,9 @@ std::string EntityTypeAttributesResponse::render(ConnectionInfo* ciP, const std:
 
 /* ****************************************************************************
 *
-* EntityTypeAttributesResponse::check -
+* EntityTypeResponse::check -
 */
-std::string EntityTypeAttributesResponse::check
+std::string EntityTypeResponse::check
 (
   ConnectionInfo*     ciP,
   const std::string&  indent,
@@ -89,11 +89,11 @@ std::string EntityTypeAttributesResponse::check
 
 /* ****************************************************************************
 *
-* EntityTypeAttributesResponse::present -
+* EntityTypeResponse::present -
 */
-void EntityTypeAttributesResponse::present(const std::string& indent)
+void EntityTypeResponse::present(const std::string& indent)
 {
-  LM_F(("%sEntityTypeAttributesResponse:\n", indent.c_str()));
+  LM_F(("%EntityTypeResponse:\n", indent.c_str()));
   entityType.present(indent + "  ");
   statusCode.present(indent + "  ");
 }
@@ -102,9 +102,9 @@ void EntityTypeAttributesResponse::present(const std::string& indent)
 
 /* ****************************************************************************
 *
-* EntityTypeAttributesResponse::release -
+* EntityTypeResponse::release -
 */
-void EntityTypeAttributesResponse::release(void)
+void EntityTypeResponse::release(void)
 {
   entityType.release();
   statusCode.release();
@@ -114,9 +114,9 @@ void EntityTypeAttributesResponse::release(void)
 
 /* ****************************************************************************
 *
-* EntityTypeAttributesResponse::toJson -
+* EntityTypeResponse::toJson -
 */
-std::string EntityTypeAttributesResponse::toJson(ConnectionInfo* ciP)
+std::string EntityTypeResponse::toJson(ConnectionInfo* ciP)
 {
   std::string  out = "{";
   char         countV[16];

--- a/src/lib/orionTypes/EntityTypeResponse.h
+++ b/src/lib/orionTypes/EntityTypeResponse.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_UTILITY_TYPEENTITY_H_
-#define SRC_LIB_UTILITY_TYPEENTITY_H_
+#ifndef SRC_LIB_UTILITY_ENTITYTYPERESPONSE_H_
+#define SRC_LIB_UTILITY_ENTITYTYPERESPONSE_H_
 
 /*
 *
@@ -26,31 +26,30 @@
 * Author: Ken Zangelin
 */
 #include <string>
+#include <vector>
 
-#include "ngsi/ContextAttributeVector.h"
-#include "rest/ConnectionInfo.h"
+#include "common/Format.h"
+#include "ngsi/Request.h"
+#include "ngsi/StatusCode.h"
+#include "orionTypes/EntityType.h"
 
 
 
 /* ****************************************************************************
 *
-* TypeEntity - 
+* EntityTypeResponse -
 */
-class TypeEntity
+class EntityTypeResponse
 {
  public:
-  std::string              type;
-  ContextAttributeVector   contextAttributeVector;
-  long long                count;
+  EntityType    entityType;
+  StatusCode    statusCode;
 
-  TypeEntity();
-  explicit TypeEntity(std::string _type);
-
+  std::string   render(ConnectionInfo* ciP, const std::string& indent);
+  std::string   toJson(ConnectionInfo* ciP);
   std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
-  std::string   render(ConnectionInfo* ciP, const std::string& indent, bool comma = false, bool typeNameBefore = false);  
   void          present(const std::string& indent);
   void          release(void);
-  std::string   toJson(ConnectionInfo* ciP);
 };
 
-#endif  // SRC_LIB_UTILITY_TYPEENTITY_H_
+#endif  // SRC_LIB_UTILITY_ENTITYTYPERESPONSE_H_

--- a/src/lib/orionTypes/EntityTypeVector.cpp
+++ b/src/lib/orionTypes/EntityTypeVector.cpp
@@ -34,16 +34,16 @@
 #include "common/tag.h"
 #include "ngsi/Request.h"
 #include "rest/ConnectionInfo.h"
-#include "orionTypes/TypeEntity.h"
-#include "orionTypes/TypeEntityVector.h"
+#include "orionTypes/EntityType.h"
+#include "orionTypes/EntityTypeVector.h"
 
 
 
 /* ****************************************************************************
 *
-* TypeEntityVector::TypeEntityVector -
+* EntityTypeVector::EntityTypeVector -
 */
-TypeEntityVector::TypeEntityVector()
+EntityTypeVector::EntityTypeVector()
 {
   vec.clear();
 }
@@ -51,9 +51,9 @@ TypeEntityVector::TypeEntityVector()
 
 /* ****************************************************************************
 *
-* TypeEntityVector::render -
+* EntityTypeVector::render -
 */
-std::string TypeEntityVector::render
+std::string EntityTypeVector::render
 (
   ConnectionInfo*     ciP,
   const std::string&  indent,
@@ -84,9 +84,9 @@ std::string TypeEntityVector::render
 
 /* ****************************************************************************
 *
-* TypeEntityVector::check -
+* EntityTypeVector::check -
 */
-std::string TypeEntityVector::check
+std::string EntityTypeVector::check
 (
   ConnectionInfo*     ciP,
   const std::string&  indent,
@@ -110,11 +110,11 @@ std::string TypeEntityVector::check
 
 /* ****************************************************************************
 *
-* TypeEntityVector::present -
+* EntityTypeVector::present -
 */
-void TypeEntityVector::present(const std::string& indent)
+void EntityTypeVector::present(const std::string& indent)
 {
-  LM_F(("%lu TypeEntitys", (uint64_t) vec.size()));
+  LM_F(("%lu items in entityTypeVector", (uint64_t) vec.size()));
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
@@ -126,9 +126,9 @@ void TypeEntityVector::present(const std::string& indent)
 
 /* ****************************************************************************
 *
-* TypeEntityVector::push_back -
+* EntityTypeVector::push_back -
 */
-void TypeEntityVector::push_back(TypeEntity* item)
+void EntityTypeVector::push_back(EntityType* item)
 {
   vec.push_back(item);
 }
@@ -137,9 +137,9 @@ void TypeEntityVector::push_back(TypeEntity* item)
 
 /* ****************************************************************************
 *
-* TypeEntityVector::get -
+* EntityTypeVector::get -
 */
-TypeEntity* TypeEntityVector::get(unsigned int ix)
+EntityType* EntityTypeVector::get(unsigned int ix)
 {
   if (ix < vec.size())
     return vec[ix];
@@ -150,9 +150,9 @@ TypeEntity* TypeEntityVector::get(unsigned int ix)
 
 /* ****************************************************************************
 *
-* TypeEntityVector::size -
+* EntityTypeVector::size -
 */
-unsigned int TypeEntityVector::size(void)
+unsigned int EntityTypeVector::size(void)
 {
   return vec.size();
 }
@@ -161,9 +161,9 @@ unsigned int TypeEntityVector::size(void)
 
 /* ****************************************************************************
 *
-* TypeEntityVector::release -
+* EntityTypeVector::release -
 */
-void TypeEntityVector::release(void)
+void EntityTypeVector::release(void)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/orionTypes/EntityTypeVector.h
+++ b/src/lib/orionTypes/EntityTypeVector.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_UTILITY_ENTITYTYPEATTRIBUTESRESPONSE_H_
-#define SRC_LIB_UTILITY_ENTITYTYPEATTRIBUTESRESPONSE_H_
+#ifndef SRC_LIB_UTILITY_ENTITYTYPEVECTOR_H_
+#define SRC_LIB_UTILITY_ENTITYTYPEVECTOR_H_
 
 /*
 *
@@ -28,28 +28,38 @@
 #include <string>
 #include <vector>
 
-#include "common/Format.h"
-#include "ngsi/Request.h"
-#include "ngsi/StatusCode.h"
-#include "orionTypes/TypeEntity.h"
+#include "orionTypes/EntityType.h"
 
 
 
 /* ****************************************************************************
 *
-* EntityTypeAttributesResponse -
+* EntityTypeVector -
 */
-class EntityTypeAttributesResponse
+class EntityTypeVector
 {
  public:
-  TypeEntity    entityType;
-  StatusCode    statusCode;
+  std::vector<EntityType*> vec;
 
-  std::string   render(ConnectionInfo* ciP, const std::string& indent);
-  std::string   toJson(ConnectionInfo* ciP);
-  std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
+  EntityTypeVector();
+
   void          present(const std::string& indent);
+  void          push_back(EntityType* item);
+  unsigned int  size(void);
+  EntityType*   get(unsigned int ix);
   void          release(void);
+  std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
+  std::string   render(ConnectionInfo* ciP, const std::string& indent, bool comma = false);  
+
+  EntityType*   operator[](unsigned int ix)
+  {
+    if (ix < vec.size())
+    {
+      return vec[ix];
+    }
+
+    return NULL;
+  }
 };
 
-#endif  // SRC_LIB_UTILITY_ENTITYTYPEATTRIBUTESRESPONSE_H_
+#endif  // SRC_LIB_UTILITY_ENTITYTYPEVECTOR_H_

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -32,22 +32,22 @@
 #include "common/tag.h"
 #include "ngsi/Request.h"
 #include "rest/uriParamNames.h"
-#include "orionTypes/EntityTypesResponse.h"
+#include "orionTypes/EntityTypeVectorResponse.h"
 
 
 /* ****************************************************************************
 *
-* EntityTypesResponse::render -
+* EntityTypeVectorResponse::render -
 */
-std::string EntityTypesResponse::render(ConnectionInfo* ciP, const std::string& indent)
+std::string EntityTypeVectorResponse::render(ConnectionInfo* ciP, const std::string& indent)
 {
   std::string out                 = "";
-  std::string tag                 = "entityTypesResponse";
+  std::string tag                 = "entityTypeVectorResponse";
 
   out += startTag(indent, tag, ciP->outFormat, false);
 
-  if (typeEntityVector.size() > 0)
-    out += typeEntityVector.render(ciP, indent + "  ", true);
+  if (entityTypeVector.size() > 0)
+    out += entityTypeVector.render(ciP, indent + "  ", true);
 
   out += statusCode.render(ciP->outFormat, indent + "  ");
 
@@ -60,9 +60,9 @@ std::string EntityTypesResponse::render(ConnectionInfo* ciP, const std::string& 
 
 /* ****************************************************************************
 *
-* EntityTypesResponse::check -
+* EntityTypeVectorResponse::check -
 */
-std::string EntityTypesResponse::check
+std::string EntityTypeVectorResponse::check
 (
   ConnectionInfo*     ciP,
   const std::string&  indent,
@@ -75,7 +75,7 @@ std::string EntityTypesResponse::check
   {
     statusCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = typeEntityVector.check(ciP, indent, predetectedError)) != "OK")
+  else if ((res = entityTypeVector.check(ciP, indent, predetectedError)) != "OK")
   {
     LM_W(("Bad Input (%s)", res.c_str()));
     statusCode.fill(SccBadRequest, res);
@@ -90,13 +90,13 @@ std::string EntityTypesResponse::check
 
 /* ****************************************************************************
 *
-* EntityTypesResponse::present -
+* EntityTypeVectorResponse::present -
 */
-void EntityTypesResponse::present(const std::string& indent)
+void EntityTypeVectorResponse::present(const std::string& indent)
 {
-  LM_F(("%s%d EntityTypesResponses:\n", indent.c_str(), typeEntityVector.size()));
+  LM_F(("%s%d items in EntityTypeVectorResponse:\n", indent.c_str(), entityTypeVector.size()));
 
-  typeEntityVector.present(indent + "  ");
+  entityTypeVector.present(indent + "  ");
   statusCode.present(indent + "  ");
 }
 
@@ -104,29 +104,29 @@ void EntityTypesResponse::present(const std::string& indent)
 
 /* ****************************************************************************
 *
-* EntityTypesResponse::release -
+* EntityTypeVectorResponse::release -
 */
-void EntityTypesResponse::release(void)
+void EntityTypeVectorResponse::release(void)
 {
-  typeEntityVector.release();
+  entityTypeVector.release();
   statusCode.release();
 }
 
 
 /* ****************************************************************************
 *
-* EntityTypesResponse::toJson - 
+* EntityTypeVectorResponse::toJson - 
 */
-std::string EntityTypesResponse::toJson(ConnectionInfo* ciP)
+std::string EntityTypeVectorResponse::toJson(ConnectionInfo* ciP)
 {
   std::string  out = "{";
 
-  for (unsigned int ix = 0; ix < typeEntityVector.vec.size(); ++ix)
+  for (unsigned int ix = 0; ix < entityTypeVector.vec.size(); ++ix)
   {
-    out += JSON_STR(typeEntityVector.vec[ix]->type) + ":";
-    out += typeEntityVector.vec[ix]->toJson(ciP);
+    out += JSON_STR(entityTypeVector.vec[ix]->type) + ":";
+    out += entityTypeVector.vec[ix]->toJson(ciP);
 
-    if (ix != typeEntityVector.vec.size() - 1)
+    if (ix != entityTypeVector.vec.size() - 1)
     {
       out += ",";
     }

--- a/src/lib/orionTypes/EntityTypeVectorResponse.h
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_UTILITY_ENTITYTYPESRESPONSE_H_
-#define SRC_LIB_UTILITY_ENTITYTYPESRESPONSE_H_
+#ifndef SRC_LIB_UTILITY_ENTITYTYPEVECTORRESPONSE_H_
+#define SRC_LIB_UTILITY_ENTITYTYPEVECTORRESPONSE_H_
 
 /*
 *
@@ -31,18 +31,18 @@
 #include "common/Format.h"
 #include "ngsi/Request.h"
 #include "ngsi/StatusCode.h"
-#include "orionTypes/TypeEntityVector.h"
+#include "orionTypes/EntityTypeVector.h"
 
 
 
 /* ****************************************************************************
 *
-* EntityTypesResponse - 
+* EntityTypeVectorResponse -
 */
-class EntityTypesResponse
+class EntityTypeVectorResponse
 {
  public:
-  TypeEntityVector  typeEntityVector;
+  EntityTypeVector  entityTypeVector;
   StatusCode        statusCode;
 
   std::string       render(ConnectionInfo* ciP, const std::string& indent);  
@@ -52,4 +52,4 @@ class EntityTypesResponse
   std::string       toJson(ConnectionInfo* ciP);
 };
 
-#endif  // SRC_LIB_UTILITY_ENTITYTYPESRESPONSE_H_
+#endif  // SRC_LIB_UTILITY_ENTITYTYPEVECTORRESPONSE_H_

--- a/src/lib/serviceRoutines/getAttributesForEntityType.cpp
+++ b/src/lib/serviceRoutines/getAttributesForEntityType.cpp
@@ -27,7 +27,7 @@
 
 #include "rest/ConnectionInfo.h"
 #include "ngsi/ParseData.h"
-#include "orionTypes/EntityTypeAttributesResponse.h"
+#include "orionTypes/EntityTypeResponse.h"
 #include "rest/uriParamNames.h"
 #include "serviceRoutines/getAttributesForEntityType.h"
 
@@ -41,7 +41,7 @@
 * GET /v1/contextTypes/{entity::type}
 *
 * Payload In:  None
-* Payload Out: EntityTypeAttributesResponse
+* Payload Out: EntityTypeResponse
 *
 * URI parameters:
 *   - attributesFormat=object
@@ -55,7 +55,7 @@ std::string getAttributesForEntityType
   ParseData*                 parseDataP
 )
 {
-  EntityTypeAttributesResponse  response;
+  EntityTypeResponse  response;
   std::string                   entityTypeName = compV[2];
 
   response.statusCode.fill(SccOk);

--- a/src/lib/serviceRoutines/getEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getEntityTypes.cpp
@@ -27,7 +27,7 @@
 
 #include "rest/ConnectionInfo.h"
 #include "ngsi/ParseData.h"
-#include "orionTypes/EntityTypesResponse.h"
+#include "orionTypes/EntityTypeVectorResponse.h"
 #include "serviceRoutines/getEntityTypes.h"
 #include "mongoBackend/mongoQueryTypes.h"
 
@@ -40,7 +40,7 @@
 * GET /v1/contextTypes
 *
 * Payload In:  None
-* Payload Out: EntityTypesResponse
+* Payload Out: EntityTypeVectorResponse
 *
 * URI parameters:
 *   - attributesFormat=object
@@ -54,7 +54,7 @@ std::string getEntityTypes
   ParseData*                 parseDataP
 )
 {
-  EntityTypesResponse response;
+  EntityTypeVectorResponse response;
 
   response.statusCode.fill(SccOk);
   mongoEntityTypes(&response, ciP->tenant, ciP->servicePathV, ciP->uriParam);

--- a/src/lib/serviceRoutinesV2/getEntityAllTypes.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAllTypes.cpp
@@ -28,7 +28,7 @@
 #include "rest/ConnectionInfo.h"
 #include "ngsi/ParseData.h"
 #include "serviceRoutinesV2/getEntityAllTypes.h"
-#include "orionTypes/EntityTypesResponse.h"
+#include "orionTypes/EntityTypeVectorResponse.h"
 #include "mongoBackend/mongoQueryTypes.h"
 
 
@@ -40,7 +40,7 @@
 * GET /v2/type
 *
 * Payload In:  None
-* Payload Out: EntityTypesResponse
+* Payload Out: EntityTypeVectorResponse
 */
 std::string getEntityAllTypes
 (
@@ -50,8 +50,8 @@ std::string getEntityAllTypes
   ParseData*                 parseDataP
 )
 {
-  EntityTypesResponse  response;
-  std::string          answer;
+  EntityTypeVectorResponse  response;
+  std::string               answer;
 
   mongoEntityTypes(&response, ciP->tenant, ciP->servicePathV, ciP->uriParam);
   answer = response.toJson(ciP);
@@ -61,9 +61,9 @@ std::string getEntityAllTypes
     long long  acc = 0;
     char       cVec[64];
 
-    for (unsigned int ix = 0; ix < response.typeEntityVector.size(); ++ix)
+    for (unsigned int ix = 0; ix < response.entityTypeVector.size(); ++ix)
     {
-      acc += response.typeEntityVector[ix]->count;
+      acc += response.entityTypeVector[ix]->count;
     }
 
     snprintf(cVec, sizeof(cVec), "%lld", acc);

--- a/src/lib/serviceRoutinesV2/getEntityType.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityType.cpp
@@ -39,7 +39,7 @@
 * GET /v2/type/<entityType>
 *
 * Payload In:  None
-* Payload Out: EntityTypeAttributesResponse
+* Payload Out: EntityTypeResponse
 */
 std::string getEntityType
 (
@@ -49,9 +49,9 @@ std::string getEntityType
   ParseData*                 parseDataP
 )
 {
-  EntityTypeAttributesResponse  response;
-  std::string                   entityTypeName = compV[2];
-  std::string                   answer;
+  EntityTypeResponse  response;
+  std::string         entityTypeName = compV[2];
+  std::string         answer;
 
   mongoAttributesForEntityType(entityTypeName, &response, ciP->tenant, ciP->servicePathV, ciP->uriParam);
 

--- a/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
@@ -30,8 +30,8 @@
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
 #include "mongoBackend/mongoQueryTypes.h"
-#include "orionTypes/EntityTypesResponse.h"
-#include "orionTypes/EntityTypeAttributesResponse.h"
+#include "orionTypes/EntityTypeVectorResponse.h"
+#include "orionTypes/EntityTypeResponse.h"
 
 #include "mongo/client/dbclient.h"
 
@@ -193,7 +193,7 @@ ContextAttribute* getAttr(ContextAttributeVector& caV, std::string name, std::st
 TEST(mongoQueryTypes, queryAllType)
 {
     HttpStatusCode         ms;
-    EntityTypesResponse    res;
+    EntityTypeVectorResponse    res;
 
     utInit();
 
@@ -210,43 +210,43 @@ TEST(mongoQueryTypes, queryAllType)
     EXPECT_EQ("OK", res.statusCode.reasonPhrase);
     EXPECT_EQ("", res.statusCode.details);
 
-    ASSERT_EQ(3, res.typeEntityVector.size());
+    ASSERT_EQ(3, res.entityTypeVector.size());
     ContextAttribute* ca;
 
     /* Type # 1 */
-    EXPECT_EQ("Car", res.typeEntityVector.get(0)->type);
-    EXPECT_EQ(3, res.typeEntityVector.get(0)->count);
-    ASSERT_EQ(5, res.typeEntityVector.get(0)->contextAttributeVector.size());
+    EXPECT_EQ("Car", res.entityTypeVector.get(0)->type);
+    EXPECT_EQ(3, res.entityTypeVector.get(0)->count);
+    ASSERT_EQ(5, res.entityTypeVector.get(0)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "fuel");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "fuel");
     EXPECT_EQ("fuel", ca->name);
     EXPECT_EQ("fuel_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "plate");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "plate");
     EXPECT_EQ("plate", ca->name);
     EXPECT_EQ("plate_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "temp");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "temp");
     EXPECT_EQ("temp", ca->name);
     EXPECT_EQ("temp_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "colour");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "colour");
     EXPECT_EQ("colour", ca->name);
     EXPECT_EQ("colour_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "pos");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "pos");
     EXPECT_EQ("pos", ca->name);
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -254,18 +254,18 @@ TEST(mongoQueryTypes, queryAllType)
     EXPECT_EQ(0, ca->metadataVector.size());
 
     /* Type # 2 */
-    EXPECT_EQ("Lamp", res.typeEntityVector.get(1)->type);
-    EXPECT_EQ(1, res.typeEntityVector.get(1)->count);
-    ASSERT_EQ(2, res.typeEntityVector.get(1)->contextAttributeVector.size());
+    EXPECT_EQ("Lamp", res.entityTypeVector.get(1)->type);
+    EXPECT_EQ(1, res.entityTypeVector.get(1)->count);
+    ASSERT_EQ(2, res.entityTypeVector.get(1)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(1)->contextAttributeVector, "status");
+    ca = getAttr(res.entityTypeVector.get(1)->contextAttributeVector, "status");
     EXPECT_EQ("status", ca->name);
     EXPECT_EQ("status_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(1)->contextAttributeVector, "battery");
+    ca = getAttr(res.entityTypeVector.get(1)->contextAttributeVector, "battery");
     EXPECT_EQ("battery", ca->name);
     EXPECT_EQ("battery_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -273,25 +273,25 @@ TEST(mongoQueryTypes, queryAllType)
     EXPECT_EQ(0, ca->metadataVector.size());
 
     /* Type # 3 */
-    EXPECT_EQ("Room", res.typeEntityVector.get(2)->type);
-    EXPECT_EQ(2, res.typeEntityVector.get(2)->count);
-    ASSERT_EQ(3, res.typeEntityVector.get(2)->contextAttributeVector.size());
+    EXPECT_EQ("Room", res.entityTypeVector.get(2)->type);
+    EXPECT_EQ(2, res.entityTypeVector.get(2)->count);
+    ASSERT_EQ(3, res.entityTypeVector.get(2)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(2)->contextAttributeVector, "humidity");
+    ca = getAttr(res.entityTypeVector.get(2)->contextAttributeVector, "humidity");
     EXPECT_EQ("humidity", ca->name);
     EXPECT_EQ("humidity_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(2)->contextAttributeVector, "temp");
+    ca = getAttr(res.entityTypeVector.get(2)->contextAttributeVector, "temp");
     EXPECT_EQ("temp", ca->name);
     EXPECT_EQ("temp_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(2)->contextAttributeVector, "pos");
+    ca = getAttr(res.entityTypeVector.get(2)->contextAttributeVector, "pos");
     EXPECT_EQ("pos", ca->name);
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -311,7 +311,7 @@ TEST(mongoQueryTypes, queryAllType)
 TEST(mongoQueryTypes, queryAllPaginationDetails)
 {
     HttpStatusCode         ms;
-    EntityTypesResponse    res;
+    EntityTypeVectorResponse    res;
 
     utInit();
 
@@ -330,43 +330,43 @@ TEST(mongoQueryTypes, queryAllPaginationDetails)
     EXPECT_EQ("OK", res.statusCode.reasonPhrase);
     EXPECT_EQ("Count: 3", res.statusCode.details);
 
-    ASSERT_EQ(3, res.typeEntityVector.size());
+    ASSERT_EQ(3, res.entityTypeVector.size());
     ContextAttribute* ca;
 
     /* Type # 1 */
-    EXPECT_EQ("Car", res.typeEntityVector.get(0)->type);
-    EXPECT_EQ(3, res.typeEntityVector.get(0)->count);
-    ASSERT_EQ(5, res.typeEntityVector.get(0)->contextAttributeVector.size());
+    EXPECT_EQ("Car", res.entityTypeVector.get(0)->type);
+    EXPECT_EQ(3, res.entityTypeVector.get(0)->count);
+    ASSERT_EQ(5, res.entityTypeVector.get(0)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "fuel");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "fuel");
     EXPECT_EQ("fuel", ca->name);
     EXPECT_EQ("fuel_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "plate");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "plate");
     EXPECT_EQ("plate", ca->name);
     EXPECT_EQ("plate_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "temp");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "temp");
     EXPECT_EQ("temp", ca->name);
     EXPECT_EQ("temp_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "colour");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "colour");
     EXPECT_EQ("colour", ca->name);
     EXPECT_EQ("colour_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "pos");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "pos");
     EXPECT_EQ("pos", ca->name);
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -374,18 +374,18 @@ TEST(mongoQueryTypes, queryAllPaginationDetails)
     EXPECT_EQ(0, ca->metadataVector.size());
 
     /* Type # 2 */
-    EXPECT_EQ("Lamp", res.typeEntityVector.get(1)->type);
-    EXPECT_EQ(1, res.typeEntityVector.get(1)->count);
-    ASSERT_EQ(2, res.typeEntityVector.get(1)->contextAttributeVector.size());
+    EXPECT_EQ("Lamp", res.entityTypeVector.get(1)->type);
+    EXPECT_EQ(1, res.entityTypeVector.get(1)->count);
+    ASSERT_EQ(2, res.entityTypeVector.get(1)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(1)->contextAttributeVector, "status");
+    ca = getAttr(res.entityTypeVector.get(1)->contextAttributeVector, "status");
     EXPECT_EQ("status", ca->name);
     EXPECT_EQ("status_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(1)->contextAttributeVector, "battery");
+    ca = getAttr(res.entityTypeVector.get(1)->contextAttributeVector, "battery");
     EXPECT_EQ("battery", ca->name);
     EXPECT_EQ("battery_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -393,25 +393,25 @@ TEST(mongoQueryTypes, queryAllPaginationDetails)
     EXPECT_EQ(0, ca->metadataVector.size());
 
     /* Type # 3 */
-    EXPECT_EQ("Room", res.typeEntityVector.get(2)->type);
-    EXPECT_EQ(2, res.typeEntityVector.get(2)->count);
-    ASSERT_EQ(3, res.typeEntityVector.get(2)->contextAttributeVector.size());
+    EXPECT_EQ("Room", res.entityTypeVector.get(2)->type);
+    EXPECT_EQ(2, res.entityTypeVector.get(2)->count);
+    ASSERT_EQ(3, res.entityTypeVector.get(2)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(2)->contextAttributeVector, "humidity");
+    ca = getAttr(res.entityTypeVector.get(2)->contextAttributeVector, "humidity");
     EXPECT_EQ("humidity", ca->name);
     EXPECT_EQ("humidity_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(2)->contextAttributeVector, "temp");
+    ca = getAttr(res.entityTypeVector.get(2)->contextAttributeVector, "temp");
     EXPECT_EQ("temp", ca->name);
     EXPECT_EQ("temp_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(2)->contextAttributeVector, "pos");
+    ca = getAttr(res.entityTypeVector.get(2)->contextAttributeVector, "pos");
     EXPECT_EQ("pos", ca->name);
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -432,7 +432,7 @@ TEST(mongoQueryTypes, queryAllPaginationDetails)
 TEST(mongoQueryTypes, queryAllPaginationAll)
 {
     HttpStatusCode         ms;
-    EntityTypesResponse    res;
+    EntityTypeVectorResponse    res;
 
     utInit();
 
@@ -451,43 +451,43 @@ TEST(mongoQueryTypes, queryAllPaginationAll)
     EXPECT_EQ("OK", res.statusCode.reasonPhrase);
     EXPECT_EQ("", res.statusCode.details);
 
-    ASSERT_EQ(3, res.typeEntityVector.size());
+    ASSERT_EQ(3, res.entityTypeVector.size());
     ContextAttribute* ca;
 
     /* Type # 1 */
-    EXPECT_EQ("Car", res.typeEntityVector.get(0)->type);
-    EXPECT_EQ(3, res.typeEntityVector.get(0)->count);
-    ASSERT_EQ(5, res.typeEntityVector.get(0)->contextAttributeVector.size());
+    EXPECT_EQ("Car", res.entityTypeVector.get(0)->type);
+    EXPECT_EQ(3, res.entityTypeVector.get(0)->count);
+    ASSERT_EQ(5, res.entityTypeVector.get(0)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "fuel");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "fuel");
     EXPECT_EQ("fuel", ca->name);
     EXPECT_EQ("fuel_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "plate");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "plate");
     EXPECT_EQ("plate", ca->name);
     EXPECT_EQ("plate_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "temp");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "temp");
     EXPECT_EQ("temp", ca->name);
     EXPECT_EQ("temp_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "colour");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "colour");
     EXPECT_EQ("colour", ca->name);
     EXPECT_EQ("colour_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "pos");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "pos");
     EXPECT_EQ("pos", ca->name);
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -495,18 +495,18 @@ TEST(mongoQueryTypes, queryAllPaginationAll)
     EXPECT_EQ(0, ca->metadataVector.size());
 
     /* Type # 2 */
-    EXPECT_EQ("Lamp", res.typeEntityVector.get(1)->type);
-    EXPECT_EQ(1, res.typeEntityVector.get(1)->count);
-    ASSERT_EQ(2, res.typeEntityVector.get(1)->contextAttributeVector.size());
+    EXPECT_EQ("Lamp", res.entityTypeVector.get(1)->type);
+    EXPECT_EQ(1, res.entityTypeVector.get(1)->count);
+    ASSERT_EQ(2, res.entityTypeVector.get(1)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(1)->contextAttributeVector, "status");
+    ca = getAttr(res.entityTypeVector.get(1)->contextAttributeVector, "status");
     EXPECT_EQ("status", ca->name);
     EXPECT_EQ("status_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(1)->contextAttributeVector, "battery");
+    ca = getAttr(res.entityTypeVector.get(1)->contextAttributeVector, "battery");
     EXPECT_EQ("battery", ca->name);
     EXPECT_EQ("battery_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -514,25 +514,25 @@ TEST(mongoQueryTypes, queryAllPaginationAll)
     EXPECT_EQ(0, ca->metadataVector.size());
 
     /* Type # 3 */
-    EXPECT_EQ("Room", res.typeEntityVector.get(2)->type);
-    EXPECT_EQ(2, res.typeEntityVector.get(2)->count);
-    ASSERT_EQ(3, res.typeEntityVector.get(2)->contextAttributeVector.size());
+    EXPECT_EQ("Room", res.entityTypeVector.get(2)->type);
+    EXPECT_EQ(2, res.entityTypeVector.get(2)->count);
+    ASSERT_EQ(3, res.entityTypeVector.get(2)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(2)->contextAttributeVector, "humidity");
+    ca = getAttr(res.entityTypeVector.get(2)->contextAttributeVector, "humidity");
     EXPECT_EQ("humidity", ca->name);
     EXPECT_EQ("humidity_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(2)->contextAttributeVector, "temp");
+    ca = getAttr(res.entityTypeVector.get(2)->contextAttributeVector, "temp");
     EXPECT_EQ("temp", ca->name);
     EXPECT_EQ("temp_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(2)->contextAttributeVector, "pos");
+    ca = getAttr(res.entityTypeVector.get(2)->contextAttributeVector, "pos");
     EXPECT_EQ("pos", ca->name);
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -553,7 +553,7 @@ TEST(mongoQueryTypes, queryAllPaginationAll)
 TEST(mongoQueryTypes, queryAllPaginationOnlyFirst)
 {
     HttpStatusCode         ms;
-    EntityTypesResponse    res;
+    EntityTypeVectorResponse    res;
 
     utInit();
 
@@ -572,43 +572,43 @@ TEST(mongoQueryTypes, queryAllPaginationOnlyFirst)
     EXPECT_EQ("OK", res.statusCode.reasonPhrase);
     EXPECT_EQ("", res.statusCode.details);
 
-    ASSERT_EQ(1, res.typeEntityVector.size());
+    ASSERT_EQ(1, res.entityTypeVector.size());
     ContextAttribute* ca;
 
     /* Type # 1 */
-    EXPECT_EQ("Car", res.typeEntityVector.get(0)->type);
-    EXPECT_EQ(3, res.typeEntityVector.get(0)->count);
-    ASSERT_EQ(5, res.typeEntityVector.get(0)->contextAttributeVector.size());
+    EXPECT_EQ("Car", res.entityTypeVector.get(0)->type);
+    EXPECT_EQ(3, res.entityTypeVector.get(0)->count);
+    ASSERT_EQ(5, res.entityTypeVector.get(0)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "fuel");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "fuel");
     EXPECT_EQ("fuel", ca->name);
     EXPECT_EQ("fuel_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "plate");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "plate");
     EXPECT_EQ("plate", ca->name);
     EXPECT_EQ("plate_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "temp");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "temp");
     EXPECT_EQ("temp", ca->name);
     EXPECT_EQ("temp_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "colour");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "colour");
     EXPECT_EQ("colour", ca->name);
     EXPECT_EQ("colour_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "pos");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "pos");
     EXPECT_EQ("pos", ca->name);
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -629,7 +629,7 @@ TEST(mongoQueryTypes, queryAllPaginationOnlyFirst)
 TEST(mongoQueryTypes, queryAllPaginationOnlySecond)
 {
     HttpStatusCode         ms;
-    EntityTypesResponse    res;
+    EntityTypeVectorResponse    res;
 
     utInit();
 
@@ -649,22 +649,22 @@ TEST(mongoQueryTypes, queryAllPaginationOnlySecond)
     EXPECT_EQ("OK", res.statusCode.reasonPhrase);
     EXPECT_EQ("", res.statusCode.details);
 
-    ASSERT_EQ(1, res.typeEntityVector.size());
+    ASSERT_EQ(1, res.entityTypeVector.size());
     ContextAttribute* ca;
 
     /* Type # 2 */
-    EXPECT_EQ("Lamp", res.typeEntityVector.get(0)->type);
-    EXPECT_EQ(1, res.typeEntityVector.get(0)->count);
-    ASSERT_EQ(2, res.typeEntityVector.get(0)->contextAttributeVector.size());
+    EXPECT_EQ("Lamp", res.entityTypeVector.get(0)->type);
+    EXPECT_EQ(1, res.entityTypeVector.get(0)->count);
+    ASSERT_EQ(2, res.entityTypeVector.get(0)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "status");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "status");
     EXPECT_EQ("status", ca->name);
     EXPECT_EQ("status_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "battery");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "battery");
     EXPECT_EQ("battery", ca->name);
     EXPECT_EQ("battery_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -685,7 +685,7 @@ TEST(mongoQueryTypes, queryAllPaginationOnlySecond)
 TEST(mongoQueryTypes, queryAllPaginationRange)
 {
     HttpStatusCode         ms;
-    EntityTypesResponse    res;
+    EntityTypeVectorResponse    res;
 
     utInit();
 
@@ -705,22 +705,22 @@ TEST(mongoQueryTypes, queryAllPaginationRange)
     EXPECT_EQ("OK", res.statusCode.reasonPhrase);
     EXPECT_EQ("", res.statusCode.details);
 
-    ASSERT_EQ(2, res.typeEntityVector.size());
+    ASSERT_EQ(2, res.entityTypeVector.size());
     ContextAttribute* ca;
 
     /* Type # 1 */
-    EXPECT_EQ("Lamp", res.typeEntityVector.get(0)->type);
-    EXPECT_EQ(1, res.typeEntityVector.get(0)->count);
-    ASSERT_EQ(2, res.typeEntityVector.get(0)->contextAttributeVector.size());
+    EXPECT_EQ("Lamp", res.entityTypeVector.get(0)->type);
+    EXPECT_EQ(1, res.entityTypeVector.get(0)->count);
+    ASSERT_EQ(2, res.entityTypeVector.get(0)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "status");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "status");
     EXPECT_EQ("status", ca->name);
     EXPECT_EQ("status_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "battery");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "battery");
     EXPECT_EQ("battery", ca->name);
     EXPECT_EQ("battery_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -728,25 +728,25 @@ TEST(mongoQueryTypes, queryAllPaginationRange)
     EXPECT_EQ(0, ca->metadataVector.size());
 
     /* Type # 2 */
-    EXPECT_EQ("Room", res.typeEntityVector.get(1)->type);
-    EXPECT_EQ(2, res.typeEntityVector.get(1)->count);
-    ASSERT_EQ(3, res.typeEntityVector.get(1)->contextAttributeVector.size());
+    EXPECT_EQ("Room", res.entityTypeVector.get(1)->type);
+    EXPECT_EQ(2, res.entityTypeVector.get(1)->count);
+    ASSERT_EQ(3, res.entityTypeVector.get(1)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(1)->contextAttributeVector, "humidity");
+    ca = getAttr(res.entityTypeVector.get(1)->contextAttributeVector, "humidity");
     EXPECT_EQ("humidity", ca->name);
     EXPECT_EQ("humidity_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(1)->contextAttributeVector, "temp");
+    ca = getAttr(res.entityTypeVector.get(1)->contextAttributeVector, "temp");
     EXPECT_EQ("temp", ca->name);
     EXPECT_EQ("temp_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(1)->contextAttributeVector, "pos");
+    ca = getAttr(res.entityTypeVector.get(1)->contextAttributeVector, "pos");
     EXPECT_EQ("pos", ca->name);
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -767,7 +767,7 @@ TEST(mongoQueryTypes, queryAllPaginationRange)
 TEST(mongoQueryTypes, queryAllPaginationNonExisting)
 {
     HttpStatusCode         ms;
-    EntityTypesResponse    res;
+    EntityTypeVectorResponse    res;
 
     utInit();
 
@@ -787,7 +787,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExisting)
     EXPECT_EQ("No context element found", res.statusCode.reasonPhrase);
     EXPECT_EQ("", res.statusCode.details);
 
-    ASSERT_EQ(0, res.typeEntityVector.size());
+    ASSERT_EQ(0, res.entityTypeVector.size());
 
     /* Release connection */
     setMongoConnectionForUnitTest(NULL);
@@ -803,7 +803,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExisting)
 TEST(mongoQueryTypes, queryAllPaginationNonExistingOverlap)
 {
     HttpStatusCode         ms;
-    EntityTypesResponse    res;
+    EntityTypeVectorResponse    res;
 
     utInit();
 
@@ -823,29 +823,29 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingOverlap)
     EXPECT_EQ("OK", res.statusCode.reasonPhrase);
     EXPECT_EQ("", res.statusCode.details);
 
-    ASSERT_EQ(1, res.typeEntityVector.size());
+    ASSERT_EQ(1, res.entityTypeVector.size());
     ContextAttribute* ca;
 
     /* Type # 1 */
-    EXPECT_EQ("Room", res.typeEntityVector.get(0)->type);
-    EXPECT_EQ(2, res.typeEntityVector.get(0)->count);
-    ASSERT_EQ(3, res.typeEntityVector.get(0)->contextAttributeVector.size());
+    EXPECT_EQ("Room", res.entityTypeVector.get(0)->type);
+    EXPECT_EQ(2, res.entityTypeVector.get(0)->count);
+    ASSERT_EQ(3, res.entityTypeVector.get(0)->contextAttributeVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "humidity");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "humidity");
     EXPECT_EQ("humidity", ca->name);
     EXPECT_EQ("humidity_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "temp");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "temp");
     EXPECT_EQ("temp", ca->name);
     EXPECT_EQ("temp_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    ca = getAttr(res.typeEntityVector.get(0)->contextAttributeVector, "pos");
+    ca = getAttr(res.entityTypeVector.get(0)->contextAttributeVector, "pos");
     EXPECT_EQ("pos", ca->name);
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
@@ -866,7 +866,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingOverlap)
 TEST(mongoQueryTypes, queryAllPaginationNonExistingDetails)
 {
     HttpStatusCode         ms;
-    EntityTypesResponse    res;
+    EntityTypeVectorResponse    res;
 
     utInit();
 
@@ -886,7 +886,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingDetails)
     EXPECT_EQ("No context element found", res.statusCode.reasonPhrase);
     EXPECT_EQ("Number of types: 3. Offset is 7", res.statusCode.details);
 
-    ASSERT_EQ(0, res.typeEntityVector.size());
+    ASSERT_EQ(0, res.entityTypeVector.size());
 
     /* Release connection */
     setMongoConnectionForUnitTest(NULL);
@@ -902,7 +902,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingDetails)
 TEST(mongoQueryTypes, queryAllDbException)
 {
   HttpStatusCode         ms;
-  EntityTypesResponse    res;
+  EntityTypeVectorResponse    res;
 
   /* Prepare mock */
   const DBException e = DBException("boom!!", 33);
@@ -925,7 +925,7 @@ TEST(mongoQueryTypes, queryAllDbException)
   EXPECT_EQ("database: utest - "
             "command: { aggregate: \"entities\", pipeline: [ { $match: { _id.servicePath: { $in: [ /^/.*/, null ] } } }, { $project: { _id: 1, attrNames: 1 } }, { $project: { attrNames: { $cond: [ { $eq: [ \"$attrNames\", [] ] }, [ null ], \"$attrNames\" ] } } }, { $unwind: \"$attrNames\" }, { $group: { _id: \"$_id.type\", attrs: { $addToSet: \"$attrNames\" } } }, { $sort: { _id: 1 } } ] } - "
             "exception: boom!!", res.statusCode.details);
-  EXPECT_EQ(0,res.typeEntityVector.size());
+  EXPECT_EQ(0,res.entityTypeVector.size());
 
   /* Release mock */
   delete connectionMock;
@@ -943,7 +943,7 @@ TEST(mongoQueryTypes, queryAllDbException)
 TEST(mongoQueryTypes, queryAllGenericException)
 {
   HttpStatusCode         ms;
-  EntityTypesResponse    res;
+  EntityTypeVectorResponse    res;
 
   /* Prepare mock */
   const std::exception e;
@@ -967,7 +967,7 @@ TEST(mongoQueryTypes, queryAllGenericException)
   EXPECT_EQ("database: utest - "
             "command: { aggregate: \"entities\", pipeline: [ { $match: { _id.servicePath: { $in: [ /^/.*/, null ] } } }, { $project: { _id: 1, attrNames: 1 } }, { $project: { attrNames: { $cond: [ { $eq: [ \"$attrNames\", [] ] }, [ null ], \"$attrNames\" ] } } }, { $unwind: \"$attrNames\" }, { $group: { _id: \"$_id.type\", attrs: { $addToSet: \"$attrNames\" } } }, { $sort: { _id: 1 } } ] } - "
             "exception: generic", res.statusCode.details);
-  EXPECT_EQ(0,res.typeEntityVector.size());
+  EXPECT_EQ(0,res.entityTypeVector.size());
 
   /* Release mock */
   delete connectionMock;
@@ -984,7 +984,7 @@ TEST(mongoQueryTypes, queryAllGenericException)
 TEST(mongoQueryTypes, queryGivenTypeBasic)
 {
     HttpStatusCode                ms;
-    EntityTypeAttributesResponse  res;
+    EntityTypeResponse  res;
 
     utInit();
 
@@ -1053,7 +1053,7 @@ TEST(mongoQueryTypes, queryGivenTypeBasic)
 TEST(mongoQueryTypes, queryGivenTypePaginationDetails)
 {
     HttpStatusCode               ms;
-    EntityTypeAttributesResponse res;
+    EntityTypeResponse res;
 
     utInit();
 
@@ -1124,7 +1124,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationDetails)
 TEST(mongoQueryTypes, queryGivenTypePaginationAll)
 {
     HttpStatusCode               ms;
-    EntityTypeAttributesResponse res;
+    EntityTypeResponse res;
 
     utInit();
 
@@ -1195,7 +1195,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationAll)
 TEST(mongoQueryTypes, queryGivenTypePaginationOnlyFirst)
 {
     HttpStatusCode               ms;
-    EntityTypeAttributesResponse res;
+    EntityTypeResponse res;
 
     utInit();
 
@@ -1237,7 +1237,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationOnlyFirst)
 TEST(mongoQueryTypes, queryGivenTypePaginationOnlySecond)
 {
     HttpStatusCode               ms;
-    EntityTypeAttributesResponse res;
+    EntityTypeResponse res;
 
     utInit();
 
@@ -1281,7 +1281,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationOnlySecond)
 TEST(mongoQueryTypes, queryGivenTypePaginationRange)
 {
     HttpStatusCode               ms;
-    EntityTypeAttributesResponse res;
+    EntityTypeResponse res;
 
     utInit();
 
@@ -1339,7 +1339,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationRange)
 TEST(mongoQueryTypes, queryGivenTypePaginationNonExisting)
 {
     HttpStatusCode               ms;
-    EntityTypeAttributesResponse res;
+    EntityTypeResponse res;
 
     utInit();
 
@@ -1375,7 +1375,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExisting)
 TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingOverlap)
 {
     HttpStatusCode               ms;
-    EntityTypeAttributesResponse res;
+    EntityTypeResponse res;
 
     utInit();
 
@@ -1426,7 +1426,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingOverlap)
 TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingDetails)
 {
     HttpStatusCode               ms;
-    EntityTypeAttributesResponse res;
+    EntityTypeResponse res;
 
     utInit();
 
@@ -1462,7 +1462,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingDetails)
 TEST(mongoQueryTypes, queryGiveyTypeDbException)
 {
   HttpStatusCode               ms;
-  EntityTypeAttributesResponse res;
+  EntityTypeResponse res;
 
   /* Prepare mock */
   const DBException e = DBException("boom!!", 33);
@@ -1503,7 +1503,7 @@ TEST(mongoQueryTypes, queryGiveyTypeDbException)
 TEST(mongoQueryTypes, queryGivenTypeGenericException)
 {
   HttpStatusCode               ms;
-  EntityTypeAttributesResponse res;
+  EntityTypeResponse res;
 
   /* Prepare mock */
   const std::exception e;


### PR DESCRIPTION
Implements #1173. No CNR entry needed (this is an  internal change in the code base, without external effects).

* TypeEntity => EntityType
* TypeEntityVector  => EntityTypeVector
* EntityTypeAttributesResponse => EntityTypeResponse
* EntityTypesResponse => EntityTypeVectorResponse

Tested with: make unit_test, make test compilations (functional tests without effect) and grep:

```
$ grep -i TypeEntity -R src/*
$ grep -i TypeEntity -R test/unittests/*
$ grep -i TypeEntityVector -R src/*
$ grep -i TypeEntityVector -R test/unittests/*
$ grep -i EntityTypeAttributesResponse -R src/*
$ grep -i EntityTypeAttributesResponse -R test/unittests/*
fermin@oriondeb:~/src/fiware-orion$ grep -i EntityTypesResponse -R src/*
src/lib/ngsi/Request.h:  RtEntityTypesResponse,
src/lib/ngsi/Request.cpp:  case RtEntityTypesResponse:                            return "EntityTypesResponse";
src/lib/common/statistics.cpp:int noOfEntityTypesResponse                              = -1;
src/lib/common/statistics.cpp:  case RtEntityTypesResponse:                            ++noOfEntityTypesResponse; break;
$ grep -i EntityTypesResponse -R test/unittests/*
test/unittests/ngsi/Request_test.cpp:    { RtEntityTypesResponse,                       "EntityTypesResponse"                                    },
```

Not sure if the noOf* and Rt* lines should be also changed...
