### PR TITLE
FIX typo in test harness comment

### DIFF
--- a/test/functionalTest/cases/0953_list_all_ents_id/GET_v2_entities_pattern.test
+++ b/test/functionalTest/cases/0953_list_all_ents_id/GET_v2_entities_pattern.test
@@ -33,7 +33,7 @@ brokerStart CB
 # 01. GET /v2/entities?idPattern=E.*
 # 02. POST /v2/entities, creating E1
 # 03. GET /v2/entities?idPattern=E.*
-# 04. GET /v2/entities?idPattern=E1&count=true
+# 04. GET /v2/entities?idPattern=E1&options=count,normalized
 # 05. POST /v2/entities, creating E2 with compound attribute value
 # 06. GET /v2/entities?idPattern=E(1|2)
 # 07. GET /v2/entities?idPattern=E[2-3]


### PR DESCRIPTION
It seems we leave some comment without fix in a past PR (I have spoted by coincidence)