### PR TITLE
FIX hardening mongoBackend checking for field existence and proper type to avoid broker crashes due to DB corruption

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -27,3 +27,4 @@ Add:  Functional test to PUT/POST/PATCH with 'empty' JSON object as payload (Iss
 Fix:  performance problem in NGSIv2 API due to uncontrolled log trace printing
 Add:  empty attribute values supported in NGSIv1 API operations (Issue #1358)
 Add:  Add CLI argument for notification mode (Issue #1370)
+Add:  hardening mongoBackend checking for field existence and proper type to avoid broker crashes due to DB corruption (Issue #136)

--- a/src/lib/mongoBackend/CMakeLists.txt
+++ b/src/lib/mongoBackend/CMakeLists.txt
@@ -42,6 +42,7 @@ SET (SOURCES
     mongoConnectionPool.cpp
     mongoGetSubscriptions.cpp
     connectionOperations.cpp
+    safeBsonGet.cpp
 )
 
 SET (HEADERS
@@ -66,6 +67,7 @@ SET (HEADERS
     mongoConnectionPool.h
     mongoGetSubscriptions.h
     connectionOperations.h
+    safeBsonGet.h
 )
 
 

--- a/src/lib/mongoBackend/MongoCommonRegister.cpp
+++ b/src/lib/mongoBackend/MongoCommonRegister.cpp
@@ -233,7 +233,7 @@ static bool addTriggeredSubscriptions
   while (cursor->more())
   {
     BSONObj     sub     = cursor->next();
-    BSONElement idField = sub.getField("_id");
+    BSONElement idField = getField(sub, "_id");
 
     //
     // BSONElement::eoo returns true if 'not found', i.e. the field "_id" doesn't exist in 'sub'

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -133,9 +133,15 @@ using namespace mongo;
 /*****************************************************************************
 *
 * Macros to ease extracting fields from BSON objects
+*
+* FIXME P10: probably the STR_FIELD macro (and maybe C_STR_FIELD) are not needed at
+* the end
 */
-#define STR_FIELD(i, sf) std::string(i.getStringField(sf))
-#define C_STR_FIELD(i, sf) i.getStringField(sf)
+//#define STR_FIELD(i, sf) std::string(i.getStringField(sf))
+//#define C_STR_FIELD(i, sf) i.getStringField(sf)
+#include "mongoBackend/safeBsonGet.h"
+#define STR_FIELD(i, sf) getStringField(i, sf)
+#define C_STR_FIELD(i, sf) getStringField(i, sf).c_str()
 
 
 

--- a/src/lib/mongoBackend/mongoConnectionPool.cpp
+++ b/src/lib/mongoBackend/mongoConnectionPool.cpp
@@ -247,7 +247,7 @@ static DBClientBase* mongoConnect
   BSONObj     result;
   std::string extra;
   runCollectionCommand(connection, "admin", BSON("buildinfo" << 1), &result, &err);
-  std::string versionString = std::string(result.getStringField("version"));
+  std::string versionString = std::string(getStringField(result, "version"));
   if (!versionParse(versionString, mongoVersionMayor, mongoVersionMinor, extra))
   {
     LM_E(("Database Startup Error (invalid version format: %s)", versionString.c_str()));

--- a/src/lib/mongoBackend/mongoOntimeintervalOperations.cpp
+++ b/src/lib/mongoBackend/mongoOntimeintervalOperations.cpp
@@ -69,7 +69,7 @@ HttpStatusCode mongoGetContextSubscriptionInfo
     }
 
     /* Build the ContextSubcriptionInfo object */
-    std::vector<BSONElement> entities = sub.getField(CSUB_ENTITIES).Array();
+    std::vector<BSONElement> entities = getField(sub, CSUB_ENTITIES).Array();
     for (unsigned int ix = 0; ix < entities.size(); ++ix) {
         BSONObj entity = entities[ix].embeddedObject();
         EntityId* enP = new EntityId;
@@ -79,23 +79,23 @@ HttpStatusCode mongoGetContextSubscriptionInfo
         csiP->entityIdVector.push_back(enP);
 
     }
-    std::vector<BSONElement> attrs = sub.getField(CSUB_ATTRS).Array();
+    std::vector<BSONElement> attrs = getField(sub, CSUB_ATTRS).Array();
     for (unsigned int ix = 0; ix < attrs.size(); ++ix) {
         csiP->attributeList.push_back(attrs[ix].String());
     }
 
-    BSONElement be = sub.getField(CSUB_EXPIRATION);
+    BSONElement be = getField(sub, CSUB_EXPIRATION);
     csiP->expiration = be.numberLong();
 
     csiP->url = STR_FIELD(sub, CSUB_REFERENCE);
     if (sub.hasElement(CSUB_LASTNOTIFICATION)) {
-        csiP->lastNotification = sub.getIntField(CSUB_LASTNOTIFICATION);
+        csiP->lastNotification = getIntField(sub, CSUB_LASTNOTIFICATION);
     }
     else {
         csiP->lastNotification = -1;
     }
 
-    csiP->throttling = sub.hasField(CSUB_THROTTLING) ? sub.getField(CSUB_THROTTLING).numberLong() : -1;
+    csiP->throttling = sub.hasField(CSUB_THROTTLING) ? getField(sub, CSUB_THROTTLING).numberLong() : -1;
 
     /* Get format. If not found in the csubs document (it could happen in the case of updating Orion using an existing database) we use XML */
     std::string fmt = STR_FIELD(sub, CSUB_FORMAT);

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -72,7 +72,7 @@ static std::string attributeType
     /* It could happen that different entities within the same entity type may have attributes with the same name
      * but different types. In that case, one type (at random) is returned. A list could be returned but the
      * NGSIv2 operations only allow to set one type */
-    return r.getField(ENT_ATTRS).embeddedObject().getField(attrName).embeddedObject().getStringField(ENT_ATTRS_TYPE);
+    return getStringField(getField(getField(r, ENT_ATTRS).embeddedObject(), attrName).embeddedObject(), ENT_ATTRS_TYPE);
   }
 
   return "";
@@ -199,7 +199,7 @@ HttpStatusCode mongoEntityTypes
   // Processing result to build response
   LM_T(LmtMongo, ("aggregation result: %s", result.toString().c_str()));
 
-  std::vector<BSONElement> resultsArray = result.getField("result").Array();
+  std::vector<BSONElement> resultsArray = getField(result, "result").Array();
 
   if (resultsArray.size() == 0)
   {
@@ -221,8 +221,8 @@ HttpStatusCode mongoEntityTypes
   for (unsigned int ix = offset; ix < MIN(resultsArray.size(), offset + limit); ++ix)
   {
     BSONObj                   resultItem  = resultsArray[ix].embeddedObject();
-    EntityType*               entityType  = new EntityType(resultItem.getStringField("_id"));
-    std::vector<BSONElement>  attrsArray  = resultItem.getField("attrs").Array();
+    EntityType*               entityType  = new EntityType(getStringField(resultItem, "_id"));
+    std::vector<BSONElement>  attrsArray  = getField(resultItem, "attrs").Array();
 
     entityType->count = countEntities(tenant, servicePathV, entityType->type);
 
@@ -348,7 +348,7 @@ HttpStatusCode mongoAttributesForEntityType
   /* Processing result to build response */
   LM_T(LmtMongo, ("aggregation result: %s", result.toString().c_str()));
 
-  std::vector<BSONElement> resultsArray = result.getField("result").Array();
+  std::vector<BSONElement> resultsArray = getField(result, "result").Array();
 
   responseP->entityType.count = countEntities(tenant, servicePathV, entityType);
 

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -72,7 +72,9 @@ static std::string attributeType
     /* It could happen that different entities within the same entity type may have attributes with the same name
      * but different types. In that case, one type (at random) is returned. A list could be returned but the
      * NGSIv2 operations only allow to set one type */
-    return getStringField(getField(getField(r, ENT_ATTRS).embeddedObject(), attrName).embeddedObject(), ENT_ATTRS_TYPE);
+    BSONObj attrs = getField(r, ENT_ATTRS).embeddedObject();
+    BSONObj attr = getField(attrs, attrName).embeddedObject();
+    return getStringField(attr, ENT_ATTRS_TYPE);
   }
 
   return "";

--- a/src/lib/mongoBackend/mongoUpdateContextAvailabilitySubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextAvailabilitySubscription.cpp
@@ -127,7 +127,7 @@ HttpStatusCode mongoUpdateContextAvailabilitySubscription
 
   /* Duration (optional) */
   if (requestP->duration.isEmpty()) {
-      newSub.append(CASUB_EXPIRATION, sub.getField(CASUB_EXPIRATION).numberLong());
+      newSub.append(CASUB_EXPIRATION, getField(sub, CASUB_EXPIRATION).numberLong());
   }
   else {
       long long expiration = getCurrentTime() + requestP->duration.parse();
@@ -138,11 +138,11 @@ HttpStatusCode mongoUpdateContextAvailabilitySubscription
   /* Reference is not updatable, so it is appended directly */
   newSub.append(CASUB_REFERENCE, STR_FIELD(sub, CASUB_REFERENCE));
 
-  int count = sub.hasField(CASUB_COUNT) ? sub.getIntField(CASUB_COUNT) : 0;
+  int count = sub.hasField(CASUB_COUNT) ? getIntField(sub, CASUB_COUNT) : 0;
 
   /* The hasField check is needed due to lastNotification/count could not be present in the original doc */
   if (sub.hasField(CASUB_LASTNOTIFICATION)) {
-      newSub.append(CASUB_LASTNOTIFICATION, sub.getIntField(CASUB_LASTNOTIFICATION));
+      newSub.append(CASUB_LASTNOTIFICATION, getIntField(sub, CASUB_LASTNOTIFICATION));
   }
   if (sub.hasField(CASUB_COUNT)) {
       newSub.append(CASUB_COUNT, count);

--- a/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
@@ -103,13 +103,13 @@ HttpStatusCode mongoUpdateContextSubscription
   BSONObjBuilder newSub;
 
   /* Entities, attribute list and reference are not updatable, so they are appended directly */
-  newSub.appendArray(CSUB_ENTITIES, sub.getField(CSUB_ENTITIES).Obj());
-  newSub.appendArray(CSUB_ATTRS, sub.getField(CSUB_ATTRS).Obj());
+  newSub.appendArray(CSUB_ENTITIES, getField(sub, CSUB_ENTITIES).Obj());
+  newSub.appendArray(CSUB_ATTRS, getField(sub, CSUB_ATTRS).Obj());
   newSub.append(CSUB_REFERENCE, STR_FIELD(sub, CSUB_REFERENCE));
 
   /* Duration update */
   if (requestP->duration.isEmpty()) {      
-      newSub.append(CSUB_EXPIRATION, sub.getField(CSUB_EXPIRATION).numberLong());
+      newSub.append(CSUB_EXPIRATION, getField(sub, CSUB_EXPIRATION).numberLong());
   }
   else {
       long long expiration = getCurrentTime() + requestP->duration.parse();
@@ -131,14 +131,14 @@ HttpStatusCode mongoUpdateContextSubscription
   else {
       /* The hasField check is needed due to Throttling could not be present in the original doc */
       if (sub.hasField(CSUB_THROTTLING)) {
-          newSub.append(CSUB_THROTTLING, sub.getField(CSUB_THROTTLING).numberLong());
+          newSub.append(CSUB_THROTTLING, getField(sub, CSUB_THROTTLING).numberLong());
       }
   }
 
   /* Notify conditions */
   bool notificationDone = false;
   if (requestP->notifyConditionVector.size() == 0) {
-    newSub.appendArray(CSUB_CONDITIONS, sub.getField(CSUB_CONDITIONS).embeddedObject());
+    newSub.appendArray(CSUB_CONDITIONS, getField(sub, CSUB_CONDITIONS).embeddedObject());
   }
   else {
       /* Destroy any previous ONTIMEINTERVAL thread */
@@ -168,7 +168,7 @@ HttpStatusCode mongoUpdateContextSubscription
        attrL.release();
   }
 
-  int count = sub.hasField(CSUB_COUNT) ? sub.getIntField(CSUB_COUNT) : 0;
+  int count = sub.hasField(CSUB_COUNT) ? getIntField(sub, CSUB_COUNT) : 0;
 
   /* Last notification */
   if (notificationDone) {
@@ -178,7 +178,7 @@ HttpStatusCode mongoUpdateContextSubscription
   else {
       /* The hasField check is needed due to lastNotification/count could not be present in the original doc */
       if (sub.hasField(CSUB_LASTNOTIFICATION)) {
-          newSub.append(CSUB_LASTNOTIFICATION, sub.getIntField(CSUB_LASTNOTIFICATION));
+          newSub.append(CSUB_LASTNOTIFICATION, getIntField(sub, CSUB_LASTNOTIFICATION));
       }
       if (sub.hasField(CSUB_COUNT)) {
           newSub.append(CSUB_COUNT, count);

--- a/src/lib/mongoBackend/safeBsonGet.cpp
+++ b/src/lib/mongoBackend/safeBsonGet.cpp
@@ -1,0 +1,130 @@
+/*
+*
+* Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Fermin Galan Marquez
+*/
+
+#include "mongoBackend/safeBsonGet.h"
+#include "logMsg/logMsg.h"
+
+using namespace mongo;
+
+/* ****************************************************************************
+*
+* getObjectField -
+*
+*/
+BSONObj getObjectField(const BSONObj& b, const std::string& field)
+{
+  if (!b.hasField(field))
+  {
+    LM_E(("Runtime Error (object field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
+    return BSONObj();
+  }
+  if (b.getField(field).type() != Object)
+  {
+
+    LM_E(("Runtime Error (field '%s' was supposed to be an object but type=%d in BSONObj <%s>)",
+          field.c_str(), b.getField(field).type(), b.toString().c_str()));
+    return BSONObj();
+  }
+  return b.getObjectField(field);
+}
+
+/* ****************************************************************************
+*
+* getStringField -
+*
+*/
+std::string getStringField(const BSONObj& b, const std::string& field)
+{
+  if (!b.hasField(field))
+  {
+    LM_E(("Runtime Error (string field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
+    return "";
+  }
+  if (b.getField(field).type() != String)
+  {
+    LM_E(("Runtime Error (field '%s' was supposed to be a string but type=%d in BSONObj <%s>)",
+          field.c_str(), b.getField(field).type(), b.toString().c_str()));
+    return "";
+  }
+  return b.getStringField(field);
+}
+
+/* ****************************************************************************
+*
+* getIntField -
+*
+*/
+int getIntField(const BSONObj& b, const std::string& field)
+{
+  if (!b.hasField(field))
+  {
+    LM_E(("Runtime Error (int field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
+    return -1;
+  }
+  if (b.getField(field).type() != NumberInt)
+  {
+    LM_E(("Runtime Error (field '%s' was supposed to be a int but type=%d in BSONObj <%s>)",
+          field.c_str(), b.getField(field).type(), b.toString().c_str()));
+    return -1;
+  }
+  return b.getIntField(field);
+}
+
+/* ****************************************************************************
+*
+* getBoolField -
+*
+*/
+bool getBoolField(const BSONObj& b, const std::string& field)
+{
+  if (!b.hasField(field))
+  {
+    LM_E(("Runtime Error (bool field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
+    return -1;
+  }
+  if (b.getField(field).type() != Bool)
+  {
+    LM_E(("Runtime Error (field '%s' was supposed to be a bool but type=%d in BSONObj <%s>)",
+          field.c_str(), b.getField(field).type(), b.toString().c_str()));
+    return -1;
+  }
+  return b.getBoolField(field);
+}
+
+/* ****************************************************************************
+*
+* getField -
+*
+*/
+BSONElement getField(const BSONObj& b, const std::string& field)
+{
+  if (!b.hasField(field))
+  {
+    LM_E(("Runtime Error (field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
+    return BSONElement();
+  }
+  return b.getField(field);
+}
+

--- a/src/lib/mongoBackend/safeBsonGet.cpp
+++ b/src/lib/mongoBackend/safeBsonGet.cpp
@@ -35,19 +35,22 @@ using namespace mongo;
 */
 BSONObj getObjectField(const BSONObj& b, const std::string& field)
 {
+  if (b.hasField(field) && b.getField(field).type() == Object)
+  {
+    return b.getObjectField(field);
+  }
+
+  // Detect error
   if (!b.hasField(field))
   {
     LM_E(("Runtime Error (object field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
-    return BSONObj();
   }
-  if (b.getField(field).type() != Object)
+  else
   {
-
     LM_E(("Runtime Error (field '%s' was supposed to be an object but type=%d in BSONObj <%s>)",
           field.c_str(), b.getField(field).type(), b.toString().c_str()));
-    return BSONObj();
   }
-  return b.getObjectField(field);
+  return BSONObj();
 }
 
 /* ****************************************************************************
@@ -57,18 +60,22 @@ BSONObj getObjectField(const BSONObj& b, const std::string& field)
 */
 std::string getStringField(const BSONObj& b, const std::string& field)
 {
+  if (b.hasField(field) && b.getField(field).type() == String)
+  {
+    return b.getStringField(field);
+  }
+
+  // Detect error
   if (!b.hasField(field))
   {
     LM_E(("Runtime Error (string field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
-    return "";
   }
-  if (b.getField(field).type() != String)
+  else
   {
     LM_E(("Runtime Error (field '%s' was supposed to be a string but type=%d in BSONObj <%s>)",
           field.c_str(), b.getField(field).type(), b.toString().c_str()));
-    return "";
   }
-  return b.getStringField(field);
+  return "";
 }
 
 /* ****************************************************************************
@@ -78,18 +85,22 @@ std::string getStringField(const BSONObj& b, const std::string& field)
 */
 int getIntField(const BSONObj& b, const std::string& field)
 {
+  if (b.hasField(field) && b.getField(field).type() == NumberInt)
+  {
+    return b.getIntField(field);
+  }
+
+  // Detect error
   if (!b.hasField(field))
   {
     LM_E(("Runtime Error (int field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
-    return -1;
   }
-  if (b.getField(field).type() != NumberInt)
+  else
   {
     LM_E(("Runtime Error (field '%s' was supposed to be a int but type=%d in BSONObj <%s>)",
           field.c_str(), b.getField(field).type(), b.toString().c_str()));
-    return -1;
-  }
-  return b.getIntField(field);
+  }  
+  return -1;
 }
 
 /* ****************************************************************************
@@ -99,18 +110,22 @@ int getIntField(const BSONObj& b, const std::string& field)
 */
 bool getBoolField(const BSONObj& b, const std::string& field)
 {
+  if (b.hasField(field) && b.getField(field).type() == Bool)
+  {
+    return b.getBoolField(field);
+  }
+
+  // Detect error
   if (!b.hasField(field))
   {
     LM_E(("Runtime Error (bool field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
-    return -1;
   }
-  if (b.getField(field).type() != Bool)
+  else 
   {
     LM_E(("Runtime Error (field '%s' was supposed to be a bool but type=%d in BSONObj <%s>)",
           field.c_str(), b.getField(field).type(), b.toString().c_str()));
-    return -1;
   }
-  return b.getBoolField(field);
+  return false;
 }
 
 /* ****************************************************************************
@@ -120,11 +135,12 @@ bool getBoolField(const BSONObj& b, const std::string& field)
 */
 BSONElement getField(const BSONObj& b, const std::string& field)
 {
-  if (!b.hasField(field))
+  if (b.hasField(field))
   {
-    LM_E(("Runtime Error (field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
-    return BSONElement();
+    return b.getField(field);
   }
-  return b.getField(field);
+
+  LM_E(("Runtime Error (field '%s' is missing in BSONObj <%s>)", field.c_str(), b.toString().c_str()));
+  return BSONElement();
 }
 

--- a/src/lib/mongoBackend/safeBsonGet.h
+++ b/src/lib/mongoBackend/safeBsonGet.h
@@ -1,0 +1,66 @@
+#ifndef SRC_LIB_MONGOBACKEND_SAFEBSONGET_H_
+#define SRC_LIB_MONGOBACKEND_SAFEBSONGET_H_
+
+/*
+*
+* Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Fermin Galan Marquez
+*/
+
+#include "mongo/client/dbclient.h"
+
+/* ****************************************************************************
+*
+* getObjectField -
+*
+*/
+extern mongo::BSONObj getObjectField(const mongo::BSONObj& b, const std::string& field);
+
+/* ****************************************************************************
+*
+* getStringField -
+*
+*/
+extern std::string getStringField(const mongo::BSONObj& b, const std::string& field);
+
+/* ****************************************************************************
+*
+* getIntField -
+*
+*/
+extern int getIntField(const mongo::BSONObj& b, const std::string& field);
+
+/* ****************************************************************************
+*
+* getBoolField -
+*
+*/
+extern bool getBoolField(const mongo::BSONObj& b, const std::string& field);
+
+/* ****************************************************************************
+*
+* getField -
+*
+*/
+extern mongo::BSONElement getField(const mongo::BSONObj& b, const std::string& field);
+
+#endif // SRC_LIB_MONGOBACKEND_SAFEBSONGET_H_


### PR DESCRIPTION
Partial implementation of #136 

Instead of using directly BSON class method, I have defined "wrapper" functions that do all the checking and prevent cases in the safeBsonGet.h module.

At the end, no code should use directly BSON methods (except unit test code). However, note that some leftover remains in cache/ (I have preferred not to touch there, as the cache is being re-done and the work will eventually land in develop branch).