### PR TITLE
Documentation changes to deprecate ONTIMEINTERVAL

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -18,3 +18,4 @@
 - Fix: Only 1 query at csubs collection/cache is done per context element processing at updateContext (previously one query per attribute were done) (Issue #1475)
 - Fix: 'count' and 'lastNotificationTime' now maintained by subCache (and synched via DB) (Issue #1476)
 - Fix: updates including several attributes with the same name are now reported as InvalidModification (Issue #908)
+- Deprecated: ONTIMEINTERVAL subscriptions

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -86,55 +86,55 @@ Fields:
 Example document:
 
 ```
- {
-   "_id":
-       "id": "E1",
-       "type": "T1",
-       "servicePath": "/"
-   },
-   "attrs": {
-       "A1": {
-           "type": "TA1",
-           "value": "282",
-           "creDate" : 1389376081,
-           "modDate" : 1389376120,
-           "md" : [
-              { 
-                 "name" : "customMD1",
-                 "type" : "string",
-                 "value" : "AKAKA"
-              },
-              {
-                 "name" : "customMD2",
-                 "type" : "integer",
-                 "value" : "23232"
-              }
-           ]
-       },
-       "A2_ID101": {
-           "type": "TA2",
-           "value": "176",
-           "creDate" : 1389376244,
-           "modDate" : 1389376244
-       },
-       "position": {
-           "type": "location",
-           "value": "40.418889, -3.691944",
-           "creDate" : 1389376244,
-           "modDate" : 1389376244
-       }
-   },
-   "attrNames": [ "A1", "A2", "position" ],
-   "creDate": 1389376081,
-   "modDate": 1389376244,
-   "location": {
-       "attrName": "position",
-       "coords": {
-           "type": "Point",
-           "coordinates": [ -3.691944, 40.418889 ]
-       }
-   }
- }
+ {
+   "_id":
+       "id": "E1",
+       "type": "T1",
+       "servicePath": "/"
+   },
+   "attrs": {
+       "A1": {
+           "type": "TA1",
+           "value": "282",
+           "creDate" : 1389376081,
+           "modDate" : 1389376120,
+           "md" : [
+              { 
+                 "name" : "customMD1",
+                 "type" : "string",
+                 "value" : "AKAKA"
+              },
+              {
+                 "name" : "customMD2",
+                 "type" : "integer",
+                 "value" : "23232"
+              }
+           ]
+       },
+       "A2_ID101": {
+           "type": "TA2",
+           "value": "176",
+           "creDate" : 1389376244,
+           "modDate" : 1389376244
+       },
+       "position": {
+           "type": "location",
+           "value": "40.418889, -3.691944",
+           "creDate" : 1389376244,
+           "modDate" : 1389376244
+       }
+   },
+   "attrNames": [ "A1", "A2", "position" ],
+   "creDate": 1389376081,
+   "modDate": 1389376244,
+   "location": {
+       "attrName": "position",
+       "coords": {
+           "type": "Point",
+           "coordinates": [ -3.691944, 40.418889 ]
+       }
+   }
+ }
 ```
 [Top](#top)
 
@@ -178,40 +178,40 @@ Fields:
 Example document:
 
 ```
- {
-   "_id": ObjectId("5149f60cf0075f2fabca43da"),
-   "fwdRegId": "5149f60cf0075f241bca22f1",
-   "expiration": 1360232760,
-   "contextRegistration": [
-       {
-           "entities": [
-               {
-                   "id": "E1",
-                   "type": "T1",
-                   "isPattern": "false"
-               },
-               {
-                   "id": "E2",
-                   "type": "T2",
-                   "isPattern": "false"
-               }
-           ],
-           "attrs": [
-               {
-                   "name": "A1",
-                   "type": "TA1",
-                   "isDomain": "false"
-               },
-               {
-                   "name": "A2",
-                  "type": "TA2",
-                   "isDomain": "true"
-               }
-           ],
-           "providingApplication": "http://foo.bar/notif"
-      },
-  ]
- }
+ {
+   "_id": ObjectId("5149f60cf0075f2fabca43da"),
+   "fwdRegId": "5149f60cf0075f241bca22f1",
+   "expiration": 1360232760,
+   "contextRegistration": [
+       {
+           "entities": [
+               {
+                   "id": "E1",
+                   "type": "T1",
+                   "isPattern": "false"
+               },
+               {
+                   "id": "E2",
+                   "type": "T2",
+                   "isPattern": "false"
+               }
+           ],
+           "attrs": [
+               {
+                   "name": "A1",
+                   "type": "TA1",
+                   "isDomain": "false"
+               },
+               {
+                   "name": "A2",
+                  "type": "TA2",
+                   "isDomain": "true"
+               }
+           ],
+           "providingApplication": "http://foo.bar/notif"
+      },
+  ]
+ }
 ```
 [Top](#top)
 
@@ -253,35 +253,35 @@ Fields:
 Example document:
 
 ```
- {
-   "_id": ObjectId("5149fd46f0075f83a4ca0300"),
-   "expiration": 1360236300,
-   "lastNotification": 1360232700,
-   "throttling": 10,
-   "reference": "http://notify.me",
-   "entities": [
-       {
-           "id": "E1",
-           "type": "T1",
-           "isPattern": "false"
-       }
-   ],
-   "attrs": [
-        "A1",
-        "A2"
-   ],
-   "conditions": [
-       {
-           "type": "ONCHANGE",
-           "value": [
-               "A1",
-               "A2"
-           ]
-       }
-   ],
-   "count": 27,
-   "format": "JSON"
- }
+ {
+   "_id": ObjectId("5149fd46f0075f83a4ca0300"),
+   "expiration": 1360236300,
+   "lastNotification": 1360232700,
+   "throttling": 10,
+   "reference": "http://notify.me",
+   "entities": [
+       {
+           "id": "E1",
+           "type": "T1",
+           "isPattern": "false"
+       }
+   ],
+   "attrs": [
+        "A1",
+        "A2"
+   ],
+   "conditions": [
+       {
+           "type": "ONCHANGE",
+           "value": [
+               "A1",
+               "A2"
+           ]
+       }
+   ],
+   "count": 27,
+   "format": "JSON"
+ }
 ```
 [Top](#top)
 
@@ -317,29 +317,29 @@ Fields:
 Example document:
 
 ```
- {
-   "_id": ObjectId("51756c2220be8dc1b5f415ff"),
-   "expiration": 1360236300,
-   "reference": "`[`http://notify.me`](http://notify.me)`",
-   "entities": [
-       {
-           "id": "E5",
-           "type": "T5",
-           "isPattern": "false"
-       },
-       {
-           "id": "E6",
-           "type": "T6",
-           "isPattern": "false"
-       }
-   ],
-   "attrs": [
-       "A1",
-       "A2"
-   ],
-   "lastNotification" : 1381132312,
-   "count": 42,
-   "format": "JSON"
- }
+ {
+   "_id": ObjectId("51756c2220be8dc1b5f415ff"),
+   "expiration": 1360236300,
+   "reference": "`[`http://notify.me`](http://notify.me)`",
+   "entities": [
+       {
+           "id": "E5",
+           "type": "T5",
+           "isPattern": "false"
+       },
+       {
+           "id": "E6",
+           "type": "T6",
+           "isPattern": "false"
+       }
+   ],
+   "attrs": [
+       "A1",
+       "A2"
+   ],
+   "lastNotification" : 1381132312,
+   "count": 42,
+   "format": "JSON"
+ }
 ```
 [Top](#top)

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -86,55 +86,55 @@ Fields:
 Example document:
 
 ```
- {
-   "_id":
-       "id": "E1",
-       "type": "T1",
-       "servicePath": "/"
-   },
-   "attrs": {
-       "A1": {
-           "type": "TA1",
-           "value": "282",
-           "creDate" : 1389376081,
-           "modDate" : 1389376120,
-           "md" : [
-              { 
-                 "name" : "customMD1",
-                 "type" : "string",
-                 "value" : "AKAKA"
-              },
-              {
-                 "name" : "customMD2",
-                 "type" : "integer",
-                 "value" : "23232"
-              }
-           ]
-       },
-       "A2_ID101": {
-           "type": "TA2",
-           "value": "176",
-           "creDate" : 1389376244,
-           "modDate" : 1389376244
-       },
-       "position": {
-           "type": "location",
-           "value": "40.418889, -3.691944",
-           "creDate" : 1389376244,
-           "modDate" : 1389376244
-       }
-   },
-   "attrNames": [ "A1", "A2", "position" ],
-   "creDate": 1389376081,
-   "modDate": 1389376244,
-   "location": {
-       "attrName": "position",
-       "coords": {
-           "type": "Point",
-           "coordinates": [ -3.691944, 40.418889 ]
-       }
-   }
- }
+ {
+   "_id":
+       "id": "E1",
+       "type": "T1",
+       "servicePath": "/"
+   },
+   "attrs": {
+       "A1": {
+           "type": "TA1",
+           "value": "282",
+           "creDate" : 1389376081,
+           "modDate" : 1389376120,
+           "md" : [
+              { 
+                 "name" : "customMD1",
+                 "type" : "string",
+                 "value" : "AKAKA"
+              },
+              {
+                 "name" : "customMD2",
+                 "type" : "integer",
+                 "value" : "23232"
+              }
+           ]
+       },
+       "A2_ID101": {
+           "type": "TA2",
+           "value": "176",
+           "creDate" : 1389376244,
+           "modDate" : 1389376244
+       },
+       "position": {
+           "type": "location",
+           "value": "40.418889, -3.691944",
+           "creDate" : 1389376244,
+           "modDate" : 1389376244
+       }
+   },
+   "attrNames": [ "A1", "A2", "position" ],
+   "creDate": 1389376081,
+   "modDate": 1389376244,
+   "location": {
+       "attrName": "position",
+       "coords": {
+           "type": "Point",
+           "coordinates": [ -3.691944, 40.418889 ]
+       }
+   }
+ }
 ```
 [Top](#top)
 
@@ -178,40 +178,40 @@ Fields:
 Example document:
 
 ```
- {
-   "_id": ObjectId("5149f60cf0075f2fabca43da"),
-   "fwdRegId": "5149f60cf0075f241bca22f1",
-   "expiration": 1360232760,
-   "contextRegistration": [
-       {
-           "entities": [
-               {
-                   "id": "E1",
-                   "type": "T1",
-                   "isPattern": "false"
-               },
-               {
-                   "id": "E2",
-                   "type": "T2",
-                   "isPattern": "false"
-               }
-           ],
-           "attrs": [
-               {
-                   "name": "A1",
-                   "type": "TA1",
-                   "isDomain": "false"
-               },
-               {
-                   "name": "A2",
-                  "type": "TA2",
-                   "isDomain": "true"
-               }
-           ],
-           "providingApplication": "http://foo.bar/notif"
-      },
-  ]
- }
+ {
+   "_id": ObjectId("5149f60cf0075f2fabca43da"),
+   "fwdRegId": "5149f60cf0075f241bca22f1",
+   "expiration": 1360232760,
+   "contextRegistration": [
+       {
+           "entities": [
+               {
+                   "id": "E1",
+                   "type": "T1",
+                   "isPattern": "false"
+               },
+               {
+                   "id": "E2",
+                   "type": "T2",
+                   "isPattern": "false"
+               }
+           ],
+           "attrs": [
+               {
+                   "name": "A1",
+                   "type": "TA1",
+                   "isDomain": "false"
+               },
+               {
+                   "name": "A2",
+                  "type": "TA2",
+                   "isDomain": "true"
+               }
+           ],
+           "providingApplication": "http://foo.bar/notif"
+      },
+  ]
+ }
 ```
 [Top](#top)
 
@@ -244,9 +244,7 @@ Fields:
 -   **entities**: an array of entities (mandatory). The JSON for each
     entity contains **id**, **type** and **isPattern**.
 -   **attrs**: an array of attribute names (strings) (optional).
--   **conditions**: a list of conditions that trigger notifications. The
-    two different cases currently supported are shown in the example
-    below (we think they're quite straightforward)
+-   **conditions**: a list of conditions that trigger notifications.
 -   **count**: the number of notifications sent associated to
     the subscription.
 -   **format**: the format to use to send notification, either "XML" or "JSON".
@@ -255,39 +253,35 @@ Fields:
 Example document:
 
 ```
- {
-   "_id": ObjectId("5149fd46f0075f83a4ca0300"),
-   "expiration": 1360236300,
-   "lastNotification": 1360232700,
-   "throttling": 10,
-   "reference": "http://notify.me",
-   "entities": [
-       {
-           "id": "E1",
-           "type": "T1",
-           "isPattern": "false"
-       }
-   ],
-   "attrs": [
-        "A1",
-        "A2"
-   ],
-   "conditions": [
-       {
-           "type": "ONTIMEINTERVAL",
-           "value": 60
-       },
-       {
-           "type": "ONCHANGE",
-           "value": [
-               "A1",
-               "A2"
-           ]
-       }
-   ],
-   "count": 27,
-   "format": "JSON"
- }
+ {
+   "_id": ObjectId("5149fd46f0075f83a4ca0300"),
+   "expiration": 1360236300,
+   "lastNotification": 1360232700,
+   "throttling": 10,
+   "reference": "http://notify.me",
+   "entities": [
+       {
+           "id": "E1",
+           "type": "T1",
+           "isPattern": "false"
+       }
+   ],
+   "attrs": [
+        "A1",
+        "A2"
+   ],
+   "conditions": [
+       {
+           "type": "ONCHANGE",
+           "value": [
+               "A1",
+               "A2"
+           ]
+       }
+   ],
+   "count": 27,
+   "format": "JSON"
+ }
 ```
 [Top](#top)
 
@@ -323,29 +317,29 @@ Fields:
 Example document:
 
 ```
- {
-   "_id": ObjectId("51756c2220be8dc1b5f415ff"),
-   "expiration": 1360236300,
-   "reference": "`[`http://notify.me`](http://notify.me)`",
-   "entities": [
-       {
-           "id": "E5",
-           "type": "T5",
-           "isPattern": "false"
-       },
-       {
-           "id": "E6",
-           "type": "T6",
-           "isPattern": "false"
-       }
-   ],
-   "attrs": [
-       "A1",
-       "A2"
-   ],
-   "lastNotification" : 1381132312,
-   "count": 42,
-   "format": "JSON"
- }
+ {
+   "_id": ObjectId("51756c2220be8dc1b5f415ff"),
+   "expiration": 1360236300,
+   "reference": "`[`http://notify.me`](http://notify.me)`",
+   "entities": [
+       {
+           "id": "E5",
+           "type": "T5",
+           "isPattern": "false"
+       },
+       {
+           "id": "E6",
+           "type": "T6",
+           "isPattern": "false"
+       }
+   ],
+   "attrs": [
+       "A1",
+       "A2"
+   ],
+   "lastNotification" : 1381132312,
+   "count": 42,
+   "format": "JSON"
+ }
 ```
 [Top](#top)

--- a/doc/manuals/deprecated.md
+++ b/doc/manuals/deprecated.md
@@ -17,10 +17,10 @@ A list of deprecated features and the version in which they were deprecated foll
 
 * ONTIMEINTERVAL subscriptions are deprecated since Orion 0.26.0. ONTIMEINTERVAL subscriptions have
   several problems (introduce state in CB, thus making horizontal scaling configuration much harder,
-  and make difficult to introduce pagination/filtering). Actually, thery aren't actually needed,
+  and makes it difficult to introduce pagination/filtering). Actually, they aren't actually needed,
   as any use case based on ONTIMEINTERVAL notification can be converted to an equivalent use case
   in which the receptor runs queryContext at the same frequency (and taking advantage of the
-  functionalitiese of queryContext, such as pagination or filtering).
+  features of queryContext, such as pagination or filtering).
 * XML is deprecated since Orion 0.23.0.
 * Deprecated command line arguments in Orion 0.21.0 (removed in 0.25.0):
 	* **-ngsi9**. The broker runs only NGSI9 (NGSI10 is not used).

--- a/doc/manuals/deprecated.md
+++ b/doc/manuals/deprecated.md
@@ -15,8 +15,8 @@ not mantained or evolved any longer. In particular:
 
 A list of deprecated features and the version in which they were deprecated follows:
 
-* ONTIMEINTERVAL subscriptions are deprecated since Orion 0.25.0. OTIMEINTERVAL subscriptions have
-  several problems (introduce state in CB, thus making much harder horizontal scaling configuration,
+* ONTIMEINTERVAL subscriptions are deprecated since Orion 0.26.0. ONTIMEINTERVAL subscriptions have
+  several problems (introduce state in CB, thus making horizontal scaling configuration much harder,
   and make difficult to introduce pagination/filtering). Actually, thery aren't actually needed,
   as any use case based on ONTIMEINTERVAL notification can be converted to an equivalent use case
   in which the receptor runs queryContext at the same frequency (and taking advantage of the

--- a/doc/manuals/deprecated.md
+++ b/doc/manuals/deprecated.md
@@ -6,13 +6,21 @@ not mantained or evolved any longer. In particular:
 -   Bugs or issues related with deprecated features and not affecting
     any other feature are not addressed (they are closed in github.com
     as soon as they are spotted).
--   Documentation on deprecated features is removed from the repository documentation. Documentation is still 	available in the documentation set associated to older versions (either in the respository release branches or   	the pre-0.23.0 documentation in the FIWARE wiki). 
+-   Documentation on deprecated features is removed from the repository documentation.
+    Documentation is still available in the documentation set associated to older versions
+    (either in the respository release branches or the pre-0.23.0 documentation in the FIWARE wiki).
 -   Deprecated functionality is eventually removed from Orion. Thus you
     are strongly encouraged to change your implementations using Orion
     in order not rely on deprecated functionality.
 
 A list of deprecated features and the version in which they were deprecated follows:
 
+* ONTIMEINTERVAL subscriptions are deprecated since Orion 0.25.0. OTIMEINTERVAL subscriptions have
+  several problems (introduce state in CB, thus making much harder horizontal scaling configuration,
+  and make difficult to introduce pagination/filtering). Actually, thery aren't actually needed,
+  as any use case based on ONTIMEINTERVAL notification can be converted to an equivalent use case
+  in which the receptor runs queryContext at the same frequency (and taking advantage of the
+  functionalitiese of queryContext, such as pagination or filtering).
 * XML is deprecated since Orion 0.23.0.
 * Deprecated command line arguments in Orion 0.21.0 (removed in 0.25.0):
 	* **-ngsi9**. The broker runs only NGSI9 (NGSI10 is not used).

--- a/doc/manuals/user/walkthrough_apiv1.md
+++ b/doc/manuals/user/walkthrough_apiv1.md
@@ -1008,10 +1008,10 @@ Let's examine in detail the different elements included in the payload:
     [Update context elements](#update-context-elements) trigger
     the notification. The rule is that if at least one of the attributes
     in the list changes (e.g. some kind of "OR" condition), then a
-    notification is sent. But note  that notification includes the
+    notification is sent. But note that a notification includes the
     attributes in the attribute vector, which doesn't necessarily
     include any attribute in the condValue. For example, in this case,
-    when Room1 pressure changes the Room1 temperature value is notified,
+    when Room1 pressure changes, the Room1 temperature value is notified,
     but not pressure itself. If you want also pressure to be notified,
     the request would need to include
     &lt;attribute&gt;pressure&lt;/attribute&gt; within the attribute vector
@@ -1022,12 +1022,11 @@ Let's examine in detail the different elements included in the payload:
     way only to show the enormous flexibility of subscriptions.
 -   The throttling element is used to specify a minimum
     inter-notification arrival time. So, setting throttling to 5 seconds
-    as in the example above makes that a notification will not be sent
+    as in the example above, makes a notification not to be sent
     if a previous notification was sent less than 5 seconds ago, no
-    matter how many actual changes take place in that period. This is to
-    not stress the notification receptor in case of having context
-    producers that update attribute values too frequently.
-
+    matter how many actual changes take place in that period. This is give the 
+   notification receptor a means to protect itself against context producers 
+   that update attribute values too frequently.
 
 The response corresponding to that request contains a subscription ID (a
 24 hexadecimal number used for updating and cancelling the subscription
@@ -1106,7 +1105,7 @@ behavior could be changed in a later version. What's your opinion? :)
 
 Now, do the following exercise, based on what you know from [update
 context](#update-context-elements): Do the following 4
-updates, in sequence and letting pass more than 5 seconds between one
+updates in sequence, letting pass more than 5 seconds between one
 and the next (to avoid losing notifications due to throttling):
 
 -   update Room1 temperature to 27: nothing happens, as temperature is
@@ -1114,8 +1113,8 @@ and the next (to avoid losing notifications due to throttling):
 -   update Room1 pressure to 765: you will get a notification with the
     current value of Room1 temperature (27)
 -   update Room1 pressure to 765: nothing happens, as the broker is
-    clever enough to know that the previous value to the updateContext
-    request was also 765 so no actual update have occurred and
+    clever enough to know that the value previous to the updateContext
+    request was also 765 so no actual update has occurred and
     consequently no notification is sent.
 -   update Room2 pressure to 740: nothing happens, as the subscription
     is for Room1, not Room2.
@@ -1181,7 +1180,7 @@ successful.
 }
 ```
 
-You can do some more updates a look at accumulator-server.py to check that the
+You can do some more updates and look at accumulator-server.py to check that the
 notification flow has stopped.
 
 [Top](#top)


### PR DESCRIPTION
As usual, straighforward English fixes can be done directly in the PR, without needed of commenting.