### PR TITLE
Feature/1476 count and last notification not in db

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -13,3 +13,4 @@
 - Hardening: exhaustive try/catch (mainly at mongoBackend module) 
 - Add: Unpatterned subscriptions now also in subscription cache (Issue #1475)
 - Fix: Fixed an uptil now unknown bug with throttling
+- Fix: 'count' and 'lastNotificationTime' now maintained by subCache (and synched via DB) (Issue #1476)

--- a/src/lib/logMsg/traceLevels.h
+++ b/src/lib/logMsg/traceLevels.h
@@ -89,6 +89,7 @@ typedef enum TraceLevels
   LmtMongo = 100,
   LmtMongoSubCache,
   LmtMongoSubCacheMatch,
+  LmtMongoCacheSync,
 
   /* Cleanup (120-139) */
   LmtDestructor = 120,

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1337,7 +1337,7 @@ static bool addTriggeredSubscriptions_noCache
 
     std::string subIdStr = idField.OID().toString();
 
-    if (subs.count(subIdStr) == 0)
+    if (subs.count(subIdStr) == 0)  // KZ: count
     {
       LM_T(LmtMongo, ("adding subscription: '%s'", sub.toString().c_str()));
 
@@ -1522,48 +1522,39 @@ static bool processSubscriptions
                                                  tenant,
                                                  xauthToken))
     {
-      BSONObj query = BSON("_id" << OID(mapSubId));
-      BSONObj update = BSON("$set" << BSON(CSUB_LASTNOTIFICATION << (long long) getCurrentTime()) <<
-                            "$inc" << BSON(CSUB_COUNT << 1));
-
-      if (collectionUpdate(getSubscribeContextCollectionName(tenant), query, update, false, err))
+      //
+      // Saving lastNotificationTime and count for cached subscription
+      //
+      if (trigs->cacheSubId != "")
       {
-        //
-        // Saving lastNotificationTime for cached subscription
-        //
-        if (trigs->cacheSubId != "")
+        cacheSemTake(__FUNCTION__, "update lastNotificationTime for cached subscription");
+
+        CachedSubscription*  cSubP = mongoSubCacheItemLookup(trigs->tenant.c_str(), trigs->cacheSubId.c_str());
+
+        if (cSubP != NULL)
         {
-          cacheSemTake(__FUNCTION__, "update lastNotificationTime for cached subscription");
+          cSubP->pendingNotifications -= 1;
+          LM_T(LmtMongoSubCache, ("Found sub '%s', set its pendingNotifications to %d", trigs->cacheSubId.c_str(), cSubP->pendingNotifications));
 
-          CachedSubscription*  cSubP = mongoSubCacheItemLookup(trigs->tenant.c_str(), trigs->cacheSubId.c_str());
-
-          if (cSubP != NULL)
+          if (cSubP->pendingNotifications == 0)
           {
-            cSubP->pendingNotifications -= 1;
-            LM_T(LmtMongoSubCache, ("Found sub '%s', set its pendingNotifications to %d", trigs->cacheSubId.c_str(), cSubP->pendingNotifications));
+            cSubP->lastNotificationTime = getCurrentTime();
+            cSubP->count               += 1;  // DOUBT:  What if we had three notifications? Do we count updates of actual notifs?
 
-            if (cSubP->pendingNotifications == 0)
-            {
-              cSubP->lastNotificationTime = getCurrentTime();
-              LM_T(LmtMongoSubCache, ("set lastNotificationTime to %lu for '%s'", cSubP->lastNotificationTime, cSubP->subscriptionId));
-            }
-            else
-            {
-              LM_T(LmtMongoSubCache, ("Not touching lastNotificationTime for sub '%s' - its pendingNotifications == %d", cSubP->subscriptionId, cSubP->pendingNotifications));
-            }
+            LM_T(LmtMongoSubCache, ("set lastNotificationTime to %lu and count to %lu for '%s'", cSubP->lastNotificationTime, cSubP->count, cSubP->subscriptionId));
           }
           else
           {
-            LM_E(("Runtime Error (cached subscription '%s' for tenant '%s' not found)",
-                  trigs->cacheSubId.c_str(), trigs->tenant.c_str()));
+            LM_T(LmtMongoSubCache, ("Not touching lastNotificationTime for sub '%s' - its pendingNotifications == %d", cSubP->subscriptionId, cSubP->pendingNotifications));
           }
-
-          cacheSemGive(__FUNCTION__, "update lastNotificationTime for cached subscription");
         }
-      }
-      else
-      {
-        ret = false;
+        else
+        {
+          LM_E(("Runtime Error (cached subscription '%s' for tenant '%s' not found)",
+                trigs->cacheSubId.c_str(), trigs->tenant.c_str()));
+        }
+
+        cacheSemGive(__FUNCTION__, "update lastNotificationTime for cached subscription");
       }
     }
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1174,8 +1174,6 @@ static bool addTriggeredSubscriptions_withCache
       }
       else
       {
-        cSubP->pendingNotifications += 1;
-
         LM_T(LmtMongoSubCache, ("subscription '%s' NOT ignored due to throttling (T: %lu, LNT: %lu, NOW: %lu, NOW-LNT: %lu, T: %lu)",
                                 cSubP->subscriptionId,
                                 cSubP->throttling,
@@ -1187,8 +1185,6 @@ static bool addTriggeredSubscriptions_withCache
     }
     else
     {
-      cSubP->pendingNotifications += 1;
-
       LM_T(LmtMongoSubCache, ("subscription '%s' NOT ignored due to throttling II (T: %lu, LNT: %lu, NOW: %lu, NOW-LNT: %lu, T: %lu)",
                               cSubP->subscriptionId,
                               cSubP->throttling,
@@ -1533,20 +1529,10 @@ static bool processSubscriptions
 
         if (cSubP != NULL)
         {
-          cSubP->pendingNotifications -= 1;
-          LM_T(LmtMongoSubCache, ("Found sub '%s', set its pendingNotifications to %d", trigs->cacheSubId.c_str(), cSubP->pendingNotifications));
+          cSubP->lastNotificationTime = getCurrentTime();
+          cSubP->count               += 1;
 
-          if (cSubP->pendingNotifications == 0)
-          {
-            cSubP->lastNotificationTime = getCurrentTime();
-            cSubP->count               += 1;
-
-            LM_T(LmtMongoSubCache, ("set lastNotificationTime to %lu and count to %lu for '%s'", cSubP->lastNotificationTime, cSubP->count, cSubP->subscriptionId));
-          }
-          else
-          {
-            LM_T(LmtMongoSubCache, ("Not touching lastNotificationTime for sub '%s' - its pendingNotifications == %d", cSubP->subscriptionId, cSubP->pendingNotifications));
-          }
+          LM_T(LmtMongoSubCache, ("set lastNotificationTime to %lu and count to %lu for '%s'", cSubP->lastNotificationTime, cSubP->count, cSubP->subscriptionId));
         }
         else
         {
@@ -2517,7 +2503,6 @@ void processContextElement
   bool                                 checkEntityExistance
 )
 {
-
   /* Check preconditions */
   if (!contextElementPreconditionsCheck(ceP, responseP, action))
   {

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1337,7 +1337,7 @@ static bool addTriggeredSubscriptions_noCache
 
     std::string subIdStr = idField.OID().toString();
 
-    if (subs.count(subIdStr) == 0)  // KZ: count
+    if (subs.count(subIdStr) == 0)
     {
       LM_T(LmtMongo, ("adding subscription: '%s'", sub.toString().c_str()));
 
@@ -1539,7 +1539,7 @@ static bool processSubscriptions
           if (cSubP->pendingNotifications == 0)
           {
             cSubP->lastNotificationTime = getCurrentTime();
-            cSubP->count               += 1;  // DOUBT:  What if we had three notifications? Do we count updates of actual notifs?
+            cSubP->count               += 1;
 
             LM_T(LmtMongoSubCache, ("set lastNotificationTime to %lu and count to %lu for '%s'", cSubP->lastNotificationTime, cSubP->count, cSubP->subscriptionId));
           }

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -45,11 +45,9 @@ using namespace ngsiv2;
 *
 * setSubscriptionId -
 */
-static std::string setSubscriptionId(Subscription* s, const BSONObj& r)
+static void setSubscriptionId(Subscription* s, const BSONObj& r)
 {
   s->id = getField(r, "_id").OID().toString();
-
-  return s->id;
 }
 
 
@@ -141,7 +139,7 @@ static void setNotification(Subscription* s, const BSONObj& r, const std::string
     if (cSubP->count != 0)
     {
       //
-      // First, compensate for eventual -1 in 'timesSent'
+      // First, compensate for -1 in 'timesSent'
       //
       if (s->notification.timesSent == -1)
       {

--- a/src/lib/mongoBackend/mongoSubCache.h
+++ b/src/lib/mongoBackend/mongoSubCache.h
@@ -82,6 +82,7 @@ typedef struct CachedSubscription
   int64_t                     throttling;
   int64_t                     expirationTime;
   int64_t                     lastNotificationTime;
+  int64_t                     count;
   int                         pendingNotifications;
   Format                      notifyFormat;
   char*                       reference;

--- a/src/lib/mongoBackend/mongoSubCache.h
+++ b/src/lib/mongoBackend/mongoSubCache.h
@@ -185,7 +185,7 @@ extern int mongoSubCacheItemRemove(CachedSubscription* cSubP);
 *
 * mongoSubCacheRefresh - 
 */
-extern void mongoSubCacheRefresh(bool semAlreadyTaken = false);
+extern void mongoSubCacheRefresh(void);
 
 
 

--- a/src/lib/mongoBackend/mongoSubCache.h
+++ b/src/lib/mongoBackend/mongoSubCache.h
@@ -83,7 +83,6 @@ typedef struct CachedSubscription
   int64_t                     expirationTime;
   int64_t                     lastNotificationTime;
   int64_t                     count;
-  int                         pendingNotifications;
   Format                      notifyFormat;
   char*                       reference;
   struct CachedSubscription*  next;

--- a/src/lib/mongoBackend/mongoSubCache.h
+++ b/src/lib/mongoBackend/mongoSubCache.h
@@ -151,7 +151,9 @@ extern void mongoSubCacheItemInsert
   const char*               subscriptionId,
   int64_t                   expiration,
   int64_t                   throttling,
-  Format                    notifyFormat
+  Format                    notifyFormat,
+  bool                      notificationDone,
+  int64_t                   lastNotificationTime
 );
 
 
@@ -184,7 +186,15 @@ extern int mongoSubCacheItemRemove(CachedSubscription* cSubP);
 *
 * mongoSubCacheRefresh - 
 */
-extern void mongoSubCacheRefresh(void);
+extern void mongoSubCacheRefresh(bool semAlreadyTaken = false);
+
+
+
+/* ****************************************************************************
+*
+* mongoSubCacheSync - 
+*/
+extern void mongoSubCacheSync(void);
 
 
 

--- a/src/lib/mongoBackend/mongoSubscribeContext.cpp
+++ b/src/lib/mongoBackend/mongoSubscribeContext.cpp
@@ -141,9 +141,13 @@ HttpStatusCode mongoSubscribeContext
                                              xauthToken,
                                              servicePathV);
     sub.append(CSUB_CONDITIONS, conds);
+
+    long long lastNotificationTime = 0;
     if (notificationDone)
     {
-      sub.append(CSUB_LASTNOTIFICATION, (long long) getCurrentTime());
+      lastNotificationTime = (long long) getCurrentTime();
+
+      sub.append(CSUB_LASTNOTIFICATION, lastNotificationTime);
       sub.append(CSUB_COUNT, 1);
     }
 
@@ -167,7 +171,15 @@ HttpStatusCode mongoSubscribeContext
     LM_T(LmtMongoSubCache, ("inserting a new sub in cache (%s)", oidString.c_str()));
 
     cacheSemTake(__FUNCTION__, "Inserting subscription in cache");
-    mongoSubCacheItemInsert(tenant.c_str(), servicePath.c_str(), requestP, oidString.c_str(), expiration, throttling, notifyFormat);
+    mongoSubCacheItemInsert(tenant.c_str(),
+                            servicePath.c_str(),
+                            requestP,
+                            oidString.c_str(),
+                            expiration,
+                            throttling,
+                            notifyFormat,
+                            notificationDone,
+                            lastNotificationTime);
     cacheSemGive(__FUNCTION__, "Inserting subscription in cache");
 
     reqSemGive(__FUNCTION__, "ngsi10 subscribe request", reqSemTaken);

--- a/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
@@ -55,6 +55,7 @@ HttpStatusCode mongoUpdateContextSubscription
 )
 { 
   bool          reqSemTaken;
+
   reqSemTake(__FUNCTION__, "ngsi10 update subscription request", SemWriteOp, &reqSemTaken);
 
   /* Look for document */
@@ -186,14 +187,35 @@ HttpStatusCode mongoUpdateContextSubscription
   
   int count = sub.hasField(CSUB_COUNT) ? getIntField(sub, CSUB_COUNT) : 0;
 
+  //
+  // Update from cached value, is applicable
+  //
+  CachedSubscription*  cSubP                = mongoSubCacheItemLookup(tenant.c_str(), requestP->subscriptionId.get().c_str());
+  long long            lastNotificationTime = 0;
+
+  if (cSubP != NULL)
+  {
+    count                += cSubP->count;
+    lastNotificationTime  = cSubP->lastNotificationTime;
+  }
+
   /* Last notification */
-  long long lastNotification = -1;
   if (notificationDone)
   {
-    lastNotification = getCurrentTime();
-    LM_T(LmtMongoSubCache, ("notificationDone => lastNotification set to %lu", lastNotification));
-    newSub.append(CSUB_LASTNOTIFICATION, lastNotification);
+    lastNotificationTime = getCurrentTime();
+
+    //
+    // Update sub-cache
+    //
+    if (cSubP != NULL)
+    {
+      cSubP->count                 += 1; // 'count' to be reset later if DB operation OK
+      cSubP->lastNotificationTime  = lastNotificationTime;
+    }
+
+    newSub.append(CSUB_LASTNOTIFICATION, lastNotificationTime);
     newSub.append(CSUB_COUNT, count + 1);
+    LM_T(LmtMongoSubCache, ("notificationDone => lastNotification set to %lu", lastNotificationTime));
   }
   else
   {
@@ -207,7 +229,17 @@ HttpStatusCode mongoUpdateContextSubscription
     /* The hasField checks are needed as lastNotification/count might not be present in the original doc */
     if (sub.hasField(CSUB_LASTNOTIFICATION))
     {
-      newSub.append(CSUB_LASTNOTIFICATION, getIntOrLongFieldAsLong(sub, CSUB_LASTNOTIFICATION));
+      long long lastNotification = getIntOrLongFieldAsLong(sub, CSUB_LASTNOTIFICATION);
+
+      //
+      // Compare with 'lastNotificationTime', that might come from the sub-cache.
+      // If the cached value of lastNotificationTime is higher, then use it.
+      //
+      if (lastNotificationTime > lastNotification)
+      {
+        lastNotification = lastNotificationTime;
+      }
+      newSub.append(CSUB_LASTNOTIFICATION, lastNotification);
     }
 
     if (sub.hasField(CSUB_COUNT))
@@ -226,6 +258,11 @@ HttpStatusCode mongoUpdateContextSubscription
     reqSemGive(__FUNCTION__, "ngsi10 update subscription request (mongo db exception)", reqSemTaken);
     responseP->subscribeError.errorCode.fill(SccReceiverInternalError, err);
     return SccOk;
+  }
+
+  if (cSubP != NULL)
+  {
+    cSubP->count = 0; // New 'count' has been sent to DB - must be reset here
   }
 
   // Duration and throttling are optional parameters, they are only added in the case they were used for update
@@ -271,13 +308,14 @@ HttpStatusCode mongoUpdateContextSubscription
 
   cacheSemTake(__FUNCTION__, "Updating cached subscription");
 
-  CachedSubscription*  cSubP            = mongoSubCacheItemLookup(tenant.c_str(), requestP->subscriptionId.get().c_str());
-  char*                subscriptionId   = (char*) requestP->subscriptionId.get().c_str();
-  char*                servicePath      = (char*) ((cSubP == NULL)? "" : cSubP->servicePath);
+  cSubP = mongoSubCacheItemLookup(tenant.c_str(), requestP->subscriptionId.get().c_str());
+
+  char* subscriptionId   = (char*) requestP->subscriptionId.get().c_str();
+  char* servicePath      = (char*) ((cSubP == NULL)? "" : cSubP->servicePath);
 
   LM_T(LmtMongoSubCache, ("update: %s", newSubObject.toString().c_str()));
 
-  int mscInsert = mongoSubCacheItemInsert(tenant.c_str(), newSubObject, subscriptionId, servicePath, lastNotification, expiration);
+  int mscInsert = mongoSubCacheItemInsert(tenant.c_str(), newSubObject, subscriptionId, servicePath, lastNotificationTime, expiration);
 
   if (cSubP != NULL)
   {

--- a/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
@@ -188,7 +188,7 @@ HttpStatusCode mongoUpdateContextSubscription
   int count = sub.hasField(CSUB_COUNT) ? getIntField(sub, CSUB_COUNT) : 0;
 
   //
-  // Update from cached value, is applicable
+  // Update from cached value, if applicable
   //
   CachedSubscription*  cSubP                = mongoSubCacheItemLookup(tenant.c_str(), requestP->subscriptionId.get().c_str());
   long long            lastNotificationTime = 0;

--- a/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange.test
+++ b/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange.test
@@ -29,7 +29,6 @@ brokerStart CB
 accumulatorStart
 
 --SHELL--
-url="/v1/contextSubscriptions"
 payload='<?xml version="1.0"?>
 <subscribeContextRequest>
   <entityIdList>
@@ -53,14 +52,13 @@ payload='<?xml version="1.0"?>
     </notifyCondition>
   </notifyConditions>
 </subscribeContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/contextSubscriptions --payload "$payload"
 
 SUB_ID=$(echo "$_response" | grep subscriptionId | awk -F '>' '{print $2}' | awk -F '<' '{print $1}' | grep -v '^$' )
-
 echo SUB_ID: $SUB_ID > /tmp/SUB_ID
 
+
 echo "1: ++++++++++++++++++++"
-url="/v1/updateContext"
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -84,13 +82,10 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
 
-# Get notifications count
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 
 echo "2: ++++++++++++++++++++"
-url="/v1/updateContext"
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -114,30 +109,22 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
 
-# Get notifications count
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 
 echo "3: ++++++++++++++++++++"
-url="/v1/contextSubscriptions/${SUB_ID}"
 payload='<?xml version="1.0"?>
 <updateContextSubscriptionRequest>
   <duration>P1Y</duration>
   <subscriptionId>'$SUB_ID'</subscriptionId>
   <throttling>PT6S</throttling>
 </updateContextSubscriptionRequest>'
-orionCurl --url "$url" --payload "$payload" -X "PUT"
+orionCurl --url /v1/contextSubscriptions/${SUB_ID} --payload "$payload" -X "PUT"
 
-# Get notifications count
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 
 echo "4: ++++++++++++++++++++"
-
-#Wait sleep >6s to reset the throttling interval
+# Wait >6s to reset the throttling interval
 sleep 10
-
-url="/v1/updateContext"
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -161,13 +148,10 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
 
-# Get notifications count
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 
 echo "5: ++++++++++++++++++++"
-url="/v1/updateContext"
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -191,13 +175,12 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
+
+
 echo "6: ++++++++++++++++++++"
-
-#Wait sleep >6s to reset the throttling interval
+# Wait >6s to reset the throttling interval
 sleep 10
-
-url="/v1/updateContext"
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -216,13 +199,10 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
 
-# Get notifications count
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 
 echo "7: ++++++++++++++++++++"
-url="/v1/updateContext"
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -241,14 +221,15 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>UPDATE</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
+
 
 echo "8: ++++++++++++++++++++"
 echo SUB_ID: ${SUB_ID} >> /tmp/SUB_ID
 orionCurl --url "/v1/contextSubscriptions/${SUB_ID}" -X "DELETE"
 
+
 echo "9: ++++++++++++++++++++"
-url="/v1/updateContext"
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -267,11 +248,13 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
+
 
 echo "10: ++++++++++++++++++++"
-#Get accumulated data
+# Get accumulated data
 accumulatorDump
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK
@@ -320,7 +303,6 @@ Date: REGEX(.*)
     </contextElementResponse>
   </contextResponseList>
 </updateContextResponse>
-{ "count" : 1 }
 2: ++++++++++++++++++++
 HTTP/1.1 200 OK
 Content-Length: 809
@@ -355,7 +337,6 @@ Date: REGEX(.*)
     </contextElementResponse>
   </contextResponseList>
 </updateContextResponse>
-{ "count" : 2 }
 3: ++++++++++++++++++++
 HTTP/1.1 200 OK
 Content-Length: 243
@@ -370,7 +351,6 @@ Date: REGEX(.*)
     <throttling>PT6S</throttling>
   </subscribeResponse>
 </updateContextSubscriptionResponse>
-{ "count" : 2 }
 4: ++++++++++++++++++++
 HTTP/1.1 200 OK
 Content-Length: 805
@@ -405,7 +385,6 @@ Date: REGEX(.*)
     </contextElementResponse>
   </contextResponseList>
 </updateContextResponse>
-{ "count" : 3 }
 5: ++++++++++++++++++++
 HTTP/1.1 200 OK
 Content-Length: 805
@@ -469,7 +448,6 @@ Date: REGEX(.*)
     </contextElementResponse>
   </contextResponseList>
 </updateContextResponse>
-{ "count" : 4 }
 7: ++++++++++++++++++++
 HTTP/1.1 200 OK
 Content-Length: 636

--- a/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange_nocache.test.DISABLED
+++ b/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange_nocache.test.DISABLED
@@ -1,0 +1,692 @@
+# Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Subscription sequence ONCHANGE
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart
+
+--SHELL--
+url="/v1/contextSubscriptions"
+payload='<?xml version="1.0"?>
+<subscribeContextRequest>
+  <entityIdList>
+    <entityId type="Room" isPattern="false">
+      <id>OfficeRoom</id>
+    </entityId>
+  </entityIdList>
+  <attributeList>
+    <attribute>temperature</attribute>
+    <attribute>lightstatus</attribute>
+  </attributeList>
+  <reference>http://127.0.0.1:'${LISTENER_PORT}'/notify</reference>
+  <duration>PT1H</duration>
+  <notifyConditions>
+    <notifyCondition>
+      <type>ONCHANGE</type>
+      <condValueList>
+        <condValue>temperature</condValue>
+        <condValue>lightstatus</condValue>
+      </condValueList>          
+    </notifyCondition>
+  </notifyConditions>
+</subscribeContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+
+SUB_ID=$(echo "$_response" | grep subscriptionId | awk -F '>' '{print $2}' | awk -F '<' '{print $1}' | grep -v '^$' )
+
+echo SUB_ID: $SUB_ID > /tmp/SUB_ID
+
+echo "1: ++++++++++++++++++++"
+url="/v1/updateContext"
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>pressure</name>
+                  <type>clima</type>
+                  <contextValue>p2300</contextValue>
+                </contextAttribute>
+            <contextAttribute>
+          <name>lightstatus</name>
+                  <type>light</type>
+                  <contextValue>L23</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+
+# Get notifications count
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+
+echo "2: ++++++++++++++++++++"
+url="/v1/updateContext"
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>temperature</name>
+                  <type>degree</type>
+                  <contextValue>t100</contextValue>
+                </contextAttribute>
+            <contextAttribute>
+          <name>lightstatus</name>
+                  <type>light</type>
+                  <contextValue>L23</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+
+# Get notifications count
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+
+echo "3: ++++++++++++++++++++"
+url="/v1/contextSubscriptions/${SUB_ID}"
+payload='<?xml version="1.0"?>
+<updateContextSubscriptionRequest>
+  <duration>P1Y</duration>
+  <subscriptionId>'$SUB_ID'</subscriptionId>
+  <throttling>PT6S</throttling>
+</updateContextSubscriptionRequest>'
+orionCurl --url "$url" --payload "$payload" -X "PUT"
+
+# Get notifications count
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+
+echo "4: ++++++++++++++++++++"
+
+#Wait sleep >6s to reset the throttling interval
+sleep 10
+
+url="/v1/updateContext"
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>pressure</name>
+                  <type>clima</type>
+                  <contextValue>p5300</contextValue>
+                </contextAttribute>
+            <contextAttribute>
+          <name>lightstatus</name>
+                  <type>light</type>
+                  <contextValue>L53</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+
+# Get notifications count
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+
+echo "5: ++++++++++++++++++++"
+url="/v1/updateContext"
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>pressure</name>
+                  <type>clima</type>
+                  <contextValue>p6300</contextValue>
+                </contextAttribute>
+            <contextAttribute>
+          <name>lightstatus</name>
+                  <type>light</type>
+                  <contextValue>L63</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+echo "6: ++++++++++++++++++++"
+
+#Wait sleep >6s to reset the throttling interval
+sleep 10
+
+url="/v1/updateContext"
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>temperature</name>
+                  <type>degree</type>
+                  <contextValue>t39</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+
+# Get notifications count
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+
+echo "7: ++++++++++++++++++++"
+url="/v1/updateContext"
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>pressure</name>
+                  <type>clima</type>
+                  <contextValue>p230</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>UPDATE</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+
+echo "8: ++++++++++++++++++++"
+echo SUB_ID: ${SUB_ID} >> /tmp/SUB_ID
+orionCurl --url "/v1/contextSubscriptions/${SUB_ID}" -X "DELETE"
+
+echo "9: ++++++++++++++++++++"
+url="/v1/updateContext"
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>temperature</name>
+                  <type>degree</type>
+                  <contextValue>t59</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+
+echo "10: ++++++++++++++++++++"
+#Get accumulated data
+accumulatorDump
+
+--REGEXPECT--
+HTTP/1.1 200 OK
+Content-Length: 192
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<subscribeContextResponse>
+  <subscribeResponse>
+    <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+    <duration>PT1H</duration>
+  </subscribeResponse>
+</subscribeContextResponse>
+1: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 805
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>pressure</name>
+            <type>clima</type>
+            <contextValue/>
+          </contextAttribute>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+{ "count" : 1 }
+2: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 809
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue/>
+          </contextAttribute>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+{ "count" : 2 }
+3: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 243
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextSubscriptionResponse>
+  <subscribeResponse>
+    <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+    <duration>P1Y</duration>
+    <throttling>PT6S</throttling>
+  </subscribeResponse>
+</updateContextSubscriptionResponse>
+{ "count" : 2 }
+4: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 805
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>pressure</name>
+            <type>clima</type>
+            <contextValue/>
+          </contextAttribute>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+{ "count" : 3 }
+5: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 805
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>pressure</name>
+            <type>clima</type>
+            <contextValue/>
+          </contextAttribute>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+6: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 640
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+{ "count" : 4 }
+7: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 636
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>pressure</name>
+            <type>clima</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+8: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 207
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<unsubscribeContextResponse>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <statusCode>
+    <code>200</code>
+    <reasonPhrase>OK</reasonPhrase>
+  </statusCode>
+</unsubscribeContextResponse>
+9: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 640
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+10: ++++++++++++++++++++
+POST http://127.0.0.1:REGEX(\d+)/notify
+Content-Length: 737
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/xml, application/json
+Content-Type: application/xml
+
+<notifyContextRequest>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <originator>localhost</originator>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue>L23</contextValue>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</notifyContextRequest>
+=======================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Content-Length: 911
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/xml, application/json
+Content-Type: application/xml
+
+<notifyContextRequest>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <originator>localhost</originator>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue>L23</contextValue>
+          </contextAttribute>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue>t100</contextValue>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</notifyContextRequest>
+=======================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Content-Length: 911
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/xml, application/json
+Content-Type: application/xml
+
+<notifyContextRequest>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <originator>localhost</originator>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue>L53</contextValue>
+          </contextAttribute>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue>t100</contextValue>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</notifyContextRequest>
+=======================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Content-Length: 910
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/xml, application/json
+Content-Type: application/xml
+
+<notifyContextRequest>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <originator>localhost</originator>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue>L63</contextValue>
+          </contextAttribute>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue>t39</contextValue>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</notifyContextRequest>
+=======================================
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange.test
@@ -30,7 +30,6 @@ accumulatorStart
 
 --SHELL--
 
-url="/v1/subscribeContext"
 payload='<?xml version="1.0"?>
 <subscribeContextRequest>
   <entityIdList>
@@ -54,12 +53,12 @@ payload='<?xml version="1.0"?>
     </notifyCondition>
   </notifyConditions>
 </subscribeContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/subscribeContext --payload "$payload"
 SUB_ID=$(echo "$_response" | grep subscriptionId | awk -F '>' '{print $2}' | awk -F '<' '{print $1}' | grep -v '^$' )
+echo
 echo
 
 echo "1: ++++++++++++++++++++"
-url="/v1/updateContext"
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -83,16 +82,12 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
 echo
-echo Notification count from mongo:
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 echo
 
 
 echo "2: ++++++++++++++++++++"
-url=/v1/updateContext
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -116,24 +111,20 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
 echo
-echo Notification count from mongo:
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 echo
 
+
 echo "3: ++++++++++++++++++++"
-url=/v1/updateContextSubscription
 payload='<?xml version="1.0"?>
 <updateContextSubscriptionRequest>
   <duration>P1Y</duration>
   <subscriptionId>'$SUB_ID'</subscriptionId>
   <throttling>PT6S</throttling>
 </updateContextSubscriptionRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContextSubscription --payload "$payload"
 echo
-echo Notification count from mongo:
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 echo
 
 
@@ -141,7 +132,6 @@ echo
 sleep 10
 
 echo "4: ++++++++++++++++++++"
-url=/v1/updateContext
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -165,16 +155,12 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
 echo
-echo Notification count from mongo:
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 echo
 
 
 echo "5: ++++++++++++++++++++"
-url=/v1/updateContext
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -198,15 +184,14 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
+echo
 echo
 
 
 echo "6: ++++++++++++++++++++"
 # Wait - sleep >6s to reset the throttling interval
 sleep 10
-url=/v1/updateContext
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -225,15 +210,12 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
 echo
-echo Notification count from mongo:
-mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
 echo
 
 
 echo "7: ++++++++++++++++++++"
-url=/v1/updateContext
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -252,22 +234,22 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>UPDATE</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
+echo
 echo
 
 
 echo "8: ++++++++++++++++++++"
-url=/v1/unsubscribeContext
 payload='<?xml version="1.0"?>
 <unsubscribeContextRequest>
   <subscriptionId>'$SUB_ID'</subscriptionId>
 </unsubscribeContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/unsubscribeContext --payload "$payload"
+echo
 echo
 
 
 echo "9: ++++++++++++++++++++"
-url=/v1/updateContext
 payload='<?xml version="1.0"?>
 <updateContextRequest>
   <contextElementList>
@@ -286,7 +268,8 @@ payload='<?xml version="1.0"?>
   </contextElementList>
   <updateAction>APPEND</updateAction>
 </updateContextRequest>'
-orionCurl --url "$url" --payload "$payload"
+orionCurl --url /v1/updateContext --payload "$payload"
+echo
 echo
 
 
@@ -294,6 +277,8 @@ echo "Accumulated data:"
 echo "================="
 accumulatorDump
 echo
+echo
+
 
 --REGEXPECT--
 HTTP/1.1 200 OK
@@ -308,6 +293,7 @@ Date: REGEX(.*)
     <duration>PT1H</duration>
   </subscribeResponse>
 </subscribeContextResponse>
+
 
 1: ++++++++++++++++++++
 HTTP/1.1 200 OK
@@ -344,8 +330,6 @@ Date: REGEX(.*)
   </contextResponseList>
 </updateContextResponse>
 
-Notification count from mongo:
-{ "count" : 1 }
 
 2: ++++++++++++++++++++
 HTTP/1.1 200 OK
@@ -382,8 +366,6 @@ Date: REGEX(.*)
   </contextResponseList>
 </updateContextResponse>
 
-Notification count from mongo:
-{ "count" : 2 }
 
 3: ++++++++++++++++++++
 HTTP/1.1 200 OK
@@ -400,8 +382,6 @@ Date: REGEX(.*)
   </subscribeResponse>
 </updateContextSubscriptionResponse>
 
-Notification count from mongo:
-{ "count" : 2 }
 
 4: ++++++++++++++++++++
 HTTP/1.1 200 OK
@@ -438,8 +418,6 @@ Date: REGEX(.*)
   </contextResponseList>
 </updateContextResponse>
 
-Notification count from mongo:
-{ "count" : 3 }
 
 5: ++++++++++++++++++++
 HTTP/1.1 200 OK
@@ -476,6 +454,7 @@ Date: REGEX(.*)
   </contextResponseList>
 </updateContextResponse>
 
+
 6: ++++++++++++++++++++
 HTTP/1.1 200 OK
 Content-Length: 640
@@ -506,8 +485,6 @@ Date: REGEX(.*)
   </contextResponseList>
 </updateContextResponse>
 
-Notification count from mongo:
-{ "count" : 4 }
 
 7: ++++++++++++++++++++
 HTTP/1.1 200 OK
@@ -539,6 +516,7 @@ Date: REGEX(.*)
   </contextResponseList>
 </updateContextResponse>
 
+
 8: ++++++++++++++++++++
 HTTP/1.1 200 OK
 Content-Length: 207
@@ -553,6 +531,7 @@ Date: REGEX(.*)
     <reasonPhrase>OK</reasonPhrase>
   </statusCode>
 </unsubscribeContextResponse>
+
 
 9: ++++++++++++++++++++
 HTTP/1.1 200 OK
@@ -583,6 +562,7 @@ Date: REGEX(.*)
     </contextElementResponse>
   </contextResponseList>
 </updateContextResponse>
+
 
 Accumulated data:
 =================
@@ -729,6 +709,7 @@ Content-Type: application/xml
   </contextResponseList>
 </notifyContextRequest>
 =======================================
+
 
 --TEARDOWN--
 brokerStop CB

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange_nocache.test.DISABLED
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange_nocache.test.DISABLED
@@ -1,0 +1,736 @@
+# Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Subscription sequence ONCHANGE
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart
+
+--SHELL--
+
+url="/v1/subscribeContext"
+payload='<?xml version="1.0"?>
+<subscribeContextRequest>
+  <entityIdList>
+    <entityId type="Room" isPattern="false">
+      <id>OfficeRoom</id>
+    </entityId>
+  </entityIdList>
+  <attributeList>
+    <attribute>temperature</attribute>
+    <attribute>lightstatus</attribute>
+  </attributeList>
+  <reference>http://127.0.0.1:'${LISTENER_PORT}'/notify</reference>
+  <duration>PT1H</duration>
+  <notifyConditions>
+    <notifyCondition>
+      <type>ONCHANGE</type>
+      <condValueList>
+        <condValue>temperature</condValue>
+        <condValue>lightstatus</condValue>
+      </condValueList>          
+    </notifyCondition>
+  </notifyConditions>
+</subscribeContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+SUB_ID=$(echo "$_response" | grep subscriptionId | awk -F '>' '{print $2}' | awk -F '<' '{print $1}' | grep -v '^$' )
+echo
+
+echo "1: ++++++++++++++++++++"
+url="/v1/updateContext"
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>pressure</name>
+                  <type>clima</type>
+                  <contextValue>p2300</contextValue>
+                </contextAttribute>
+            <contextAttribute>
+          <name>lightstatus</name>
+                  <type>light</type>
+                  <contextValue>L23</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+
+orionCurl --url "$url" --payload "$payload"
+echo
+echo Notification count from mongo:
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+echo
+
+
+echo "2: ++++++++++++++++++++"
+url=/v1/updateContext
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+    <contextElement>
+      <entityId type="Room" isPattern="false">
+        <id>OfficeRoom</id>
+      </entityId>
+      <contextAttributeList>
+        <contextAttribute>
+          <name>temperature</name>
+          <type>degree</type>
+          <contextValue>t100</contextValue>
+        </contextAttribute>
+        <contextAttribute>
+          <name>lightstatus</name>
+          <type>light</type>
+          <contextValue>L23</contextValue>
+        </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+echo
+echo Notification count from mongo:
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+echo
+
+echo "3: ++++++++++++++++++++"
+url=/v1/updateContextSubscription
+payload='<?xml version="1.0"?>
+<updateContextSubscriptionRequest>
+  <duration>P1Y</duration>
+  <subscriptionId>'$SUB_ID'</subscriptionId>
+  <throttling>PT6S</throttling>
+</updateContextSubscriptionRequest>'
+orionCurl --url "$url" --payload "$payload"
+echo
+echo Notification count from mongo:
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+echo
+
+
+# Wait - sleep >6s to reset the throttling interval
+sleep 10
+
+echo "4: ++++++++++++++++++++"
+url=/v1/updateContext
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+    <contextElement>
+      <entityId type="Room" isPattern="false">
+        <id>OfficeRoom</id>
+      </entityId>
+      <contextAttributeList>
+        <contextAttribute>
+          <name>pressure</name>
+          <type>clima</type>
+          <contextValue>p5300</contextValue>
+        </contextAttribute>
+        <contextAttribute>
+          <name>lightstatus</name>
+          <type>light</type>
+          <contextValue>L53</contextValue>
+        </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+
+orionCurl --url "$url" --payload "$payload"
+echo
+echo Notification count from mongo:
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+echo
+
+
+echo "5: ++++++++++++++++++++"
+url=/v1/updateContext
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>pressure</name>
+                  <type>clima</type>
+                  <contextValue>p6300</contextValue>
+                </contextAttribute>
+            <contextAttribute>
+          <name>lightstatus</name>
+                  <type>light</type>
+                  <contextValue>L63</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+
+orionCurl --url "$url" --payload "$payload"
+echo
+
+
+echo "6: ++++++++++++++++++++"
+# Wait - sleep >6s to reset the throttling interval
+sleep 10
+url=/v1/updateContext
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+    <contextElement>
+      <entityId type="Room" isPattern="false">
+        <id>OfficeRoom</id>
+      </entityId>
+      <contextAttributeList>
+        <contextAttribute>
+          <name>temperature</name>
+          <type>degree</type>
+          <contextValue>t39</contextValue>
+        </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+echo
+echo Notification count from mongo:
+mongoCmd ${CB_DB_NAME} "db.csubs.findOne({_id: ObjectId(\"$SUB_ID\")}, {_id: 0, count: 1})"
+echo
+
+
+echo "7: ++++++++++++++++++++"
+url=/v1/updateContext
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>pressure</name>
+                  <type>clima</type>
+                  <contextValue>p230</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>UPDATE</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+echo
+
+
+echo "8: ++++++++++++++++++++"
+url=/v1/unsubscribeContext
+payload='<?xml version="1.0"?>
+<unsubscribeContextRequest>
+  <subscriptionId>'$SUB_ID'</subscriptionId>
+</unsubscribeContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+echo
+
+
+echo "9: ++++++++++++++++++++"
+url=/v1/updateContext
+payload='<?xml version="1.0"?>
+<updateContextRequest>
+  <contextElementList>
+        <contextElement>
+          <entityId type="Room" isPattern="false">
+                <id>OfficeRoom</id>
+          </entityId>
+          <contextAttributeList>
+            <contextAttribute>
+          <name>temperature</name>
+                  <type>degree</type>
+                  <contextValue>t39</contextValue>
+                </contextAttribute>
+      </contextAttributeList>
+    </contextElement>
+  </contextElementList>
+  <updateAction>APPEND</updateAction>
+</updateContextRequest>'
+orionCurl --url "$url" --payload "$payload"
+echo
+
+
+echo "Accumulated data:"
+echo "================="
+accumulatorDump
+echo
+
+--REGEXPECT--
+HTTP/1.1 200 OK
+Content-Length: 192
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<subscribeContextResponse>
+  <subscribeResponse>
+    <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+    <duration>PT1H</duration>
+  </subscribeResponse>
+</subscribeContextResponse>
+
+1: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 805
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>pressure</name>
+            <type>clima</type>
+            <contextValue/>
+          </contextAttribute>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+
+Notification count from mongo:
+{ "count" : 1 }
+
+2: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 809
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue/>
+          </contextAttribute>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+
+Notification count from mongo:
+{ "count" : 2 }
+
+3: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 243
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextSubscriptionResponse>
+  <subscribeResponse>
+    <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+    <duration>P1Y</duration>
+    <throttling>PT6S</throttling>
+  </subscribeResponse>
+</updateContextSubscriptionResponse>
+
+Notification count from mongo:
+{ "count" : 2 }
+
+4: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 805
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>pressure</name>
+            <type>clima</type>
+            <contextValue/>
+          </contextAttribute>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+
+Notification count from mongo:
+{ "count" : 3 }
+
+5: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 805
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>pressure</name>
+            <type>clima</type>
+            <contextValue/>
+          </contextAttribute>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+
+6: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 640
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+
+Notification count from mongo:
+{ "count" : 4 }
+
+7: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 636
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>pressure</name>
+            <type>clima</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+
+8: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 207
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<unsubscribeContextResponse>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <statusCode>
+    <code>200</code>
+    <reasonPhrase>OK</reasonPhrase>
+  </statusCode>
+</unsubscribeContextResponse>
+
+9: ++++++++++++++++++++
+HTTP/1.1 200 OK
+Content-Length: 640
+Content-Type: application/xml
+Date: REGEX(.*)
+
+<?xml version="1.0"?>
+<updateContextResponse>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue/>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</updateContextResponse>
+
+Accumulated data:
+=================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Content-Length: 737
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/xml, application/json
+Content-Type: application/xml
+
+<notifyContextRequest>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <originator>localhost</originator>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue>L23</contextValue>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</notifyContextRequest>
+=======================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Content-Length: 911
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/xml, application/json
+Content-Type: application/xml
+
+<notifyContextRequest>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <originator>localhost</originator>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue>L23</contextValue>
+          </contextAttribute>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue>t100</contextValue>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</notifyContextRequest>
+=======================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Content-Length: 911
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/xml, application/json
+Content-Type: application/xml
+
+<notifyContextRequest>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <originator>localhost</originator>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue>L53</contextValue>
+          </contextAttribute>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue>t100</contextValue>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</notifyContextRequest>
+=======================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Content-Length: 910
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/xml, application/json
+Content-Type: application/xml
+
+<notifyContextRequest>
+  <subscriptionId>REGEX([0-9a-f]{24})</subscriptionId>
+  <originator>localhost</originator>
+  <contextResponseList>
+    <contextElementResponse>
+      <contextElement>
+        <entityId type="Room" isPattern="false">
+          <id>OfficeRoom</id>
+        </entityId>
+        <contextAttributeList>
+          <contextAttribute>
+            <name>lightstatus</name>
+            <type>light</type>
+            <contextValue>L63</contextValue>
+          </contextAttribute>
+          <contextAttribute>
+            <name>temperature</name>
+            <type>degree</type>
+            <contextValue>t39</contextValue>
+          </contextAttribute>
+        </contextAttributeList>
+      </contextElement>
+      <statusCode>
+        <code>200</code>
+        <reasonPhrase>OK</reasonPhrase>
+      </statusCode>
+    </contextElementResponse>
+  </contextResponseList>
+</notifyContextRequest>
+=======================================
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB

--- a/test/functionalTest/cases/1126_GET_v2_subscriptions/GET_v2_all_subscriptions.test
+++ b/test/functionalTest/cases/1126_GET_v2_subscriptions/GET_v2_all_subscriptions.test
@@ -312,7 +312,7 @@ Date: REGEX(.*)
                 "speed",
                 "location"
             ],
-            "callback": "http://127.0.0.1:REGEX(\d+)/notify",            
+            "callback": "http://127.0.0.1:REGEX(\d+)/notify",
             "lastNotification": "REGEX(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.00Z)",
             "timesSent": 1
         },

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
@@ -435,9 +435,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -499,11 +499,10 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
-    /* Release mock */
     delete notifierMock;
     delete timerMock;
 }
@@ -559,9 +558,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));   
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -626,11 +625,15 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_noType)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-    sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860004")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* sub1P = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+    CachedSubscription* sub2P = mongoSubCacheItemLookup("", "51307b66f481db11bf860004");
+
+    ASSERT_TRUE(sub1P != NULL);
+    ASSERT_TRUE(sub2P != NULL);
+
+    EXPECT_EQ(1360232700, sub1P->lastNotificationTime);
+    EXPECT_EQ(1360232700, sub2P->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -697,11 +700,15 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_noType)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-    sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860004")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* sub1P = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+    CachedSubscription* sub2P = mongoSubCacheItemLookup("", "51307b66f481db11bf860004");
+
+    ASSERT_TRUE(sub1P != NULL);
+    ASSERT_TRUE(sub2P != NULL);
+
+    EXPECT_EQ(1360232700, sub1P->lastNotificationTime);
+    EXPECT_EQ(1360232700, sub2P->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -764,11 +771,14 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_noType)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
-    sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860004")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* sub1P = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+    CachedSubscription* sub2P = mongoSubCacheItemLookup("", "51307b66f481db11bf860004");
+
+    ASSERT_TRUE(sub1P != NULL);
+    ASSERT_TRUE(sub2P != NULL);
+
+    EXPECT_EQ(1360232700, sub1P->lastNotificationTime);
+    EXPECT_EQ(1360232700, sub2P->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -828,9 +838,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_pattern)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860003")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860003");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -892,9 +904,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_pattern)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860003")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860003");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -952,9 +966,10 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_pattern)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860003")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860003");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -1014,9 +1029,10 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_pattern_noT
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860005")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860005");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -1078,9 +1094,10 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_pattern_noT
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860005")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860005");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -1138,9 +1155,10 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_pattern_noT
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860005")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860005");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -1200,9 +1218,10 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatchDisjoint)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -1262,9 +1281,10 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatchDisjoint)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -1324,9 +1344,10 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatchDisjoint)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -1375,9 +1396,10 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateNoMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(20000000, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(20000000, subP->lastNotificationTime);
 
     /* Release mock */
     delete notifierMock;
@@ -1592,9 +1614,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMixMatchNoMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -1658,9 +1682,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMixMatchNoMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -1720,9 +1746,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMixMatchNoMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -1784,9 +1812,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_update2Matches1Notifica
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(20000000, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -1850,9 +1880,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_append2Matches1Notifica
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(20000000, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -1910,9 +1942,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_delete2Matches1Notifica
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -1973,9 +2007,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2037,9 +2073,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2097,9 +2135,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2159,9 +2199,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatchDisjoint)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2221,9 +2263,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMatchDisjoint)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2283,9 +2327,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMatchDisjoint)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2551,9 +2597,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMixMatchNoMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2617,9 +2665,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMixMatchNoMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2679,9 +2729,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMixMatchNoMatch)
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2743,9 +2795,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_update2Matches1Notifica
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(30000000, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2809,9 +2863,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_append2Matches1Notifica
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(30000000, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2869,9 +2925,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_delete2Matches1Notifica
     EXPECT_EQ(SccOk, ms);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860002")));
-    EXPECT_EQ(1360232700, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+
 
     /* Release mock */
     delete notifierMock;
@@ -2944,9 +3002,11 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, DISABLED_MongoDbQueryFail)
     EXPECT_EQ("", RES_CER_STATUS(0).details);
 
     /* Check lastNotification */
-    DBClientBase* connection = getMongoConnection();
-    BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID("51307b66f481db11bf860001")));
-    EXPECT_EQ(20000000, sub.getIntField("lastNotification"));
+    CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
+
+    ASSERT_TRUE(subP != NULL);
+    EXPECT_EQ(20000000, subP->lastNotificationTime);
+
 
     /* Restore real DB connection */
     setMongoConnectionForUnitTest(connectionDb);

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
@@ -1815,7 +1815,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_update2Matches1Notifica
     CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
 
     ASSERT_TRUE(subP != NULL);
-    EXPECT_EQ(20000000, subP->lastNotificationTime);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+    EXPECT_EQ(1, subP->count);
 
 
     /* Release mock */
@@ -1883,7 +1884,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_append2Matches1Notifica
     CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860001");
 
     ASSERT_TRUE(subP != NULL);
-    EXPECT_EQ(20000000, subP->lastNotificationTime);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+    EXPECT_EQ(1, subP->count);
 
 
     /* Release mock */
@@ -2798,7 +2800,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_update2Matches1Notifica
     CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
 
     ASSERT_TRUE(subP != NULL);
-    EXPECT_EQ(30000000, subP->lastNotificationTime);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+    EXPECT_EQ(1, subP->count);
 
 
     /* Release mock */
@@ -2866,7 +2869,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_append2Matches1Notifica
     CachedSubscription* subP = mongoSubCacheItemLookup("", "51307b66f481db11bf860002");
 
     ASSERT_TRUE(subP != NULL);
-    EXPECT_EQ(30000000, subP->lastNotificationTime);
+    EXPECT_EQ(1360232700, subP->lastNotificationTime);
+    EXPECT_EQ(1, subP->count);
 
 
     /* Release mock */


### PR DESCRIPTION
Implements #1476 

No longer maintaining subscription 'count' and 'lastNotificationTime' in DB, but in sub-cache.
DB is just used for synchronizing.
