### PR TITLE
Feature/1126 get subscription list at mongo backend

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -17,3 +17,4 @@ Remove: deprecated command line arguments -ngsi9, -fwdHost and -fwdPort
 Remove: deprecated functionality related with associations
 Fix:  Update PATCH request with invalid service-path never return a response (#1280)
 Fix:  Error must be Not Found, when updating an unknown attribute of an existing entity on NGSIv2 update PATCH (#1278)
+Add:  NGSIv2 operation GET /v2/subscriptions (#1126)

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -191,7 +191,7 @@
 #include "cache/subCache.h"
 #include "cache/SubscriptionCache.h"
 
-
+using namespace orion;
 
 /* ****************************************************************************
 *

--- a/src/lib/apiTypesV2/Subscription.cpp
+++ b/src/lib/apiTypesV2/Subscription.cpp
@@ -31,6 +31,9 @@
 
 #include "common/JsonHelper.h"
 
+namespace ngsiv2
+{
+
 /* ****************************************************************************
 *
 * Subscription::toJson -
@@ -41,8 +44,8 @@ std::string Subscription::toJson()
 
   jh.addString("id", this->id);
   if (!this->duration.isEmpty())
-  {
-    jh.addRaw("duration: ",this->duration.render(JSON,"", false));
+  {    
+    jh.addRaw("duration: ", "\"" + this->duration.get() + "\"");
   }
   jh.addRaw("subject", this->subject.toJson());
   jh.addRaw("notification", this->notification.toJson());
@@ -62,8 +65,8 @@ std::string Notification::toJson()
 
   jh.addString("callback", this->callback);
   if (!this->throttling.isEmpty())
-  {
-    jh.addRaw("throttling", this->throttling.render(JSON,"",false));
+  {    
+    jh.addRaw("throttling", "\"" + this->throttling.get() + "\"");
   }
   jh.addRaw("attributes", vectorToJson(this->attributes));
 
@@ -126,4 +129,6 @@ std::string EntID::toJson()
   jh.addString("type", this->type);
 
   return jh.str();
+}
+
 }

--- a/src/lib/apiTypesV2/Subscription.h
+++ b/src/lib/apiTypesV2/Subscription.h
@@ -32,6 +32,8 @@
 #include "ngsi/Duration.h"
 #include "ngsi/Throttling.h"
 
+namespace ngsiv2 {
+
 struct EntID
 {
   std::string id;
@@ -81,6 +83,8 @@ struct Subscription
   Duration     duration;
   Notification notification;
   std::string  toJson();
+};
+
 };
 
 #endif // SRC_LIB_APITYPESV2_SUBSCRIPTION_H

--- a/src/lib/jsonParse/jsonParse.cpp
+++ b/src/lib/jsonParse/jsonParse.cpp
@@ -55,7 +55,7 @@
 #include "jsonParse/jsonParse.h"
 
 using boost::property_tree::ptree;
-
+using namespace orion;
 
 
 /* ****************************************************************************
@@ -262,7 +262,7 @@ void eatCompound
   if (containerP == NULL)
   {
     LM_T(LmtCompoundValue, ("COMPOUND: '%s'", nodeName.c_str()));
-    containerP = new CompoundValueNode(orion::ValueTypeObject);
+    containerP = new CompoundValueNode(ValueTypeObject);
     ciP->compoundValueRoot = containerP;
   }
   else
@@ -291,17 +291,17 @@ void eatCompound
     else if ((nodeName != "") && (nodeValue == ""))  // Named Container
     {
       LM_T(LmtCompoundValue, ("Adding container '%s' under '%s'", nodeName.c_str(), containerP->cpath()));
-      containerP = containerP->add(orion::ValueTypeObject, nodeName, "");
+      containerP = containerP->add(ValueTypeObject, nodeName, "");
     }
     else if ((nodeName == "") && (nodeValue == ""))  // Name-Less container
     {
       LM_T(LmtCompoundValue, ("Adding name-less container under '%s' (parent may be a Vector!)", containerP->cpath()));
-      containerP->valueType = orion::ValueTypeVector;
-      containerP = containerP->add(orion::ValueTypeObject, "item", "");
+      containerP->valueType = ValueTypeVector;
+      containerP = containerP->add(ValueTypeObject, "item", "");
     }
     else if ((nodeName == "") && (nodeValue != ""))  // Name-Less String + its container is a vector
     {
-      containerP->valueType = orion::ValueTypeVector;
+      containerP->valueType = ValueTypeVector;
       LM_T(LmtCompoundValue, ("Set '%s' to be a vector", containerP->cpath()));
       containerP->add(orion::ValueTypeString, "item", nodeValue);
       LM_T(LmtCompoundValue, ("Added a name-less string (value: '%s') under '%s'",

--- a/src/lib/mongoBackend/CMakeLists.txt
+++ b/src/lib/mongoBackend/CMakeLists.txt
@@ -42,6 +42,7 @@ SET (SOURCES
     TriggeredSubscription.cpp
     mongoConnectionPool.cpp
     mongoListSubscriptions.cpp
+    collectionOperations.cpp
 )
 
 SET (HEADERS
@@ -66,6 +67,7 @@ SET (HEADERS
     TriggeredSubscription.h
     mongoConnectionPool.h
     mongoListSubscriptions.h
+    collectionOperations.h
 )
 
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -51,6 +51,7 @@
 using std::string;
 using std::map;
 using std::auto_ptr;
+using namespace orion;
 
 
 /* ****************************************************************************

--- a/src/lib/mongoBackend/TriggeredSubscription.cpp
+++ b/src/lib/mongoBackend/TriggeredSubscription.cpp
@@ -33,12 +33,12 @@
 */
 TriggeredSubscription::TriggeredSubscription
 (
-  long long          _throttling,
-  long long          _lastNotification,
-  Format             _format,
-  const std::string& _reference,
-  AttributeList      _attrL,
-  Subscription*      _cacheSubReference
+  long long            _throttling,
+  long long            _lastNotification,
+  Format               _format,
+  const std::string&   _reference,
+  AttributeList        _attrL,
+  orion::Subscription* _cacheSubReference
 )
 {
   throttling        = _throttling;

--- a/src/lib/mongoBackend/TriggeredSubscription.h
+++ b/src/lib/mongoBackend/TriggeredSubscription.h
@@ -48,19 +48,19 @@
 class TriggeredSubscription
 {
  public:
-  long long     throttling;
-  long long     lastNotification;
-  Format        format;
-  std::string   reference;
-  AttributeList attrL;
-  Subscription* cacheSubReference;
+  long long            throttling;
+  long long            lastNotification;
+  Format               format;
+  std::string          reference;
+  AttributeList        attrL;
+  orion::Subscription* cacheSubReference;
 
-  TriggeredSubscription(long long          _throttling,
-                        long long          _lastNotification,
-                        Format             _format,
-                        const std::string& _reference,
-                        AttributeList      _attrL,
-                        Subscription*      _cacheSubReference);
+  TriggeredSubscription(long long            _throttling,
+                        long long            _lastNotification,
+                        Format               _format,
+                        const std::string&   _reference,
+                        AttributeList        _attrL,
+                        orion::Subscription* _cacheSubReference);
 
   TriggeredSubscription(Format             _format,
                         const std::string& _reference,

--- a/src/lib/mongoBackend/collectionOperations.cpp
+++ b/src/lib/mongoBackend/collectionOperations.cpp
@@ -1,0 +1,88 @@
+/*
+*
+* Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Fermín Galán
+*/
+
+#include "mongoBackend/MongoGlobal.h"
+#include "logMsg/traceLevels.h"
+
+#include "mongo/client/dbclient.h"
+
+using namespace mongo;
+
+/* ****************************************************************************
+*
+* query -
+*
+*/
+bool query
+(
+    const std::string&             col,
+    const BSONObj&                 q,
+    std::auto_ptr<DBClientCursor>* cursor,
+    std::string*                   err
+)
+{
+  DBClientBase* connection = getMongoConnection();
+
+  if (connection == NULL)
+  {
+     LM_E(("Fatal Error (null DB connection)"));
+     *err = "null DB connection";
+     return false;
+  }
+
+  LM_T(LmtMongo, ("query() in '%s' collection: '%s'", col.c_str(), q.toString().c_str()));
+
+  try
+  {
+    *cursor = connection->query(col.c_str(), q);
+
+    // We have observed that in some cases of DB errors (e.g. the database daemon is down) instead of
+    // raising an exception, the query() method sets the cursor to NULL. In this case, we raise the
+    // exception ourselves
+    //
+    if (cursor->get() == NULL)
+    {
+      throw DBException("Null cursor from mongo (details on this is found in the source code)", 0);
+    }
+    releaseMongoConnection(connection);
+    LM_I(("Database Operation Successful (%s)", q.toString().c_str()));
+  }
+  catch (const DBException &e)
+  {
+    releaseMongoConnection(connection);
+    LM_E(("Database Error (%s)", e.what()));
+    *err = "Database Error: " + std::string(e.what());
+    return false;
+  }
+  catch (...)
+  {
+    releaseMongoConnection(connection);
+    LM_E(("Database Error (generic exception)"));
+    *err = "Database Error: generic exception";
+    return false;
+  }
+
+  return true;
+}

--- a/src/lib/mongoBackend/collectionOperations.h
+++ b/src/lib/mongoBackend/collectionOperations.h
@@ -1,3 +1,6 @@
+#ifndef SRC_LIB_MONGOBACKEND_COLLECTIONOPERATIONS_H_
+#define SRC_LIB_MONGOBACKEND_COLLECTIONOPERATIONS_H_
+
 /*
 *
 * Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
@@ -20,50 +23,26 @@
 * For those usages not covered by this license please contact with
 * iot_support at tid dot es
 *
-* Author: Orion dev team
+* Author: Fermín Galán
 */
 
-#include "serviceRoutinesV2/getAllSubscriptions.h"
+#include "mongo/client/dbclient.h"
 
-#include <string>
-#include <vector>
-
-#include "apiTypesV2/Subscription.h"
-#include "common/JsonHelper.h"
-#include "common/string.h"
-#include "mongoBackend/mongoListSubscriptions.h"
-#include "ngsi/ParseData.h"
-#include "rest/ConnectionInfo.h"
-#include "rest/OrionError.h"
+using namespace mongo;
 
 /* ****************************************************************************
 *
-* getAllSubscriptions -
-*
-* GET /v2/subscriptions
+* query -
 *
 */
-std::string getAllSubscriptions
+extern bool query
 (
-    ConnectionInfo*            ciP,
-    int                        components,
-    std::vector<std::string>&  compV,
-    ParseData*                 parseDataP
-)
-{
+    const std::string&             col,
+    const BSONObj&                 q,
+    std::auto_ptr<DBClientCursor>* cursor,
+    std::string*                   err
+);
 
-  std::vector<ngsiv2::Subscription> subs;
-  OrionError                oe = mongoListSubscriptions(subs, ciP->uriParam, ciP->tenant);
 
-  if (oe.code != SccOk)
-  {
-    return oe.render(ciP,"");
-  }
 
-  if ((ciP->uriParamOptions["count"]))
-  {
-    ciP->httpHeader.push_back("X-Total-Count");
-    ciP->httpHeaderValue.push_back(toString(subs.size()));
-  }
-  return  vectorToJson(subs);
-}
+#endif // SRC_LIB_MONGOBACKEND_COLLECTIONOPERATIONS_H_

--- a/src/lib/mongoBackend/mongoListSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoListSubscriptions.cpp
@@ -23,42 +23,169 @@
 * Author: Orion dev team
 */
 
-#include "mongoBackend/mongoListSubscriptions.h"
+#include "common/sem.h"
 
+#include "logMsg/logMsg.h"
+#include "logMsg/traceLevels.h"
+
+#include "mongoBackend/mongoListSubscriptions.h"
+#include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/collectionOperations.h"
+
+#include "mongo/client/dbclient.h"
+
+using namespace ngsiv2;
+
+/* ****************************************************************************
+*
+* setSubscriptionId -
+*/
+static void setSubscriptionId(Subscription* s, const BSONObj& r)
+{
+  s->id = r.getField("_id").OID().toString();
+}
+
+
+/* ****************************************************************************
+*
+* setSubject -
+*/
+static void setSubject(Subscription* s, const BSONObj& r)
+{
+  // Entities
+  std::vector<BSONElement> ents = r.getField(CSUB_ENTITIES).Array();
+  for (unsigned int ix = 0; ix < ents.size(); ++ix)
+  {
+    BSONObj ent           = ents[ix].embeddedObject();
+    std::string id        = ent.getStringField(CSUB_ENTITY_ID);
+    std::string type      = ent.getStringField(CSUB_ENTITY_TYPE);
+    std::string isPattern = ent.getStringField(CSUB_ENTITY_ISPATTERN);
+
+    EntID en;
+    if (isFalse(isPattern))
+    {
+      en.id = id;
+    }
+    else
+    {
+      en.idPattern = id;
+    }
+    en.type = type;
+
+    s->subject.entities.push_back(en);
+  }
+
+  // Condition
+  std::vector<BSONElement> conds = r.getField(CSUB_CONDITIONS).Array();
+  for (unsigned int ix = 0; ix < conds.size(); ++ix)
+  {
+    BSONObj cond = conds[ix].embeddedObject();
+    // The ONCHANGE check is needed, as a subscription could mix different conditions types in DB
+    if (std::string(cond.getStringField(CSUB_CONDITIONS_TYPE)) == "ONCHANGE")
+    {
+      std::vector<BSONElement> condValues = cond.getField(CSUB_CONDITIONS_VALUE).Array();
+      for (unsigned int jx = 0; jx < condValues.size(); ++jx)
+      {
+        std::string attr = condValues[jx].String();
+        s->subject.condition.attributes.push_back(attr);
+      }
+    }
+  }
+
+  // Note that current DB model is based on NGSIv1 and doesn't consider expressions. Thus
+  // subject.condition.expression cannot be filled. The implemetion will be enhanced once
+  // the DB model gets defined
+  // TBD
+
+}
+
+
+/* ****************************************************************************
+*
+* setNotification -
+*/
+static void setNotification(Subscription* s, const BSONObj& r)
+{
+  // Attributes
+  std::vector<BSONElement> attrs = r.getField(CSUB_ATTRS).Array();
+  for (unsigned int ix = 0; ix < attrs.size(); ++ix)
+  {
+    std::string attr = attrs[ix].String();
+    s->notification.attributes.push_back(attr);
+  }
+
+  // Callback
+  s->notification.callback = r.getStringField(CSUB_REFERENCE);
+
+  // Throttling
+  long long throttling = r.hasField(CSUB_THROTTLING)? r.getField(CSUB_THROTTLING).numberLong() : -1;
+  if (throttling > -1)
+  {
+    // FIXME P10: int -> str conversion needed
+    s->notification.throttling.set("FIXME");
+  }
+}
+
+
+/* ****************************************************************************
+*
+* setDuration -
+*/
+static void setDuration(Subscription* s, const BSONObj& r)
+{
+  //long long expiration = r.hasField(CSUB_EXPIRATION)? r.getField(CSUB_EXPIRATION).numberLong() : 0;
+  // FIXME P10: int -> str conversion needed
+  s->duration.set("FIXME");
+}
+
+/* ****************************************************************************
+*
+* mongoListSubscriptions -
+*/
 OrionError mongoListSubscriptions
 (
-  std::vector<Subscription>& subs,
+  std::vector<Subscription>&           subs,
   std::map<std::string, std::string>&  uriParam,
-  const std::string&                   tenant,
-  const std::vector<std::string>&      servicePathV
+  const std::string&                   tenant
 )
 {
-  OrionError oe;
-  oe.code = SccOk;
 
-  Subscription s1,s2;
-  EntID ei;
-  ei.id ="ID1";
-  s1.id ="s1";
-  s1.subject.entities.push_back(ei);
-  s1.subject.condition.attributes.push_back("A \nsc sub 1");
-  s1.subject.condition.attributes.push_back("B \tsc sub 1");
-  s1.subject.condition.attributes.push_back("Z \fsc sub 2");
-  s1.notification.attributes.push_back("notification attributes  1");
-  s1.notification.attributes.push_back("notification attributes 2");
+  // FIXME P10: Pagination not yet implemented
 
-  subs.push_back(s1);
+  bool           reqSemTaken = false;
 
-  ei.idPattern ="IDP2";
-  ei.id = "";
-  ei.type ="FENOTIPO";
-  s2.id = "s2";
-  s2.subject.entities.push_back(ei);
-  s2.subject.condition.expression.q ="Q";
-  s2.subject.condition.expression.geometry ="G";
-  s2.subject.condition.expression.coords ="C";
+  reqSemTake(__FUNCTION__, "Mongo List Subscriptions", SemReadOp, &reqSemTaken);
 
-  subs.push_back(s2);
+  LM_T(LmtMongo, ("Mongo List Subscriptions"));
 
-  return oe;
+  /* ONTIMEINTERVAL subscription are not part of NGSIv2, so they are excluded.
+   * Note that expiration is not taken into account (in the future, a q= query
+   * could be added to the operation in order to filter results) */
+  std::auto_ptr<DBClientCursor>  cursor;
+  std::string                    err;
+  std::string                    conds = std::string(CSUB_CONDITIONS) + "." + CSUB_CONDITIONS_TYPE;
+  BSONObj                        q     = BSON(conds << "ONCHANGE");
+
+  if (!query(getSubscribeContextCollectionName(tenant), q, &cursor, &err))
+  {
+    reqSemGive(__FUNCTION__, "Mongo List Subscriptions", reqSemTaken);
+    return OrionError(SccReceiverInternalError, err);
+  }
+
+  /* Process query result */
+  while (cursor->more())
+  {
+    BSONObj r = cursor->next();
+    LM_T(LmtMongo, ("retrieved document: '%s'", r.toString().c_str()));
+
+    Subscription s;
+    setSubscriptionId(&s, r);
+    setSubject(&s, r);
+    setNotification(&s, r);
+    setDuration(&s, r);
+    subs.push_back(s);
+  }
+
+  reqSemGive(__FUNCTION__, "Mongo List Subscriptions", reqSemTaken);
+  return OrionError(SccOk);
 }

--- a/src/lib/mongoBackend/mongoListSubscriptions.h
+++ b/src/lib/mongoBackend/mongoListSubscriptions.h
@@ -39,10 +39,9 @@
 */
 OrionError mongoListSubscriptions
 (
-  std::vector<Subscription>& vec,
-  std::map<std::string, std::string>&  uriParam,
-  const std::string&                   tenant,
-  const std::vector<std::string>&      servicePathV
+  std::vector<ngsiv2::Subscription>&  vec,
+  std::map<std::string, std::string>& uriParam,
+  const std::string&                  tenant
 );
 
 #endif // MONGOLISTSUBSCRIPTIONS_H

--- a/src/lib/mongoBackend/mongoSubscribeContext.cpp
+++ b/src/lib/mongoBackend/mongoSubscribeContext.cpp
@@ -213,7 +213,7 @@ HttpStatusCode mongoSubscribeContext
     {
       std::string oidString = oid.toString();
 
-      subCache->insert(new orion::Subscription(tenant, servicePath, requestP, oidString, expiration, notifyFormat));
+      orion::subCache->insert(new orion::Subscription(tenant, servicePath, requestP, oidString, expiration, notifyFormat));
     }
 
 

--- a/src/lib/mongoBackend/mongoUnsubscribeContext.cpp
+++ b/src/lib/mongoBackend/mongoUnsubscribeContext.cpp
@@ -173,7 +173,7 @@ HttpStatusCode mongoUnsubscribeContext(UnsubscribeContextRequest* requestP, Unsu
     //
     // Removing subscription from cache
     //
-    subCache->remove(tenant, "", requestP->subscriptionId.get());
+    orion::subCache->remove(tenant, "", requestP->subscriptionId.get());
 
     return SccOk;
 }

--- a/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
@@ -288,16 +288,16 @@ HttpStatusCode mongoUpdateContextSubscription
   std::string servicePath;
 
   servicePath = (servicePathV.size() == 0)? "" : servicePathV[0];
-  Subscription* subP = subCache->lookupById(tenant, servicePath, requestP->subscriptionId.get());
+  orion::Subscription* subP = orion::subCache->lookupById(tenant, servicePath, requestP->subscriptionId.get());
 
   // 1. Remove 'sub' from sub-cache (if present)
   if (subP)
   {
-    subCache->remove(subP);
+    orion::subCache->remove(subP);
   }
 
   // 2. Create 'newSub' in sub-cache (if applicable)
-  subCache->insert(tenant, newSub.obj());  // The insert method takes care of making sure isPattern and ONCHANGE is there
+  orion::subCache->insert(tenant, newSub.obj());  // The insert method takes care of making sure isPattern and ONCHANGE is there
 
   return SccOk;
 }

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -41,6 +41,8 @@
 // libraries which need it)
 #define FT(x) (x == true)? "true" : "false"
 
+using namespace orion;
+
 /* ****************************************************************************
 *
 * ContextAttribute::~ContextAttribute - 

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -34,7 +34,7 @@
 #include "ngsi/Scope.h"
 #include "parse/forbiddenChars.h"
 
-
+using namespace orion;
 
 /* ****************************************************************************
 *

--- a/src/lib/ngsi/Scope.h
+++ b/src/lib/ngsi/Scope.h
@@ -31,9 +31,6 @@
 #include "common/Format.h"
 #include "orionTypes/areas.h"
 
-using namespace orion;
-
-
 
 /* ****************************************************************************
 *

--- a/src/lib/serviceRoutines/statisticsTreat.cpp
+++ b/src/lib/serviceRoutines/statisticsTreat.cpp
@@ -458,7 +458,7 @@ std::string statisticsTreat
     out += TAG_ADD_STRING("curlContextMutexWaitingTime", ccMutexWaitingTime);
 
     char subCacheMutexWaitingTime[64];
-    subCacheMutexWaitingTimeGet(subCacheMutexWaitingTime, sizeof(subCacheMutexWaitingTime));
+    orion::subCacheMutexWaitingTimeGet(subCacheMutexWaitingTime, sizeof(subCacheMutexWaitingTime));
     out += TAG_ADD_STRING("subCacheMutexWaitingTime", subCacheMutexWaitingTime);
   }
 

--- a/src/lib/xmlParse/xmlParse.cpp
+++ b/src/lib/xmlParse/xmlParse.cpp
@@ -40,6 +40,7 @@
 #include "xmlParse/XmlNode.h"
 #include "xmlParse/xmlParse.h"
 
+using namespace orion;
 
 /* ****************************************************************************
 *

--- a/src/lib/xmlParse/xmlUpdateContextRequest.cpp
+++ b/src/lib/xmlParse/xmlUpdateContextRequest.cpp
@@ -156,7 +156,7 @@ static int contextAttributeValue(xml_node<>* node, ParseData* parseDataP)
 
   LM_T(LmtParse, ("Got an attribute value: '%s'", node->value()));
   parseDataP->upcr.attributeP->stringValue = node->value();
-  parseDataP->upcr.attributeP->valueType   = ValueTypeString;
+  parseDataP->upcr.attributeP->valueType   = orion::ValueTypeString;
 
   if (parseDataP->upcr.attributeP->stringValue == " ")
   {

--- a/test/functionalTest/cases/1126_GET_v2_subscriptions/GET_v2_all_subscriptions.test
+++ b/test/functionalTest/cases/1126_GET_v2_subscriptions/GET_v2_all_subscriptions.test
@@ -30,40 +30,140 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. GET /v2/subscriptions
+# 01. Create 2 subscriptions
+# 02. GET /v2/subscriptions
 #
 
-echo "01. GET /v2/subscriptions"
+echo "01. Create 2 subscriptions"
+echo "=========================="
+payload='{
+  "entities": [
+    {
+      "type": "Room",
+      "isPattern": "false",
+      "id": "ConferenceRoom"
+    },
+    {
+      "type": "Room",
+      "isPattern": "false",
+      "id": "OfficeRoom"
+    }
+  ],
+  "attributes": [
+    "temperature",
+    "occupancy",
+    "lightstatus"
+  ],
+  "reference": "127.0.0.1",
+  "duration": "P5Y",
+  "notifyConditions": [
+    {
+      "type": "ONCHANGE",
+      "condValues": [
+        "temperature",
+        "timestamp"
+      ]
+    }
+  ],
+  "throttling": "P5Y"
+}'
+orionCurl --url /v1/subscribeContext --payload "${payload}" --json
+echo
+echo
+
+payload='{
+  "entities": [
+    {
+      "type": "Car",
+      "isPattern": "false",
+      "id": "MyCar"
+    },
+    {
+      "type": "Room",
+      "isPattern": "false",
+      "id": "OtherCar"
+    }
+  ],
+  "attributes": [
+    "speed",
+    "location"
+  ],
+  "reference": "localhost",
+  "duration": "P5Y",
+  "notifyConditions": [
+    {
+      "type": "ONCHANGE",
+      "condValues": [
+        "speed"
+      ]
+    }
+  ]
+}'
+orionCurl --url /v1/subscribeContext --payload "${payload}" --json
+echo
+echo
+
+echo "02. GET /v2/subscriptions"
 echo "========================="
-orionCurl --url /v2/subscriptions?options=count --json
+orionCurl --url /v2/subscriptions --json
 echo
 echo
 
 --REGEXPECT--
-01. GET /v2/subscriptions
+01. Create 2 subscriptions
+==========================
+HTTP/1.1 200 OK
+Content-Length: 134
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "subscribeResponse": {
+        "duration": "P5Y",
+        "subscriptionId": "REGEX([0-9a-f]{24})",
+        "throttling": "P5Y"
+    }
+}
+
+
+HTTP/1.1 200 OK
+Content-Length: 108
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "subscribeResponse": {
+        "duration": "P5Y",
+        "subscriptionId": "REGEX([0-9a-f]{24})"
+    }
+}
+
+
+02. GET /v2/subscriptions
 =========================
 HTTP/1.1 200 OK
-Content-Length: 513
+Content-Length: 733
 Content-Type: application/json
-X-Total-Count: 2
 Date: REGEX(.*)
 
 [
     {
-        "id": "s1",
+        "duration: ": "FIXME",
+        "id": "REGEX([0-9a-f]{24})",
         "notification": {
             "attributes": [
-                "notification attributes 1",
-                "notification attributes 2"
+                "temperature",
+                "occupancy",
+                "lightstatus"
             ],
-            "callback": ""
+            "callback": "127.0.0.1",
+            "throttling": "FIXME"
         },
         "subject": {
             "condition": {
                 "attributes": [
-                    "A \nsc sub 1",
-                    "B \tsc sub 1",
-                    "Z \fsc sub 2"
+                    "temperature",
+                    "timestamp"
                 ],
                 "expression": {
                     "coords": "",
@@ -73,33 +173,49 @@ Date: REGEX(.*)
             },
             "entities": [
                 {
-                    "id": "ID1",
+                    "id": "ConferenceRoom",
                     "idPattern": "",
-                    "type": ""
+                    "type": "Room"
+                },
+                {
+                    "id": "OfficeRoom",
+                    "idPattern": "",
+                    "type": "Room"
                 }
             ]
         }
     },
     {
-        "id": "s2",
+        "duration: ": "FIXME",
+        "id": "REGEX([0-9a-f]{24})",
         "notification": {
-            "attributes": [],
-            "callback": ""
+            "attributes": [
+                "speed",
+                "location"
+            ],
+            "callback": "localhost"
         },
         "subject": {
             "condition": {
-                "attributes": [],
+                "attributes": [
+                    "speed"
+                ],
                 "expression": {
-                    "coords": "C",
-                    "geometry": "G",
-                    "q": "Q"
+                    "coords": "",
+                    "geometry": "",
+                    "q": ""
                 }
             },
             "entities": [
                 {
-                    "id": "",
-                    "idPattern": "IDP2",
-                    "type": "FENOTIPO"
+                    "id": "MyCar",
+                    "idPattern": "",
+                    "type": "Car"
+                },
+                {
+                    "id": "OtherCar",
+                    "idPattern": "",
+                    "type": "Room"
                 }
             ]
         }

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -213,6 +213,7 @@ SET (SOURCES
     mongoBackend/mongoContextProvidersUpdate_test.cpp
     mongoBackend/mongoQueryTypes_test.cpp
     mongoBackend/mongoQueryContextFilterExistEntity_test.cpp
+    mongoBackend/mongoListSubscriptions_test.cpp
 
     parse/CompoundValueNode_test.cpp
     parse/compoundValue_test.cpp

--- a/test/unittests/cache/SubscriptionCache_test.cpp
+++ b/test/unittests/cache/SubscriptionCache_test.cpp
@@ -35,6 +35,7 @@
 
 #include "unittest.h"
 
+using namespace orion;
 
 extern void setMongoConnectionForUnitTest(DBClientBase* _connection);
 

--- a/test/unittests/mongoBackend/mongoListSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoListSubscriptions_test.cpp
@@ -1,0 +1,177 @@
+/*
+*
+* Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Fermin Galan
+*/
+#include "gtest/gtest.h"
+#include "testInit.h"
+
+#include "logMsg/logMsg.h"
+#include "logMsg/traceLevels.h"
+
+#include "common/globals.h"
+#include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoListSubscriptions.h"
+
+#include "mongo/client/dbclient.h"
+
+#include "commonMocks.h"
+#include "unittest.h"
+
+using ::testing::_;
+using ::testing::Throw;
+using ::testing::Return;
+
+using namespace ngsiv2;
+
+extern void setMongoConnectionForUnitTest(DBClientBase*);
+
+/* ****************************************************************************
+*
+* - getAllSubscriptionsV1Info
+*
+*/
+
+/* ****************************************************************************
+*
+* prepareDatabaseV1Subs -
+*/
+static void prepareDatabaseV1Subs(void) {
+
+    /* Set database */
+    setupDatabase();
+
+    DBClientBase* connection = getMongoConnection();
+
+    BSONObj sub1 = BSON("_id" << OID("51307b66f481db11bf860001") <<
+                        "expiration" << 10000000 <<
+                        "lastNotification" << 15000000 <<
+                        "reference" << "http://notify1.me" <<
+                        "entities" << BSON_ARRAY(BSON("id" << "E1" << "type" << "T1" << "isPattern" << "false")) <<
+                        "attrs" << BSONArray() <<
+                        "conditions" << BSON_ARRAY(BSON(
+                                                       "type" << "ONCHANGE" <<
+                                                       "value" << BSON_ARRAY("AX1" << "AY1")
+                                                       ))
+                        );
+
+    BSONObj sub2 = BSON("_id" << OID("51307b66f481db11bf860002") <<
+                        "expiration" << 20000000 <<
+                        "lastNotification" << 25000000 <<
+                        "reference" << "http://notify2.me" <<
+                        "entities" << BSON_ARRAY(BSON("id" << "E.*" << "type" << "T2" << "isPattern" << "true")) <<
+                        "attrs" << BSON_ARRAY("A1" << "A2") <<
+                        "conditions" << BSON_ARRAY(BSON(
+                                                       "type" << "ONCHANGE" <<
+                                                       "value" << BSON_ARRAY("AX2" << "AY2")
+                                                       )) <<
+                        "throttling" << 5.0
+                        );
+
+    BSONObj sub3 = BSON("_id" << OID("51307b66f481db11bf860003") <<
+                        "expiration" << 20000000 <<
+                        "lastNotification" << 25000000 <<
+                        "reference" << "http://notify2.me" <<
+                        "entities" << BSON_ARRAY(BSON("id" << "E.*" << "type" << "T2" << "isPattern" << "true")) <<
+                        "attrs" << BSON_ARRAY("A1" << "A2") <<
+                        "conditions" << BSON_ARRAY(BSON(
+                                                     "type" << "ONTIMEINTERVAL" <<
+                                                     "value" << 100
+                                                     ))
+                        );
+
+    connection->insert(SUBSCRIBECONTEXT_COLL, sub1);
+    connection->insert(SUBSCRIBECONTEXT_COLL, sub2);
+    connection->insert(SUBSCRIBECONTEXT_COLL, sub3);
+
+}
+
+/* ****************************************************************************
+*
+* getAllSubscriptionsV1Info -
+*/
+TEST(mongoListSubscriptions, getAllSubscriptionsV1Info)
+{
+  OrionError oe;
+
+  /* Prepare database */
+  prepareDatabaseV1Subs();
+
+  /* Invoke the function in mongoBackend library */
+  std::vector<Subscription> subs;
+  oe = mongoListSubscriptions(subs, uriParams, "");
+
+  /* Check response is as expected */
+  EXPECT_EQ(SccOk, oe.code);
+  EXPECT_EQ("OK", oe.reasonPhrase);
+  EXPECT_EQ("", oe.details);
+
+  ASSERT_EQ(2, subs.size());
+  Subscription             s;
+  std::vector<EntID>       ents;
+  std::vector<std::string> attrs;
+
+  /* Subscription #1 */
+  s = subs[0];
+  EXPECT_EQ("51307b66f481db11bf860001", s.id);
+  ents = s.subject.entities;
+  ASSERT_EQ(1, ents.size());
+  EXPECT_EQ("E1", ents[0].id);
+  EXPECT_EQ("T1", ents[0].type);
+  EXPECT_EQ("", ents[0].idPattern);
+  attrs = s.subject.condition.attributes;
+  ASSERT_EQ(2, attrs.size());
+  EXPECT_EQ("AX1", attrs[0]);
+  EXPECT_EQ("AY1", attrs[1]);
+  EXPECT_EQ("", s.subject.condition.expression.q);
+  EXPECT_EQ("", s.subject.condition.expression.geometry);
+  EXPECT_EQ("", s.subject.condition.expression.coords);
+  attrs = s.notification.attributes;
+  ASSERT_EQ(0, attrs.size());
+  EXPECT_EQ("http://notify1.me", s.notification.callback);
+  EXPECT_TRUE(s.notification.throttling.isEmpty());
+  EXPECT_EQ("FIXME", s.duration.get());
+
+  /* Subscription #2 */
+  s = subs[1];
+  EXPECT_EQ("51307b66f481db11bf860002", s.id);
+  ents = s.subject.entities;
+  ASSERT_EQ(1, ents.size());
+  EXPECT_EQ("", ents[0].id);
+  EXPECT_EQ("T2", ents[0].type);
+  EXPECT_EQ("E.*", ents[0].idPattern);
+  attrs = s.subject.condition.attributes;
+  ASSERT_EQ(2, attrs.size());
+  EXPECT_EQ("AX2", attrs[0]);
+  EXPECT_EQ("AY2", attrs[1]);
+  EXPECT_EQ("", s.subject.condition.expression.q);
+  EXPECT_EQ("", s.subject.condition.expression.geometry);
+  EXPECT_EQ("", s.subject.condition.expression.coords);
+  attrs = s.notification.attributes;
+  ASSERT_EQ(2, attrs.size());
+  EXPECT_EQ("A1", attrs[0]);
+  EXPECT_EQ("A2", attrs[1]);
+  EXPECT_EQ("http://notify2.me", s.notification.callback);
+  EXPECT_EQ("FIXME", s.notification.throttling.get());
+  EXPECT_EQ("FIXME", s.duration.get());
+
+}

--- a/test/unittests/mongoBackend/mongoQueryContextCompoundValues_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContextCompoundValues_test.cpp
@@ -47,16 +47,16 @@
 * - CompoundValue1PlusSimpleValue
 * - CompoundValue2PlusSimpleValue
 *
-* Compound 1 is based in: [ 22, {x: [x1, x2], y: 3}, [z1, z2] ]
-* Compound 2 is based in: { x: {x1: a, x2: b}, y: [ y1, y2 ] }
+* Compound 1 is based on: [ 22, {x: [x1, x2], y: 3}, [z1, z2] ]
+* Compound 2 is based on: { x: {x1: a, x2: b}, y: [ y1, y2 ] }
 *
 * - CompoundValue1Native
 * - CompoundValue2Native
 * - CompoundValue1PlusSimpleValueNative
 * - CompoundValue2PlusSimpleValueNative
 *
-* Compound 1 is based in: [ 22, {x: [x1, x2], y: 3}, [z1, false] ]
-* Compound 2 is based in: { x: {x1: a, x2: true}, y: [ y1, y2 ] }
+* Compound 1 is based on: [ 22, {x: [x1, x2], y: 3}, [z1, false] ]
+* Compound 2 is based on: { x: {x1: a, x2: true}, y: [ y1, y2 ] }
 *
 */
 

--- a/test/unittests/mongoBackend/mongoQueryContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_test.cpp
@@ -37,6 +37,8 @@
 
 #include "mongo/client/dbclient.h"
 
+using namespace orion;
+
 extern void setMongoConnectionForUnitTest(DBClientBase*);
 
 /* ****************************************************************************

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
@@ -293,7 +293,7 @@ static void prepareDatabase(bool initializeCache = true) {
   /* Given that preparation including csubs, we have to init cache */
   if (initializeCache == true)
   {
-    subscriptionCacheInit("");
+    orion::subscriptionCacheInit("");
   }
 }
 
@@ -375,7 +375,7 @@ static void prepareDatabaseWithNoTypeSubscriptions(void) {
     connection->insert(SUBSCRIBECONTEXT_COLL, sub5);
 
     /* Given that preparation including csubs, we have to init cache */
-    subscriptionCacheInit("");
+    orion::subscriptionCacheInit("");
 }
 
 /* ****************************************************************************

--- a/test/unittests/unittest.cpp
+++ b/test/unittests/unittest.cpp
@@ -137,7 +137,7 @@ void utInit(void)
   servicePathVector.clear();
 
   // Init subs cache (this initialization is overriden in test that use csubs)
-  subscriptionCacheInit("");
+  orion::subscriptionCacheInit("");
 }
 
 


### PR DESCRIPTION
Get all subscription functionality in mongoBackend, except some things deferred to a next PR:

* Pagination
* duration/expiration/throlling, as they are not clear yet in NGSIv2