### PR TITLE
FIX semaphore releasing bug in unsubscribeContext when subscription ID is the empty string

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,3 +5,4 @@
 - Add: possibility to limit the maximum number of simultaneous connections, using the CLI option -maxConnections (Issue #1384)
 - Add: possibility to use thread pool for incoming connections, using CLI option -reqPoolSize (Issue #1384)
 - Fix: A bug in the request reading logic that may cause unexpected Parse Errors or even SIGSEGVs
+- Fix: Semaphore releasing bug in unsubscribeContext when subscription ID is the empty string (Issue #1488)

--- a/src/lib/mongoBackend/mongoUnsubscribeContext.cpp
+++ b/src/lib/mongoBackend/mongoUnsubscribeContext.cpp
@@ -57,6 +57,7 @@ HttpStatusCode mongoUnsubscribeContext(UnsubscribeContextRequest* requestP, Unsu
 
     if (responseP->subscriptionId.get() == "")
     {
+        reqSemGive(__FUNCTION__, "ngsi10 unsubscribe request (no subscriptions found)", reqSemTaken);
         responseP->statusCode.fill(SccContextElementNotFound);
         LM_W(("Bad Input (no subscriptionId)"));
         return SccOk;
@@ -93,7 +94,6 @@ HttpStatusCode mongoUnsubscribeContext(UnsubscribeContextRequest* requestP, Unsu
     if (sub.isEmpty())
     {
        reqSemGive(__FUNCTION__, "ngsi10 unsubscribe request (no subscriptions found)", reqSemTaken);
-
        responseP->statusCode.fill(SccContextElementNotFound, std::string("subscriptionId: /") + requestP->subscriptionId.get() + "/");
        return SccOk;
     }

--- a/test/functionalTest/cases/1471_ngsiv1_render_not_string_in_compounds/ngsiv1_render_not_string_in_compounds.test
+++ b/test/functionalTest/cases/1471_ngsiv1_render_not_string_in_compounds/ngsiv1_render_not_string_in_compounds.test
@@ -1,0 +1,190 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Correct NGSIv1 rendering for not string values (numbers, bools, etc) inside compound values
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. POST /v2/entities E1 (object)
+# 02. POST /v2/entities E2 (vector)
+# 03. GET /v1/contextEntities/E1
+# 04. GET /v1/contextEntities/E2
+#
+
+echo "01. POST /v2/entities E1 (object)"
+echo "================================="
+payload='{
+  "id": "E1",
+  "type": "T1",
+  "compattr": {
+    "x": {
+      "x1": "a",
+      "x2": 42
+    },
+    "y": [ 24, "y2", true ]
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload" --json
+echo
+echo
+
+
+echo "02. POST /v2/entities E2 (vector)"
+echo "================================="
+payload='{
+  "id": "E2",
+  "type": "T2",
+  "compattr": [
+    22,
+    false,
+    {
+      "x" : [ 64, "x2" ],
+      "y" : 3
+    },
+    [ "z1", true ]
+  ]
+}'
+orionCurl --url /v2/entities --payload "$payload" --json
+echo
+echo
+
+
+echo "03. GET /v1/contextEntities/E1"
+echo "=============================="
+orionCurl --url /v1/contextEntities/E1 --json
+echo
+echo
+
+
+echo "04. GET /v1/contextEntities/E2"
+echo "=============================="
+orionCurl --url /v1/contextEntities/E2 --json
+echo
+echo
+
+
+--REGEXPECT--
+01. POST /v2/entities E1 (object)
+=================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1
+Date: REGEX(.*)
+
+
+
+02. POST /v2/entities E2 (vector)
+=================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E2
+Date: REGEX(.*)
+
+
+
+03. GET /v1/contextEntities/E1
+==============================
+HTTP/1.1 200 OK
+Content-Length: 459
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "compattr",
+                "type": "",
+                "value": {
+                    "x": {
+                        "x1": "a",
+                        "x2": 42.0
+                    },
+                    "y": [
+                        24.0,
+                        "y2",
+                        true
+                    ]
+                }
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": "T1"
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+04. GET /v1/contextEntities/E2
+==============================
+HTTP/1.1 200 OK
+Content-Length: 515
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "compattr",
+                "type": "",
+                "value": [
+                    22.0,
+                    false,
+                    {
+                        "x": [
+                            64.0,
+                            "x2"
+                        ],
+                        "y": 3.0
+                    },
+                    [
+                        "z1",
+                        true
+                    ]
+                ]
+            }
+        ],
+        "id": "E2",
+        "isPattern": "false",
+        "type": "T2"
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/1488_unsubscribe_sem_bug/unsubscribe_sem_bug.test
+++ b/test/functionalTest/cases/1488_unsubscribe_sem_bug/unsubscribe_sem_bug.test
@@ -1,0 +1,87 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Unsubscribe semaphore safety-check
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Unsubscribe with empty ID first time
+# 02. Unsubscribe with empty ID second time (ensuring that semaphore releasing was ok first time)
+#
+
+echo "01. Unsubscribe with empty ID first time"
+echo "========================================"
+payload='{
+  "subscriptionId": ""
+}'
+orionCurl --url /v1/unsubscribeContext --payload "${payload}" --json
+echo
+echo
+
+echo "02. Unsubscribe with empty ID second time (ensuring that semaphore releasing was ok first time)"
+echo "==============================================================================================="
+orionCurl --url /v1/unsubscribeContext --payload "${payload}" --json
+echo
+echo
+
+--REGEXPECT--
+01. Unsubscribe with empty ID first time
+========================================
+HTTP/1.1 200 OK
+Content-Length: 144
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "statusCode": {
+        "code": "404",
+        "reasonPhrase": "No context element found"
+    },
+    "subscriptionId": "000000000000000000000000"
+}
+
+
+02. Unsubscribe with empty ID second time (ensuring that semaphore releasing was ok first time)
+===============================================================================================
+HTTP/1.1 200 OK
+Content-Length: 144
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "statusCode": {
+        "code": "404",
+        "reasonPhrase": "No context element found"
+    },
+    "subscriptionId": "000000000000000000000000"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fix #1488 

In addition, to save time, it includes a missing .tes (closing #1472)