### PR TITLE
Not string values in ngsv1 compounds renders

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: number/bool correct rendering in NGSIv1 compound values

--- a/src/lib/common/tag.cpp
+++ b/src/lib/common/tag.cpp
@@ -287,7 +287,8 @@ std::string valueTag
   const std::string&  unescapedValue,
   Format              format,
   bool                showComma,
-  bool                isVectorElement
+  bool                isVectorElement,
+  bool                valueIsNumberOrBool
 )
 {
 
@@ -317,20 +318,19 @@ std::string valueTag
     return out;
   }
 
+  std::string effectiveValue = valueIsNumberOrBool ? value : std::string("\"") + value + "\"";
+  free(value);
+
   if (showComma == true)
   {
     if (isVectorElement == true)
     {
-      std::string out = indent + "\"" + value + "\",\n";
-
-      free(value);
+      std::string out = indent + effectiveValue + ",\n";
       return out;
     }
     else
     {
-      std::string out = indent + "\"" + tagName + "\" : \"" + value + "\",\n";
-
-      free(value);
+      std::string out = indent + "\"" + tagName + "\" : " + effectiveValue + ",\n";
       return out;
     }
   }
@@ -338,16 +338,12 @@ std::string valueTag
   {
     if (isVectorElement == true)
     {
-      std::string out = indent + "\"" + value + "\"\n";
-
-      free(value);
+      std::string out = indent + effectiveValue + "\n";
       return out;
     }
     else
     {
-      std::string out = indent + "\"" + tagName + "\" : \"" + value + "\"\n";
-
-      free(value);
+      std::string out = indent + "\"" + tagName + "\" : " + effectiveValue + "\n";
       return out;
     }
   }

--- a/src/lib/common/tag.h
+++ b/src/lib/common/tag.h
@@ -108,7 +108,8 @@ extern std::string valueTag
   const std::string&  value,
   Format              format,
   bool                showComma           = false,
-  bool                isVectorElement     = false
+  bool                isVectorElement     = false,
+  bool                valueIsNumberOrBool = false
 );
 
 extern std::string valueTag

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -469,7 +469,7 @@ std::string ContextAttribute::render
       case ValueTypeNumber:
         char num[32];
         snprintf(num, sizeof(num), "%f", numberValue);
-        effectiveValue      = std::string(num);
+        effectiveValue      = num;
         valueIsNumberOrBool = true;
         break;
 

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -583,6 +583,19 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, Format format, const 
     LM_T(LmtCompoundValueRender, ("I am a String (%s)", name.c_str()));
     out = valueTag(indent, tagName, stringValue, format, jsonComma, container->valueType == orion::ValueTypeVector);
   }
+  else if (valueType == orion::ValueTypeNumber)
+  {
+    LM_T(LmtCompoundValueRender, ("I am a number (%s)", name.c_str()));
+    char num[32];
+    snprintf(num, sizeof(num), "%f", numberValue);
+    std::string effectiveValue = std::string(num);
+    out = valueTag(indent, tagName, effectiveValue, format, jsonComma, container->valueType == orion::ValueTypeVector, true);
+  }
+  else if (valueType == orion::ValueTypeBoolean)
+  {
+    LM_T(LmtCompoundValueRender, ("I am a bool (%s)", name.c_str()));
+    out = valueTag(indent, tagName, boolValue? "true" : "false", format, jsonComma, container->valueType == orion::ValueTypeVector, true);
+  }
   else if ((valueType == orion::ValueTypeVector) && (container != this))
   {
     LM_T(LmtCompoundValueRender, ("I am a Vector (%s)", name.c_str()));

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -588,7 +588,7 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, Format format, const 
     LM_T(LmtCompoundValueRender, ("I am a number (%s)", name.c_str()));
     char num[32];
     snprintf(num, sizeof(num), "%f", numberValue);
-    std::string effectiveValue = std::string(num);
+    std::string effectiveValue = num;
     out = valueTag(indent, tagName, effectiveValue, format, jsonComma, container->valueType == orion::ValueTypeVector, true);
   }
   else if (valueType == orion::ValueTypeBoolean)


### PR DESCRIPTION
Exceptionally, this PR doesn't include test func (they will be added in a next PR).