### PR TITLE
ADD Warning about characters with URL meaning

### DIFF
--- a/doc/manuals/user/forbidden_characters.md
+++ b/doc/manuals/user/forbidden_characters.md
@@ -30,7 +30,7 @@ request to Orion (e.g. [URL
 encoding](http://www.degraeve.com/reference/urlencoding.php)).
 
 There is another set of characters that requires special care from the 
-user persepective. Are those in the following list:
+user perspective. Are those in the following list:
 
 -   #
 -   ?

--- a/doc/manuals/user/forbidden_characters.md
+++ b/doc/manuals/user/forbidden_characters.md
@@ -30,7 +30,7 @@ request to Orion (e.g. [URL
 encoding](http://www.degraeve.com/reference/urlencoding.php)).
 
 There is another set of characters that requires special care from the 
-user perspective. Are those in the following list:
+user perspective. Namely, the ones in the following list:
 
 -   #
 -   ?
@@ -40,6 +40,6 @@ user perspective. Are those in the following list:
 
 These characters have special meaning in the URL interpretation, and, 
 considering there are convenience operations that use entity, type and
-attribute identifiers as part of the URL, its use should be avoided. 
-The use of this characters is perfectly safe when only standard operations
+attribute identifiers as part of the URL, their use should be avoided. 
+The use of these characters is perfectly safe when only standard operations
 are involved, anyway. 

--- a/doc/manuals/user/forbidden_characters.md
+++ b/doc/manuals/user/forbidden_characters.md
@@ -28,3 +28,18 @@ If your aplication needs to use these characteres, you should encode it
 using a scheme not including forbidden characters before sending the
 request to Orion (e.g. [URL
 encoding](http://www.degraeve.com/reference/urlencoding.php)).
+
+There is another set of characters that requires special care from the 
+user persepective. Are those in the following list:
+
+-   #
+-   ?
+-   /
+-   %
+-   &
+
+These characters have special meaning in the URL interpretation, and, 
+considering there are convenience operations that use entity, type and
+attribute identifiers as part of the URL, its use should be avoided. 
+The use of this characters is perfectly safe when only standard operations
+are concerned, anyway. 

--- a/doc/manuals/user/forbidden_characters.md
+++ b/doc/manuals/user/forbidden_characters.md
@@ -42,4 +42,4 @@ These characters have special meaning in the URL interpretation, and,
 considering there are convenience operations that use entity, type and
 attribute identifiers as part of the URL, its use should be avoided. 
 The use of this characters is perfectly safe when only standard operations
-are concerned, anyway. 
+are involved, anyway. 


### PR DESCRIPTION
Add a warning in the documentation about the use of characters with meaning for the URL decoding.