### PR TITLE
FIX coverage for functional tests

### DIFF
--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -166,22 +166,6 @@ static DBClientBase* connection = NULL;
 
 /* ****************************************************************************
 *
-* mongoConnect -
-*
-* This method is intended for unit testing, that needs the DBClientConnection
-* object to be mocked.
-*
-*/
-bool mongoConnect(DBClientConnection* c)
-{
-  connection = c;
-
-  return true;
-}
-
-
-/* ****************************************************************************
-*
 * For unit tests there is only one connection. This connection is stored right here (DBClientBase* connection) and
 * given out using the function getMongoConnection().
 */
@@ -232,7 +216,11 @@ DBClientBase* getMongoConnection(void)
 */
 void releaseMongoConnection(DBClientBase* connection)
 {
-  mongoPoolConnectionRelease(connection);
+#ifdef UNIT_TEST
+  return;
+#else
+  return mongoPoolConnectionRelease(connection);
+#endif
 }
 
 

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -161,8 +161,7 @@ extern bool mongoStart
 
 
 #ifdef UNIT_TEST
-extern bool mongoConnect(const char* host);
-extern bool mongoConnect(DBClientConnection* c);
+extern void setMongoConnectionForUnitTest(DBClientBase* _connection);
 #endif
 
 /*****************************************************************************

--- a/src/lib/mongoBackend/mongoConnectionPool.cpp
+++ b/src/lib/mongoBackend/mongoConnectionPool.cpp
@@ -283,6 +283,12 @@ int mongoConnectionPoolInit
   bool         semTimeStat
 )
 {
+#ifdef UNIT_TEST
+  /* Basically, we are mocking all the DB pool with a single connection. The getMongoConnection() and mongoReleaseConnection() methods
+   * are mocked in similar way to ensure a coherent behaviour */
+  setMongoConnectionForUnitTest(mongoConnect(host, db, rplSet, username, passwd, multitenant, writeConcern, timeout));
+  return 0;
+#else
   //
   // Create the pool
   //
@@ -330,6 +336,7 @@ int mongoConnectionPoolInit
   semStatistics = semTimeStat;
 
   return 0;
+#endif
 }
 
 

--- a/test/unittests/cache/SubscriptionCache_test.cpp
+++ b/test/unittests/cache/SubscriptionCache_test.cpp
@@ -123,6 +123,5 @@ TEST(cache, SubscriptionCache)
   EXPECT_EQ("012345678901234567890124", subV[1]->subscriptionId);
   subV.clear();
 
-  utExit();
-  setMongoConnectionForUnitTest(NULL);
+  utExit();  
 }

--- a/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
@@ -627,7 +627,6 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrsAll)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);  	
   utExit();
 }
 
@@ -687,9 +686,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrOneSingle)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -754,9 +751,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrOneMulti)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 
@@ -822,9 +817,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternAttrsSubset)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -903,9 +896,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternSeveralCREs)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -978,9 +969,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternSeveralRegistrations)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1016,9 +1005,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternNoEntity)
 
   ASSERT_EQ(0, res.contextElementResponseVector.size());
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 
@@ -1061,9 +1048,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternNoAttribute)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1176,9 +1161,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntity)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1245,9 +1228,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiAttr)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1337,9 +1318,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternMultiEntityAttrs)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1440,9 +1419,7 @@ TEST(mongoContextProvidersQueryRequest, noPatternNoType)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1543,9 +1520,7 @@ TEST(mongoContextProvidersQueryRequest, pattern0Attr)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1603,9 +1578,7 @@ TEST(mongoContextProvidersQueryRequest, pattern1AttrSingle)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1684,9 +1657,7 @@ TEST(mongoContextProvidersQueryRequest, pattern1AttrMulti)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1778,9 +1749,7 @@ TEST(mongoContextProvidersQueryRequest, patternNAttr)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1820,9 +1789,7 @@ TEST(mongoContextProvidersQueryRequest, patternFail)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1937,9 +1904,7 @@ TEST(mongoContextProvidersQueryRequest, patternNoType)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -2080,9 +2045,7 @@ TEST(mongoContextProvidersQueryRequest, mixPatternAndNotPattern)
   DBClientBase* connection = getMongoConnection();
   ASSERT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 
@@ -2180,9 +2143,7 @@ TEST(mongoContextProvidersQueryRequest, severalCprs1)
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -2273,9 +2234,7 @@ TEST(mongoContextProvidersQueryRequest, severalCprs2)
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -2349,9 +2308,7 @@ TEST(mongoContextProvidersQueryRequest, severalCprs3)
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(0).details.size());
 
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -2424,9 +2381,6 @@ TEST(mongoContextProvidersQueryRequest, severalCprsFormat)
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-  setMongoConnectionForUnitTest(NULL);  
   
   utExit();
-
 }

--- a/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
@@ -499,8 +499,6 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrsAll)
   EXPECT_EQ("", RES_CER_STATUS(0).details);
   EXPECT_EQ(0, RES_CER(0).contextAttributeVector.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -559,10 +557,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrOneSingle)
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);  
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -625,10 +620,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrOneMulti)
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 
@@ -697,10 +689,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternAttrsSubset)
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 
@@ -759,10 +748,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternNoAttribute)
   EXPECT_EQ("No context element found", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -826,10 +812,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntity)
   EXPECT_EQ("", RES_CER_STATUS(1).details);
   EXPECT_EQ(0, RES_CER(1).contextAttributeVector.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -909,10 +892,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiAttr)
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1042,10 +1022,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternMultiEntityAttrs)
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(1).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1117,10 +1094,7 @@ TEST(mongoContextProvidersUpdateRequest, noPatternNoType)
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1162,10 +1136,7 @@ TEST(DISABLED_mongoContextProvidersUpdateRequest, pattern0Attr)
   EXPECT_EQ(SccOk, ms);
   // TBD
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1203,10 +1174,7 @@ TEST(DISABLED_mongoContextProvidersUpdateRequest, pattern1AttrSingle)
   EXPECT_EQ(SccOk, ms);
   // TBD
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1246,10 +1214,7 @@ TEST(DISABLED_mongoContextProvidersUpdateRequest, pattern1AttrMulti)
   EXPECT_EQ(SccOk, ms);
   // TBD
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1291,10 +1256,7 @@ TEST(DISABLED_mongoContextProvidersUpdateRequest, patternNAttr)
   EXPECT_EQ(SccOk, ms);
   // TBD
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1332,10 +1294,7 @@ TEST(DISABLED_mongoContextProvidersUpdateRequest, patternFail)
   EXPECT_EQ(SccOk, ms);
   //TBD
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1379,10 +1338,7 @@ TEST(DISABLED_mongoContextProvidersUpdateRequest, patternNoType)
   EXPECT_EQ(SccOk, ms);
   // TBD
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1425,10 +1381,7 @@ TEST(DISABLED_mongoContextProvidersUpdateRequest, mixPatternAndNotPattern)
   EXPECT_EQ(SccOk, ms);
   //TBD
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1634,10 +1587,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprs)
   EXPECT_STREQ("30", C_STR_FIELD(a3, "value"));
   EXPECT_EQ(1360232700, a3.getIntField("modDate"));
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -1843,10 +1793,7 @@ TEST(mongoContextProvidersUpdateRequest, severalCprsFormat)
   EXPECT_STREQ("30", C_STR_FIELD(a3, "value"));
   EXPECT_EQ(1360232700, a3.getIntField("modDate"));
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 
@@ -1902,8 +1849,6 @@ TEST(mongoContextProvidersUpdateRequest, notFoundUpdate)
   EXPECT_EQ("No context element found", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -1959,7 +1904,5 @@ TEST(mongoContextProvidersUpdateRequest, notFoundDelete)
   EXPECT_EQ("No context element found", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }

--- a/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
@@ -454,8 +454,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationDetails)
   EXPECT_EQ(0, res.responseVector.get(4)->errorCode.reasonPhrase.size());
   EXPECT_EQ(0, res.responseVector.get(4)->errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -559,8 +557,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationAll)
   EXPECT_EQ(0, res.responseVector.get(4)->errorCode.reasonPhrase.size());
   EXPECT_EQ(0, res.responseVector.get(4)->errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -610,8 +606,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationOnlyFirst)
   EXPECT_EQ(0, res.responseVector.get(0)->errorCode.reasonPhrase.size());
   EXPECT_EQ(0, res.responseVector.get(0)->errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -661,8 +655,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationOnlySecond)
   EXPECT_EQ(0, res.responseVector.get(0)->errorCode.reasonPhrase.size());
   EXPECT_EQ(0, res.responseVector.get(0)->errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -740,8 +732,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationRange)
   EXPECT_EQ(0, res.responseVector.get(2)->errorCode.reasonPhrase.size());
   EXPECT_EQ(0, res.responseVector.get(2)->errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -778,8 +768,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationNonExisting)
 
   ASSERT_EQ(0,res.responseVector.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -829,8 +817,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationNonExistingOverlap)
   EXPECT_EQ(0, res.responseVector.get(0)->errorCode.reasonPhrase.size());
   EXPECT_EQ(0, res.responseVector.get(0)->errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -867,8 +853,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationNonExistingDetails)
 
   ASSERT_EQ(0,res.responseVector.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -923,8 +907,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrsAll)
   EXPECT_EQ(0, res.responseVector.get(0)->errorCode.reasonPhrase.size());
   EXPECT_EQ(0, res.responseVector.get(0)->errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 }
 
@@ -980,8 +962,6 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrOneSingle)
     EXPECT_EQ(0, res.responseVector.get(0)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(0)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
 
@@ -1058,12 +1038,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrOneMulti)
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
-
 }
 
 
@@ -1123,11 +1099,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrsSubset)
     EXPECT_EQ(0, res.responseVector.get(0)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(0)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1204,11 +1177,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternSeveralCREs)
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1285,11 +1255,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternSeveralRegistrations)
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1329,11 +1296,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternNoEntity)
     EXPECT_EQ(0, res.errorCode.details.size());
     EXPECT_EQ(0,res.responseVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 
@@ -1376,11 +1340,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternNoAttribute)
     EXPECT_EQ(0, res.errorCode.details.size());
     EXPECT_EQ(0,res.responseVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1479,11 +1440,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternMultiEntity)
     EXPECT_EQ(0, res.responseVector.get(2)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(2)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1554,11 +1512,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternMultiAttr)
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1648,11 +1603,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternMultiEntityAttrs)
     EXPECT_EQ(0, res.responseVector.get(2)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(2)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1756,11 +1708,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternNoType)
     EXPECT_EQ(0, res.responseVector.get(3)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(3)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1845,11 +1794,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, pattern0Attr)
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1904,11 +1850,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, pattern1AttrSingle)
     EXPECT_EQ(0, res.responseVector.get(0)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(0)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1981,11 +1924,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, pattern1AttrMulti)
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(1)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -2077,11 +2017,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, patternNAttr)
     EXPECT_EQ(0, res.responseVector.get(2)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(2)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -2121,11 +2058,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, patternFail)
     EXPECT_EQ(0, res.errorCode.details.size());
     EXPECT_EQ(0,res.responseVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -2232,11 +2166,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, patternNoType)
     EXPECT_EQ(0, res.responseVector.get(3)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(3)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -2341,11 +2272,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, mixPatternAndNotPattern)
     EXPECT_EQ(0, res.responseVector.get(2)->errorCode.reasonPhrase.size());
     EXPECT_EQ(0, res.responseVector.get(2)->errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Delete mock */
     delete timerMock;
-
 }
 
 
@@ -2374,7 +2302,8 @@ TEST(mongoDiscoverContextAvailabilityRequest, mongoDbQueryFail)
     setTimer(timerMock);
 
     /* Set MongoDB connection */
-    mongoConnect(connectionMock);
+    DBClientBase* connectionDb = getMongoConnection();
+    setMongoConnectionForUnitTest(connectionMock);
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en("E3", "T3");
@@ -2397,8 +2326,9 @@ TEST(mongoDiscoverContextAvailabilityRequest, mongoDbQueryFail)
               ", orderby: { _id: 1 } } - exception: boom!!)", res.errorCode.details);
     EXPECT_EQ(0,res.responseVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
     /* Release mock */
     delete connectionMock;
     delete timerMock;

--- a/test/unittests/mongoBackend/mongoNotifyContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoNotifyContextAvailability_test.cpp
@@ -120,10 +120,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_At0_Ok)
   EXPECT_EQ("OK", res.responseCode.reasonPhrase);
   EXPECT_EQ(0, res.responseCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -184,10 +181,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_At0_Ok_XML)
   EXPECT_EQ("OK", res.responseCode.reasonPhrase);
   EXPECT_EQ(0, res.responseCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -248,11 +242,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_At0_Ok_JSON)
   EXPECT_EQ("OK", res.responseCode.reasonPhrase);
   EXPECT_EQ(0, res.responseCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -310,11 +300,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_At0_Ok)
   EXPECT_EQ("OK", res.responseCode.reasonPhrase);
   EXPECT_EQ(0, res.responseCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -384,11 +370,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_AtN_Ok)
   EXPECT_EQ("OK", res.responseCode.reasonPhrase);
   EXPECT_EQ(0, res.responseCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -458,11 +440,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1_AtNnt_Ok)
   EXPECT_EQ("OK", res.responseCode.reasonPhrase);
   EXPECT_EQ(0, res.responseCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -532,11 +510,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_AtN_Ok)
   EXPECT_EQ("OK", res.responseCode.reasonPhrase);
   EXPECT_EQ(0, res.responseCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -606,9 +580,6 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_En1nt_AtNnt_Ok)
   EXPECT_EQ("OK", res.responseCode.reasonPhrase);
   EXPECT_EQ(0, res.responseCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 
 }
@@ -673,11 +644,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_At0_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -740,11 +707,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_At0_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -819,11 +782,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_AtN_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -898,11 +857,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnN_AtNnt_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -977,11 +932,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_AtN_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1056,11 +1007,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ce1_EnNnt_AtNnt_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1133,11 +1080,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_At0_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1210,11 +1153,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_At0_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1312,11 +1251,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_AtN_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1414,11 +1349,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1_AtNnt_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1516,11 +1447,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_AtN_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1618,11 +1545,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_En1nt_AtNnt_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1706,11 +1629,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_At0_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1794,11 +1713,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_At0_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1906,11 +1821,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_AtN_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2018,11 +1929,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnN_AtNnt_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2130,11 +2037,7 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_AtN_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2242,9 +2145,5 @@ TEST(mongoNotifyContextAvailabilityRequest, ceN_EnNnt_AtNnt_Ok)
     EXPECT_EQ("OK", res.responseCode.reasonPhrase);
     EXPECT_EQ(0, res.responseCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }

--- a/test/unittests/mongoBackend/mongoNotifyContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoNotifyContext_test.cpp
@@ -312,11 +312,8 @@ TEST(mongoNotifyContextRequest, Ent1Attr1)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -462,11 +459,8 @@ TEST(mongoNotifyContextRequest, Ent1AttrN)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -615,11 +609,8 @@ TEST(mongoNotifyContextRequest, EntNAttr1)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -772,11 +763,8 @@ TEST(mongoNotifyContextRequest, EntNAttrN)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -936,10 +924,7 @@ TEST(mongoNotifyContextRequest, createEntity)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete timerMock;
-
 }
 

--- a/test/unittests/mongoBackend/mongoOntimeintervalOperations_test.cpp
+++ b/test/unittests/mongoBackend/mongoOntimeintervalOperations_test.cpp
@@ -280,6 +280,7 @@ TEST(mongoOntimeintervalOperations, mongoGetContextSubscriptionInfo_dbfail)
 
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Do operation */
@@ -291,8 +292,10 @@ TEST(mongoOntimeintervalOperations, mongoGetContextSubscriptionInfo_dbfail)
               "- findOne(): { _id: ObjectId('51307b66f481db11bf860001') } "
               "- exception: boom!!)", err);
 
-    /* Release mock */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
+    /* Release mocks */
     delete connectionMock;
 }
 
@@ -510,6 +513,7 @@ TEST(mongoOntimeintervalOperations, mongoGetContextElementResponses_dbfail)
 
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Do operation */
@@ -522,8 +526,10 @@ TEST(mongoOntimeintervalOperations, mongoGetContextElementResponses_dbfail)
               "attrNames: { $in: [ \"A1\", \"A2\", \"A3\", \"A4\" ] } }, orderby: { creDate: 1 } } - "
               "exception: boom!!)", err);
 
-    /* Release mock */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
+    /* Release mocks */
     delete connectionMock;
 }
 
@@ -633,7 +639,7 @@ TEST(mongoOntimeintervalOperations, mongoUpdateCsubNewNotification_dbfail)
     /* Set MongoDB connection (prepare database first with the "actual" connection object)
      * Note that we preserve the "actual" connection for future database checking */
     prepareDatabase();
-    DBClientBase* connection = getMongoConnection();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Do operation */
@@ -650,15 +656,17 @@ TEST(mongoOntimeintervalOperations, mongoUpdateCsubNewNotification_dbfail)
     // Sleeping a little to "give mongod time to process its input".
     usleep(1000);
 
-    BSONObj sub1 = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    BSONObj sub2 = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
+    BSONObj sub1 = connectionDb->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
+    BSONObj sub2 = connectionDb->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(20000000, sub1.getIntField("lastNotification"));
     EXPECT_EQ(20, sub1.getIntField("count"));
     EXPECT_EQ(30000000, sub2.getIntField("lastNotification"));
     EXPECT_EQ(30, sub2.getIntField("count"));
 
-    /* Release mocks */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
+    /* Release mocks */    
     delete timerMock;
     delete connectionMock;
 }

--- a/test/unittests/mongoBackend/mongoQueryContextFilterExistEntity_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContextFilterExistEntity_test.cpp
@@ -148,8 +148,6 @@ TEST(mongoQueryContextExistEntity, entityTypeWithoutFilter)
     EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
  
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -203,9 +201,6 @@ TEST(mongoQueryContextExistEntity, entityTypeFilterExist)
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -258,10 +253,6 @@ TEST(mongoQueryContextExistEntity, entityTypeFilterNotExist)
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 
   utExit();
 }

--- a/test/unittests/mongoBackend/mongoQueryContextGeo_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContextGeo_test.cpp
@@ -250,8 +250,6 @@ TEST(mongoQueryContextGeoRequest, queryGeoCircleIn1)
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -366,9 +364,6 @@ TEST(mongoQueryContextGeoRequest, queryGeoCircleIn2)
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -441,9 +436,6 @@ TEST(mongoQueryContextGeoRequest, queryGeoCircleOut)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -540,9 +532,6 @@ TEST(mongoQueryContextGeoRequest, queryGeoPolygonIn1)
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -638,9 +627,6 @@ TEST(mongoQueryContextGeoRequest, queryGeoPolygonIn2)
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -713,9 +699,6 @@ TEST(mongoQueryContextGeoRequest, queryGeoPolygonIn3)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -791,9 +774,6 @@ TEST(mongoQueryContextGeoRequest, queryGeoPolygonOut1)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -889,9 +869,6 @@ TEST(mongoQueryContextGeoRequest, queryGeoPolygonOut2)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }

--- a/test/unittests/mongoBackend/mongoQueryContext_filters_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_filters_test.cpp
@@ -294,9 +294,6 @@ TEST(mongoQueryContextRequest_filters, equalToOne_s)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -336,9 +333,6 @@ TEST(mongoQueryContextRequest_filters, equalToOne_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -391,9 +385,6 @@ TEST(mongoQueryContextRequest_filters, equalToMulti_s)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -434,9 +425,6 @@ TEST(mongoQueryContextRequest_filters, equalToMulti_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -489,9 +477,6 @@ TEST(mongoQueryContextRequest_filters, unequalToOne_s)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -534,9 +519,6 @@ TEST(mongoQueryContextRequest_filters, unequalToOne_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -588,9 +570,6 @@ TEST(mongoQueryContextRequest_filters, unequalToMany_s)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -632,9 +611,6 @@ TEST(mongoQueryContextRequest_filters, unequalToMany_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -687,9 +663,6 @@ TEST(mongoQueryContextRequest_filters, greaterThan_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -741,9 +714,6 @@ TEST(mongoQueryContextRequest_filters, greaterThanOrEqual_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -796,9 +766,6 @@ TEST(mongoQueryContextRequest_filters, lesserThan_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -850,9 +817,6 @@ TEST(mongoQueryContextRequest_filters, lesserThanOrEqual_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -904,9 +868,6 @@ TEST(mongoQueryContextRequest_filters, insideRange_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -959,9 +920,6 @@ TEST(mongoQueryContextRequest_filters, outsideRange_n)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -1016,9 +974,6 @@ TEST(mongoQueryContextRequest_filters, withAttribute)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -1063,9 +1018,6 @@ TEST(mongoQueryContextRequest_filters, withoutAttribute)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -1113,9 +1065,6 @@ TEST(mongoQueryContextRequest_filters, withEntityType)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -1156,9 +1105,6 @@ TEST(mongoQueryContextRequest_filters, withoutEntityType)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -1199,9 +1145,6 @@ TEST(mongoQueryContextRequest_filters, stringsWithCommas)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -1241,9 +1184,6 @@ TEST(mongoQueryContextRequest_filters, cobingingSeveralFilters)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -1284,9 +1224,6 @@ TEST(mongoQueryContextRequest_filters, repeatSameFilter)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -1327,8 +1264,5 @@ TEST(mongoQueryContextRequest_filters, rangeWithDecimals)
 
   /* Release dynamic memory used by response (mongoBackend allocates it) */
   res.contextElementResponseVector.release();
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 }
 

--- a/test/unittests/mongoBackend/mongoQueryContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_test.cpp
@@ -682,8 +682,6 @@ TEST(mongoQueryContextRequest, paginationDetails)
     EXPECT_EQ("OK", RES_CER_STATUS(5).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(5).details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -792,9 +790,6 @@ TEST(mongoQueryContextRequest, paginationAll)
     EXPECT_EQ("OK", RES_CER_STATUS(5).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(5).details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -842,9 +837,6 @@ TEST(mongoQueryContextRequest, paginationOnlyFirst)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -894,9 +886,6 @@ TEST(mongoQueryContextRequest, paginationOnlySecond)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -971,9 +960,6 @@ TEST(mongoQueryContextRequest, paginationRange)
     EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -1011,9 +997,6 @@ TEST(mongoQueryContextRequest, paginationNonExisting)
     EXPECT_EQ("", res.errorCode.details);
 
     ASSERT_EQ(0, res.contextElementResponseVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -1064,9 +1047,6 @@ TEST(mongoQueryContextRequest, paginationNonExistingOverlap)
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -1105,9 +1085,6 @@ TEST(mongoQueryContextRequest, paginationNonExistingDetails)
     EXPECT_EQ("Number of matching entities: 6. Offset is 7", res.errorCode.details);
 
     ASSERT_EQ(0, res.contextElementResponseVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -1180,9 +1157,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_2levels)
   EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
   EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 
   utExit();
 }
@@ -1292,9 +1266,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_1level)
   EXPECT_EQ("OK", RES_CER_STATUS(5).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(5).details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -1380,9 +1351,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_0levels)
   EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -1442,9 +1410,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_1levelbis)
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 
   utExit();
 }
@@ -1516,9 +1481,6 @@ TEST(mongoQueryContextRequest, queryWithIdenticalEntitiesButDifferentServicePath
   EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -1567,9 +1529,6 @@ TEST(mongoQueryContextRequest, queryWithIdenticalEntitiesButDifferentServicePath
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -1617,9 +1576,6 @@ TEST(mongoQueryContextRequest, queryWithIdenticalEntitiesButDifferentServicePath
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
  
   utExit();
 }
@@ -1669,9 +1625,6 @@ TEST(mongoQueryContextRequest, queryWithIdenticalEntitiesButDifferentServicePath
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 
   utExit();
 }
@@ -1755,10 +1708,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_2levels)
   EXPECT_EQ("ae_1", RES_CER_ATTR(3, 0)->stringValue);
   EXPECT_EQ(SccOk, RES_CER_STATUS(3).code);
   EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
-  EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
+  EXPECT_EQ(0, RES_CER_STATUS(3).details.size());  
   
   utExit();
 }
@@ -1880,9 +1830,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_1level)
   EXPECT_EQ("OK", RES_CER_STATUS(6).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(6).details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -1968,9 +1915,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_0levels)
   EXPECT_EQ("OK", RES_CER_STATUS(3).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(3).details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -2031,9 +1975,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_1levelbis)
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -2069,9 +2010,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntNoPatternTypeFail)
   EXPECT_EQ("", res.errorCode.details);
 
   EXPECT_EQ(0, res.contextElementResponseVector.size());
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 
   utExit();
 }
@@ -2120,10 +2058,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntNoPatternTypeOk)
   EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
   EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
   EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
 
   utExit();
 }
@@ -2184,10 +2118,6 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntNoPatternNoType)
   EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
 
   utExit();
 }
@@ -2251,9 +2181,6 @@ TEST(mongoQueryContextRequest, queryWithSeveralServicePaths)
   EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
   EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -2310,8 +2237,6 @@ TEST(mongoQueryContextRequest, query1Ent0Attr)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -2357,10 +2282,6 @@ TEST(mongoQueryContextRequest, query1Ent1Attr)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -2428,9 +2349,7 @@ TEST(mongoQueryContextRequest, queryNEnt0Attr)
     EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
-    res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
+    res.contextElementResponseVector.release();    
 }
 
 /* ****************************************************************************
@@ -2481,9 +2400,6 @@ TEST(mongoQueryContextRequest, queryNEnt1AttrSingle)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -2547,9 +2463,6 @@ TEST(mongoQueryContextRequest, queryNEnt1AttrMulti)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -2615,9 +2528,6 @@ TEST(mongoQueryContextRequest, queryNEntNAttr)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -2653,9 +2563,6 @@ TEST(mongoQueryContextRequest, query1Ent0AttrFail)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -2693,9 +2600,6 @@ TEST(mongoQueryContextRequest, query1Ent1AttrFail)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 
@@ -2733,9 +2637,6 @@ TEST(mongoQueryContextRequest, query1EntWA0AttrFail)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -2780,10 +2681,6 @@ TEST(mongoQueryContextRequest, query1EntWA1Attr)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
 }
 
 /* ****************************************************************************
@@ -2846,9 +2743,6 @@ TEST(mongoQueryContextRequest, queryNEntWA0Attr)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -2896,10 +2790,6 @@ TEST(mongoQueryContextRequest, queryNEntWA1Attr)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -2975,9 +2865,6 @@ TEST(mongoQueryContextRequest, queryNoType)
     EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
     EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3032,10 +2919,6 @@ TEST(mongoQueryContextRequest, queryIdMetadata)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3086,10 +2969,6 @@ TEST(mongoQueryContextRequest, queryCustomMetadata)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 
@@ -3147,10 +3026,6 @@ TEST(mongoQueryContextRequest, queryCustomMetadataNative)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 
@@ -3219,9 +3094,6 @@ TEST(mongoQueryContextRequest, queryPattern0Attr)
     EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
     EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3267,10 +3139,6 @@ TEST(mongoQueryContextRequest, queryPattern1AttrSingle)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3329,9 +3197,6 @@ TEST(mongoQueryContextRequest, queryPattern1AttrMulti)
     EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
     EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3394,9 +3259,6 @@ TEST(mongoQueryContextRequest, queryPatternNAttr)
     EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
     EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3508,9 +3370,6 @@ TEST(mongoQueryContextRequest, queryMixPatternAndNotPattern)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3610,9 +3469,6 @@ TEST(mongoQueryContextRequest, queryNoTypePattern)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3694,10 +3550,6 @@ TEST(mongoQueryContextRequest, queryIdMetadataPattern)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3767,10 +3619,6 @@ TEST(mongoQueryContextRequest, queryCustomMetadataPattern)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 }
 
 /* ****************************************************************************
@@ -3855,8 +3703,6 @@ TEST(mongoQueryContextRequest, queryNativeTypes)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 }
 
 /* ****************************************************************************
@@ -3877,6 +3723,7 @@ TEST(mongoQueryContextRequest, mongoDbQueryFail)
             .WillByDefault(Throw(e));
 
     /* Set MongoDB connection */
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3899,7 +3746,9 @@ TEST(mongoQueryContextRequest, mongoDbQueryFail)
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();    
 
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
     /* Release mock */
-    setMongoConnectionForUnitTest(NULL);
     delete connectionMock;
 }

--- a/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
@@ -298,8 +298,6 @@ TEST(mongoQueryTypes, queryAllType)
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -417,9 +415,6 @@ TEST(mongoQueryTypes, queryAllPaginationDetails)
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -539,9 +534,6 @@ TEST(mongoQueryTypes, queryAllPaginationAll)
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -615,9 +607,6 @@ TEST(mongoQueryTypes, queryAllPaginationOnlyFirst)
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -670,9 +659,6 @@ TEST(mongoQueryTypes, queryAllPaginationOnlySecond)
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -753,9 +739,6 @@ TEST(mongoQueryTypes, queryAllPaginationRange)
     EXPECT_EQ(NULL, ca->compoundValueP);
     EXPECT_EQ(0, ca->metadataVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -788,9 +771,6 @@ TEST(mongoQueryTypes, queryAllPaginationNonExisting)
     EXPECT_EQ("", res.statusCode.details);
 
     ASSERT_EQ(0, res.entityTypeVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -850,10 +830,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingOverlap)
     EXPECT_EQ("pos_T", ca->type);
     EXPECT_EQ("", ca->stringValue);
     EXPECT_EQ(NULL, ca->compoundValueP);
-    EXPECT_EQ(0, ca->metadataVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
+    EXPECT_EQ(0, ca->metadataVector.size());    
 
     utExit();
 }
@@ -888,9 +865,6 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingDetails)
 
     ASSERT_EQ(0, res.entityTypeVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -913,6 +887,7 @@ TEST(mongoQueryTypes, queryAllDbException)
   utInit();
 
   /* Set MongoDB connection */
+  DBClientBase* connectionDb = getMongoConnection();
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
@@ -927,9 +902,11 @@ TEST(mongoQueryTypes, queryAllDbException)
             "- exception: boom!!)", res.statusCode.details);
   EXPECT_EQ(0,res.entityTypeVector.size());
 
+  /* Restore real DB connection */
+  setMongoConnectionForUnitTest(connectionDb);
+
   /* Release mock */
-  delete connectionMock;
-  setMongoConnectionForUnitTest(NULL);
+  delete connectionMock;  
 
   utExit();
 
@@ -954,6 +931,7 @@ TEST(mongoQueryTypes, queryAllGenericException)
   utInit();
 
   /* Set MongoDB connection */
+  DBClientBase* connectionDb = getMongoConnection();
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
@@ -969,9 +947,12 @@ TEST(mongoQueryTypes, queryAllGenericException)
             "- exception: generic)", res.statusCode.details);
   EXPECT_EQ(0,res.entityTypeVector.size());
 
+  /* Restore real DB connection */
+  setMongoConnectionForUnitTest(connectionDb);
+
   /* Release mock */
   delete connectionMock;
-  setMongoConnectionForUnitTest(NULL);
+
   utExit();
 
 }
@@ -1038,9 +1019,6 @@ TEST(mongoQueryTypes, queryGivenTypeBasic)
     EXPECT_EQ("", res.entityType.contextAttributeVector.get(4)->stringValue);
     EXPECT_EQ(NULL, res.entityType.contextAttributeVector.get(4)->compoundValueP);
     EXPECT_EQ(0, res.entityType.contextAttributeVector.get(4)->metadataVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -1110,9 +1088,6 @@ TEST(mongoQueryTypes, queryGivenTypePaginationDetails)
     EXPECT_EQ(NULL, res.entityType.contextAttributeVector.get(4)->compoundValueP);
     EXPECT_EQ(0, res.entityType.contextAttributeVector.get(4)->metadataVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -1181,9 +1156,6 @@ TEST(mongoQueryTypes, queryGivenTypePaginationAll)
     EXPECT_EQ(NULL, res.entityType.contextAttributeVector.get(4)->compoundValueP);
     EXPECT_EQ(0, res.entityType.contextAttributeVector.get(4)->metadataVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -1222,9 +1194,6 @@ TEST(mongoQueryTypes, queryGivenTypePaginationOnlyFirst)
     EXPECT_EQ("", res.entityType.contextAttributeVector.get(0)->stringValue);
     EXPECT_EQ(NULL, res.entityType.contextAttributeVector.get(0)->compoundValueP);
     EXPECT_EQ(0, res.entityType.contextAttributeVector.get(0)->metadataVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -1266,9 +1235,6 @@ TEST(mongoQueryTypes, queryGivenTypePaginationOnlySecond)
     EXPECT_EQ("", res.entityType.contextAttributeVector.get(0)->stringValue);
     EXPECT_EQ(NULL, res.entityType.contextAttributeVector.get(0)->compoundValueP);
     EXPECT_EQ(0, res.entityType.contextAttributeVector.get(0)->metadataVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -1325,9 +1291,6 @@ TEST(mongoQueryTypes, queryGivenTypePaginationRange)
     EXPECT_EQ(NULL, res.entityType.contextAttributeVector.get(2)->compoundValueP);
     EXPECT_EQ(0, res.entityType.contextAttributeVector.get(2)->metadataVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -1360,9 +1323,6 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExisting)
     EXPECT_EQ("", res.statusCode.details);
 
     ASSERT_EQ(0, res.entityType.contextAttributeVector.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -1412,9 +1372,6 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingOverlap)
     EXPECT_EQ(NULL, res.entityType.contextAttributeVector.get(1)->compoundValueP);
     EXPECT_EQ(0, res.entityType.contextAttributeVector.get(1)->metadataVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -1448,9 +1405,6 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingDetails)
 
     ASSERT_EQ(0, res.entityType.contextAttributeVector.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -1473,6 +1427,7 @@ TEST(mongoQueryTypes, queryGivenTypeDbException)
   utInit();
 
   /* Set MongoDB connection */
+  DBClientBase* connectionDb = getMongoConnection();
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
@@ -1488,9 +1443,11 @@ TEST(mongoQueryTypes, queryGivenTypeDbException)
             "- exception: boom!!)", res.statusCode.details);
   EXPECT_EQ(0,res.entityType.contextAttributeVector.size());
 
+  /* Restore real DB connection */
+  setMongoConnectionForUnitTest(connectionDb);
+
   /* Release mock */
-  delete connectionMock;
-  setMongoConnectionForUnitTest(NULL);
+  delete connectionMock;  
 
   utExit();
 }
@@ -1514,6 +1471,7 @@ TEST(mongoQueryTypes, queryGivenTypeGenericException)
   utInit();
 
   /* Set MongoDB connection */
+  DBClientBase* connectionDb = getMongoConnection();
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
@@ -1529,9 +1487,11 @@ TEST(mongoQueryTypes, queryGivenTypeGenericException)
             "- exception: generic)", res.statusCode.details);
   EXPECT_EQ(0,res.entityType.contextAttributeVector.size());
 
+  /* Restore real DB connection */
+  setMongoConnectionForUnitTest(connectionDb);
+
   /* Release mock */
-  delete connectionMock;
-  setMongoConnectionForUnitTest(NULL);
+  delete connectionMock; 
 
   utExit();
 }

--- a/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
@@ -179,10 +179,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_At0_Ok)
   EXPECT_EQ("OK", res.errorCode.reasonPhrase);
   EXPECT_EQ(0, res.errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -247,10 +244,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_At0_Ok_XML)
   EXPECT_EQ("OK", res.errorCode.reasonPhrase);
   EXPECT_EQ(0, res.errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -315,10 +309,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_At0_Ok_JSON)
   EXPECT_EQ("OK", res.errorCode.reasonPhrase);
   EXPECT_EQ(0, res.errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -381,10 +372,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_At0_Ok)
   EXPECT_EQ("OK", res.errorCode.reasonPhrase);
   EXPECT_EQ(0, res.errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -459,10 +447,7 @@ TEST(mongoRegisterContextRequest, ce1_En1_AtN_Ok)
   EXPECT_EQ("OK", res.errorCode.reasonPhrase);
   EXPECT_EQ(0, res.errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -537,8 +522,6 @@ TEST(mongoRegisterContextRequest, ce1_En1_AtNnt_Ok)
   EXPECT_EQ("OK", res.errorCode.reasonPhrase);
   EXPECT_EQ(0, res.errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
 
 }
@@ -606,10 +589,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_AtN_Ok)
   EXPECT_STREQ("TA2", C_STR_FIELD(rattr1, "type"));
   EXPECT_STREQ("true", C_STR_FIELD(rattr1, "isDomain"));
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -684,10 +664,7 @@ TEST(mongoRegisterContextRequest, ce1_En1nt_AtNnt_Ok)
   EXPECT_EQ("OK", res.errorCode.reasonPhrase);
   EXPECT_EQ(0, res.errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -755,10 +732,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_At0_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -826,10 +800,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_At0_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -910,10 +881,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_AtN_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -994,10 +962,7 @@ TEST(mongoRegisterContextRequest, ce1_EnN_AtNnt_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1078,10 +1043,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_AtN_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1162,10 +1124,7 @@ TEST(mongoRegisterContextRequest, ce1_EnNnt_AtNnt_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1242,10 +1201,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_At0_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1322,10 +1278,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_At0_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1427,10 +1380,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_AtN_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1532,10 +1482,7 @@ TEST(mongoRegisterContextRequest, ceN_En1_AtNnt_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1637,10 +1584,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_AtN_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1742,10 +1686,7 @@ TEST(mongoRegisterContextRequest, ceN_En1nt_AtNnt_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1833,10 +1774,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_At0_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1924,10 +1862,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_At0_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2039,10 +1974,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_AtN_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2154,10 +2086,7 @@ TEST(mongoRegisterContextRequest, ceN_EnN_AtNnt_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2269,10 +2198,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_AtN_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2384,10 +2310,7 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_AtNnt_Ok)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 
@@ -2447,13 +2370,9 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability1)
   /* The only collection affected by this operation is registrations, which has been extensively
    * testbed by other unit tests, so we don't include checking in the present unit test */
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   /* Delete mock */
   delete timerMock;
   delete notifierMock;
-
 }
 
 /* ****************************************************************************
@@ -2519,12 +2438,9 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability2)
   /* The only collection affected by this operation is registrations, which has been extensively
    * testbed by other unit tests, so we don't include checking in the present unit test */
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   /* Delete mock */
   delete timerMock;
   delete notifierMock;
-
 }
 
 /* ****************************************************************************
@@ -2587,8 +2503,6 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability3)
   /* The only collection affected by this operation is registrations, which has been extensively
    * testbed by other unit tests, so we don't include checking in the present unit test */
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   /* Delete mock */
   delete timerMock;
   delete notifierMock;
@@ -2654,10 +2568,7 @@ TEST(mongoRegisterContextRequest, defaultDuration)
   EXPECT_EQ("OK", res.errorCode.reasonPhrase);
   EXPECT_EQ(0, res.errorCode.details.size());
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
   utExit();
-
 }
 
 /* ****************************************************************************
@@ -2698,7 +2609,7 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
     req.duration.set("PT1M");
 
     /* Set MongoDB connection mock (preserving the "actual" connection for later use) */
-    DBClientBase* connection = getMongoConnection();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
@@ -2724,16 +2635,16 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
     EXPECT_EQ("'), expiration: 1360232760, servicePath: \"/\", format: \"XML\", contextRegistration: [ { entities: [ { id: \"E1\", type: \"T1\" } ], attrs: [], providingApplication: \"http://dummy.com\" } ] }> "
               "- exception: boom!!)", s3);
 
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
     /* Release mock */
-    setMongoConnectionForUnitTest(NULL);
     delete connectionMock;
 
     /* check collection has not been touched */    
-    EXPECT_EQ(0, connection->count(REGISTRATIONS_COLL, BSONObj()));
-    EXPECT_EQ(0, connection->count(ENTITIES_COLL, BSONObj()));
+    EXPECT_EQ(0, connectionDb->count(REGISTRATIONS_COLL, BSONObj()));
+    EXPECT_EQ(0, connectionDb->count(ENTITIES_COLL, BSONObj()));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 
 }

--- a/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
@@ -380,13 +380,9 @@ TEST(mongoSubscribeContextAvailability, Ent1_Attr0_noPattern)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -458,12 +454,9 @@ TEST(mongoSubscribeContextAvailability, Ent1_Attr0_noPattern_JSON)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -536,12 +529,9 @@ TEST(mongoSubscribeContextAvailability, Ent1_AttrN_noPattern)
     EXPECT_EQ("A1", attrs[0].String());
     EXPECT_EQ("A2", attrs[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -616,12 +606,9 @@ TEST(mongoSubscribeContextAvailability, EntN_Attr0_noPattern)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -700,8 +687,6 @@ TEST(mongoSubscribeContextAvailability, EntN_AttrN_noPattern)
     EXPECT_EQ("A1", attrs[0].String());
     EXPECT_EQ("A2", attrs[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -777,12 +762,9 @@ TEST(mongoSubscribeContextAvailability, Ent1_Attr0_pattern)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -867,12 +849,9 @@ TEST(mongoSubscribeContextAvailability, noPatternAttrsAll)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -959,12 +938,9 @@ TEST(mongoSubscribeContextAvailability, noPatternAttrsAll_JSON)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1047,12 +1023,9 @@ TEST(mongoSubscribeContextAvailability, noPatternAttrOneSingle)
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A4", attrs[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1144,12 +1117,9 @@ TEST(mongoSubscribeContextAvailability, noPatternAttrOneMulti)
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A1", attrs[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 
@@ -1237,8 +1207,6 @@ TEST(mongoSubscribeContextAvailability, noPatternAttrsSubset)
     EXPECT_EQ("A1", attrs[0].String());
     EXPECT_EQ("A2", attrs[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1333,8 +1301,6 @@ TEST(mongoSubscribeContextAvailability, noPatternSeveralCREs)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1428,8 +1394,6 @@ TEST(mongoSubscribeContextAvailability, noPatternSeveralRegistrations)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1538,8 +1502,6 @@ TEST(mongoSubscribeContextAvailability, noPatternMultiEntity)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1635,8 +1597,6 @@ TEST(mongoSubscribeContextAvailability, noPatternMultiAttr)
     EXPECT_EQ("A4", attrs[1].String());
     EXPECT_EQ("A5", attrs[2].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1745,8 +1705,6 @@ TEST(mongoSubscribeContextAvailability, noPatternMultiEntityAttrs)
     EXPECT_EQ("A4", attrs[1].String());
     EXPECT_EQ("A5", attrs[2].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1853,8 +1811,6 @@ TEST(mongoSubscribeContextAvailability, noPatternNoType)
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A1", attrs[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1954,8 +1910,6 @@ TEST(mongoSubscribeContextAvailability, pattern0Attr)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2040,8 +1994,6 @@ TEST(mongoSubscribeContextAvailability, pattern1AttrSingle)
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A4", attrs[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2133,8 +2085,6 @@ TEST(mongoSubscribeContextAvailability, pattern1AttrMulti)
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A1", attrs[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2235,8 +2185,6 @@ TEST(mongoSubscribeContextAvailability, patternNAttr)
     EXPECT_EQ("A1", attrs[0].String());
     EXPECT_EQ("A2", attrs[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2345,8 +2293,6 @@ TEST(mongoSubscribeContextAvailability, patternNoType)
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A2", attrs[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2456,8 +2402,6 @@ TEST(mongoSubscribeContextAvailability, mixPatternAndNotPattern)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2529,9 +2473,6 @@ TEST(mongoSubscribeContextAvailability, defaultDuration)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2573,7 +2514,7 @@ TEST(mongoSubscribeContextAvailability, MongoDbInsertFail)
     /* Set MongoDB connection (prepare database first with the "actual" connection object).
      * The "actual" conneciton is preserved for later use */
     prepareDatabase();
-    DBClientBase* connection = getMongoConnection();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
@@ -2592,13 +2533,15 @@ TEST(mongoSubscribeContextAvailability, MongoDbInsertFail)
     EXPECT_EQ("'), expiration: 1360236300, reference: \"http://notify.me\", entities: [ { id: \"E5\", type: \"T5\", isPattern: \"false\" } ], attrs: [], format: \"XML\" } "
               "- exception: boom!!)", s2);
 
-    /* Release mocks */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
+    /* Release mocks */    
     delete notifierMock;
     delete connectionMock;
     delete timerMock;
 
     /* Check actual database has not been touched */
-    ASSERT_EQ(0, connection->count(SUBSCRIBECONTEXTAVAIL_COLL, BSONObj()));
+    ASSERT_EQ(0, connectionDb->count(SUBSCRIBECONTEXTAVAIL_COLL, BSONObj()));
 
 }

--- a/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
@@ -392,14 +392,10 @@ TEST(mongoSubscribeContext, Ent1_Attr0_T1_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -483,14 +479,10 @@ TEST(mongoSubscribeContext, Ent1_Attr0_T1_C0_JSON)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -575,10 +567,6 @@ TEST(mongoSubscribeContext, Ent1_AttrN_T1_C0)
     BSONObj cond0 = conds[0].embeddedObject();
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -672,18 +660,12 @@ TEST(mongoSubscribeContext, Ent1_Attr0_TN_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
-    EXPECT_EQ(120, cond1.getIntField("value"));
-
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
+    EXPECT_EQ(120, cond1.getIntField("value"));  
 
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -777,15 +759,10 @@ TEST(mongoSubscribeContext, Ent1_AttrN_TN_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
     EXPECT_EQ(120, cond1.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -869,14 +846,10 @@ TEST(mongoSubscribeContext, Ent1_Attr0_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -964,16 +937,12 @@ TEST(mongoSubscribeContext, Ent1_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * Ent1_Attr0_T0_CN -
@@ -1064,15 +1033,12 @@ TEST(mongoSubscribeContext, Ent1_Attr0_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-    
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * Ent1_Attr0_T0_CNbis -
@@ -1154,18 +1120,14 @@ TEST(mongoSubscribeContext, Ent1_Attr0_T0_CNbis)
     std::vector<BSONElement> condValues = cond0.getField("value").Array();
     ASSERT_EQ(2, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
-    EXPECT_EQ("A20", condValues[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
+    EXPECT_EQ("A20", condValues[1].String());   
 
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 *  Ent1_AttrN_T0_CN -
@@ -1261,16 +1223,12 @@ TEST(mongoSubscribeContext, Ent1_AttrN_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * Ent1_AttrN_T0_CNbis -
@@ -1358,15 +1316,12 @@ TEST(mongoSubscribeContext, Ent1_AttrN_T0_CNbis)
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 *  Ent1_Attr0_TN_CN -
@@ -1471,16 +1426,12 @@ TEST(mongoSubscribeContext, Ent1_Attr0_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * Ent1_Attr0_TN_CNbis -
@@ -1576,18 +1527,14 @@ TEST(mongoSubscribeContext, Ent1_Attr0_TN_CNbis)
     std::vector<BSONElement> condValues = cond2.getField("value").Array();
     ASSERT_EQ(2, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
-    EXPECT_EQ("A20", condValues[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
+    EXPECT_EQ("A20", condValues[1].String());   
 
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * Ent1_AttrN_TN_CN -
@@ -1696,16 +1643,12 @@ TEST(mongoSubscribeContext, Ent1_AttrN_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * Ent1_AttrN_TN_CNbis -
@@ -1807,14 +1750,10 @@ TEST(mongoSubscribeContext, Ent1_AttrN_TN_CNbis)
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1902,15 +1841,10 @@ TEST(mongoSubscribeContext, EntN_Attr0_T1_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2002,14 +1936,10 @@ TEST(mongoSubscribeContext, EntN_AttrN_T1_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2105,15 +2035,10 @@ TEST(mongoSubscribeContext, EntN_Attr0_TN_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
     EXPECT_EQ(120, cond1.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2213,14 +2138,10 @@ TEST(mongoSubscribeContext, EntN_AttrN_TN_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
     EXPECT_EQ(120, cond1.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2310,14 +2231,10 @@ TEST(mongoSubscribeContext, EntN_Attr0_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2411,15 +2328,12 @@ TEST(mongoSubscribeContext, EntN_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * EntN_Attr0_T0_CN -
@@ -2516,16 +2430,12 @@ TEST(mongoSubscribeContext, EntN_Attr0_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * EntN_Attr0_T0_CNbis -
@@ -2615,15 +2525,12 @@ TEST(mongoSubscribeContext, EntN_Attr0_T0_CNbis)
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * EntN_AttrN_T0_CN -
@@ -2724,15 +2631,12 @@ TEST(mongoSubscribeContext, EntN_AttrN_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * EntN_AttrN_T0_CNbis -
@@ -2826,15 +2730,12 @@ TEST(mongoSubscribeContext, EntN_AttrN_T0_CNbis)
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 *  EntN_Attr0_TN_CN -
@@ -2945,15 +2846,12 @@ TEST(mongoSubscribeContext, EntN_Attr0_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * EntN_Attr0_TN_CNbis -
@@ -3057,16 +2955,12 @@ TEST(mongoSubscribeContext, EntN_Attr0_TN_CNbis)
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
 
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * EntN_AttrN_TN_CN -
@@ -3181,22 +3075,18 @@ TEST(mongoSubscribeContext, EntN_AttrN_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * EntN_AttrN_TN_CNbis -
 */
 TEST(mongoSubscribeContext, EntN_AttrN_TN_CNbis)
 {
-
     HttpStatusCode           ms;
     SubscribeContextRequest  req;
     SubscribeContextResponse res;    
@@ -3297,14 +3187,10 @@ TEST(mongoSubscribeContext, EntN_AttrN_TN_CNbis)
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3387,14 +3273,10 @@ TEST(mongoSubscribeContext, Ent1_Attr0_T1_C0_throttling)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3481,14 +3363,10 @@ TEST(mongoSubscribeContext, Ent1_AttrN_T1_C0_throttling)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3577,14 +3455,10 @@ TEST(mongoSubscribeContext, EntN_Attr0_T1_C0_throttling)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3677,14 +3551,10 @@ TEST(mongoSubscribeContext, EntN_AttrN_T1_C0_throttling)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3780,14 +3650,10 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3884,14 +3750,10 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_T0_C1_JSON)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3988,14 +3850,10 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4093,14 +3951,10 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_T0_C1_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4212,14 +4066,10 @@ TEST(mongoSubscribeContext, matchEnt1NoType_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4331,15 +4181,10 @@ TEST(mongoSubscribeContext, matchEnt1NoType_AttrN_T0_C1_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
 
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4444,14 +4289,10 @@ TEST(mongoSubscribeContext, matchEnt1Pattern_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4556,14 +4397,10 @@ TEST(mongoSubscribeContext, matchEnt1Pattern_AttrN_T0_C1_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4680,14 +4517,10 @@ TEST(mongoSubscribeContext, matchEnt1PatternNoType_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4804,14 +4637,10 @@ TEST(mongoSubscribeContext, matchEnt1PatternNoType_AttrN_T0_C1_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4916,14 +4745,10 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5028,14 +4853,10 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_T0_CN_partial)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A5", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 
@@ -5133,14 +4954,10 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_T0_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5247,15 +5064,10 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_T0_CN_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5362,14 +5174,10 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_T0_CN_partial)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A5", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5476,14 +5284,10 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_T0_CN_partial_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A5", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5583,15 +5387,12 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_T0_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 *  matchEnt1_Attr0_TN_CN -
@@ -5708,15 +5509,12 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEnt1_Attr0_TN_CNbis -
@@ -5826,15 +5624,12 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_TN_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEnt1_AttrN_TN_CN -
@@ -5953,15 +5748,12 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEnt1_AttrN_TN_CNbis -
@@ -6073,14 +5865,10 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_TN_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -6190,14 +5978,10 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -6307,15 +6091,12 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_Attr0_T0_CN -
@@ -6432,15 +6213,12 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_Attr0_T0_CNbis -
@@ -6550,15 +6328,12 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_T0_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_AttrN_T0_CN -
@@ -6675,15 +6450,12 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_AttrN_T0_CNbis -
@@ -6791,15 +6563,13 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_T0_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
 
 }
+
 /* ****************************************************************************
 *
 *  matchEntN_Attr0_TN_CN -
@@ -6928,14 +6698,10 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 /* ****************************************************************************
 *
@@ -7058,15 +6824,12 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_TN_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_AttrN_TN_CN -
@@ -7195,15 +6958,12 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matcnEntN_AttrN_TN_CNbis -
@@ -7325,14 +7085,10 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_TN_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -7413,14 +7169,10 @@ TEST(mongoSubscribeContext, defaultDuration)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -7466,7 +7218,7 @@ TEST(mongoSubscribeContext, MongoDbInsertFail)
     /* Set MongoDB connection (prepare database first with the "actual" connection object).
      * The "actual" conneciton is preserved for later use */
     prepareDatabase();
-    DBClientBase* connection = getMongoConnection();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
@@ -7485,14 +7237,15 @@ TEST(mongoSubscribeContext, MongoDbInsertFail)
     EXPECT_EQ("'), expiration: 1360236300, reference: \"http://notify.me\", entities: [ { id: \"E1\", type: \"T1\", isPattern: \"false\" } ], attrs: [], conditions: [ { type: \"ONTIMEINTERVAL\", value: 60 } ], format: \"XML\" } "
               "- exception: boom!!)", s2);
 
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
     /* Release mocks */
-    setMongoConnectionForUnitTest(NULL);
     delete notifierMock;
     delete connectionMock;    
 
     /* check collection has not been touched */ 
-    EXPECT_EQ(0, connection->count(SUBSCRIBECONTEXT_COLL, BSONObj()));
+    EXPECT_EQ(0, connectionDb->count(SUBSCRIBECONTEXT_COLL, BSONObj()));
 
     utExit();
-
 }

--- a/test/unittests/mongoBackend/mongoUnsubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoUnsubscribeContextAvailability_test.cpp
@@ -123,9 +123,6 @@ TEST(mongoUnsubscribeContextAvailability, subscriptionNotFound)
     DBClientBase* connection = getMongoConnection();
     ASSERT_EQ(2, connection->count(SUBSCRIBECONTEXTAVAIL_COLL, BSONObj()));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 }
@@ -168,9 +165,6 @@ TEST(mongoUnsubscribeContextAvailability, unsubscribe)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXTAVAIL_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ("51307b66f481db11bf860002", sub.getField("_id").OID().toString());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 }
@@ -204,7 +198,7 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbFindOneFail)
     /* Set MongoDB connection (prepare database first with the "actual" connection object).
      * The "actual" conneciton is preserved for later use */
     prepareDatabase();
-    DBClientBase* connection = getMongoConnection();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
@@ -223,12 +217,14 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbFindOneFail)
     // Without this sleep, this tests fails around 50% of the times (in Ubuntu 13.04)
     usleep(1000);
 
-    int count = connection->count(SUBSCRIBECONTEXTAVAIL_COLL, BSONObj());
+    int count = connectionDb->count(SUBSCRIBECONTEXTAVAIL_COLL, BSONObj());
 
     ASSERT_EQ(2, count);
 
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
     /* Release mocks */
-    setMongoConnectionForUnitTest(NULL);
     delete notifierMock;
     delete connectionMock;
 }
@@ -268,7 +264,7 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbRemoveFail)
     /* Set MongoDB connection (prepare database first with the "actual" connection object).
      * The "actual" conneciton is preserved for later use */
     prepareDatabase();
-    DBClientBase* connection = getMongoConnection();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
@@ -287,10 +283,12 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbRemoveFail)
     // Without this sleep, this tests fails around 50% of the times (in Ubuntu 13.04)
     usleep(1000);
 
-    ASSERT_EQ(2, connection->count(SUBSCRIBECONTEXTAVAIL_COLL, BSONObj()));
+    ASSERT_EQ(2, connectionDb->count(SUBSCRIBECONTEXTAVAIL_COLL, BSONObj()));
 
-    /* Release mocks */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
+    /* Release mocks */    
     delete notifierMock;
     delete connectionMock;
 }

--- a/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
@@ -429,14 +429,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, Ent1_Attr0_noPattern)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -504,14 +499,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, Ent1_Attr0_noPattern_JSON)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -582,14 +572,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, Ent1_AttrN_noPattern)
     EXPECT_EQ("A1", attrs[0].String());
     EXPECT_EQ("A2", attrs[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -662,14 +647,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, EntN_Attr0_noPattern)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -746,9 +726,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, EntN_AttrN_noPattern)
     EXPECT_EQ("A1", attrs[0].String());
     EXPECT_EQ("A2", attrs[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -822,13 +799,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, Ent1_Attr0_pattern)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -912,14 +885,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternAttrsAll)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1003,13 +971,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternAttrsAll_JSON)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1091,13 +1055,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternAttrOneSingle)
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A4", attrs[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1188,13 +1148,9 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternAttrOneMulti)
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A1", attrs[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 
@@ -1280,9 +1236,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternAttrsSubset)
     ASSERT_EQ(2, attrs.size());
     EXPECT_EQ("A1", attrs[0].String());
     EXPECT_EQ("A2", attrs[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -1377,9 +1330,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternSeveralCREs)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1471,9 +1421,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternSeveralRegistrations)
 
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -1582,10 +1529,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternMultiEntity)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1679,9 +1622,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternMultiAttr)
     EXPECT_EQ("A3", attrs[0].String());
     EXPECT_EQ("A4", attrs[1].String());
     EXPECT_EQ("A5", attrs[2].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -1788,10 +1728,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternMultiEntityAttrs)
     ASSERT_EQ(3, attrs.size());
     EXPECT_EQ("A3", attrs[0].String());
     EXPECT_EQ("A4", attrs[1].String());
-    EXPECT_EQ("A5", attrs[2].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
+    EXPECT_EQ("A5", attrs[2].String());  
 
     /* Release mock */
     delete notifierMock;
@@ -1898,9 +1835,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, noPatternNoType)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A1", attrs[0].String());
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2000,9 +1934,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, pattern0Attr)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2085,10 +2016,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, pattern1AttrSingle)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A4", attrs[0].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2179,9 +2106,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, pattern1AttrMulti)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A1", attrs[0].String());
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2281,10 +2205,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, patternNAttr)
     ASSERT_EQ(2, attrs.size());
     EXPECT_EQ("A1", attrs[0].String());
     EXPECT_EQ("A2", attrs[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2392,9 +2312,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, patternNoType)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(1, attrs.size());
     EXPECT_EQ("A2", attrs[0].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -2504,10 +2421,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, mixPatternAndNotPattern)
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2587,10 +2500,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, updateDurationAndEntN_AttrN_noP
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     ASSERT_EQ(2, attrs.size());
     EXPECT_EQ("A1", attrs[0].String());
-    EXPECT_EQ("A2", attrs[1].String());
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
+    EXPECT_EQ("A2", attrs[1].String());   
 
     /* Release mock */
     delete notifierMock;
@@ -2676,10 +2586,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, updateDurationAndNoPatternAttrs
     std::vector<BSONElement> attrs = sub.getField("attrs").Array();
     EXPECT_EQ(0, attrs.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2721,10 +2627,6 @@ TEST(mongoUpdateContextAvailabilitySubscription, subscriptionNotFound)
     EXPECT_EQ("No context element found", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 }
@@ -2759,6 +2661,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbFindOneFail)
 
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
@@ -2773,11 +2676,12 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbFindOneFail)
               "- findOne(): { _id: ObjectId('51307b66f481db11bf860010') } "
               "- exception: boom!!)", res.errorCode.details);
 
-    /* Release mocks */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
+    /* Release mocks */    
     delete notifierMock;
     delete connectionMock;
-
 }
 
 /* ****************************************************************************
@@ -2821,6 +2725,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbUpdateFail)
 
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
@@ -2835,12 +2740,11 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbUpdateFail)
               "- update(): <{ _id: ObjectId('51307b66f481db11bf860010') },{ entities: [ { id: \"E5\", type: \"T5\", isPattern: \"false\" } ], attrs: [], expiration: 1360250700, reference: \"http://notify1.me\", format: \"XML\" }> "
               "- exception: boom!!)", res.errorCode.details);
 
-    /* Release mocks */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
+    /* Release mocks */    
     delete notifierMock;
     delete connectionMock;
     delete timerMock;
-
 }
-
-

--- a/test/unittests/mongoBackend/mongoUpdateContextGeo_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextGeo_test.cpp
@@ -246,10 +246,7 @@ TEST(mongoUpdateContextGeoRequest, newEntityLocAttribute)
     EXPECT_EQ(-5, coordX(ent));
     EXPECT_EQ(4, coordY(ent));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -366,8 +363,6 @@ TEST(mongoUpdateContextGeoRequest, appendLocAttribute)
     EXPECT_EQ(-9, coordX(ent));
     EXPECT_EQ(8, coordY(ent));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -472,8 +467,6 @@ TEST(mongoUpdateContextGeoRequest, updateLocAttribute)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -570,8 +563,6 @@ TEST(mongoUpdateContextGeoRequest, deleteLocAttribute)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -694,8 +685,6 @@ TEST(mongoUpdateContextGeoRequest, newEntityTwoLocAttributesFail)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -805,8 +794,6 @@ TEST(mongoUpdateContextGeoRequest, newEntityWrongCoordinatesFormatFail)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -916,8 +903,6 @@ TEST(mongoUpdateContextGeoRequest, newEntityNotSupportedLocationFail)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -1028,8 +1013,6 @@ TEST(mongoUpdateContextGeoRequest, appendAdditionalLocAttributeFail)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -1139,8 +1122,6 @@ TEST(mongoUpdateContextGeoRequest, appendWrongCoordinatesFormatFail)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -1250,8 +1231,6 @@ TEST(mongoUpdateContextGeoRequest, appendNotSupportedLocationFail)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -1356,8 +1335,6 @@ TEST(mongoUpdateContextGeoRequest, updateWrongCoordinatesFormatFail)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -1467,8 +1444,6 @@ TEST(mongoUpdateContextGeoRequest, updateLocationMetadataFail)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }
 
@@ -1579,7 +1554,5 @@ TEST(mongoUpdateContextGeoRequest, deleteLocationMetadataFail)
     EXPECT_FALSE(a2.hasField("modDate"));
     EXPECT_FALSE(ent.hasField("location"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     utExit();
 }

--- a/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
@@ -584,9 +584,6 @@ TEST(mongoUpdateContextSubscription, subscriptionNotFound)
     EXPECT_EQ("No context element found", res.subscribeError.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.subscribeError.errorCode.details.size());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 }
@@ -673,9 +670,6 @@ TEST(mongoUpdateContextSubscription, updateDuration)
     EXPECT_EQ("AY1", condValues[1].String());
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
     EXPECT_EQ(100, cond1.getIntField("value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -773,9 +767,6 @@ TEST(mongoUpdateContextSubscription, updateThrottling)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
     EXPECT_EQ(500, cond1.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
@@ -859,9 +850,6 @@ TEST(mongoUpdateContextSubscription, clearThrottling)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
     EXPECT_EQ(500, cond1.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 }
@@ -941,13 +929,8 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_T1_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
-
 }
 
 /* ****************************************************************************
@@ -1025,12 +1008,8 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_T1_C0_JSON)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
-
 }
 
 /* ****************************************************************************
@@ -1110,12 +1089,8 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_T1_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
-
 }
 
 /* ****************************************************************************
@@ -1201,12 +1176,8 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_TN_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
     EXPECT_EQ(120, cond1.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
-
 }
 
 /* ****************************************************************************
@@ -1292,14 +1263,10 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_TN_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
-    EXPECT_EQ(120, cond1.getIntField("value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
+    EXPECT_EQ(120, cond1.getIntField("value"));    
 
     /* Release mock */
     delete notifierMock;
-
 }
 
 /* ****************************************************************************
@@ -1381,10 +1348,6 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_T0_C1)
     std::vector<BSONElement> condValues = cond0.getField("value").Array();
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mocks */
     delete notifierMock;
@@ -1474,10 +1437,6 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_T0_C1)
     std::vector<BSONElement> condValues = cond0.getField("value").Array();
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -1574,9 +1533,6 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1665,10 +1621,6 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_T0_CNbis)
     ASSERT_EQ(2, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -1769,9 +1721,6 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1862,10 +1811,6 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_T0_CNbis)
     ASSERT_EQ(2, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -1977,9 +1922,6 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2082,9 +2024,6 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_TN_CNbis)
     ASSERT_EQ(2, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -2198,9 +2137,6 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2306,10 +2242,6 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_TN_CNbis)
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2398,9 +2330,6 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_T1_C0)
     BSONObj cond0 = conds[0].embeddedObject();
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -2492,10 +2421,6 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_T1_C0)
     BSONObj cond0 = conds[0].embeddedObject();
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2593,10 +2518,6 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_TN_C0)
     EXPECT_EQ(60, cond0.getIntField("value"));
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
     EXPECT_EQ(120, cond1.getIntField("value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2697,9 +2618,6 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_TN_C0)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond1, "type"));
     EXPECT_EQ(120, cond1.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2790,10 +2708,6 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_T0_C1)
     std::vector<BSONElement> condValues = cond0.getField("value").Array();
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2887,10 +2801,6 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_T0_C1)
     std::vector<BSONElement> condValues = cond0.getField("value").Array();
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2992,10 +2902,6 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -3084,9 +2990,6 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_T0_CNbis)
     ASSERT_EQ(2, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -3188,10 +3091,6 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
@@ -3283,9 +3182,6 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_T0_CNbis)
     ASSERT_EQ(2, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -3399,10 +3295,6 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
@@ -3507,9 +3399,6 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_TN_CNbis)
     ASSERT_EQ(2, condValues.size());
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -3625,10 +3514,6 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A20", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
@@ -3736,9 +3621,6 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_TN_CNbis)
     EXPECT_EQ("A10", condValues[0].String());
     EXPECT_EQ("A20", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
@@ -3836,9 +3718,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_T0_C1)
     std::vector<BSONElement> condValues = cond0.getField("value").Array();
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -3938,10 +3817,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_T0_C1_JSON)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
@@ -4039,10 +3914,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
@@ -4138,9 +4009,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_T0_C1_disjoint)
     std::vector<BSONElement> condValues = cond0.getField("value").Array();
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -4253,9 +4121,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1NoType_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
@@ -4366,9 +4231,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1NoType_AttrN_T0_C1_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
@@ -4473,14 +4335,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1Pattern_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4581,14 +4439,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1Pattern_AttrN_T0_C1_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4701,14 +4555,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1PatternNoType_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4821,14 +4671,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1PatternNoType_AttrN_T0_C1_disjoint
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4931,14 +4777,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5041,14 +4883,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_T0_CN_partial)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A5", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 
@@ -5145,14 +4983,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_T0_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5255,15 +5089,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_T0_CN_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A3", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5366,14 +5195,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_T0_CN_partial)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A5", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5476,14 +5301,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_T0_CN_partial_disjoint)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A5", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5579,15 +5400,12 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_T0_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 *  matchEnt1_Attr0_TN_CN -
@@ -5702,15 +5520,12 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEnt1_Attr0_TN_CNbis -
@@ -5818,15 +5633,12 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_TN_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEnt1_AttrN_TN_CN -
@@ -5941,15 +5753,12 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEnt1_AttrN_TN_CNbis -
@@ -6057,14 +5866,10 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_TN_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -6170,14 +5975,10 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -6281,15 +6082,12 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_T0_C1)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A1", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_Attr0_T0_CN -
@@ -6402,15 +6200,12 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_Attr0_T0_CNbis -
@@ -6516,15 +6311,12 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_T0_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_AttrN_T0_CN -
@@ -6635,15 +6427,12 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_T0_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_AttrN_T0_CNbis -
@@ -6745,15 +6534,12 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_T0_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 *  matchEntN_Attr0_TN_CN -
@@ -6878,15 +6664,12 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_Attr0_TN_CNbis -
@@ -7004,15 +6787,12 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_TN_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matchEntN_AttrN_TN_CN -
@@ -7135,15 +6915,12 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_TN_CN)
     ASSERT_EQ(1, condValues.size());
     EXPECT_EQ("A2", condValues[0].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
+
 /* ****************************************************************************
 *
 * matcnEntN_AttrN_TN_CNbis -
@@ -7259,14 +7036,10 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_TN_CNbis)
     EXPECT_EQ("A1", condValues[0].String());
     EXPECT_EQ("A2", condValues[1].String());
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -7346,14 +7119,10 @@ TEST(mongoUpdateContextSubscription, updateDurationAndNotifyConditions)
     EXPECT_STREQ("ONTIMEINTERVAL", C_STR_FIELD(cond0, "type"));
     EXPECT_EQ(60, cond0.getIntField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -7390,6 +7159,7 @@ TEST(mongoUpdateContextSubscription, MongoDbFindOneFail)
 
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
@@ -7404,11 +7174,12 @@ TEST(mongoUpdateContextSubscription, MongoDbFindOneFail)
               "- findOne(): { _id: ObjectId('51307b66f481db11bf860001') } "
               "- exception: boom!!)", res.subscribeError.errorCode.details);
 
-    /* Release mocks */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
+    /* Release mocks */    
     delete notifierMock;
     delete connectionMock;
-
 }
 
 /* ****************************************************************************
@@ -7460,6 +7231,7 @@ TEST(mongoUpdateContextSubscription, MongoDbUpdateFail)
 
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
@@ -7474,8 +7246,10 @@ TEST(mongoUpdateContextSubscription, MongoDbUpdateFail)
               "- update(): <{ _id: ObjectId('51307b66f481db11bf860001') },{ entities: [ { id: \"E1\", type: \"T1\", isPattern: \"false\" } ], attrs: [], reference: \"http://notify1.me\", expiration: 1360250700, conditions: [], lastNotification: 15000000, format: \"XML\" }> "
               "- exception: boom!!)", res.subscribeError.errorCode.details);
 
-    /* Release mocks */
-    setMongoConnectionForUnitTest(NULL);
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
+    /* Release mocks */    
     delete notifierMock;
     delete connectionMock;
     delete timerMock;

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -579,10 +579,6 @@ TEST(mongoUpdateContextRequest, update1Ent1Attr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     utExit();
 }
 
@@ -737,12 +733,7 @@ TEST(mongoUpdateContextRequest, update1Ent1AttrNoType)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -922,11 +913,7 @@ TEST(mongoUpdateContextRequest, update1EntNoType1Attr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1106,13 +1093,9 @@ TEST(mongoUpdateContextRequest, update1EntNoType1AttrNoType)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     utExit();
 
-   }
+}
 
 /* ****************************************************************************
 *
@@ -1281,11 +1264,7 @@ TEST(mongoUpdateContextRequest, updateNEnt1Attr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1445,11 +1424,7 @@ TEST(mongoUpdateContextRequest, update1EntNAttr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1631,12 +1606,7 @@ TEST(mongoUpdateContextRequest, updateNEntNAttr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1794,12 +1764,7 @@ TEST(mongoUpdateContextRequest, append1Ent1Attr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -1956,12 +1921,8 @@ TEST(mongoUpdateContextRequest, append1Ent1AttrNoType)
     EXPECT_STREQ("TA2", C_STR_FIELD(a2, "type"));
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2154,12 +2115,8 @@ TEST(mongoUpdateContextRequest, append1EntNoType1Attr)
     EXPECT_STREQ("TA8", C_STR_FIELD(a8, "type"));
     EXPECT_STREQ("val8", C_STR_FIELD(a8, "value"));
     EXPECT_EQ(1360232700, a8.getIntField("modDate"));
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2352,12 +2309,8 @@ TEST(mongoUpdateContextRequest, append1EntNoType1AttrNoType)
     EXPECT_STREQ("", C_STR_FIELD(a8, "type"));
     EXPECT_STREQ("val8", C_STR_FIELD(a8, "value"));
     EXPECT_EQ(1360232700, a8.getIntField("modDate"));
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2537,11 +2490,7 @@ TEST(mongoUpdateContextRequest, appendNEnt1Attr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2710,11 +2659,7 @@ TEST(mongoUpdateContextRequest, append1EntNAttr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -2916,12 +2861,8 @@ TEST(mongoUpdateContextRequest, appendNEntNAttr)
     EXPECT_STREQ("TA2", C_STR_FIELD(a2, "type"));
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
     
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3048,11 +2989,7 @@ TEST(mongoUpdateContextRequest, delete1Ent0Attr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3199,11 +3136,7 @@ TEST(mongoUpdateContextRequest, delete1Ent1Attr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3351,11 +3284,7 @@ TEST(mongoUpdateContextRequest, delete1Ent1AttrNoType)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3467,11 +3396,7 @@ TEST(mongoUpdateContextRequest, delete1EntNoType0Attr)
     EXPECT_FALSE(a6.hasField("value"));
     EXPECT_FALSE(a6.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3640,11 +3565,7 @@ TEST(mongoUpdateContextRequest, delete1EntNoType1Attr)
     EXPECT_STREQ("val1-nt", C_STR_FIELD(a1, "value"));
     EXPECT_FALSE(a1.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3813,11 +3734,7 @@ TEST(mongoUpdateContextRequest, delete1EntNoType1AttrNoType)
     EXPECT_STREQ("val1-nt", C_STR_FIELD(a1, "value"));
     EXPECT_FALSE(a1.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -3976,12 +3893,7 @@ TEST(mongoUpdateContextRequest, deleteNEnt1Attr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
-
 }
 
 /* ****************************************************************************
@@ -4130,11 +4042,7 @@ TEST(mongoUpdateContextRequest, delete1EntNAttr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4297,11 +4205,7 @@ TEST(mongoUpdateContextRequest, deleteNEntNAttr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4460,11 +4364,7 @@ TEST(mongoUpdateContextRequest, updateEntityFails)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4633,11 +4533,7 @@ TEST(mongoUpdateContextRequest, createEntity)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4811,11 +4707,7 @@ TEST(mongoUpdateContextRequest, createEntityWithId)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -4978,9 +4870,6 @@ TEST(mongoUpdateContextRequest, createEntityMixIdNoIdFails)
     EXPECT_STREQ("TA2", C_STR_FIELD(a2, "type"));
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -5169,11 +5058,7 @@ TEST(mongoUpdateContextRequest, createEntityMd)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5326,11 +5211,7 @@ TEST(mongoUpdateContextRequest, updateEmptyValueOk)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5489,11 +5370,7 @@ TEST(mongoUpdateContextRequest, appendEmptyValueOk)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5651,11 +5528,7 @@ TEST(mongoUpdateContextRequest, updateAttrNotFoundFail)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5808,11 +5681,7 @@ TEST(mongoUpdateContextRequest, deleteAttrNotFoundFail)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -5998,11 +5867,7 @@ TEST(mongoUpdateContextRequest, mixUpdateAndCreate)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -6155,11 +6020,7 @@ TEST(mongoUpdateContextRequest, appendExistingAttr)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -6340,11 +6201,7 @@ TEST(mongoUpdateContextRequest, updateAttrWithId)
     EXPECT_STREQ("val2", C_STR_FIELD(a2, "value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -6531,11 +6388,7 @@ TEST(mongoUpdateContextRequest, updateAttrWithAndWithoutId)
     EXPECT_STREQ("new_val2", C_STR_FIELD(a2, "value"));
     EXPECT_EQ(1360232700, a2.getIntField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -6720,11 +6573,7 @@ TEST(mongoUpdateContextRequest, appendAttrWithId)
     EXPECT_STREQ("val2", C_STR_FIELD(a2, "value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -6920,11 +6769,7 @@ TEST(mongoUpdateContextRequest, appendAttrWithAndWithoutId)
     EXPECT_STREQ("new_val3", C_STR_FIELD(a3, "value"));
     EXPECT_EQ(1360232700, a3.getIntField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -7105,11 +6950,7 @@ TEST(mongoUpdateContextRequest, appendAttrWithIdFails)
     EXPECT_STREQ("val2", C_STR_FIELD(a2, "value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -7285,11 +7126,7 @@ TEST(mongoUpdateContextRequest, appendAttrWithoutIdFails)
     EXPECT_STREQ("val2", C_STR_FIELD(a2, "value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -7465,11 +7302,7 @@ TEST(mongoUpdateContextRequest, deleteAttrWithId)
     EXPECT_STREQ("val2", C_STR_FIELD(a2, "value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -7647,11 +7480,7 @@ TEST(mongoUpdateContextRequest, deleteAttrWithAndWithoutId)
     EXPECT_STREQ("val12", C_STR_FIELD(a1id2, "value"));
     EXPECT_FALSE(a1id2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -7747,9 +7576,6 @@ TEST(mongoUpdateContextRequest, appendCreateEntWithMd)
     EXPECT_EQ("TMD2", getStringField(mdV[1].embeddedObject(), "type"));
     EXPECT_EQ("MD2val", getStringField(mdV[1].embeddedObject(), "value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -7841,9 +7667,6 @@ TEST(mongoUpdateContextRequest, appendMdAllExisting)
     EXPECT_EQ("TMD2", getStringField(mdV[1].embeddedObject(), "type"));
     EXPECT_EQ("MD2val", getStringField(mdV[1].embeddedObject(), "value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -7934,9 +7757,6 @@ TEST(mongoUpdateContextRequest, updateMdAllExisting)
     EXPECT_EQ("MD2", getStringField(mdV[1].embeddedObject(), "name"));
     EXPECT_EQ("TMD2", getStringField(mdV[1].embeddedObject(), "type"));
     EXPECT_EQ("MD2val", getStringField(mdV[1].embeddedObject(), "value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -8032,10 +7852,6 @@ TEST(mongoUpdateContextRequest, appendMdAllNew)
     EXPECT_EQ("TMD2", getStringField(mdV[2].embeddedObject(), "type"));
     EXPECT_EQ("MD2val", getStringField(mdV[2].embeddedObject(), "value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     utExit();
 }
 
@@ -8129,9 +7945,6 @@ TEST(mongoUpdateContextRequest, updateMdAllNew)
     EXPECT_EQ("MD2", getStringField(mdV[2].embeddedObject(), "name"));
     EXPECT_EQ("TMD2", getStringField(mdV[2].embeddedObject(), "type"));
     EXPECT_EQ("MD2val", getStringField(mdV[2].embeddedObject(), "value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -8232,9 +8045,6 @@ TEST(mongoUpdateContextRequest, appendMdSomeNew)
     EXPECT_EQ("TMD1", getStringField(mdV[2].embeddedObject(), "type"));
     EXPECT_EQ("MD1val", getStringField(mdV[2].embeddedObject(), "value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -8334,9 +8144,6 @@ TEST(mongoUpdateContextRequest, updateMdSomeNew)
     EXPECT_EQ("TMD1", getStringField(mdV[2].embeddedObject(), "type"));
     EXPECT_EQ("MD1val", getStringField(mdV[2].embeddedObject(), "value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -8428,9 +8235,6 @@ TEST(mongoUpdateContextRequest, appendValueAndMd)
     EXPECT_EQ("TMD2", getStringField(mdV[1].embeddedObject(), "type"));
     EXPECT_EQ("MD2val", getStringField(mdV[1].embeddedObject(), "value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -8521,9 +8325,6 @@ TEST(mongoUpdateContextRequest, updateValueAndMd)
     EXPECT_EQ("MD2", getStringField(mdV[1].embeddedObject(), "name"));
     EXPECT_EQ("TMD2", getStringField(mdV[1].embeddedObject(), "type"));
     EXPECT_EQ("MD2val", getStringField(mdV[1].embeddedObject(), "value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -8617,9 +8418,6 @@ TEST(mongoUpdateContextRequest, appendMdNoActualChanges)
     EXPECT_EQ("TMD2", getStringField(mdV[1].embeddedObject(), "type"));
     EXPECT_EQ("MD2val", getStringField(mdV[1].embeddedObject(), "value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -8710,9 +8508,6 @@ TEST(mongoUpdateContextRequest, updateMdNoActualChanges)
     EXPECT_EQ("MD2", getStringField(mdV[1].embeddedObject(), "name"));
     EXPECT_EQ("TMD2", getStringField(mdV[1].embeddedObject(), "type"));
     EXPECT_EQ("MD2val", getStringField(mdV[1].embeddedObject(), "value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -8881,11 +8676,7 @@ TEST(mongoUpdateContextRequest, patternUnsupported)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -9041,9 +8832,6 @@ TEST(mongoUpdateContextRequest, notExistFilter)
     EXPECT_STREQ("TA2", C_STR_FIELD(a2, "type"));
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -9239,9 +9027,6 @@ TEST(mongoUpdateContextRequest, createNativeTypes)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -9401,10 +9186,6 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     utExit();
 }
 
@@ -9504,9 +9285,6 @@ TEST(mongoUpdateContextRequest, preservingNativeTypes)
     EXPECT_EQ("x1", a5.getField("value").Array()[0].str());
     EXPECT_EQ("x2", a5.getField("value").Array()[1].str());
     EXPECT_FALSE(a5.hasField("modDate"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -9706,9 +9484,6 @@ TEST(mongoUpdateContextRequest, createMdNativeTypes)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -9814,10 +9589,6 @@ TEST(mongoUpdateContextRequest, updateMdNativeTypes)
     EXPECT_EQ("T", getStringField(mdV[2].embeddedObject(), "type"));
     EXPECT_TRUE(mdV[2].embeddedObject().getBoolField("value"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     utExit();
 }
 
@@ -9906,9 +9677,6 @@ TEST(mongoUpdateContextRequest, preservingMdNativeTypes)
     EXPECT_EQ("MD3", getStringField(mdV[2].embeddedObject(), "name"));
     EXPECT_EQ("T", getStringField(mdV[2].embeddedObject(), "type"));
     EXPECT_FALSE(mdV[2].embeddedObject().getBoolField("value"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -10080,9 +9848,6 @@ TEST(mongoUpdateContextRequest, replace)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
 }
 
@@ -10231,9 +9996,6 @@ TEST(mongoUpdateContextRequest, tooManyEntitiesNGSIv2)
   EXPECT_STREQ("TA2", C_STR_FIELD(a2, "type"));
   EXPECT_FALSE(a2.hasField("value"));
   EXPECT_FALSE(a2.hasField("modDate"));
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 
   utExit();
 }
@@ -10390,9 +10152,6 @@ TEST(mongoUpdateContextRequest, onlyOneEntityNGSIv2)
   EXPECT_FALSE(a2.hasField("value"));
   EXPECT_FALSE(a2.hasField("modDate"));
 
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
   utExit();
 }
 
@@ -10458,6 +10217,7 @@ TEST(mongoUpdateContextRequest, mongoDbUpdateFail)
             .WillByDefault(Throw(e));
 
     /* Set MongoDB connection */
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -10496,9 +10256,11 @@ TEST(mongoUpdateContextRequest, mongoDbUpdateFail)
               "- update(): <{ _id.id: \"E1\", _id.type: \"T1\", _id.servicePath: { $exists: false } },{ $set: { attrs.A1: { value: \"new_val\", type: \"TA1\", modDate: 1360232700 }, modDate: 1360232700 }, $unset: { location: 1 } }> "
               "- exception: boom!!)", RES_CER_STATUS(0).details);
 
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
     /* Release mocks */
-    delete connectionMock;
-    setMongoConnectionForUnitTest(NULL);
+    delete connectionMock;    
 
     utExit();
 
@@ -10523,6 +10285,7 @@ TEST(mongoUpdateContextRequest, mongoDbQueryFail)
             .WillByDefault(Throw(e));
 
     /* Set MongoDB connection */
+    DBClientBase* connectionDb = getMongoConnection();
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -10556,9 +10319,11 @@ TEST(mongoUpdateContextRequest, mongoDbQueryFail)
               "- query(): { _id.id: \"E1\", _id.type: \"T1\", _id.servicePath: { $exists: false } } "
               "- exception: boom!!)", RES_CER_STATUS(0).details);
 
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
+
     /* Release mock */
-    delete connectionMock;
-    setMongoConnectionForUnitTest(NULL);
+    delete connectionMock;   
 
     utExit();
 }
@@ -10650,10 +10415,7 @@ TEST(mongoUpdateContextRequest, servicePathEntityUpdate_3levels)
   EXPECT_TRUE(findAttr(attrNames, "A1"));
   EXPECT_STREQ("TA1",C_STR_FIELD(a1, "type"));
   EXPECT_STREQ("kz02", C_STR_FIELD(a1, "value"));
-  EXPECT_FALSE(a1.hasField("modDate"));
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
+  EXPECT_FALSE(a1.hasField("modDate"));  
 
   utExit();
 }
@@ -10751,10 +10513,6 @@ TEST(mongoUpdateContextRequest, servicePathEntityAppend_3levels)
   EXPECT_STREQ("TA1",C_STR_FIELD(a1, "type"));
   EXPECT_STREQ("kz02", C_STR_FIELD(a1, "value"));
   EXPECT_FALSE(a1.hasField("modDate"));
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
-
 
   utExit();
 }
@@ -10863,11 +10621,7 @@ TEST(mongoUpdateContextRequest, servicePathEntityCreation_2levels)
     EXPECT_EQ(1360232700, a1.getIntField("modDate"));
     EXPECT_EQ(1360232700, a1.getIntField("creDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -10974,11 +10728,7 @@ TEST(mongoUpdateContextRequest, servicePathEntityCreation_3levels)
     EXPECT_EQ(1360232700, a1.getIntField("modDate"));
     EXPECT_EQ(1360232700, a1.getIntField("creDate"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     utExit();
-
 }
 
 /* ****************************************************************************
@@ -11048,9 +10798,6 @@ TEST(mongoUpdateContextRequest, servicePathEntityDeletion_3levels)
     EXPECT_STREQ("TA1",C_STR_FIELD(a1, "type"));
     EXPECT_STREQ("kz02", C_STR_FIELD(a1, "value"));
     EXPECT_FALSE(a1.hasField("modDate"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     utExit();
 }
@@ -11194,9 +10941,6 @@ TEST(mongoUpdateContextRequest, servicePathEntityVectorNotAllowed)
   EXPECT_STREQ("TA2", C_STR_FIELD(a2, "type"));
   EXPECT_FALSE(a2.hasField("value"));
   EXPECT_FALSE(a2.hasField("modDate"));
-
-  /* Release connection */
-  setMongoConnectionForUnitTest(NULL);
 
   utExit();
 }

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
@@ -439,10 +439,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -507,9 +503,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -568,11 +561,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch)
     /* Check lastNotification */
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-    
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
+    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));   
 
     /* Release mock */
     delete notifierMock;
@@ -642,9 +631,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_noType)
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
     sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860004")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -717,9 +703,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_noType)
     sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860004")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -787,10 +770,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_noType)
     sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860004")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -852,9 +831,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_pattern)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860003")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -919,8 +895,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_pattern)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860003")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -981,9 +955,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_pattern)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860003")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -1046,9 +1017,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_pattern_noT
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860005")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -1114,9 +1082,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_pattern_noT
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860005")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1176,9 +1141,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_pattern_noT
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860005")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -1242,9 +1204,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatchDisjoint)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1306,10 +1265,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatchDisjoint)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -1373,10 +1328,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatchDisjoint)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1428,14 +1379,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateNoMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(20000000, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1483,10 +1429,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendNoMatch)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(20000000, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -1539,9 +1481,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteNoMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(20000000, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1592,9 +1531,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatchWithoutChang
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(20000000, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -1660,13 +1596,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMixMatchNoMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -1730,9 +1662,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMixMatchNoMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1794,9 +1723,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMixMatchNoMatch)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -1861,9 +1787,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_update2Matches1Notifica
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -1931,9 +1854,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_append2Matches1Notifica
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -1993,12 +1913,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_delete2Matches1Notifica
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
-
 
     /* Release mock */
     delete notifierMock;
@@ -2062,10 +1976,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatch)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2131,9 +2041,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2193,10 +2100,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMatch)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2260,9 +2163,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatchDisjoint)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2324,10 +2224,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMatchDisjoint)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
 
     /* Release mock */
     delete notifierMock;
@@ -2391,9 +2287,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMatchDisjoint)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2445,13 +2338,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateNoMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(30000000, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -2500,11 +2389,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendNoMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(30000000, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
-
     delete notifierMock;
     delete timerMock;
 }
@@ -2554,9 +2439,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteNoMatch)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(30000000, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -2608,9 +2490,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatchWithoutChang
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(30000000, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -2676,13 +2555,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMixMatchNoMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
-
 }
 
 /* ****************************************************************************
@@ -2746,9 +2621,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMixMatchNoMatch)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -2810,9 +2682,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMixMatchNoMatch)
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -2877,9 +2746,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_update2Matches1Notifica
     DBClientBase* connection = getMongoConnection();
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
 
     /* Release mock */
     delete notifierMock;
@@ -2947,9 +2813,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_append2Matches1Notifica
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -3010,9 +2873,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_delete2Matches1Notifica
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
     EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
     /* Release mock */
     delete notifierMock;
     delete timerMock;
@@ -3051,7 +2911,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, DISABLED_MongoDbQueryFail)
     setNotifier(notifierMock);
 
     /* Set MongoDB connection */
-    mongoConnect(connectionMock);
+    DBClientBase* connectionDb = getMongoConnection();
+    setMongoConnectionForUnitTest(connectionMock);
 
     /* Forge the request (from "inside" to "outside") */
     ContextElement ce;
@@ -3087,13 +2948,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, DISABLED_MongoDbQueryFail)
     BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
     EXPECT_EQ(20000000, sub.getIntField("lastNotification"));
 
-    /* Release connection */
-    setMongoConnectionForUnitTest(NULL);
-
+    /* Restore real DB connection */
+    setMongoConnectionForUnitTest(connectionDb);
 
     /* Release mock */
     delete notifierMock;
-
 }
 
 /* ****************************************************************************

--- a/test/unittests/testInit.cpp
+++ b/test/unittests/testInit.cpp
@@ -48,23 +48,18 @@ void setupDatabase(void)
     /* mongoStart is needed one time to create the connection pool */
     if (mongoStarted == false)
     {
+      /* In fact, the mongoStart() parameters related with the pool, e.g. pool size, are irrelevant, given that the connection
+       * creation is mocked under UNIT_TEST in the mongoBackend library */
       mongoStart("localhost", "", "", "", "", false, 0, 10);
       mongoStarted = true;
     }
 
     connection = getMongoConnection();
-    if (connection == NULL)
-    {
-      connection = mongoInitialConnectionGetForUnitTest();
-      setMongoConnectionForUnitTest(connection);
-    }
 
     connection->dropCollection(REGISTRATIONS_COLL);
     connection->dropCollection(ENTITIES_COLL);
     connection->dropCollection(SUBSCRIBECONTEXT_COLL);
-    connection->dropCollection(SUBSCRIBECONTEXTAVAIL_COLL);
-
-    releaseMongoConnection(connection);
+    connection->dropCollection(SUBSCRIBECONTEXTAVAIL_COLL);    
 
     setDbPrefix(DBPREFIX);
     setRegistrationsCollectionName("registrations");


### PR DESCRIPTION
Functional test were not generating coverage in report since DB pool implementation. This PR is supossed to fix that.

The PR is long, but most of the changes in *_test.cpp files are all the same. The interesting parts to review are in: MongoGlobal.cpp/h, mongoConnectionPool.cpp and testInit.cpp.