### PR TITLE
Check of Subscription ID before sending request to mongo layer

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -22,4 +22,4 @@
 - Fix: no longer adding subscriptions from all tenants in the cache if broker isn't multitenant (Issue #1555)
 - Fix: resetting temporal counters at synching the subscription cache (Issue #1562)
 - Fix: using the text "too many sbuscriptions" at cache statistics operations in the case of too many results
-- Fix: crash due to subscription ID not conforming to supposed syntax (Issue #1552)
+- Fix: crash due to subscription ID not conforming to supposed syntax in request "GET /v2/subscriptions/XXX" (Issue #1552)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -22,3 +22,4 @@
 - Fix: no longer adding subscriptions from all tenants in the cache if broker isn't multitenant (Issue #1555)
 - Fix: resetting temporal counters at synching the subscription cache (Issue #1562)
 - Fix: using the text "too many sbuscriptions" at cache statistics operations in the case of too many results
+- Fix: crash due to subscription ID not conforming to supposed syntax (Issue #1552)

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -264,10 +264,12 @@ void mongoGetSubscription
 {
   bool         reqSemTaken = false;
   std::string  err;
+  OID          oid;
+  StatusCode   sc;
 
-  if ((err = idCheck(idSub)) != "OK")
+  if (safeGetSubId(idSub, &oid, &sc) == false)
   {
-    *oe = OrionError(SccBadRequest, err);
+    *oe = OrionError(sc);
     return;
   }
 
@@ -276,7 +278,7 @@ void mongoGetSubscription
   LM_T(LmtMongo, ("Mongo Get Subscription"));
 
   std::auto_ptr<DBClientCursor>  cursor;
-  BSONObj                        q     = BSON("_id" << OID(idSub));
+  BSONObj                        q     = BSON("_id" << oid);
 
   if (!collectionQuery(getSubscribeContextCollectionName(tenant), q, &cursor, &err))
   {

--- a/src/lib/serviceRoutinesV2/getSubscription.cpp
+++ b/src/lib/serviceRoutinesV2/getSubscription.cpp
@@ -38,6 +38,7 @@
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/OrionError.h"
+#include "common/idCheck.h"
 
 
 
@@ -60,12 +61,19 @@ std::string getSubscription
   std::string          idSub = compV[2];
   OrionError           oe;
   std::string          out;
+  std::string          err;
+
+  if ((err = idCheck(idSub)) != "OK")
+  {
+    OrionError oe(SccBadRequest, err);
+    return oe.render(ciP, "Invalid subscription ID");
+  }
 
   TIMED_MONGO(mongoGetSubscription(&sub, &oe, idSub, ciP->uriParam, ciP->tenant));
 
   if (oe.code != SccOk)
   {
-    TIMED_RENDER(out = oe.render(ciP,""));
+    TIMED_RENDER(out = oe.render(ciP, "Invalid subscription ID"));
     return out;
   }
 

--- a/test/functionalTest/cases/1552_invalid_sub_id/invalid_sub_id.test
+++ b/test/functionalTest/cases/1552_invalid_sub_id/invalid_sub_id.test
@@ -1,0 +1,82 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Invalid subscripton id
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Ask to see a subscription with invalid ID
+# 02. Ask to see a subscription that doesn't exist
+#
+
+echo "01. Ask to see a subscription with invalid ID"
+echo "============================================="
+orionCurl --url /v2/subscriptions/inexistentid --json
+echo
+echo
+
+
+echo "02. Ask to see a subscription that doesn't exist"
+echo "================================================"
+orionCurl --url /v2/subscriptions/000011112222333344445555 --json
+echo
+echo
+
+
+--REGEXPECT--
+01. Ask to see a subscription with invalid ID
+=============================================
+HTTP/1.1 400 Bad Request
+Content-Length: 69
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "bad length - 24 chars expected",
+    "error": "BadRequest"
+}
+
+
+02. Ask to see a subscription that doesn't exist
+================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 89
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "",
+    "error": "subscriptionId does not correspond to an active subscription"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+
+


### PR DESCRIPTION
Fixes issue #1552 

Checking subscription ID before letting it pass down to mongo layer, for GET "/v2/subscriptions/XXX"