### PR TITLE
Task/part2 rendering of entities

### DIFF
--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -41,7 +41,7 @@ std::string Attribute::render(ConnectionInfo* ciP, RequestType requestType, bool
     std::string out;
 
     out = "{";
-    out += pcontextAttribute->toJson(true, false);  // param 1 'true' as it is the last and only element
+    out += pcontextAttribute->toJson(true, false, "normalized");  // param 1 'true' as it is the last and only element
     out += "}";
 
     if (comma)

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -55,9 +55,28 @@ Entity::~Entity()
 /* ****************************************************************************
 *
 * Entity::render - 
+*
+* The rendering of JSON in APIv2 depends on the URI param 'options'
+* Rendering methods:
+*   o 'normalized' (default)
+*   o 'keyValues'  (less verbose, only name and values shown for attributes - no type, no metadatas)
+*   o 'values'     (only the values of the attributes are printed, in a vector)
 */
 std::string Entity::render(ConnectionInfo* ciP, RequestType requestType, bool comma)
 {
+  std::string renderMode = "normalized";
+
+  if (ciP->uriParamOptions["keyValues"] == true)
+  {
+    renderMode = "keyValues";
+  }
+  else if (ciP->uriParamOptions["values"]== true)
+  {
+    renderMode = "values";
+  }
+
+  LM_M(("KZ: renderMode == %s", renderMode.c_str()));
+
   if ((errorCode.description == "") && ((errorCode.error == "OK") || (errorCode.error == "")))
   {
     std::string out = "{";
@@ -69,7 +88,8 @@ std::string Entity::render(ConnectionInfo* ciP, RequestType requestType, bool co
     if (attributeVector.size() != 0)
     {
       out += ",";
-      out += attributeVector.toJson(true, false);
+
+      out += attributeVector.toJson(true, false, renderMode);
     }
 
     out += "}";

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -97,7 +97,6 @@ std::string Entity::render(ConnectionInfo* ciP, RequestType requestType, bool co
       out += ",";
     }
 
-    LM_M(("KZ: Done: '%s'", out.c_str()));
     return out;
   }
 

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -75,8 +75,6 @@ std::string Entity::render(ConnectionInfo* ciP, RequestType requestType, bool co
     renderMode = "values";
   }
 
-  LM_M(("KZ: renderMode == %s", renderMode.c_str()));
-
   if ((errorCode.description == "") && ((errorCode.error == "OK") || (errorCode.error == "")))
   {
     std::string out = "{";
@@ -99,6 +97,7 @@ std::string Entity::render(ConnectionInfo* ciP, RequestType requestType, bool co
       out += ",";
     }
 
+    LM_M(("KZ: Done: '%s'", out.c_str()));
     return out;
   }
 

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -63,12 +63,8 @@ std::string Entity::render(ConnectionInfo* ciP, RequestType requestType, bool co
     std::string out = "{";
 
     out += JSON_VALUE("id", id);
-
-    if (type != "")
-    {
-      out += ",";
-      out += JSON_VALUE("type", type);
-    }
+    out += ",";
+    out += JSON_STR("type") + ":" + ((type != "")? JSON_STR(type) : "null");
 
     if (attributeVector.size() != 0)
     {

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -523,7 +523,6 @@ std::string ContextAttribute::toJson(bool isLastElement, bool types, const std::
 {
   std::string  out;
 
-  LM_M(("KZ: renderMode: %s", renderMode.c_str()));
   if (types == true)
   {
     out = JSON_STR(name) + ":{" + JSON_STR("type") + ":" + JSON_STR(type) + "}"; 
@@ -532,7 +531,18 @@ std::string ContextAttribute::toJson(bool isLastElement, bool types, const std::
   {
     out = (renderMode == "keyValues")? JSON_STR(name) + ":" : "";
 
-    if (valueType == orion::ValueTypeNumber)
+    if (compoundValueP != NULL)
+    {
+      if (compoundValueP->isObject())
+      {
+        out += "{" + compoundValueP->toJson(true) + "}";
+      }
+      else if (compoundValueP->isVector())
+      {
+        out += "[" + compoundValueP->toJson(true) + "]";
+      }
+    }
+    else if (valueType == orion::ValueTypeNumber)
     {
       char num[32];
       snprintf(num, sizeof(num), "%f", numberValue);
@@ -545,17 +555,6 @@ std::string ContextAttribute::toJson(bool isLastElement, bool types, const std::
     else if (valueType == orion::ValueTypeBoolean)
     {
       out += (boolValue == true)? "true" : "false";
-    }
-    else if (compoundValueP != NULL)
-    {
-      if (compoundValueP->isObject())
-      {
-        out += "{" + compoundValueP->toJson(true) + "}";
-      }
-      else if (compoundValueP->isVector())
-      {
-        out += "[" + compoundValueP->toJson(true) + "]";
-      }
     }
   }
   else  // Render mode: normalized 

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -83,7 +83,7 @@ typedef struct ContextAttribute
   std::string  render(ConnectionInfo* ciP, RequestType request, const std::string& indent, bool comma = false, bool omitValue = false);
   std::string  renderAsJsonObject(ConnectionInfo* ciP, RequestType request, const std::string& indent, bool comma, bool omitValue = false);
   std::string  renderAsNameString(ConnectionInfo* ciP, RequestType request, const std::string& indent, bool comma = false);
-  std::string  toJson(bool isLastElement, bool types);
+  std::string  toJson(bool isLastElement, bool types, const std::string& renderMode);
   void         present(const std::string& indent, int ix);
   void         release(void);
   std::string  toString(void);

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -80,7 +80,7 @@ static std::string addedLookup(const std::vector<std::string>& added, std::strin
 * If anybody needs an attribute named 'id' or 'type', then API v1
 * will have to be used to retrieve that information.
 */
-std::string ContextAttributeVector::toJson(bool isLastElement, bool types)
+std::string ContextAttributeVector::toJson(bool isLastElement, bool types, const std::string& renderMode)
 {
   if (vec.size() == 0)
   {
@@ -125,7 +125,7 @@ std::string ContextAttributeVector::toJson(bool isLastElement, bool types)
     }
 
     ++renderedAttributes;
-    out += vec[ix]->toJson(renderedAttributes == validAttributes, types);
+    out += vec[ix]->toJson(renderedAttributes == validAttributes, types, renderMode);
   }
 
   return out;

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -117,6 +117,12 @@ std::string ContextAttributeVector::toJson(bool isLastElement, bool types, const
   //
   std::string  out;
   int          renderedAttributes = 0;
+
+  if (renderMode == "values")
+  {
+    out = JSON_STR("attributeValues") + ":" + "[";
+  }
+  
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     if ((vec[ix]->name == "id") || (vec[ix]->name == "type"))
@@ -126,6 +132,11 @@ std::string ContextAttributeVector::toJson(bool isLastElement, bool types, const
 
     ++renderedAttributes;
     out += vec[ix]->toJson(renderedAttributes == validAttributes, types, renderMode);
+  }
+
+  if (renderMode == "values")
+  {
+    out += "]";
   }
 
   return out;

--- a/src/lib/ngsi/ContextAttributeVector.h
+++ b/src/lib/ngsi/ContextAttributeVector.h
@@ -74,7 +74,7 @@ typedef struct ContextAttributeVector
                             bool                comma     = false,
                             bool                omitValue = false,
                             bool                attrsAsName = false);
-  std::string        toJson(bool isLastElement, bool types);
+  std::string        toJson(bool isLastElement, bool types, const std::string& renderMode);
 } ContextAttributeVector;
 
 #endif  // SRC_LIB_NGSI_CONTEXTATTRIBUTEVECTOR_H_

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -273,57 +273,33 @@ std::string Metadata::toJson(bool isLastElement)
 {
   std::string  out;
 
-  if (type == "")
+  out = JSON_STR(name) + ":{";
+
+  out += (type != "")? JSON_VALUE("type", type) : JSON_STR("type") + ":" + "null";
+  out += ",";
+
+  if (valueType == orion::ValueTypeString)
   {
-    if (valueType == orion::ValueTypeNumber)
-    {
-      char num[32];
-    
-      snprintf(num, sizeof(num), "%f", numberValue);
-      out = JSON_VALUE_NUMBER(name, num);
-    }
-    else if (valueType == orion::ValueTypeBoolean)
-    {
-      out = JSON_VALUE_BOOL(name, boolValue);
-    }
-    else if (valueType == orion::ValueTypeString)
-    {
-      out = JSON_VALUE(name, stringValue);
-    }
-    else
-    {
-      LM_E(("Runtime Error (invalid type for metadata %s)", name.c_str()));
-      out = JSON_VALUE(name, stringValue);
-    }
+    out += JSON_VALUE("value", stringValue);
+  }
+  else if (valueType == orion::ValueTypeNumber)
+  {
+    char num[32];
+
+    snprintf(num, sizeof(num), "%f", numberValue);
+    out += JSON_VALUE_NUMBER("value", num);
+  }
+  else if (valueType == orion::ValueTypeBoolean)
+  {
+    out += JSON_VALUE_BOOL("value", boolValue);
   }
   else
   {
-    out = JSON_STR(name) + ":{";
-    out += JSON_VALUE("type", type) + ",";
-
-    if (valueType == orion::ValueTypeString)
-    {
-      out += JSON_VALUE("value", stringValue);
-    }
-    else if (valueType == orion::ValueTypeNumber)
-    {
-      char num[32];
-
-      snprintf(num, sizeof(num), "%f", numberValue);
-      out += JSON_VALUE_NUMBER("value", num);
-    }
-    else if (valueType == orion::ValueTypeBoolean)
-    {
-      out += JSON_VALUE_BOOL("value", boolValue);
-    }
-    else
-    {
-      LM_E(("Runtime Error (invalid value type for metadata %s)", name.c_str()));
-      out += JSON_VALUE("value", stringValue);
-    }
-
-    out += "}";
+    LM_E(("Runtime Error (invalid value type for metadata %s)", name.c_str()));
+    out += JSON_VALUE("value", stringValue);
   }
+
+  out += "}";
 
   if (!isLastElement)
   {

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -166,7 +166,7 @@ std::string EntityType::toJson(ConnectionInfo* ciP)
   out += JSON_STR("attrs") + ":";
 
   out += "{";
-  out += contextAttributeVector.toJson(false, true);
+  out += contextAttributeVector.toJson(false, true, "normalized");
   out += "}";
 
   out += "," + JSON_STR("count") + ":" + countV;

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -126,7 +126,7 @@ std::string EntityTypeResponse::toJson(ConnectionInfo* ciP)
   out += JSON_STR("attrs") + ":";
 
   out += "{";
-  out += entityType.contextAttributeVector.toJson(false, true);
+  out += entityType.contextAttributeVector.toJson(false, true, "normalized");
   out += "}";  
 
   out += "," + JSON_STR("count") + ":" + countV;

--- a/src/lib/rest/ConnectionInfo.cpp
+++ b/src/lib/rest/ConnectionInfo.cpp
@@ -86,7 +86,6 @@ int uriParamOptionsParse(ConnectionInfo* ciP, const char* value)
     }
 
     ciP->uriParamOptions[vec[ix]] = true;
-    LM_M(("KZ: uriParamOptions '%s' is set", vec[ix].c_str()));
   }
 
   return 0;

--- a/src/lib/rest/ConnectionInfo.cpp
+++ b/src/lib/rest/ConnectionInfo.cpp
@@ -39,6 +39,7 @@ static const char* validOptions[] =
   "count",
   "normalized",
   "values",
+  "keyValues",
   "text"
 };
 
@@ -85,6 +86,7 @@ int uriParamOptionsParse(ConnectionInfo* ciP, const char* value)
     }
 
     ciP->uriParamOptions[vec[ix]] = true;
+    LM_M(("KZ: uriParamOptions '%s' is set", vec[ix].c_str()));
   }
 
   return 0;

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -880,8 +880,6 @@ static int connectionTreat
   // 1. First call - setup ConnectionInfo and get/check HTTP headers
   if (ciP == NULL)
   {
-    LM_M(("In connectionTreat 1: path: %s", url));
-
     //
     // IP Address and port of caller
     //

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -876,9 +876,12 @@ static int connectionTreat
   size_t                 dataLen     = *upload_data_size;
   static int             reqNo       = 1;
 
+
   // 1. First call - setup ConnectionInfo and get/check HTTP headers
   if (ciP == NULL)
   {
+    LM_M(("In connectionTreat 1: path: %s", url));
+
     //
     // IP Address and port of caller
     //

--- a/test/functionalTest/cases/0947_v2_list_all_entities/GET_v2_entities.test
+++ b/test/functionalTest/cases/0947_v2_list_all_entities/GET_v2_entities.test
@@ -33,7 +33,7 @@ brokerStart CB
 # 01. GET /v2/entities
 # 02. POST /v2/entities
 # 03. GET /v2/entities
-# 04. GET /v2/entities?options=count,normalized
+# 04. GET /v2/entities?options=count,keyValues
 # 05. POST /v2/entities with compound attribute value
 #
 
@@ -102,9 +102,9 @@ echo
 echo
 
 
-echo "04. GET /v2/entities?options=count,normalized"
-echo "============================================="
-orionCurl --url /v2/entities?options=count,normalized --json
+echo "04. GET /v2/entities?options=count,keyValues"
+echo "============================================"
+orionCurl --url /v2/entities?options=count,keyValues --json
 echo
 echo
 
@@ -156,83 +156,77 @@ Date: REGEX(.*)
 03. GET /v2/entities
 ====================
 HTTP/1.1 200 OK
-Content-Length: 288
+Content-Length: 418
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
         "A0": {
-            "type": "number", 
+            "metadata": {},
+            "type": "number",
             "value": "255"
-        }, 
-        "A1": "E1/T1/A1", 
+        },
+        "A1": {
+            "metadata": {},
+            "type": null,
+            "value": "E1/T1/A1"
+        },
         "A2": {
-            "type": "AT2", 
+            "metadata": {},
+            "type": "AT2",
             "value": "E1/T1/A2"
-        }, 
+        },
         "A3": {
-            "m1": "M1", 
-            "type": "a", 
+            "metadata": {
+                "m1": {
+                    "type": null,
+                    "value": "M1"
+                }
+            },
+            "type": "a",
             "value": "E1/T1/A3/M1"
-        }, 
+        },
         "A4": {
-            "m1": "M1", 
-            "m2": {
-                "type": "tm2", 
-                "value": "M2"
-            }, 
-            "m3": {
-                "type": "number", 
-                "value": "3"
-            }, 
-            "type": "a4", 
+            "metadata": {
+                "m1": {
+                    "type": null,
+                    "value": "M1"
+                },
+                "m2": {
+                    "type": "tm2",
+                    "value": "M2"
+                },
+                "m3": {
+                    "type": "number",
+                    "value": "3"
+                }
+            },
+            "type": "a4",
             "value": "E1/T1/A4/M1-3"
-        }, 
-        "id": "E1", 
+        },
+        "id": "E1",
         "type": "T1"
     }
 ]
 
 
-04. GET /v2/entities?options=count,normalized
-=============================================
+04. GET /v2/entities?options=count,keyValues
+============================================
 HTTP/1.1 200 OK
-Content-Length: 288
+Content-Length: 108
 Content-Type: application/json
 X-Total-Count: 1
 Date: REGEX(.*)
 
 [
     {
-        "A0": {
-            "type": "number", 
-            "value": "255"
-        }, 
-        "A1": "E1/T1/A1", 
-        "A2": {
-            "type": "AT2", 
-            "value": "E1/T1/A2"
-        }, 
-        "A3": {
-            "m1": "M1", 
-            "type": "a", 
-            "value": "E1/T1/A3/M1"
-        }, 
-        "A4": {
-            "m1": "M1", 
-            "m2": {
-                "type": "tm2", 
-                "value": "M2"
-            }, 
-            "m3": {
-                "type": "number", 
-                "value": "3"
-            }, 
-            "type": "a4", 
-            "value": "E1/T1/A4/M1-3"
-        }, 
-        "id": "E1", 
+        "A0": "255",
+        "A1": "E1/T1/A1",
+        "A2": "E1/T1/A2",
+        "A3": "E1/T1/A3/M1",
+        "A4": "E1/T1/A4/M1-3",
+        "id": "E1",
         "type": "T1"
     }
 ]
@@ -250,48 +244,64 @@ Date: REGEX(.*)
 06. GET /v2/entities
 ====================
 HTTP/1.1 200 OK
-Content-Length: 337
+Content-Length: 503
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
         "A0": {
-            "type": "number", 
+            "metadata": {},
+            "type": "number",
             "value": "255"
-        }, 
-        "A1": "E1/T1/A1", 
+        },
+        "A1": {
+            "metadata": {},
+            "type": null,
+            "value": "E1/T1/A1"
+        },
         "A2": {
-            "type": "AT2", 
+            "metadata": {},
+            "type": "AT2",
             "value": "E1/T1/A2"
-        }, 
+        },
         "A3": {
-            "m1": "M1", 
-            "type": "a", 
+            "metadata": {
+                "m1": {
+                    "type": "",
+                    "value": "M1"
+                }
+            },
+            "type": "a",
             "value": "E1/T1/A3/M1"
-        }, 
+        },
         "A4": {
-            "m1": "M1", 
-            "m2": {
-                "type": "tm2", 
-                "value": "M2"
-            }, 
-            "m3": {
-                "type": "number", 
-                "value": "3"
-            }, 
-            "type": "a4", 
+            "metadata": {
+                "m1": {
+                    "type": null,
+                    "value": "M1"
+                },
+                "m2": {
+                    "type": "tm2",
+                    "value": "M2"
+                },
+                "m3": {
+                    "type": "number",
+                    "value": "3"
+                }
+            },
+            "type": "a4",
             "value": "E1/T1/A4/M1-3"
-        }, 
-        "id": "E1", 
+        },
+        "id": "E1",
         "type": "T1"
-    }, 
+    },
     {
         "A0": {
-            "i1": "1", 
+            "i1": "1",
             "s1": "s"
-        }, 
-        "id": "E2", 
+        },
+        "id": "E2",
         "type": "T1"
     }
 ]

--- a/test/functionalTest/cases/0947_v2_list_all_entities/GET_v2_entities.test
+++ b/test/functionalTest/cases/0947_v2_list_all_entities/GET_v2_entities.test
@@ -112,14 +112,12 @@ echo
 echo "05. POST /v2/entities with compound attribute value"
 echo "==================================================="
 payload='{
-      "id":   "E2",
-      "type": "T1",
-      "A0" : 
-        {
-          "value" : { "i1": "1", "s1": "s" }
-        }
-      
-
+  "id":   "E2",
+  "type": "T1",
+  "A0": 
+  {
+    "value" : { "i1": "1", "s1": "s" }
+  }
 }'
 orionCurl --url /v2/entities --payload "$payload" --json
 echo
@@ -156,7 +154,7 @@ Date: REGEX(.*)
 03. GET /v2/entities
 ====================
 HTTP/1.1 200 OK
-Content-Length: 418
+Content-Length: 422
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -244,7 +242,7 @@ Date: REGEX(.*)
 06. GET /v2/entities
 ====================
 HTTP/1.1 200 OK
-Content-Length: 503
+Content-Length: 507
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -268,7 +266,7 @@ Date: REGEX(.*)
         "A3": {
             "metadata": {
                 "m1": {
-                    "type": "",
+                    "type": null,
                     "value": "M1"
                 }
             },
@@ -298,8 +296,12 @@ Date: REGEX(.*)
     },
     {
         "A0": {
-            "i1": "1",
-            "s1": "s"
+            "metadata": {},
+            "type": null,
+            "value": {
+                "i1": "1",
+                "s1": "s"
+            }
         },
         "id": "E2",
         "type": "T1"

--- a/test/functionalTest/cases/0950_GET_v2_entity/GET_v2_entity.test
+++ b/test/functionalTest/cases/0950_GET_v2_entity/GET_v2_entity.test
@@ -37,40 +37,39 @@ brokerStart CB
 echo "01. POST /v2/entities to create 8787GHY entity"
 echo "==================================================="
 payload='{
-
-    "id": "8787GHY",
-    "type": "Car",
-    "brand":{
-    
-            "type": "string",
-            "value": "Mercedes Benz"
-        },
-    "speed":{
-    
-            "type": "number",
-            "value" : "150"
-        },
-    "plateCountry": {
-          "value" : "ES"
-        },
-    "madeInCountry": {
-          "value" : "DE",
-          "type" : ""
-        },
-    "model" : {
-          "type": "myString",
-          "value" : "Klasse C"
-        }
+  "id": "8787GHY",
+  "type": "Car",
+  "brand":{
+    "type": "string",
+    "value": "Mercedes Benz"
+  },
+  "speed":{
+    "type": "number",
+    "value" : "150"
+  },
+  "plateCountry": {
+    "value" : "ES"
+  },
+  "madeInCountry": {
+    "value" : "DE",
+    "type" : ""
+  },
+  "model" : {
+    "type": "myString",
+    "value" : "Klasse C"
+  }
 }'
 orionCurl --url /v2/entities --payload "$payload" --json
 echo
 echo
+
 
 echo "02. GET /v2/entities/8787GHY"
 echo "============================"
 orionCurl --url /v2/entities/8787GHY --json
 echo
 echo
+
 
 --REGEXPECT--
 01. POST /v2/entities to create 8787GHY entity
@@ -85,26 +84,37 @@ Date: REGEX(.*)
 02. GET /v2/entities/8787GHY
 ============================
 HTTP/1.1 200 OK
-Content-Length: 207
+Content-Length: 321
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "brand": {
-        "type": "string", 
+        "metadata": {},
+        "type": "string",
         "value": "Mercedes Benz"
-    }, 
-    "id": "8787GHY", 
-    "madeInCountry": "DE", 
+    },
+    "id": "8787GHY",
+    "madeInCountry": {
+        "metadata": {},
+        "type": null,
+        "value": "DE"
+    },
     "model": {
-        "type": "myString", 
+        "metadata": {},
+        "type": "myString",
         "value": "Klasse C"
-    }, 
-    "plateCountry": "ES", 
+    },
+    "plateCountry": {
+        "metadata": {},
+        "type": null,
+        "value": "ES"
+    },
     "speed": {
-        "type": "number", 
+        "metadata": {},
+        "type": "number",
         "value": "150"
-    }, 
+    },
     "type": "Car"
 }
 

--- a/test/functionalTest/cases/0950_GET_v2_entity/GET_v2_entity_not_found.test
+++ b/test/functionalTest/cases/0950_GET_v2_entity/GET_v2_entity_not_found.test
@@ -45,48 +45,45 @@ echo
 echo "02. POST /v2/entities to create E1"
 echo "======================================="
 payload='{
-      "id":   "E1",
-      "type": "T1",
-      "A0" : {
-          "type": "number",
-          "value" : "255"
-        },
-       "A1" : {
-          "value" : "E1/T1/A1"
-        },
-       "A2" :{
-          "value": "E1/T1/A2",
-          "type": "AT2" 
-        },
-       "A3" :{
-          "type": "a",
-          "value": "E1/T1/A3/M1",
-          "metadata": {
-            "m1": 
-              {
-                "value": "M1"
-              }
-          }
-        },
-        "A4" : {
-          "type": "a4",
-          "value": "E1/T1/A4/M1-3",
-          "metadata": {
-            "m1":
-              {
-                "value": "M1"
-              },
-             "m2" : 
-              {
-                "type": "tm2",
-                "value": "M2"
-              },
-              "m3" :{
-                "type": "number",
-                "value": "3"
-              }
-            }
-        }
+  "id":   "E1",
+  "type": "T1",
+  "A0" : {
+    "type": "number",
+    "value" : "255"
+  },
+  "A1" : {
+    "value" : "E1/T1/A1"
+  },
+  "A2" :{
+    "value": "E1/T1/A2",
+    "type": "AT2" 
+  },
+  "A3" :{
+    "type": "a",
+    "value": "E1/T1/A3/M1",
+    "metadata": {
+      "m1": {
+        "value": "M1"
+      }
+    }
+  },
+  "A4" : {
+    "type": "a4",
+    "value": "E1/T1/A4/M1-3",
+    "metadata": {
+      "m1": {
+        "value": "M1"
+      },
+      "m2": {
+        "type": "tm2",
+        "value": "M2"
+      },
+      "m3": {
+        "type": "number",
+        "value": "3"
+      }
+    }
+  }
 }'
 orionCurl --url /v2/entities --payload "$payload" --json
 echo
@@ -126,39 +123,55 @@ Date: REGEX(.*)
 03. GET /v2/entities/E1 (ok)
 ============================
 HTTP/1.1 200 OK
-Content-Length: 286
+Content-Length: 420
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "A0": {
-        "type": "number", 
+        "metadata": {},
+        "type": "number",
         "value": "255"
-    }, 
-    "A1": "E1/T1/A1", 
+    },
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": "E1/T1/A1"
+    },
     "A2": {
-        "type": "AT2", 
+        "metadata": {},
+        "type": "AT2",
         "value": "E1/T1/A2"
-    }, 
+    },
     "A3": {
-        "m1": "M1", 
-        "type": "a", 
+        "metadata": {
+            "m1": {
+                "type": null,
+                "value": "M1"
+            }
+        },
+        "type": "a",
         "value": "E1/T1/A3/M1"
-    }, 
+    },
     "A4": {
-        "m1": "M1", 
-        "m2": {
-            "type": "tm2", 
-            "value": "M2"
-        }, 
-        "m3": {
-            "type": "number", 
-            "value": "3"
-        }, 
-        "type": "a4", 
+        "metadata": {
+            "m1": {
+                "type": null,
+                "value": "M1"
+            },
+            "m2": {
+                "type": "tm2",
+                "value": "M2"
+            },
+            "m3": {
+                "type": "number",
+                "value": "3"
+            }
+        },
+        "type": "a4",
         "value": "E1/T1/A4/M1-3"
-    }, 
-    "id": "E1", 
+    },
+    "id": "E1",
     "type": "T1"
 }
 

--- a/test/functionalTest/cases/0953_list_all_ents_id/GET_v2_entities.test
+++ b/test/functionalTest/cases/0953_list_all_ents_id/GET_v2_entities.test
@@ -47,8 +47,7 @@ echo
 
 echo "02. POST /v2/entities, creating E1"
 echo "=================================="
-payload='
-{
+payload='{
    "id":"E1",
    "type":"T1",
    "A0":255,
@@ -79,16 +78,14 @@ echo
 
 echo "05. POST /v2/entities, creating E2 with compound attribute value"
 echo "================================================================="
-payload='
-    {
-      "id":   "E2",
-      "type": "T1",
-      "A0" :
-        {
-          "value" : { "i1": 1, "s1": "s" }
-        }
-    }
-'
+payload='{
+  "id":   "E2",
+  "type": "T1",
+  "A0":
+  {
+    "value" : { "i1": 1, "s1": "s" }
+  }
+}'
 orionCurl --url /v2/entities --payload "$payload" --json
 echo
 echo
@@ -106,6 +103,8 @@ echo "============================="
 orionCurl --url /v2/entities?id=E2,E3 --json
 echo
 echo
+
+
 --REGEXPECT--
 01. GET /v2/entities?id=E1
 ==========================
@@ -129,15 +128,24 @@ Date: REGEX(.*)
 03. GET /v2/entities?id=E1
 ==========================
 HTTP/1.1 200 OK
-Content-Length: 96
+Content-Length: 182
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
-        "A0": 255.0,
-        "A1": "E1/T1/A1",
+        "A0": {
+            "metadata": {},
+            "type": null,
+            "value": 255.0
+        },
+        "A1": {
+            "metadata": {},
+            "type": null,
+            "value": "E1/T1/A1"
+        },
         "A2": {
+            "metadata": {},
             "type": "AT2",
             "value": "E1/T1/A2"
         },
@@ -150,16 +158,25 @@ Date: REGEX(.*)
 04. GET /v2/entities?id=E1&options=count,normalized
 ===================================================
 HTTP/1.1 200 OK
-Content-Length: 96
+Content-Length: 182
 Content-Type: application/json
 X-Total-Count: 1
 Date: REGEX(.*)
 
 [
     {
-        "A0": 255.0,
-        "A1": "E1/T1/A1",
+        "A0": {
+            "metadata": {},
+            "type": null,
+            "value": 255.0
+        },
+        "A1": {
+            "metadata": {},
+            "type": null,
+            "value": "E1/T1/A1"
+        },
         "A2": {
+            "metadata": {},
             "type": "AT2",
             "value": "E1/T1/A2"
         },
@@ -181,15 +198,24 @@ Date: REGEX(.*)
 06. GET /v2/entities?id=E1,E2
 =============================
 HTTP/1.1 200 OK
-Content-Length: 150
+Content-Length: 272
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
-        "A0": 255.0,
-        "A1": "E1/T1/A1",
+        "A0": {
+            "metadata": {},
+            "type": null,
+            "value": 255.0
+        },
+        "A1": {
+            "metadata": {},
+            "type": null,
+            "value": "E1/T1/A1"
+        },
         "A2": {
+            "metadata": {},
             "type": "AT2",
             "value": "E1/T1/A2"
         },
@@ -198,8 +224,12 @@ Date: REGEX(.*)
     },
     {
         "A0": {
-            "i1": 1.0,
-            "s1": "s"
+            "metadata": {},
+            "type": null,
+            "value": {
+                "i1": 1.0,
+                "s1": "s"
+            }
         },
         "id": "E2",
         "type": "T1"
@@ -210,15 +240,19 @@ Date: REGEX(.*)
 07. GET /v2/entities?id=E2,E3
 =============================
 HTTP/1.1 200 OK
-Content-Length: 55
+Content-Length: 91
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
         "A0": {
-            "i1": 1.0,
-            "s1": "s"
+            "metadata": {},
+            "type": null,
+            "value": {
+                "i1": 1.0,
+                "s1": "s"
+            }
         },
         "id": "E2",
         "type": "T1"

--- a/test/functionalTest/cases/0953_list_all_ents_id/GET_v2_entities_pattern.test
+++ b/test/functionalTest/cases/0953_list_all_ents_id/GET_v2_entities_pattern.test
@@ -106,6 +106,8 @@ echo "======================================"
 orionCurl --url '/v2/entities?idPattern=E\[23\]' --json
 echo
 echo
+
+
 --REGEXPECT--
 01. GET /v2/entities?idPattern=E.*
 ==================================
@@ -129,15 +131,24 @@ Date: REGEX(.*)
 03. GET /v2/entities?idPattern=E.*
 ==================================
 HTTP/1.1 200 OK
-Content-Length: 96
+Content-Length: 182
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
-        "A0": 255.0,
-        "A1": "E1/T1/A1",
+        "A0": {
+            "metadata": {},
+            "type": null,
+            "value": 255.0
+        },
+        "A1": {
+            "metadata": {},
+            "type": null,
+            "value": "E1/T1/A1"
+        },
         "A2": {
+            "metadata": {},
             "type": "AT2",
             "value": "E1/T1/A2"
         },
@@ -150,16 +161,25 @@ Date: REGEX(.*)
 04. GET /v2/entities?idPattern=E1&options=count,normalized
 ==========================================================
 HTTP/1.1 200 OK
-Content-Length: 96
+Content-Length: 182
 Content-Type: application/json
 X-Total-Count: 1
 Date: REGEX(.*)
 
 [
     {
-        "A0": 255.0,
-        "A1": "E1/T1/A1",
+        "A0": {
+            "metadata": {},
+            "type": null,
+            "value": 255.0
+        },
+        "A1": {
+            "metadata": {},
+            "type": null,
+            "value": "E1/T1/A1"
+        },
         "A2": {
+            "metadata": {},
             "type": "AT2",
             "value": "E1/T1/A2"
         },
@@ -181,15 +201,24 @@ Date: REGEX(.*)
 06. GET /v2/entities?idPattern=E(1|2)
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 150
+Content-Length: 272
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
-        "A0": 255.0,
-        "A1": "E1/T1/A1",
+        "A0": {
+            "metadata": {},
+            "type": null,
+            "value": 255.0
+        },
+        "A1": {
+            "metadata": {},
+            "type": null,
+            "value": "E1/T1/A1"
+        },
         "A2": {
+            "metadata": {},
             "type": "AT2",
             "value": "E1/T1/A2"
         },
@@ -198,8 +227,12 @@ Date: REGEX(.*)
     },
     {
         "A0": {
-            "i1": 1.0,
-            "s1": "s"
+            "metadata": {},
+            "type": null,
+            "value": {
+                "i1": 1.0,
+                "s1": "s"
+            }
         },
         "id": "E2",
         "type": "T1"
@@ -210,15 +243,19 @@ Date: REGEX(.*)
 07. GET /v2/entities?idPattern=E\[23\]
 ======================================
 HTTP/1.1 200 OK
-Content-Length: 55
+Content-Length: 91
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
         "A0": {
-            "i1": 1.0,
-            "s1": "s"
+            "metadata": {},
+            "type": null,
+            "value": {
+                "i1": 1.0,
+                "s1": "s"
+            }
         },
         "id": "E2",
         "type": "T1"

--- a/test/functionalTest/cases/0967_v2_query_op/q_in_uri_param_to_scope.test
+++ b/test/functionalTest/cases/0967_v2_query_op/q_in_uri_param_to_scope.test
@@ -164,23 +164,47 @@ Date: REGEX(.*)
 06. Query: URI param q=temperature<60;humidity==61..83 => E1+E2
 ===============================================================
 HTTP/1.1 200 OK
-Content-Length: 166
+Content-Length: 382
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
-        "humidity": 80.0,
+        "humidity": {
+            "metadata": {},
+            "type": null,
+            "value": 80.0
+        },
         "id": "E1",
-        "status": "OK",
-        "temperature": 20.0,
+        "status": {
+            "metadata": {},
+            "type": null,
+            "value": "OK"
+        },
+        "temperature": {
+            "metadata": {},
+            "type": null,
+            "value": 20.0
+        },
         "type": "T"
     },
     {
-        "humidity": 70.0,
+        "humidity": {
+            "metadata": {},
+            "type": null,
+            "value": 70.0
+        },
         "id": "E2",
-        "status": "ERR",
-        "temperature": 30.0,
+        "status": {
+            "metadata": {},
+            "type": null,
+            "value": "ERR"
+        },
+        "temperature": {
+            "metadata": {},
+            "type": null,
+            "value": 30.0
+        },
         "type": "T"
     }
 ]

--- a/test/functionalTest/cases/0970_create_entity/compound_creation.test
+++ b/test/functionalTest/cases/0970_create_entity/compound_creation.test
@@ -70,15 +70,19 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 79
+Content-Length: 115
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "compattr": {
-        "bool": true, 
-        "number": 2.0, 
-        "string": "1"
+        "metadata": {},
+        "type": null,
+        "value": {
+            "bool": true,
+            "number": 2.0,
+            "string": "1"
+        }
     }, 
     "id": "E1", 
     "type": "T1"

--- a/test/functionalTest/cases/0970_create_entity/compound_creation02.test
+++ b/test/functionalTest/cases/0970_create_entity/compound_creation02.test
@@ -80,48 +80,52 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 270
+Content-Length: 306
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "compattr": {
-        "a": "1", 
-        "b": 2.0, 
-        "c": true, 
-        "d": false, 
-        "e": {
-            "bvec": [
-                true, 
-                false, 
-                true, 
-                false, 
-                false
-            ], 
-            "f": 5.0, 
-            "g": "6", 
-            "h": true, 
-            "ivec": [
-                1.0, 
-                2.0, 
-                3.0, 
-                4.0, 
-                5.0
-            ], 
-            "obj": {
-                "oa": 1.0, 
-                "ob": false
-            }, 
-            "svec": [
-                "s0", 
-                "s1", 
-                "s2", 
-                "s3", 
-                "s4"
-            ]
+        "metadata": {},
+        "type": null,
+        "value": {
+            "a": "1",
+            "b": 2.0,
+            "c": true,
+            "d": false,
+            "e": {
+                "bvec": [
+                    true,
+                    false,
+                    true,
+                    false,
+                    false
+                ],
+                "f": 5.0,
+                "g": "6",
+                "h": true,
+                "ivec": [
+                    1.0,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0
+                ],
+                "obj": {
+                    "oa": 1.0,
+                    "ob": false
+                },
+                "svec": [
+                    "s0",
+                    "s1",
+                    "s2",
+                    "s3",
+                    "s4"
+                ]
+            }
         }
-    }, 
-    "id": "E1", 
+    },
+    "id": "E1",
     "type": "T1"
 }
 

--- a/test/functionalTest/cases/0970_create_entity/compound_inside_attribute_object.test
+++ b/test/functionalTest/cases/0970_create_entity/compound_inside_attribute_object.test
@@ -73,28 +73,30 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 157
+Content-Length: 185
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "attr01": {
-        "type": "Compound Object", 
+        "metadata": {},
+        "type": "Compound Object",
         "value": {
-            "a": "1", 
-            "b": 2.0, 
+            "a": "1",
+            "b": 2.0,
             "c": true
         }
-    }, 
+    },
     "attr02": {
-        "type": "Compound Vector", 
+        "metadata": {},
+        "type": "Compound Vector",
         "value": [
-            "a", 
-            "b", 
+            "a",
+            "b",
             "c"
         ]
-    }, 
-    "id": "E1", 
+    },
+    "id": "E1",
     "type": "T1"
 }
 

--- a/test/functionalTest/cases/0970_create_entity/compound_vector.test
+++ b/test/functionalTest/cases/0970_create_entity/compound_vector.test
@@ -66,17 +66,21 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 59
+Content-Length: 95
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "cvec": [
-        1.0, 
-        2.0, 
-        3.0
-    ], 
-    "id": "E1", 
+    "cvec": {
+        "metadata": {},
+        "type": null,
+        "value": [
+            1.0,
+            2.0,
+            3.0
+        ]
+    },
+    "id": "E1",
     "type": "T1"
 }
 

--- a/test/functionalTest/cases/0970_create_entity/compound_vector_with_objects.test
+++ b/test/functionalTest/cases/0970_create_entity/compound_vector_with_objects.test
@@ -86,43 +86,51 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 255
+Content-Length: 327
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "attr01": {
-        "objAndVecInVec": [
-            {
-                "a": 1.0, 
-                "b": "2", 
-                "c": true
-            }, 
-            [
-                1.0, 
-                2.0, 
-                3.0, 
-                4.0, 
-                5.0
-            ]
-        ]
-    }, 
-    "attr2": {
-        "objAndVecInObj": {
-            "nestedObj": {
-                "noa": 1.0, 
-                "nob": "2", 
-                "noc": true, 
-                "nod": false
-            }, 
-            "nestedVec": [
-                "nva", 
-                "nvb", 
-                "nvc"
+        "metadata": {},
+        "type": null,
+        "value": {
+            "objAndVecInVec": [
+                {
+                    "a": 1.0,
+                    "b": "2",
+                    "c": true
+                },
+                [
+                    1.0,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0
+                ]
             ]
         }
-    }, 
-    "id": "E1", 
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": {
+            "objAndVecInObj": {
+                "nestedObj": {
+                    "noa": 1.0,
+                    "nob": "2",
+                    "noc": true,
+                    "nod": false
+                },
+                "nestedVec": [
+                    "nva",
+                    "nvb",
+                    "nvc"
+                ]
+            }
+        }
+    },
+    "id": "E1",
     "type": "T1"
 }
 

--- a/test/functionalTest/cases/0970_create_entity/creation_with_attribute_as_object.test
+++ b/test/functionalTest/cases/0970_create_entity/creation_with_attribute_as_object.test
@@ -83,24 +83,57 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 191
+Content-Length: 493
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr01": "1", 
-    "attr02": 2.0, 
-    "attr03": 3.3, 
-    "attr04": true, 
-    "attr05": false, 
-    "attr06": "06", 
-    "attr07": 7.0, 
-    "attr08": true, 
+    "attr01": {
+        "metadata": {},
+        "type": null,
+        "value": "1"
+    },
+    "attr02": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
+    "attr03": {
+        "metadata": {},
+        "type": null,
+        "value": 3.3
+    },
+    "attr04": {
+        "metadata": {},
+        "type": null,
+        "value": true
+    },
+    "attr05": {
+        "metadata": {},
+        "type": null,
+        "value": false
+    },
+    "attr06": {
+        "metadata": {},
+        "type": null,
+        "value": "06"
+    },
+    "attr07": {
+        "metadata": {},
+        "type": null,
+        "value": 7.0
+    },
+    "attr08": {
+        "metadata": {},
+        "type": null,
+        "value": true
+    },
     "attr09": {
-        "type": "number", 
+        "metadata": {},
+        "type": "number",
         "value": 9.0
-    }, 
-    "id": "E1", 
+    },
+    "id": "E1",
     "type": "T1"
 }
 

--- a/test/functionalTest/cases/0970_create_entity/creation_with_metadata.test
+++ b/test/functionalTest/cases/0970_create_entity/creation_with_metadata.test
@@ -74,19 +74,30 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 94
+Content-Length: 173
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "attr01": {
-        "m1": "m1", 
-        "m2": 2.0, 
-        "m3": false, 
-        "type": "AT", 
+        "metadata": {
+            "m1": {
+                "type": null,
+                "value": "m1"
+            },
+            "m2": {
+                "type": null,
+                "value": 2.0
+            },
+            "m3": {
+                "type": null,
+                "value": false
+            }
+        },
+        "type": "AT",
         "value": "06"
-    }, 
-    "id": "E1", 
+    },
+    "id": "E1",
     "type": "T1"
 }
 

--- a/test/functionalTest/cases/0970_create_entity/simple_creation.test
+++ b/test/functionalTest/cases/0970_create_entity/simple_creation.test
@@ -70,17 +70,37 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 101
+Content-Length: 281
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr01": "1", 
-    "attr02": 2.0, 
-    "attr03": 3.3, 
-    "attr04": true, 
-    "attr05": false, 
-    "id": "E1", 
+    "attr01": {
+        "metadata": {},
+        "type": null,
+        "value": "1"
+    },
+    "attr02": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
+    "attr03": {
+        "metadata": {},
+        "type": null,
+        "value": 3.3
+    },
+    "attr04": {
+        "metadata": {},
+        "type": null,
+        "value": true
+    },
+    "attr05": {
+        "metadata": {},
+        "type": null,
+        "value": false
+    },
+    "id": "E1",
     "type": "T1"
 }
 

--- a/test/functionalTest/cases/0971_GET_v2_entity_param_attrs/GET_v2_entity_all_attrs.test
+++ b/test/functionalTest/cases/0971_GET_v2_entity_param_attrs/GET_v2_entity_all_attrs.test
@@ -95,37 +95,37 @@ Date: REGEX(.*)
             "contextElement": {
                 "attributes": [
                     {
-                        "name": "speed", 
-                        "type": "number", 
+                        "name": "speed",
+                        "type": "number",
                         "value": ""
-                    }, 
+                    },
                     {
-                        "name": "brand", 
-                        "type": "string", 
+                        "name": "brand",
+                        "type": "string",
                         "value": ""
-                    }, 
+                    },
                     {
-                        "name": "plateCountry", 
-                        "type": "", 
+                        "name": "plateCountry",
+                        "type": "",
                         "value": ""
-                    }, 
+                    },
                     {
-                        "name": "madeInCountry", 
-                        "type": "", 
+                        "name": "madeInCountry",
+                        "type": "",
                         "value": ""
-                    }, 
+                    },
                     {
-                        "name": "model", 
-                        "type": "myString", 
+                        "name": "model",
+                        "type": "myString",
                         "value": ""
                     }
-                ], 
-                "id": "8787GHY", 
-                "isPattern": "false", 
+                ],
+                "id": "8787GHY",
+                "isPattern": "false",
                 "type": "Car"
-            }, 
+            },
             "statusCode": {
-                "code": "200", 
+                "code": "200",
                 "reasonPhrase": "OK"
             }
         }
@@ -136,26 +136,37 @@ Date: REGEX(.*)
 02. GET /v2/entities/8787GHY?attrs=speed,brand,plateCountry,madeInCountry,model
 ===============================================================================
 HTTP/1.1 200 OK
-Content-Length: 207
+Content-Length: 321
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "brand": {
-        "type": "string", 
+        "metadata": {},
+        "type": "string",
         "value": "Mercedes Benz"
-    }, 
-    "id": "8787GHY", 
-    "madeInCountry": "DE", 
+    },
+    "id": "8787GHY",
+    "madeInCountry": {
+        "metadata": {},
+        "type": null,
+        "value": "DE"
+    },
     "model": {
-        "type": "myString", 
+        "metadata": {},
+        "type": "myString",
         "value": "Klasse C"
-    }, 
-    "plateCountry": "ES", 
+    },
+    "plateCountry": {
+        "metadata": {},
+        "type": null,
+        "value": "ES"
+    },
     "speed": {
-        "type": "number", 
+        "metadata": {},
+        "type": "number",
         "value": "150"
-    }, 
+    },
     "type": "Car"
 }
 

--- a/test/functionalTest/cases/0971_GET_v2_entity_param_attrs/GET_v2_entity_one_attr.test
+++ b/test/functionalTest/cases/0971_GET_v2_entity_param_attrs/GET_v2_entity_one_attr.test
@@ -102,37 +102,37 @@ Date: REGEX(.*)
             "contextElement": {
                 "attributes": [
                     {
-                        "name": "speed", 
-                        "type": "number", 
+                        "name": "speed",
+                        "type": "number",
                         "value": ""
-                    }, 
+                    },
                     {
-                        "name": "brand", 
-                        "type": "string", 
+                        "name": "brand",
+                        "type": "string",
                         "value": ""
-                    }, 
+                    },
                     {
-                        "name": "plateCountry", 
-                        "type": "", 
+                        "name": "plateCountry",
+                        "type": "",
                         "value": ""
-                    }, 
+                    },
                     {
-                        "name": "madeInCountry", 
-                        "type": "", 
+                        "name": "madeInCountry",
+                        "type": "",
                         "value": ""
-                    }, 
+                    },
                     {
-                        "name": "model", 
-                        "type": "myString", 
+                        "name": "model",
+                        "type": "myString",
                         "value": ""
                     }
-                ], 
-                "id": "8787GHY", 
-                "isPattern": "false", 
+                ],
+                "id": "8787GHY",
+                "isPattern": "false",
                 "type": "Car"
-            }, 
+            },
             "statusCode": {
-                "code": "200", 
+                "code": "200",
                 "reasonPhrase": "OK"
             }
         }
@@ -143,16 +143,17 @@ Date: REGEX(.*)
 02. GET /v2/entities/8787GHY?attrs=speed
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 69
+Content-Length: 83
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "id": "8787GHY", 
+    "id": "8787GHY",
     "speed": {
-        "type": "number", 
+        "metadata": {},
+        "type": "number",
         "value": "150"
-    }, 
+    },
     "type": "Car"
 }
 
@@ -160,14 +161,19 @@ Date: REGEX(.*)
 03. GET /v2/entities/8787GHY?attrs=speed,plateCountry
 =====================================================
 HTTP/1.1 200 OK
-Content-Length: 89
+Content-Length: 139
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "id": "8787GHY",
-    "plateCountry": "ES",
+    "plateCountry": {
+        "metadata": {},
+        "type": null,
+        "value": "ES"
+    },
     "speed": {
+        "metadata": {},
         "type": "number",
         "value": "150"
     },

--- a/test/functionalTest/cases/0979_patch_v2_entities_eid/patch_v2_entities_eid.test
+++ b/test/functionalTest/cases/0979_patch_v2_entities_eid/patch_v2_entities_eid.test
@@ -105,13 +105,21 @@ Date: REGEX(.*)
 03. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 57
+Content-Length: 129
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 2.0,
-    "attr2": 2.0,
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -128,13 +136,21 @@ Date: REGEX(.*)
 05. GET /v2/entities/E1 - see attr1=4 AND attr2=2 (untouched)
 =============================================================
 HTTP/1.1 200 OK
-Content-Length: 57
+Content-Length: 129
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 4.0,
-    "attr2": 2.0,
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 4.0
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
     "id": "E1",
     "type": "T1"
 }

--- a/test/functionalTest/cases/0981_POST_v2_attributes/append_and_append_only_combinations.test
+++ b/test/functionalTest/cases/0981_POST_v2_attributes/append_and_append_only_combinations.test
@@ -129,12 +129,16 @@ Date: REGEX(.*)
 02. Get E1 (only attr1)
 =======================
 HTTP/1.1 200 OK
-Content-Length: 40
+Content-Length: 76
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 1.0,
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
     "id": "E1",
     "type": null
 }
@@ -152,13 +156,21 @@ Date: REGEX(.*)
 04. Get E1 (attr1, attr2)
 =========================
 HTTP/1.1 200 OK
-Content-Length: 57
+Content-Length: 129
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 1.0,
-    "attr2": 2.0,
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
     "id": "E1",
     "type": null
 }
@@ -176,14 +188,26 @@ Date: REGEX(.*)
 06. Get E1 (attr1, attr2, attr3)
 ================================
 HTTP/1.1 200 OK
-Content-Length: 74
+Content-Length: 182
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 1.0,
-    "attr2": 2.0,
-    "attr3": 3.0,
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
+    "attr3": {
+        "metadata": {},
+        "type": null,
+        "value": 3.0
+    },
     "id": "E1",
     "type": null
 }
@@ -201,15 +225,31 @@ Date: REGEX(.*)
 08. Get E1 (attr1, attr2, attr3, att4)
 =======================================
 HTTP/1.1 200 OK
-Content-Length: 92
+Content-Length: 236
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 1.0,
-    "attr2": 2.0,
-    "attr3": 33.0,
-    "attr4": 4.0,
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
+    "attr3": {
+        "metadata": {},
+        "type": null,
+        "value": 33.0
+    },
+    "attr4": {
+        "metadata": {},
+        "type": null,
+        "value": 4.0
+    },
     "id": "E1",
     "type": null
 }
@@ -231,16 +271,36 @@ Date: REGEX(.*)
 10. Get E1 (attr1, attr2, attr3, attr4, attr5)
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 109
+Content-Length: 289
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 1.0,
-    "attr2": 2.0,
-    "attr3": 33.0,
-    "attr4": 4.0,
-    "attr5": 5.0,
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
+    "attr3": {
+        "metadata": {},
+        "type": null,
+        "value": 33.0
+    },
+    "attr4": {
+        "metadata": {},
+        "type": null,
+        "value": 4.0
+    },
+    "attr5": {
+        "metadata": {},
+        "type": null,
+        "value": 5.0
+    },
     "id": "E1",
     "type": null
 }

--- a/test/functionalTest/cases/0981_POST_v2_attributes/append_and_append_only_combinations.test
+++ b/test/functionalTest/cases/0981_POST_v2_attributes/append_and_append_only_combinations.test
@@ -129,13 +129,14 @@ Date: REGEX(.*)
 02. Get E1 (only attr1)
 =======================
 HTTP/1.1 200 OK
-Content-Length: 28
+Content-Length: 40
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "attr1": 1.0,
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 
@@ -151,14 +152,15 @@ Date: REGEX(.*)
 04. Get E1 (attr1, attr2)
 =========================
 HTTP/1.1 200 OK
-Content-Length: 45
+Content-Length: 57
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "attr1": 1.0,
     "attr2": 2.0,
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 
@@ -174,7 +176,7 @@ Date: REGEX(.*)
 06. Get E1 (attr1, attr2, attr3)
 ================================
 HTTP/1.1 200 OK
-Content-Length: 62
+Content-Length: 74
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -182,7 +184,8 @@ Date: REGEX(.*)
     "attr1": 1.0,
     "attr2": 2.0,
     "attr3": 3.0,
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 
@@ -198,7 +201,7 @@ Date: REGEX(.*)
 08. Get E1 (attr1, attr2, attr3, att4)
 =======================================
 HTTP/1.1 200 OK
-Content-Length: 80
+Content-Length: 92
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -207,7 +210,8 @@ Date: REGEX(.*)
     "attr2": 2.0,
     "attr3": 33.0,
     "attr4": 4.0,
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 
@@ -227,7 +231,7 @@ Date: REGEX(.*)
 10. Get E1 (attr1, attr2, attr3, attr4, attr5)
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 97
+Content-Length: 109
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -237,7 +241,8 @@ Date: REGEX(.*)
     "attr3": 33.0,
     "attr4": 4.0,
     "attr5": 5.0,
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 

--- a/test/functionalTest/cases/0981_POST_v2_attributes/append_only_attribute_already_there.test
+++ b/test/functionalTest/cases/0981_POST_v2_attributes/append_only_attribute_already_there.test
@@ -84,13 +84,14 @@ Date: REGEX(.*)
 03. Make sure E1 exists - and that attr1 == 1, not 2
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 28
+Content-Length: 40
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "attr1": 1.0, 
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 

--- a/test/functionalTest/cases/0981_POST_v2_attributes/append_only_attribute_already_there.test
+++ b/test/functionalTest/cases/0981_POST_v2_attributes/append_only_attribute_already_there.test
@@ -84,12 +84,16 @@ Date: REGEX(.*)
 03. Make sure E1 exists - and that attr1 == 1, not 2
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 40
+Content-Length: 76
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 1.0, 
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
     "id": "E1",
     "type": null
 }

--- a/test/functionalTest/cases/0981_POST_v2_attributes/append_only_error_if_exists.test
+++ b/test/functionalTest/cases/0981_POST_v2_attributes/append_only_error_if_exists.test
@@ -96,12 +96,16 @@ Date: REGEX(.*)
 02. Make sure E1 exists
 =======================
 HTTP/1.1 200 OK
-Content-Length: 40
+Content-Length: 76
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 1.0, 
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
     "id": "E1",
     "type": null
 }
@@ -123,12 +127,16 @@ Date: REGEX(.*)
 04. Make sure it didn't work
 ============================
 HTTP/1.1 200 OK
-Content-Length: 40
+Content-Length: 76
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 1.0, 
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
     "id": "E1",
     "type": null
 }
@@ -146,12 +154,16 @@ Date: REGEX(.*)
 06. Make sure it worked
 =======================
 HTTP/1.1 200 OK
-Content-Length: 40
+Content-Length: 76
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 5.0, 
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 5.0
+    },
     "id": "E1",
     "type": null
 }

--- a/test/functionalTest/cases/0981_POST_v2_attributes/append_only_error_if_exists.test
+++ b/test/functionalTest/cases/0981_POST_v2_attributes/append_only_error_if_exists.test
@@ -96,13 +96,14 @@ Date: REGEX(.*)
 02. Make sure E1 exists
 =======================
 HTTP/1.1 200 OK
-Content-Length: 28
+Content-Length: 40
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "attr1": 1.0, 
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 
@@ -122,13 +123,14 @@ Date: REGEX(.*)
 04. Make sure it didn't work
 ============================
 HTTP/1.1 200 OK
-Content-Length: 28
+Content-Length: 40
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "attr1": 1.0, 
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 
@@ -144,13 +146,14 @@ Date: REGEX(.*)
 06. Make sure it worked
 =======================
 HTTP/1.1 200 OK
-Content-Length: 28
+Content-Length: 40
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "attr1": 5.0, 
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 

--- a/test/functionalTest/cases/0985_DELETE_v2_entity/delete_ok.test
+++ b/test/functionalTest/cases/0985_DELETE_v2_entity/delete_ok.test
@@ -85,15 +85,19 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 79
+Content-Length: 115
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "compattr": {
-        "bool": true,
-        "number": 2.0,
-        "string": "1"
+        "metadata": {},
+        "type": null,
+        "value": {
+            "bool": true,
+            "number": 2.0,
+            "string": "1"
+        }
     },
     "id": "E1",
     "type": "T1"

--- a/test/functionalTest/cases/0987_put_attributes/put_entity_complete_replace_attributes.test
+++ b/test/functionalTest/cases/0987_put_attributes/put_entity_complete_replace_attributes.test
@@ -79,14 +79,15 @@ Date: REGEX(.*)
 02. Make sure E1 is as created
 ==============================
 HTTP/1.1 200 OK
-Content-Length: 39
+Content-Length: 51
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "A1": 1.0, 
     "A2": 2.0, 
-    "id": "E1"
+    "id": "E1",
+    "type": null
 }
 
 
@@ -101,14 +102,15 @@ Date: REGEX(.*)
 04. Make sure E1 is as modified
 ===============================
 HTTP/1.1 200 OK
-Content-Length: 39
+Content-Length: 51
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A3": 3.0, 
-    "A4": 4.0, 
-    "id": "E1"
+    "A3": 3.0,
+    "A4": 4.0,
+    "id": "E1",
+    "type": null
 }
 
 

--- a/test/functionalTest/cases/0987_put_attributes/put_entity_complete_replace_attributes.test
+++ b/test/functionalTest/cases/0987_put_attributes/put_entity_complete_replace_attributes.test
@@ -79,13 +79,21 @@ Date: REGEX(.*)
 02. Make sure E1 is as created
 ==============================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 123
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 1.0, 
-    "A2": 2.0, 
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
+    "A2": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
     "id": "E1",
     "type": null
 }
@@ -102,13 +110,21 @@ Date: REGEX(.*)
 04. Make sure E1 is as modified
 ===============================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 123
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A3": 3.0,
-    "A4": 4.0,
+    "A3": {
+        "metadata": {},
+        "type": null,
+        "value": 3.0
+    },
+    "A4": {
+        "metadata": {},
+        "type": null,
+        "value": 4.0
+    },
     "id": "E1",
     "type": null
 }

--- a/test/functionalTest/cases/0987_put_attributes/put_entity_error.test
+++ b/test/functionalTest/cases/0987_put_attributes/put_entity_error.test
@@ -100,7 +100,7 @@ Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "description": "The requested entity has not been found. Check type and id", 
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 
@@ -117,13 +117,14 @@ Date: REGEX(.*)
 04. Make sure E1 is as created
 ==============================
 HTTP/1.1 200 OK
-Content-Length: 28
+Content-Length: 40
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 3.0, 
-    "id": "E1"
+    "attr1": 3.0,
+    "id": "E1",
+    "type": null
 }
 
 
@@ -138,13 +139,14 @@ Date: REGEX(.*)
 06. Make sure E1 is as modified
 ===============================
 HTTP/1.1 200 OK
-Content-Length: 28
+Content-Length: 40
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 5.0, 
-    "id": "E1"
+    "attr1": 5.0,
+    "id": "E1",
+    "type": null
 }
 
 

--- a/test/functionalTest/cases/0987_put_attributes/put_entity_error.test
+++ b/test/functionalTest/cases/0987_put_attributes/put_entity_error.test
@@ -117,12 +117,16 @@ Date: REGEX(.*)
 04. Make sure E1 is as created
 ==============================
 HTTP/1.1 200 OK
-Content-Length: 40
+Content-Length: 76
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 3.0,
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 3.0
+    },
     "id": "E1",
     "type": null
 }
@@ -139,12 +143,16 @@ Date: REGEX(.*)
 06. Make sure E1 is as modified
 ===============================
 HTTP/1.1 200 OK
-Content-Length: 40
+Content-Length: 76
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": 5.0,
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": 5.0
+    },
     "id": "E1",
     "type": null
 }

--- a/test/functionalTest/cases/0987_put_attributes/put_entity_partially_replace_attributes.test
+++ b/test/functionalTest/cases/0987_put_attributes/put_entity_partially_replace_attributes.test
@@ -79,14 +79,15 @@ Date: REGEX(.*)
 02. Make sure E1 is as created
 ==============================
 HTTP/1.1 200 OK
-Content-Length: 39
+Content-Length: 51
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 1.0, 
-    "A2": 2.0, 
-    "id": "E1"
+    "A1": 1.0,
+    "A2": 2.0,
+    "id": "E1",
+    "type": null
 }
 
 
@@ -101,14 +102,15 @@ Date: REGEX(.*)
 04. Make sure E1 is as modified
 ===============================
 HTTP/1.1 200 OK
-Content-Length: 39
+Content-Length: 51
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A2": 2.0, 
-    "A3": 3.0, 
-    "id": "E1"
+    "A2": 2.0,
+    "A3": 3.0,
+    "id": "E1",
+    "type": null
 }
 
 

--- a/test/functionalTest/cases/0987_put_attributes/put_entity_partially_replace_attributes.test
+++ b/test/functionalTest/cases/0987_put_attributes/put_entity_partially_replace_attributes.test
@@ -79,13 +79,21 @@ Date: REGEX(.*)
 02. Make sure E1 is as created
 ==============================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 123
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 1.0,
-    "A2": 2.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
+    "A2": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
     "id": "E1",
     "type": null
 }
@@ -102,13 +110,21 @@ Date: REGEX(.*)
 04. Make sure E1 is as modified
 ===============================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 123
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A2": 2.0,
-    "A3": 3.0,
+    "A2": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
+    "A3": {
+        "metadata": {},
+        "type": null,
+        "value": 3.0
+    },
     "id": "E1",
     "type": null
 }

--- a/test/functionalTest/cases/0989_GET_v2_entity_attribute/GET_v2_entity_attribute.test
+++ b/test/functionalTest/cases/0989_GET_v2_entity_attribute/GET_v2_entity_attribute.test
@@ -117,13 +117,14 @@ Date: REGEX(.*)
 02. GET /v2/entities/8787GHY/attrs/brand
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 65
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "brand": {
-        "type": "string", 
+        "metadata": {},
+        "type": "string",
         "value": "Mercedes Benz"
     }
 }
@@ -132,12 +133,13 @@ Date: REGEX(.*)
 03. GET /v2/entities/8787GHY/attrs/model
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 48
+Content-Length: 62
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "model": {
+        "metadata": {},
         "type": "myString", 
         "value": "Klasse C"
     }
@@ -147,12 +149,13 @@ Date: REGEX(.*)
 04. GET /v2/entities/8787GHY/attrs/speed
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 41
+Content-Length: 55
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "speed": {
+        "metadata": {},
         "type": "number", 
         "value": "150"
     }
@@ -162,13 +165,18 @@ Date: REGEX(.*)
 05. GET /v2/entities/8787GHY/attrs/A3
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 86
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "A3": {
-        "m1": "M1", 
+        "metadata": {
+            "m1": {
+                "type": null,
+                "value": "M1"
+            }
+        },
         "type": "a", 
         "value": "E1/T1/A3/M1"
     }

--- a/test/functionalTest/cases/0991_update_single_attr_by_eid/update_one_of_two_attributes_changing_type_and_metadata.test
+++ b/test/functionalTest/cases/0991_update_single_attr_by_eid/update_one_of_two_attributes_changing_type_and_metadata.test
@@ -113,13 +113,21 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1 to see A1==1 and A2==1
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 123
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 1.0,
-    "A2": 1.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
+    "A2": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -136,13 +144,21 @@ Date: REGEX(.*)
 04. GET /v2/entities/E1 to see A1==3 and A2==1 (A2 untouched)
 =============================================================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 123
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 3.0,
-    "A2": 1.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 3.0
+    },
+    "A2": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -159,17 +175,30 @@ Date: REGEX(.*)
 06. GET /v2/entities/E1 to see metadata m1 and m2
 =================================================
 HTTP/1.1 200 OK
-Content-Length: 86
+Content-Length: 191
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "A1": {
-        "m1": 55.0,
-        "m2": "55",
+        "metadata": {
+            "m1": {
+                "type": null,
+                "value": 55.0
+            },
+            "m2": {
+                "type": null,
+                "value": "55"
+            }
+        },
+        "type": null,
         "value": 5.0
     },
-    "A2": 1.0,
+    "A2": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -186,17 +215,27 @@ Date: REGEX(.*)
 08. GET /v2/entities/E1 to see A2::type == 'newtype'
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 110
+Content-Length: 193
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "A1": {
-        "m1": 55.0,
-        "m2": "55",
+        "metadata": {
+            "m1": {
+                "type": null,
+                "value": 55.0
+            },
+            "m2": {
+                "type": null,
+                "value": "55"
+            }
+        },
+        "type": null,
         "value": 5.0
     },
     "A2": {
+        "metadata": {},
         "type": "newtype",
         "value": "VAL"
     },

--- a/test/functionalTest/cases/0993_DELETE_v2_entity_attr/delete_not_exist_attr.test
+++ b/test/functionalTest/cases/0993_DELETE_v2_entity_attr/delete_not_exist_attr.test
@@ -79,15 +79,19 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 79
+Content-Length: 115
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "compattr": {
-        "bool": true,
-        "number": 2.0,
-        "string": "1"
+        "metadata": {},
+        "type": null,
+        "value": {
+            "bool": true,
+            "number": 2.0,
+            "string": "1"
+        }
     },
     "id": "E1",
     "type": "T1"

--- a/test/functionalTest/cases/0993_DELETE_v2_entity_attr/delete_ok.test
+++ b/test/functionalTest/cases/0993_DELETE_v2_entity_attr/delete_ok.test
@@ -101,18 +101,26 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 109
+Content-Length: 181
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "compattr": {
-        "bool": true,
-        "number": 2.0,
-        "string": "1"
+        "metadata": {},
+        "type": null,
+        "value": {
+            "bool": true,
+            "number": 2.0,
+            "string": "1"
+        }
     },
     "id": "E1",
-    "simpleattr": "a simple value",
+    "simpleattr": {
+        "metadata": {},
+        "type": null,
+        "value": "a simple value"
+    },
     "type": "T1"
 }
 
@@ -128,13 +136,17 @@ Date: REGEX(.*)
 04. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 53
+Content-Length: 89
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "id": "E1",
-    "simpleattr": "a simple value",
+    "simpleattr": {
+        "metadata": {},
+        "type": null,
+        "value": "a simple value"
+    },
     "type": "T1"
 }
 

--- a/test/functionalTest/cases/0997_GET_v2_entity_single_attribute_value/GET_v2_entity_single_attribute_value.test
+++ b/test/functionalTest/cases/0997_GET_v2_entity_single_attribute_value/GET_v2_entity_single_attribute_value.test
@@ -180,48 +180,64 @@ Date: REGEX(.*)
 02. GET /v2/entities/8787GHY/attrs/brand/value
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 25
+Content-Length: 61
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "value": "Mercedes Benz"
+    "value": {
+        "metadata": {},
+        "type": null,
+        "value": "Mercedes Benz"
+    }
 }
 
 
 03. GET /v2/entities/8787GHY/attrs/model/value
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 20
+Content-Length: 56
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "value": "Klasse C"
+    "value": {
+        "metadata": {},
+        "type": null,
+        "value": "Klasse C"
+    }
 }
 
 
 04. GET /v2/entities/8787GHY/attrs/speed/value
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 15
+Content-Length: 51
 Content-Type: application/json
 Date: REGEX(.*)
 
-{ 
-    "value": "150"
+{
+    "value": {
+        "metadata": {},
+        "type": null,
+        "value": "150"
+    }
 }
 
 
 05. GET /v2/entities/8787GHY/attrs/A3/value
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 23
+Content-Length: 59
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "value": "E1/T1/A3/M1"
+    "value": {
+        "metadata": {},
+        "type": null,
+        "value": "E1/T1/A3/M1"
+    }
 }
 
 

--- a/test/functionalTest/cases/0999_update_single_attr_value_by_eid/update_one_of_two_attributes.test
+++ b/test/functionalTest/cases/0999_update_single_attr_value_by_eid/update_one_of_two_attributes.test
@@ -79,13 +79,21 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1 to see A1==1 and A2==1
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 123
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 1.0,
-    "A2": 1.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
+    "A2": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -102,13 +110,21 @@ Date: REGEX(.*)
 04. GET /v2/entities/E1 to see A1==3 and A2==1 (A2 untouched)
 =============================================================
 HTTP/1.1 200 OK
-Content-Length: 51
+Content-Length: 123
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 3.0,
-    "A2": 1.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 3.0
+    },
+    "A2": {
+        "metadata": {},
+        "type": null,
+        "value": 1.0
+    },
     "id": "E1",
     "type": "T1"
 }

--- a/test/functionalTest/cases/0999_update_single_attr_value_by_eid/update_single_attr_by_eid.test
+++ b/test/functionalTest/cases/0999_update_single_attr_value_by_eid/update_single_attr_by_eid.test
@@ -180,12 +180,16 @@ Date: REGEX(.*)
 03. GET /v2/entities/E1 to see A1==2
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 37
+Content-Length: 73
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 2.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 2.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -202,12 +206,16 @@ Date: REGEX(.*)
 05. GET /v2/entities/E1 to see A1==4
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 37
+Content-Length: 73
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 4.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 4.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -224,12 +232,16 @@ Date: REGEX(.*)
 07. GET /v2/entities/E1 to see A1==true
 =======================================
 HTTP/1.1 200 OK
-Content-Length: 33
+Content-Length: 69
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": true,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": true
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -246,12 +258,16 @@ Date: REGEX(.*)
 09. GET /v2/entities/E1 to see A1==false
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 34
+Content-Length: 70
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": false,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": false
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -268,12 +284,16 @@ Date: REGEX(.*)
 11. GET /v2/entities/E1 to see A1=="STRING"
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 37
+Content-Length: 73
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": "STRING",
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": "STRING"
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -290,16 +310,20 @@ Date: REGEX(.*)
 13. GET /v2/entities/E1 to see A1==[ 1, 2, 3 ]
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 57
+Content-Length: 93
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": [
-        1.0,
-        2.0,
-        3.0
-    ],
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": [
+            1.0,
+            2.0,
+            3.0
+        ]
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -316,15 +340,19 @@ Date: REGEX(.*)
 15. GET /v2/entities/E1 to see A1=={ "a": 1, "b": 2, "c": 3 }
 =============================================================
 HTTP/1.1 200 OK
-Content-Length: 69
+Content-Length: 105
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "A1": {
-        "a": 1.0,
-        "b": 2.0,
-        "c": 3.0
+        "metadata": {},
+        "type": null,
+        "value": {
+            "a": 1.0,
+            "b": 2.0,
+            "c": 3.0
+        }
     },
     "id": "E1",
     "type": "T1"

--- a/test/functionalTest/cases/1005_GET_v2_entities_string/1005_GET_v2_entities_string.test
+++ b/test/functionalTest/cases/1005_GET_v2_entities_string/1005_GET_v2_entities_string.test
@@ -84,27 +84,38 @@ Date: REGEX(.*)
 02. GET /v2/entities
 ====================
 HTTP/1.1 200 OK
-Content-Length: 209
+Content-Length: 323
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
     {
         "brand": {
-            "type": "string", 
+            "metadata": {},
+            "type": "string",
             "value": "Mercedes Benz"
-        }, 
-        "id": "8787GHY", 
-        "madeInCountry": "DE", 
+        },
+        "id": "8787GHY",
+        "madeInCountry": {
+            "metadata": {},
+            "type": null,
+            "value": "DE"
+        },
         "model": {
-            "type": "myString", 
+            "metadata": {},
+            "type": "myString",
             "value": "Klasse C"
-        }, 
-        "plateCountry": "ES", 
+        },
+        "plateCountry": {
+            "metadata": {},
+            "type": null,
+            "value": "ES"
+        },
         "speed": {
-            "type": "number", 
+            "metadata": {},
+            "type": "number",
             "value": "150"
-        }, 
+        },
         "type": "Car"
     }
 ]

--- a/test/functionalTest/cases/1041_GET_v2_entities_options_count/get_entities_option_count.test
+++ b/test/functionalTest/cases/1041_GET_v2_entities_options_count/get_entities_option_count.test
@@ -130,7 +130,7 @@ Date: REGEX(.*)
 03. GET /v2/entities
 ====================
 HTTP/1.1 200 OK
-Content-Length: 73
+Content-Length: 87
 Content-Type: application/json
 X-Total-Count: 1
 Date: REGEX(.*)
@@ -139,6 +139,7 @@ Date: REGEX(.*)
     {
         "id": "E1",
         "model": {
+            "metadata": {},
             "type": "myString",
             "value": "Klasse C"
         },
@@ -177,7 +178,7 @@ Date: REGEX(.*)
 07. GET /v2/entities
 ====================
 HTTP/1.1 200 OK
-Content-Length: 148
+Content-Length: 162
 Content-Type: application/json
 X-Total-Count: 4
 Date: REGEX(.*)
@@ -186,6 +187,7 @@ Date: REGEX(.*)
     {
         "id": "E1",
         "model": {
+            "metadata": {},
             "type": "myString",
             "value": "Klasse C"
         },

--- a/test/functionalTest/cases/1113_bug_metadata_not_updated/metadata_not_updated.test
+++ b/test/functionalTest/cases/1113_bug_metadata_not_updated/metadata_not_updated.test
@@ -92,14 +92,20 @@ Date: REGEX(.*)
 03. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 58
+Content-Length: 105
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "id": "E1",
     "temp": {
-        "m1": 2.0,
+        "metadata": {
+            "m1": {
+                "type": null,
+                "value": 2.0
+            }
+        },
+        "type": null,
         "value": "1"
     },
     "type": "T1"

--- a/test/functionalTest/cases/1127_v1_append_strict/v1_append_strict.test
+++ b/test/functionalTest/cases/1127_v1_append_strict/v1_append_strict.test
@@ -159,12 +159,16 @@ Date: REGEX(.*)
 02. Get E1 (only attr1)
 =======================
 HTTP/1.1 200 OK
-Content-Length: 35
+Content-Length: 71
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": "1",
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": "1"
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -204,13 +208,21 @@ Date: REGEX(.*)
 04. Get E1 (attr1, attr2)
 =========================
 HTTP/1.1 200 OK
-Content-Length: 47
+Content-Length: 119
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": "1",
-    "attr2": "2",
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": "1"
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": "2"
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -255,13 +267,21 @@ Date: REGEX(.*)
 06. Get E1 (attr1, attr2)
 =========================
 HTTP/1.1 200 OK
-Content-Length: 47
+Content-Length: 119
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": "1",
-    "attr2": "2",
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": "1"
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": "2"
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -313,14 +333,26 @@ Date: REGEX(.*)
 08. Get E1 (attr1, attr2, attr3)
 ================================
 HTTP/1.1 200 OK
-Content-Length: 59
+Content-Length: 167
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": "1",
-    "attr2": "2",
-    "attr3": "3",
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": "1"
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": "2"
+    },
+    "attr3": {
+        "metadata": {},
+        "type": null,
+        "value": "3"
+    },
     "id": "E1",
     "type": "T1"
 }

--- a/test/functionalTest/cases/1127_v1_replace/v1_replace.test
+++ b/test/functionalTest/cases/1127_v1_replace/v1_replace.test
@@ -98,13 +98,21 @@ Date: REGEX(.*)
 02. Get E1 (attr1, attr2)
 =========================
 HTTP/1.1 200 OK
-Content-Length: 47
+Content-Length: 119
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr1": "1",
-    "attr2": "2",
+    "attr1": {
+        "metadata": {},
+        "type": null,
+        "value": "1"
+    },
+    "attr2": {
+        "metadata": {},
+        "type": null,
+        "value": "2"
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -149,13 +157,21 @@ Date: REGEX(.*)
 04. Get E1 (attr3, attr4)
 =========================
 HTTP/1.1 200 OK
-Content-Length: 47
+Content-Length: 119
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "attr3": "3",
-    "attr4": "4",
+    "attr3": {
+        "metadata": {},
+        "type": null,
+        "value": "3"
+    },
+    "attr4": {
+        "metadata": {},
+        "type": null,
+        "value": "4"
+    },
     "id": "E1",
     "type": "T1"
 }

--- a/test/functionalTest/cases/1177_geometry_and_coords/geometry_and_coords.test
+++ b/test/functionalTest/cases/1177_geometry_and_coords/geometry_and_coords.test
@@ -222,7 +222,7 @@ Date: REGEX(.*)
 04. GET /v2/entities - see all three cities
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 407
+Content-Length: 446
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -230,9 +230,11 @@ Date: REGEX(.*)
     {
         "id": "Madrid",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.418889, -3.691944"
@@ -242,9 +244,11 @@ Date: REGEX(.*)
     {
         "id": "Leganes",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.316667, -3.75"
@@ -254,9 +258,11 @@ Date: REGEX(.*)
     {
         "id": "Alcobendas",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.533333, -3.633333"
@@ -269,7 +275,7 @@ Date: REGEX(.*)
 05. GET /v2/entities, circle with wide radius capturing all three cities
 ========================================================================
 HTTP/1.1 200 OK
-Content-Length: 407
+Content-Length: 446
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -277,9 +283,11 @@ Date: REGEX(.*)
     {
         "id": "Madrid",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.418889, -3.691944"
@@ -289,9 +297,11 @@ Date: REGEX(.*)
     {
         "id": "Leganes",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.316667, -3.75"
@@ -301,9 +311,11 @@ Date: REGEX(.*)
     {
         "id": "Alcobendas",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.533333, -3.633333"
@@ -316,7 +328,7 @@ Date: REGEX(.*)
 06. GET /v2/entities, circle with not so wide radius capturing only Madrid and Leganes
 ======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 268
+Content-Length: 294
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -324,9 +336,11 @@ Date: REGEX(.*)
     {
         "id": "Madrid",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.418889, -3.691944"
@@ -336,9 +350,11 @@ Date: REGEX(.*)
     {
         "id": "Leganes",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.316667, -3.75"
@@ -351,7 +367,7 @@ Date: REGEX(.*)
 07. GET /v2/entities, circle with narrow radius capturing only Madrid
 =====================================================================
 HTTP/1.1 200 OK
-Content-Length: 136
+Content-Length: 149
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -359,9 +375,11 @@ Date: REGEX(.*)
     {
         "id": "Madrid",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.418889, -3.691944"
@@ -374,7 +392,7 @@ Date: REGEX(.*)
 08. GET /v2/entities, inverted circle with narrow radius capturing Leganes and Alcobendas
 =========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 272
+Content-Length: 298
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -382,9 +400,11 @@ Date: REGEX(.*)
     {
         "id": "Leganes",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.316667, -3.75"
@@ -394,9 +414,11 @@ Date: REGEX(.*)
     {
         "id": "Alcobendas",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.533333, -3.633333"
@@ -409,7 +431,7 @@ Date: REGEX(.*)
 09. GET /v2/entities, polygon capturing only Leganes
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 133
+Content-Length: 146
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -417,9 +439,11 @@ Date: REGEX(.*)
     {
         "id": "Leganes",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.316667, -3.75"
@@ -432,7 +456,7 @@ Date: REGEX(.*)
 10. GET /v2/entities, inverted polygon capturing all but Leganes
 ================================================================
 HTTP/1.1 200 OK
-Content-Length: 275
+Content-Length: 301
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -440,9 +464,11 @@ Date: REGEX(.*)
     {
         "id": "Madrid",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.418889, -3.691944"
@@ -452,9 +478,11 @@ Date: REGEX(.*)
     {
         "id": "Alcobendas",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.533333, -3.633333"
@@ -467,7 +495,7 @@ Date: REGEX(.*)
 11. GET /v2/entities, polygon capturing only Alcobendas
 =======================================================
 HTTP/1.1 200 OK
-Content-Length: 140
+Content-Length: 153
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -475,9 +503,11 @@ Date: REGEX(.*)
     {
         "id": "Alcobendas",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.533333, -3.633333"
@@ -490,7 +520,7 @@ Date: REGEX(.*)
 12. GET /v2/entities, inverted polygon capturing all but Alcobendas
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 268
+Content-Length: 294
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -498,9 +528,11 @@ Date: REGEX(.*)
     {
         "id": "Madrid",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.418889, -3.691944"
@@ -510,9 +542,11 @@ Date: REGEX(.*)
     {
         "id": "Leganes",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.316667, -3.75"
@@ -525,7 +559,7 @@ Date: REGEX(.*)
 13. GET /v2/entities, polygon capturing only Madrid
 ===================================================
 HTTP/1.1 200 OK
-Content-Length: 136
+Content-Length: 149
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -533,9 +567,11 @@ Date: REGEX(.*)
     {
         "id": "Madrid",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.418889, -3.691944"
@@ -548,7 +584,7 @@ Date: REGEX(.*)
 14. GET /v2/entities, inverted polygon capturing all but Madrid
 ===============================================================
 HTTP/1.1 200 OK
-Content-Length: 272
+Content-Length: 298
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -556,9 +592,11 @@ Date: REGEX(.*)
     {
         "id": "Leganes",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.316667, -3.75"
@@ -568,9 +606,11 @@ Date: REGEX(.*)
     {
         "id": "Alcobendas",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.533333, -3.633333"
@@ -583,7 +623,7 @@ Date: REGEX(.*)
 15. GET /v2/entities, polygon capturing all three cities
 ========================================================
 HTTP/1.1 200 OK
-Content-Length: 407
+Content-Length: 446
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -591,9 +631,11 @@ Date: REGEX(.*)
     {
         "id": "Madrid",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.418889, -3.691944"
@@ -603,9 +645,11 @@ Date: REGEX(.*)
     {
         "id": "Leganes",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.316667, -3.75"
@@ -615,9 +659,11 @@ Date: REGEX(.*)
     {
         "id": "Alcobendas",
         "location": {
-            "location": {
-                "type": "string",
-                "value": "WGS84"
+            "metadata": {
+                "location": {
+                    "type": "string",
+                    "value": "WGS84"
+                }
             },
             "type": "coords",
             "value": "40.533333, -3.633333"

--- a/test/functionalTest/cases/1185_udpate_change_value_type/update_change_value_type.test
+++ b/test/functionalTest/cases/1185_udpate_change_value_type/update_change_value_type.test
@@ -164,12 +164,16 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1 to see A1==0
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 37
+Content-Length: 73
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 0.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 0.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -186,12 +190,16 @@ Date: REGEX(.*)
 04. GET /v2/entities/E1 to see A1==false
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 34
+Content-Length: 70
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": false,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": false
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -208,12 +216,16 @@ Date: REGEX(.*)
 06. GET /v2/entities/E1 to see A1==0
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 37
+Content-Length: 73
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 0.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 0.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -230,12 +242,16 @@ Date: REGEX(.*)
 08. GET /v2/entities/E1 to see A1=="x"
 ======================================
 HTTP/1.1 200 OK
-Content-Length: 32
+Content-Length: 68
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": "x",
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": "x"
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -252,12 +268,16 @@ Date: REGEX(.*)
 10. GET /v2/entities/E1 to see A1==false
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 34
+Content-Length: 70
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": false,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": false
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -274,12 +294,16 @@ Date: REGEX(.*)
 12. GET /v2/entities/E1 to see A1=="x"
 ======================================
 HTTP/1.1 200 OK
-Content-Length: 32
+Content-Length: 68
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": "x",
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": "x"
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -296,12 +320,16 @@ Date: REGEX(.*)
 14. GET /v2/entities/E1 to see A1==0
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 37
+Content-Length: 73
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 0.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 0.0
+    },
     "id": "E1",
     "type": "T1"
 }

--- a/test/functionalTest/cases/1187_empty_attribute_in_create/empty_attribute_in_create.test
+++ b/test/functionalTest/cases/1187_empty_attribute_in_create/empty_attribute_in_create.test
@@ -79,12 +79,16 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1 to see A1==""
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 31
+Content-Length: 67
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": "",
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": ""
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -102,13 +106,21 @@ Date: REGEX(.*)
 04. GET /v2/entities/E1 to see A2==""
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 39
+Content-Length: 111
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": "",
-    "A2": "",
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": ""
+    },
+    "A2": {
+        "metadata": {},
+        "type": null,
+        "value": ""
+    },
     "id": "E1",
     "type": "T1"
 }

--- a/test/functionalTest/cases/1188_empty_attribute_value/empty_attribute_value.test
+++ b/test/functionalTest/cases/1188_empty_attribute_value/empty_attribute_value.test
@@ -112,12 +112,16 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1 to see A1==1
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 32
+Content-Length: 68
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": "1",
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": "1"
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -134,12 +138,16 @@ Date: REGEX(.*)
 04. GET /v2/entities/E1 to see A1==""
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 31
+Content-Length: 67
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": "",
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": ""
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -156,12 +164,16 @@ Date: REGEX(.*)
 06. GET /v2/entities/E1 to see A1==5
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 37
+Content-Length: 73
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": 5.0,
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": 5.0
+    },
     "id": "E1",
     "type": "T1"
 }
@@ -178,12 +190,16 @@ Date: REGEX(.*)
 08. GET /v2/entities/E1 to see A1==""
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 31
+Content-Length: 67
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "A1": "",
+    "A1": {
+        "metadata": {},
+        "type": null,
+        "value": ""
+    },
     "id": "E1",
     "type": "T1"
 }

--- a/test/functionalTest/cases/1259_new_json_for_v2/putPostPatch_v2_entities_eid.test
+++ b/test/functionalTest/cases/1259_new_json_for_v2/putPostPatch_v2_entities_eid.test
@@ -130,55 +130,90 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 924
+Content-Length: 1397
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "compound_object": {
-        "a": 1.0,
-        "b": 2.0
+        "metadata": {},
+        "type": null,
+        "value": {
+            "a": 1.0,
+            "b": 2.0
+        }
     },
-    "compound_vector": [
-        1.0,
-        2.0,
-        3.0
-    ],
-    "false": false,
+    "compound_vector": {
+        "metadata": {},
+        "type": null,
+        "value": [
+            1.0,
+            2.0,
+            3.0
+        ]
+    },
+    "false": {
+        "metadata": {},
+        "type": null,
+        "value": false
+    },
     "false_object": {
+        "metadata": {},
         "type": "TA1",
         "value": false
     },
-    "float": 3.14,
+    "float": {
+        "metadata": {},
+        "type": null,
+        "value": 3.14
+    },
     "float_object": {
+        "metadata": {},
         "type": "TA1",
         "value": 22.1
     },
     "id": "E1",
-    "int": 19.0,
+    "int": {
+        "metadata": {},
+        "type": null,
+        "value": 19.0
+    },
     "int_object": {
+        "metadata": {},
         "type": "TA1",
         "value": 21.0
     },
     "object_object": {
+        "metadata": {},
         "type": "TA1",
         "value": {
             "a": 1.0,
             "b": 2.0
         }
     },
-    "string": "a1",
+    "string": {
+        "metadata": {},
+        "type": null,
+        "value": "a1"
+    },
     "string_object": {
+        "metadata": {},
         "type": "TA1",
         "value": "a1"
     },
-    "true": true,
+    "true": {
+        "metadata": {},
+        "type": null,
+        "value": true
+    },
     "true_object": {
+        "metadata": {},
         "type": "TA1",
         "value": true
     },
     "type": null,
     "vector_object": {
+        "metadata": {},
         "type": "TA1",
         "value": [
             "a",
@@ -186,31 +221,48 @@ Date: REGEX(.*)
         ]
     },
     "with_metadata01": {
-        "md_false": false,
-        "md_float:": 2.01,
-        "md_int": 1.0,
-        "md_object_false": {
-            "type": "MDBOOL",
-            "value": false
+        "metadata": {
+            "md_false": {
+                "type": null,
+                "value": false
+            },
+            "md_float:": {
+                "type": null,
+                "value": 2.01
+            },
+            "md_int": {
+                "type": null,
+                "value": 1.0
+            },
+            "md_object_false": {
+                "type": "MDBOOL",
+                "value": false
+            },
+            "md_object_float": {
+                "type": "MDFLOAT",
+                "value": 2.01
+            },
+            "md_object_int": {
+                "type": "MDINT",
+                "value": 1.0
+            },
+            "md_object_string": {
+                "type": "MDSTRING",
+                "value": "3"
+            },
+            "md_object_true": {
+                "type": "MDBOOL",
+                "value": true
+            },
+            "md_string": {
+                "type": null,
+                "value": "STRING"
+            },
+            "md_true": {
+                "type": null,
+                "value": true
+            }
         },
-        "md_object_float": {
-            "type": "MDFLOAT",
-            "value": 2.01
-        },
-        "md_object_int": {
-            "type": "MDINT",
-            "value": 1.0
-        },
-        "md_object_string": {
-            "type": "MDSTRING",
-            "value": "3"
-        },
-        "md_object_true": {
-            "type": "MDBOOL",
-            "value": true
-        },
-        "md_string": "STRING",
-        "md_true": true,
         "type": "MT1",
         "value": 0.0
     }

--- a/test/functionalTest/cases/1259_new_json_for_v2/putPostPatch_v2_entities_eid.test
+++ b/test/functionalTest/cases/1259_new_json_for_v2/putPostPatch_v2_entities_eid.test
@@ -130,7 +130,7 @@ Date: REGEX(.*)
 02. GET /v2/entities/E1
 =======================
 HTTP/1.1 200 OK
-Content-Length: 912
+Content-Length: 924
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -177,6 +177,7 @@ Date: REGEX(.*)
         "type": "TA1",
         "value": true
     },
+    "type": null,
     "vector_object": {
         "type": "TA1",
         "value": [

--- a/test/functionalTest/cases/1259_new_json_for_v2/v2_render_modes.test
+++ b/test/functionalTest/cases/1259_new_json_for_v2/v2_render_modes.test
@@ -1,0 +1,629 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+GET /v2/entities/eid render modes
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0-255
+
+--SHELL--
+
+#
+# 01. POST /v2/entities/E1 complete
+# 02. GET /v2/entities/E1
+# 03. GET /v2/entities/E1?options=keyValues
+# 04. GET /v2/entities/E1?options=values
+# 05. GET /v2/entities
+# 06. GET /v2/entities?options=keyValues
+# 07. GET /v2/entities?options=values
+#
+
+echo "01. POST /v2/entities/E1 complete"
+echo "================================="
+payload='{
+  "string": "a1",
+  "int":     19,
+  "float":   3.14,
+  "true":    true,
+  "false":   false,
+  "compound_vector":  [ 1,2,3 ],
+  "compound_object":  { "a": 1, "b": 2 },
+  "string_object": {
+    "value": "a1",
+    "type":  "TA1"
+  },
+  "int_object": {
+    "value": 21,
+    "type":  "TA1"
+  },
+  "float_object": {
+    "value": 22.1,
+    "type":  "TA1"
+  },
+  "true_object": {
+    "value": true,
+    "type":  "TA1"
+  },
+  "false_object": {
+    "value": false,
+    "type":  "TA1"
+  },
+  "object_object": {
+    "value": { "a": 1, "b": 2 },
+    "type":  "TA1"
+  },
+  "vector_object": {
+    "value": [ "a", "b" ],
+    "type":  "TA1"
+  },
+  "with_metadata01": {
+    "value": 0,
+    "type": "MT1",
+    "metadata": {
+      "md_int": 1,
+      "md_float:": 2.01,
+      "md_string": "STRING",
+      "md_true": true,
+      "md_false": false,
+      "md_object_int": {
+        "value": 1,
+        "type": "MDINT"
+      },
+      "md_object_float": {
+        "value": 2.01,
+        "type": "MDFLOAT"
+      },
+      "md_object_string": {
+        "value": "3",
+        "type": "MDSTRING"
+      },
+      "md_object_true": {
+        "value": true,
+        "type": "MDBOOL"
+      },
+      "md_object_false": {
+        "value": false,
+        "type": "MDBOOL"
+      }
+    }
+  }
+}'
+orionCurl --url /v2/entities/E1 --payload "$payload" --json
+echo
+echo
+
+
+echo "02. GET /v2/entities/E1"
+echo "======================="
+orionCurl --url /v2/entities/E1 --json
+echo
+echo
+
+
+echo "03. GET /v2/entities/E1?options=keyValues"
+echo "========================================="
+orionCurl --url '/v2/entities/E1?options=keyValues' --json
+echo
+echo
+
+
+echo "04. GET /v2/entities/E1?options=values"
+echo "======================================"
+orionCurl --url '/v2/entities/E1?options=values' --json
+echo
+echo
+
+
+echo "05. GET /v2/entities"
+echo "===================="
+orionCurl --url /v2/entities --json
+echo
+echo
+
+
+echo "06. GET /v2/entities?options=keyValues"
+echo "======================================"
+orionCurl --url '/v2/entities?options=keyValues' --json
+echo
+echo
+
+
+echo "07. GET /v2/entities?options=values"
+echo "==================================="
+orionCurl --url '/v2/entities?options=values' --json
+echo
+echo
+
+
+--REGEXPECT--
+01. POST /v2/entities/E1 complete
+=================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1
+Date: REGEX(.*)
+
+
+
+02. GET /v2/entities/E1
+=======================
+HTTP/1.1 200 OK
+Content-Length: 1397
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "compound_object": {
+        "metadata": {},
+        "type": null,
+        "value": {
+            "a": 1.0,
+            "b": 2.0
+        }
+    },
+    "compound_vector": {
+        "metadata": {},
+        "type": null,
+        "value": [
+            1.0,
+            2.0,
+            3.0
+        ]
+    },
+    "false": {
+        "metadata": {},
+        "type": null,
+        "value": false
+    },
+    "false_object": {
+        "metadata": {},
+        "type": "TA1",
+        "value": false
+    },
+    "float": {
+        "metadata": {},
+        "type": null,
+        "value": 3.14
+    },
+    "float_object": {
+        "metadata": {},
+        "type": "TA1",
+        "value": 22.1
+    },
+    "id": "E1",
+    "int": {
+        "metadata": {},
+        "type": null,
+        "value": 19.0
+    },
+    "int_object": {
+        "metadata": {},
+        "type": "TA1",
+        "value": 21.0
+    },
+    "object_object": {
+        "metadata": {},
+        "type": "TA1",
+        "value": {
+            "a": 1.0,
+            "b": 2.0
+        }
+    },
+    "string": {
+        "metadata": {},
+        "type": null,
+        "value": "a1"
+    },
+    "string_object": {
+        "metadata": {},
+        "type": "TA1",
+        "value": "a1"
+    },
+    "true": {
+        "metadata": {},
+        "type": null,
+        "value": true
+    },
+    "true_object": {
+        "metadata": {},
+        "type": "TA1",
+        "value": true
+    },
+    "type": null,
+    "vector_object": {
+        "metadata": {},
+        "type": "TA1",
+        "value": [
+            "a",
+            "b"
+        ]
+    },
+    "with_metadata01": {
+        "metadata": {
+            "md_false": {
+                "type": null,
+                "value": false
+            },
+            "md_float:": {
+                "type": null,
+                "value": 2.01
+            },
+            "md_int": {
+                "type": null,
+                "value": 1.0
+            },
+            "md_object_false": {
+                "type": "MDBOOL",
+                "value": false
+            },
+            "md_object_float": {
+                "type": "MDFLOAT",
+                "value": 2.01
+            },
+            "md_object_int": {
+                "type": "MDINT",
+                "value": 1.0
+            },
+            "md_object_string": {
+                "type": "MDSTRING",
+                "value": "3"
+            },
+            "md_object_true": {
+                "type": "MDBOOL",
+                "value": true
+            },
+            "md_string": {
+                "type": null,
+                "value": "STRING"
+            },
+            "md_true": {
+                "type": null,
+                "value": true
+            }
+        },
+        "type": "MT1",
+        "value": 0.0
+    }
+}
+
+
+03. GET /v2/entities/E1?options=keyValues
+=========================================
+HTTP/1.1 200 OK
+Content-Length: 395
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "compound_object": {
+        "a": 1.0,
+        "b": 2.0
+    },
+    "compound_vector": [
+        1.0,
+        2.0,
+        3.0
+    ],
+    "false": false,
+    "false_object": false,
+    "float": 3.14,
+    "float_object": 22.1,
+    "id": "E1",
+    "int": 19.0,
+    "int_object": 21.0,
+    "object_object": {
+        "a": 1.0,
+        "b": 2.0
+    },
+    "string": "a1",
+    "string_object": "a1",
+    "true": true,
+    "true_object": true,
+    "type": null,
+    "vector_object": [
+        "a",
+        "b"
+    ],
+    "with_metadata01": 0.0
+}
+
+
+04. GET /v2/entities/E1?options=values
+======================================
+HTTP/1.1 200 OK
+Content-Length: 218
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "attributeValues": [
+        {
+            "a": 1.0,
+            "b": 2.0
+        },
+        [
+            1.0,
+            2.0,
+            3.0
+        ],
+        false,
+        false,
+        3.14,
+        22.1,
+        19.0,
+        21.0,
+        {
+            "a": 1.0,
+            "b": 2.0
+        },
+        "a1",
+        "a1",
+        true,
+        true,
+        [
+            "a",
+            "b"
+        ],
+        0.0
+    ],
+    "id": "E1",
+    "type": null
+}
+
+
+05. GET /v2/entities
+====================
+HTTP/1.1 200 OK
+Content-Length: 1399
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    {
+        "compound_object": {
+            "metadata": {},
+            "type": null,
+            "value": {
+                "a": 1.0,
+                "b": 2.0
+            }
+        },
+        "compound_vector": {
+            "metadata": {},
+            "type": null,
+            "value": [
+                1.0,
+                2.0,
+                3.0
+            ]
+        },
+        "false": {
+            "metadata": {},
+            "type": null,
+            "value": false
+        },
+        "false_object": {
+            "metadata": {},
+            "type": "TA1",
+            "value": false
+        },
+        "float": {
+            "metadata": {},
+            "type": null,
+            "value": 3.14
+        },
+        "float_object": {
+            "metadata": {},
+            "type": "TA1",
+            "value": 22.1
+        },
+        "id": "E1",
+        "int": {
+            "metadata": {},
+            "type": null,
+            "value": 19.0
+        },
+        "int_object": {
+            "metadata": {},
+            "type": "TA1",
+            "value": 21.0
+        },
+        "object_object": {
+            "metadata": {},
+            "type": "TA1",
+            "value": {
+                "a": 1.0,
+                "b": 2.0
+            }
+        },
+        "string": {
+            "metadata": {},
+            "type": null,
+            "value": "a1"
+        },
+        "string_object": {
+            "metadata": {},
+            "type": "TA1",
+            "value": "a1"
+        },
+        "true": {
+            "metadata": {},
+            "type": null,
+            "value": true
+        },
+        "true_object": {
+            "metadata": {},
+            "type": "TA1",
+            "value": true
+        },
+        "type": null,
+        "vector_object": {
+            "metadata": {},
+            "type": "TA1",
+            "value": [
+                "a",
+                "b"
+            ]
+        },
+        "with_metadata01": {
+            "metadata": {
+                "md_false": {
+                    "type": null,
+                    "value": false
+                },
+                "md_float:": {
+                    "type": null,
+                    "value": 2.01
+                },
+                "md_int": {
+                    "type": null,
+                    "value": 1.0
+                },
+                "md_object_false": {
+                    "type": "MDBOOL",
+                    "value": false
+                },
+                "md_object_float": {
+                    "type": "MDFLOAT",
+                    "value": 2.01
+                },
+                "md_object_int": {
+                    "type": "MDINT",
+                    "value": 1.0
+                },
+                "md_object_string": {
+                    "type": "MDSTRING",
+                    "value": "3"
+                },
+                "md_object_true": {
+                    "type": "MDBOOL",
+                    "value": true
+                },
+                "md_string": {
+                    "type": null,
+                    "value": "STRING"
+                },
+                "md_true": {
+                    "type": null,
+                    "value": true
+                }
+            },
+            "type": "MT1",
+            "value": 0.0
+        }
+    }
+]
+
+
+06. GET /v2/entities?options=keyValues
+======================================
+HTTP/1.1 200 OK
+Content-Length: 397
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    {
+        "compound_object": {
+            "a": 1.0,
+            "b": 2.0
+        },
+        "compound_vector": [
+            1.0,
+            2.0,
+            3.0
+        ],
+        "false": false,
+        "false_object": false,
+        "float": 3.14,
+        "float_object": 22.1,
+        "id": "E1",
+        "int": 19.0,
+        "int_object": 21.0,
+        "object_object": {
+            "a": 1.0,
+            "b": 2.0
+        },
+        "string": "a1",
+        "string_object": "a1",
+        "true": true,
+        "true_object": true,
+        "type": null,
+        "vector_object": [
+            "a",
+            "b"
+        ],
+        "with_metadata01": 0.0
+    }
+]
+
+
+07. GET /v2/entities?options=values
+===================================
+HTTP/1.1 200 OK
+Content-Length: 220
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    {
+        "attributeValues": [
+            {
+                "a": 1.0,
+                "b": 2.0
+            },
+            [
+                1.0,
+                2.0,
+                3.0
+            ],
+            false,
+            false,
+            3.14,
+            22.1,
+            19.0,
+            21.0,
+            {
+                "a": 1.0,
+                "b": 2.0
+            },
+            "a1",
+            "a1",
+            true,
+            true,
+            [
+                "a",
+                "b"
+            ],
+            0.0
+        ],
+        "id": "E1",
+        "type": null
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Part II of issue #1259, rendering the output of /v2/entities[/< eid >]

Three renering modes implemented:
* normalized (default),
* keyValues, and
* values (tentative - format is not even fully decided yet - I think)

The mechanism right now to pick a rendering mode is via URL parameters.
This is not really decided yet - might change to URL PATH instead.
But, that is a minor change in the implementation.