### PR TITLE
FIX accumulator-server.py to work with IPv6 in Debian 8.2 (maybe it also helps others, e.g. Ubuntu)

### DIFF
--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -152,7 +152,14 @@ def record():
         #times.append(t)
 
     # Store verb and URL
-    s += request.method + ' ' + request.url + '\n'
+    #
+    # We have found that request.url can be problematic in some distributions (e.g. Debian 8.2)
+    # when used with IPv6, so we use request.scheme, request.host and request.path to compose
+    # the URL "manually"
+    #
+    #  request.url = request.scheme + '://' + request.host + request.path
+    #
+    s += request.method + ' ' + request.scheme + '://' + request.host + request.path + '\n'
 
     # Store headers
     for h in request.headers.keys():


### PR DESCRIPTION
This PR is supposed to fix the ipv4_ipv6.test problem in some distributions. In order to test, you need to re-install the accumulator-server.py, typically running:

```
make install_scripts
```
(Use the proper INSTALL_DIR if you need so)