### PR TITLE
FIX empty attribute values in PUT/POST /v1/contextEntities/<id>/attributes/<attr> operation

### DIFF
--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -45,6 +45,7 @@ UpdateContextAttributeRequest::UpdateContextAttributeRequest()
 {
   metadataVector.tagSet("metadata");
   compoundValueP = NULL;
+  valueType = orion::ValueTypeNone;
 }
 
 
@@ -118,10 +119,6 @@ std::string UpdateContextAttributeRequest::check
   if (predetectedError != "")
   {
     response.fill(SccBadRequest, predetectedError);
-  }
-  else if ((contextValue == "") && (compoundValueP == NULL))
-  {
-    response.fill(SccBadRequest, "empty context value");
   }
   else if ((res = metadataVector.check(requestType, format, indent, predetectedError, counter)) != "OK")
   {

--- a/src/lib/convenience/UpdateContextAttributeRequest.h
+++ b/src/lib/convenience/UpdateContextAttributeRequest.h
@@ -43,10 +43,10 @@ struct ConnectionInfo;
 typedef struct UpdateContextAttributeRequest
 {
   std::string                type;                // Optional
-  std::string                contextValue;        // Mandatory
-  orion::ValueType           valueType;           // Type of value: either string or none
+  std::string                contextValue;        // Mandatory  
   MetadataVector             metadataVector;      // Optional
 
+  orion::ValueType           valueType;           // Type of value: either string or none
   std::string                typeFromXmlAttribute;
   orion::CompoundValueNode*  compoundValueP;
 

--- a/src/lib/convenience/UpdateContextAttributeRequest.h
+++ b/src/lib/convenience/UpdateContextAttributeRequest.h
@@ -44,6 +44,7 @@ typedef struct UpdateContextAttributeRequest
 {
   std::string                type;                // Optional
   std::string                contextValue;        // Mandatory
+  orion::ValueType           valueType;           // Type of value: either string or none
   MetadataVector             metadataVector;      // Optional
 
   std::string                typeFromXmlAttribute;

--- a/src/lib/jsonParse/jsonUpdateContextAttributeRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextAttributeRequest.cpp
@@ -63,8 +63,8 @@ static std::string attributeValue(const std::string& path, const std::string& va
   //       save the 'typeFromXmlAttribute', a ContextAttribute has been added to 
   //       UpdateContextAttributeData.
   //
-  reqData->lastContextAttribute = &reqData->upcar.attribute;
-
+  reqData->lastContextAttribute   = &reqData->upcar.attribute;
+  reqData->upcar.res.valueType    = orion::ValueTypeString;
   reqData->upcar.res.contextValue = value;
 
   return "OK";

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -288,10 +288,7 @@ void UpdateContextRequest::fill
   else
   {
     caP = new ContextAttribute(attributeName, ucarP->type, ucarP->contextValue);
-    if (ucarP->valueType == orion::ValueTypeNone)
-    {
-      caP->valueType = orion::ValueTypeNone;
-    }
+    caP->valueType = ucarP->valueType;
   }
 
   caP->metadataVector.fill((MetadataVector*) &ucarP->metadataVector);

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -288,6 +288,10 @@ void UpdateContextRequest::fill
   else
   {
     caP = new ContextAttribute(attributeName, ucarP->type, ucarP->contextValue);
+    if (ucarP->valueType == orion::ValueTypeNone)
+    {
+      caP->valueType = orion::ValueTypeNone;
+    }
   }
 
   caP->metadataVector.fill((MetadataVector*) &ucarP->metadataVector);

--- a/src/lib/xmlParse/xmlUpdateContextAttributeRequest.cpp
+++ b/src/lib/xmlParse/xmlUpdateContextAttributeRequest.cpp
@@ -111,6 +111,7 @@ static int attributeValue(xml_node<>* node, ParseData* reqData)
   //       directly to ParseData::UpdateContextAttributeData::res, finding compoundValueP
   //
   reqData->upcar.res.typeFromXmlAttribute = xmlTypeAttributeGet(node);
+  reqData->upcar.res.valueType            = orion::ValueTypeString;
   reqData->upcar.res.contextValue         = node->value();
 
   return 0;

--- a/test/functionalTest/cases/1358_v1_empty_attribute_values/empty_values_conv_ops.test
+++ b/test/functionalTest/cases/1358_v1_empty_attribute_values/empty_values_conv_ops.test
@@ -1,0 +1,431 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+NGSIv1: Empty attribute values with convops
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create E1 with empty value
+# 02. GET E1 and see empty value
+# 03. Update E1 with non-empty value (foo)
+# 04. GET E1 and see non-empty value (foo)
+# 05. Update E1 with empty value
+# 06. GET E1 and see empty value
+# 07. Update E1 with non-empty value (bar)
+# 08. GET E1 and see non-empty value (bar)
+# 09. Update E1 with absent value
+# 10. GET E1 and see attribute hasn't changed (bar)
+#
+
+
+echo "01. Create E1 with empty value"
+echo "=============================="
+payload='{
+    "attributes": [
+        {
+            "name": "attr",
+            "type": "T",
+            "value": ""
+        }
+    ]
+}'
+orionCurl --url /v1/contextEntities/E1 --payload "$payload" --json
+echo
+echo
+
+
+echo "02. GET E1 and see empty value"
+echo "=============================="
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+echo "03. Update E1 with non-empty value (foo)"
+echo "========================================"
+payload='{
+    "attributes": [
+        {
+            "name": "attr",
+            "type": "T",
+            "value": "foo"
+        }
+    ]
+}'
+orionCurl -X PUT --url /v1/contextEntities/E1 --payload "$payload" --json
+echo
+echo
+
+
+echo "04. GET E1 and see non-empty value (foo)"
+echo "========================================"
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+echo "05. Update E1 with empty value"
+echo "=============================="
+payload='{
+    "attributes": [
+        {
+            "name": "attr",
+            "type": "T",
+            "value": ""
+        }
+    ]
+}'
+orionCurl -X PUT --url /v1/contextEntities/E1 --payload "$payload" --json
+echo
+echo
+
+
+echo "06. GET E1 and see empty value"
+echo "=============================="
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+echo "07. Update E1 with non-empty value (bar)"
+echo "========================================"
+payload='{
+    "attributes": [
+        {
+            "name": "attr",
+            "type": "T",
+            "value": "bar"
+        }
+    ]
+}'
+orionCurl -X PUT --url /v1/contextEntities/E1 --payload "$payload" --json
+echo
+echo
+
+
+echo "08. GET E1 and see non-empty value (bar)"
+echo "========================================"
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+echo "09. Update E1 with absent value"
+echo "=============================="
+payload='{
+    "attributes": [
+        {
+            "name": "attr",
+            "type": "T"
+        }
+    ]
+}'
+orionCurl -X PUT --url /v1/contextEntities/E1 --payload "$payload" --json
+echo
+echo
+
+
+echo "10. GET E1 and see attribute hasn't changed (bar)"
+echo "================================================="
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+--REGEXPECT--
+01. Create E1 with empty value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 311
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "attr",
+                    "type": "T",
+                    "value": ""
+                }
+            ],
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "id": "E1",
+    "isPattern": "false",
+    "type": ""
+}
+
+
+02. GET E1 and see empty value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 273
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": ""
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+03. Update E1 with non-empty value (foo)
+========================================
+HTTP/1.1 200 OK
+Content-Length: 256
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "attr",
+                    "type": "T",
+                    "value": ""
+                }
+            ],
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+04. GET E1 and see non-empty value (foo)
+========================================
+HTTP/1.1 200 OK
+Content-Length: 276
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": "foo"
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+05. Update E1 with empty value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 256
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "attr",
+                    "type": "T",
+                    "value": ""
+                }
+            ],
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+06. GET E1 and see empty value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 273
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": ""
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+07. Update E1 with non-empty value (bar)
+========================================
+HTTP/1.1 200 OK
+Content-Length: 256
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "attr",
+                    "type": "T",
+                    "value": ""
+                }
+            ],
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+08. GET E1 and see non-empty value (bar)
+========================================
+HTTP/1.1 200 OK
+Content-Length: 276
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": "bar"
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+09. Update E1 with absent value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 256
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "attributes": [
+                {
+                    "name": "attr",
+                    "type": "T",
+                    "value": ""
+                }
+            ],
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+10. GET E1 and see attribute hasn't changed (bar)
+=================================================
+HTTP/1.1 200 OK
+Content-Length: 276
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": "bar"
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/1392_empty_attr_conv_op/empty_attr_conv_op.test
+++ b/test/functionalTest/cases/1392_empty_attr_conv_op/empty_attr_conv_op.test
@@ -1,0 +1,338 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+NGSIv1: Empty attribute values with convops
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create E1 with empty value
+# 02. GET E1 and see empty value
+# 03. Update E1 with non-empty value (foo)
+# 04. GET E1 and see non-empty value (foo)
+# 05. Update E1 with empty value
+# 06. GET E1 and see empty value
+# 07. Update E1 with non-empty value (bar)
+# 08. GET E1 and see non-empty value (bar)
+# 09. Update E1 with absent value
+# 10. GET E1 and see attribute hasn't changed (bar)
+#
+
+
+echo "01. Create E1 with empty value"
+echo "=============================="
+payload='{
+   "type": "T",
+   "value": ""
+}'
+orionCurl --url /v1/contextEntities/E1/attributes/attr --payload "$payload" --json
+echo
+echo
+
+
+echo "02. GET E1 and see empty value"
+echo "=============================="
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+echo "03. Update E1 with non-empty value (foo)"
+echo "========================================"
+payload='{
+   "type": "T",
+   "value": "foo"
+}'
+orionCurl -X PUT --url /v1/contextEntities/E1/attributes/attr --payload "$payload" --json
+echo
+echo
+
+
+echo "04. GET E1 and see non-empty value (foo)"
+echo "========================================"
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+echo "05. Update E1 with empty value"
+echo "=============================="
+payload='{
+   "type": "T",
+   "value": ""
+}'
+orionCurl -X PUT --url /v1/contextEntities/E1/attributes/attr --payload "$payload" --json
+echo
+echo
+
+
+echo "06. GET E1 and see empty value"
+echo "=============================="
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+echo "07. Update E1 with non-empty value (bar)"
+echo "========================================"
+payload='{
+   "type": "T",
+   "value": "bar"
+}'
+orionCurl -X PUT --url /v1/contextEntities/E1/attributes/attr --payload "$payload" --json
+echo
+echo
+
+
+echo "08. GET E1 and see non-empty value (bar)"
+echo "========================================"
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+echo "09. Update E1 with absent value"
+echo "=============================="
+payload='{
+   "type": "T"
+}'
+orionCurl -X PUT --url /v1/contextEntities/E1/attributes/attr --payload "$payload" --json
+echo
+echo
+
+
+echo "10. GET E1 and see attribute hasn't changed (bar)"
+echo "================================================="
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+--REGEXPECT--
+01. Create E1 with empty value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 46
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "code": "200",
+    "reasonPhrase": "OK"
+}
+
+
+02. GET E1 and see empty value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 273
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": ""
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+03. Update E1 with non-empty value (foo)
+========================================
+HTTP/1.1 200 OK
+Content-Length: 46
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "code": "200",
+    "reasonPhrase": "OK"
+}
+
+
+04. GET E1 and see non-empty value (foo)
+========================================
+HTTP/1.1 200 OK
+Content-Length: 276
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": "foo"
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+05. Update E1 with empty value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 46
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "code": "200",
+    "reasonPhrase": "OK"
+}
+
+
+06. GET E1 and see empty value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 273
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": ""
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+07. Update E1 with non-empty value (bar)
+========================================
+HTTP/1.1 200 OK
+Content-Length: 46
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "code": "200",
+    "reasonPhrase": "OK"
+}
+
+
+08. GET E1 and see non-empty value (bar)
+========================================
+HTTP/1.1 200 OK
+Content-Length: 276
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": "bar"
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+09. Update E1 with absent value
+==============================
+HTTP/1.1 200 OK
+Content-Length: 46
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "code": "200",
+    "reasonPhrase": "OK"
+}
+
+
+10. GET E1 and see attribute hasn't changed (bar)
+=================================================
+HTTP/1.1 200 OK
+Content-Length: 276
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "attr",
+                "type": "T",
+                "value": "bar"
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": ""
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fixes #1392 

CNR entry is not included (as this is a fix in a issue adressed in 0.25.0, not present in previous versions).