### PR TITLE
REFACTOR rewritten JSON representation section in NGSIv2 reference apib

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -171,23 +171,103 @@ is typically done in the REST interface)
 (placeholder to describe roles like context provider, context producer,
 context broker, context registry, context consumer)
 
-## JSON entity representation
+## JSON Entity Representation
 
-An entity is represented by a a JSON object which contain the following properties:
+An entity is represented by a JSON object with the following syntax:
 
-* `id` for the entity ID, represented by a JSON string. If the entity has an `id` attribute itself it will be ignored.
-* `type` for the entity type, represented by a JSON string. If the entity has a `type` attribute itself it will be ignored.
-  If the entity doesn't have a type, then this property is not included.
-* A collection of properties, one per entity attribute. Properties representing attributes with no metadata
-  or type are rendered as regular JSON values. Properties representing attributes which specify a type or include
-  metadata are rendered as JSON objects with the following properties:
-  * `value`: for the attribute value, rendered as a regular JSON value (string, number or boolean), object or array.
-  * `type`: a JSON string which represents the user-defined NGSI attribute type.
-  * A collection of properties one per metadata field associated to the attribute value. Metadata properties follow
-    the same representation rules that applies to properties which represent attributes (except that a metadata
-    cannot have metadata properties).
+* The entity id is specified by the object's `id` property, which value is a string containing the entity id.
 
-### Special attribute types
+* The entity type is specified by the object's `type` property, which value is a string containing the entity's type name.
+
+* Entity attributes are specified by additional properties, which name is the `name` of the attribute and which representation
+  is described in the JSON Attribute Representation section below. Obviously, `id` and `type` are not allowed as attribute names.
+
+An example of this syntax in shown below:
+
+```
+{
+  "id": "entityID",
+  "type": "entityType",
+  "attr_1": <val_1>,
+  "attr_2": <val_2>,
+  ...
+  "attr_N": <val_N>
+}
+```
+
+The normalized representation of entities always include `id`, `type` and the properties which represent attributes. However, simplified
+or partial representations (see below at Partial Representations section), may leave out some of them. The specification of each operation
+includes details about what  representation is expected as input or what representation will be provided (rendered) as output.
+
+## JSON Attribute Representation
+
+An attribute is represented by a JSON object with the following syntax:
+
+* The attribute value is specified by the `value` property, which value may be any JSON datatype.
+
+* The attribute NGSI type is specified by the `type` property, which value is a string containing the NGSI type.
+
+* The attribute metadata is specified by the `metadata` property. Its value is another JSON object which will contain a
+  property per metadata element defined (the name of the property is the `name` of the metadata element). Each metadata element,
+  in turn, is represented by a JSON object containing the following properties:
+
+  * `value`: Its value will contain the metadata value, which may correspond to any JSON datatype.
+
+  * `type`: Its value will contain a string representation of the metadata NGSI type.
+
+An example of this syntax in shown below:
+
+```
+{
+  "value": <...>,
+  "type": <...>,
+  "metadata": <...>
+}
+```
+
+## Simplified Entity Representation
+
+There are two representation modes, which must be supported by implementations, and which allow to generate simplified representations of entities.
+
+* *keyValues* mode. This mode represents each entity attribute only by its value, leaving out the information about type and metadata.
+  Thus, when this mode is on, only the attribute value is represented and will correspond to the value of the property which represents the attribute.
+  See example below (To be provided).
+
+```
+{
+   "id": "R12345",
+   "type": "Room",
+   "temperature": 22
+}
+```
+
+* *values mode*. This mode represents the entity only by a collection of attribute values conveyed by an Array. Id and type information are left out.
+  See example below.
+
+```
+[ 'Ford', 'black', 78.3 ]
+```
+
+## Partial Representations
+
+Some operations imply that only a partial representation of an entity will be provided, which are summarized below:
+
+* `id` and `type` are not allowed in update operations, as they are inmutable properties.
+
+* In the requests in which `type` is allowed, it may be omitted. When omitted, the default value `null` is used for the type.
+
+* In some cases, not all the attributes of the entity are shown, e.g. a query which selects a subset of entity attributes.
+
+* Attribute/metadata `value` may be omitted in requests, meaning that the attribute/metadata has `null` value. It is always present in responses.
+
+* Attribute/metadata `type` may be ommitted in requests, meaning that the attribute/metadata doesn't have a NGSI type. In responses, this
+  property is set to `null` if the attribute doesn't have a type.
+
+* Attribute `metadata` may be ommitted in requests, meaning that there are not metadata elements associated to the attribute. In responses, this property is set to
+  `{}` if the attribute doesn't have metadata.
+
+
+## Special attribute types
 
 Generally speaking, user-defined attribute types are informative, they are processed by the NGSIv2 server in
 an opaque way. Nonetheless, the types described below are used to convey an special meaning
@@ -214,47 +294,6 @@ an opaque way. Nonetheless, the types described below are used to convey an spec
   "location": {
     "value": "41.3763726, 2.1864475,14",
     "type": "geo:point"
-  }
-}
-```
-
-### Canonical format description
-
-This is a variant of the represention format aimed at clients that need a regular representation of the entities
-and attributes, that can be used in the operations that support the `canonical` option.
-
-* Entity `type` is mandatory. If the entity has no type, JSON `null` is used.
-* Property `attrs` is mandatory and includes a JSON object for the attributes.
-* Each attribute is described always with `value`, `type` and `metadata`. All fields are mandatory (attributes
-  without type use JSON `null` for that property).
-* Each metadata is described always with `value` and `type`. Both fields are mandatory (metadata
-  without type use JSON `null` for that property).
-
-```
-{
-  "type": "Room",
-  "id": "Boe_Idearium",
-  "attrs": {
-    "speed": {
-      "value": 88,
-      "type": null,
-      "metadata": { }
-    },
-    "pressure": {
-      "value": 12.1,
-      "type": null,
-      "metadata": { }
-    },
-    "temperature": {
-      "value": 22,
-      "type": "urn:phenomenum:temperature",
-      "metadata": { }
-    },
-    "colour": {
-      "value": "black",
-      "type": "myString",
-      "metadata": { }
-    }
   }
 }
 ```
@@ -710,12 +749,22 @@ Response:
 
 # Group Attribute Value
 
-## By Entity ID [/v2/entities/{entityId}/attrs/{attrName}/value{?options}]
+## By Entity ID [/v2/entities/{entityId}/attrs/{attrName}/value]
 
-### Get attribute data [GET /v2/entities/{entityId}/attrs/{attrName}/value{?options}]
+### Get attribute value [GET /v2/entities/{entityId}/attrs/{attrName}/value]
 
-It returns a JSON object with a `value` propierty with the value of the attribute. The `text` option
-indicates that the attribute value must be provided as plain text (text/plain).
+It returns the `value` property with the value of the attribute.
+
+* If response payload MIME type is `application/json`:
+  * If attribute value is a JSON object or array, the payload in that JSON object or array
+  * If attribute value is a string, number, null or boolean, a HTTP error "406 Not Acceptable: accepted MIME types:
+    text/plain" is returned.
+* If response payload MIME type is `text/plain`,
+  * If attribute value is a JSON object or array, the payload in a stringification of that JSON object or array.
+  * If attribute value is a string, number, null or boolean, the payload is a text representation of that value. In the case
+    of a string, citation marks are used at the begining and end.
+
+The payload MIME type in responses is based on client-server HTTP negotiation, based on client `Accept` header.
 
 Response:
 
@@ -725,7 +774,6 @@ Response:
 + Parameters
     + entityId: Bcn_Welt (required, string) - Entity ID
     + attrName: temperature (required, string) - Attribute to be retrieved.
-    + options: (optional, string) - Options dictionary
 
 + Response 200 (application/json)
 
@@ -735,8 +783,19 @@ Response:
 
 ### Update attribute value [PUT /v2/entities/{entityId}/attrs/{attrName}/value]
 
-The request payload is the new attribute value. It can be represented as a JSON object (application/json),
-with a `value` property, or as plain text (text/plain).
+The request payload is the new attribute value.
+
+* If the request payload MIME type is `application/json`, then the value of the attribute is set to the JSON object or array
+  coded in the payload (if the payload is not a valid JSON document, then an error is returned).
+* If the request payload MIME type is `text/plain`, then the following algorithm is applied to the payload:
+  * If the payload starts and ends with citation-marks (`"`), the value is taken as a string (the citation marks themselves are not
+    considered part of the string)
+  * If `true` or `false`, the value is taken as a boolean.
+  * If `null`, the value is taken as null.
+  * If these first three tests 'fail', the text is interpreted as a number.
+  * If not a number, then an error is returned and the attribute's value is unchanged.
+
+The payload MIME type in request is specified in the `Content-Type` HTTP header.
 
 Response:
 


### PR DESCRIPTION
Old "JSON entity representation" section has been rewritten, spliten in three subsections: "JSON entity representation", "JSON attribute representation" and "Direct access to attribute value" in order to match with the new JSON format (which implementation work is associated to issue #1259).

@jmcanterafonseca has been assigned as main reviewer of this, but all the others (@kzangeli, 
@mrutid and @antoniojoseln) who have take part in the looooong ;) discussions about this (both in skype and email) are welcome to contribute to this PR with comments.