### PR TITLE
Hardening/1380 http request send return value

### DIFF
--- a/src/lib/ngsiNotify/QueueWorkers.cpp
+++ b/src/lib/ngsiNotify/QueueWorkers.cpp
@@ -106,28 +106,31 @@ static void *workerFunc(void* pSyncQ)
     }
     else // we'll send the notification
     {
-      std::string r =  httpRequestSendWithCurl(curl, params->ip,
-                                       params->port,
-                                       params->protocol,
-                                       params->verb,
-                                       params->tenant,
-                                       params->servicePath,
-                                       params->xauthToken,
-                                       params->resource,
-                                       params->content_type,
-                                       params->content,
-                                       true,
-                                       NOTIFICATION_WAIT_MODE);
+      std::string  out;
+      int          r;
 
-      if ((r != "") && (r != "error"))
-      {
-        statisticsUpdate(NotifyContextSent, params->format);
-      }
+      r =  httpRequestSendWithCurl(curl,
+                                   params->ip,
+                                   params->port,
+                                   params->protocol,
+                                   params->verb,
+                                   params->tenant,
+                                   params->servicePath,
+                                   params->xauthToken,
+                                   params->resource,
+                                   params->content_type,
+                                   params->content,
+                                   true,
+                                   NOTIFICATION_WAIT_MODE,
+                                   &out);
 
+      //
       // FIXME: ok and error counter should be incremented in the other notification modes (generalizing the concept, i.e.
       // not as member of QueueStatistics:: which seems to be tied to just the threadpool notification mode)
-      if (r != "error" && r != "")
+      //
+      if (r == 0)
       {
+        statisticsUpdate(NotifyContextSent, params->format);
         QueueStatistics::incSentOK();
       }
       else

--- a/src/lib/ngsiNotify/senderThread.cpp
+++ b/src/lib/ngsiNotify/senderThread.cpp
@@ -51,7 +51,8 @@ void* startSenderThread(void* p)
 
     if (!simulatedNotification)
     {
-      std::string r;
+      std::string  out;
+      int          r;
 
       r = httpRequestSend(params->ip,
                           params->port,
@@ -64,9 +65,10 @@ void* startSenderThread(void* p)
                           params->content_type,
                           params->content,
                           true,
-                          NOTIFICATION_WAIT_MODE);
+                          NOTIFICATION_WAIT_MODE,
+                          &out);
 
-      if ((r != "") && (r != "error"))
+      if (r == 0)
       {
         statisticsUpdate(NotifyContextSent, params->format);
       }

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -159,12 +159,21 @@ static char* curlVersionGet(char* buf, int bufLen)
 * arguments or (even better) an exception. To be solved in the future in a hardening
 * period.
 *
-* Note, we are using a hybrid approach, consisting in an static thread-local buffer of
+* Note, we are using a hybrid approach, consisting in a static thread-local buffer of
 * small size that copes with most notifications to avoid expensive
 * calloc/free syscalls if the notification payload is not very large.
 *
+* RETURN VALUES
+*   httpRequestSendWithCurl return 0 on success and a negative number on failure:
+*     -1: Invalid port
+*     -2: Invalid IP
+*     -3: Invalid verb
+*     -4: Invalid resource
+*     -5: No Content-Type BUT content present
+*     -6: Content-Type present but there is no content
+*     -7: Total outgoing message size is too big
 */
-std::string httpRequestSendWithCurl
+int httpRequestSendWithCurl
 (
    CURL                   *curl,
    const std::string&     _ip,
@@ -179,6 +188,7 @@ std::string httpRequestSendWithCurl
    const std::string&     content,
    bool                   useRush,
    bool                   waitForResponse,
+   std::string*           outP,
    const std::string&     acceptFormat,
    long                   timeoutInMilliseconds
 )
@@ -213,42 +223,54 @@ std::string httpRequestSendWithCurl
   {
     LM_E(("Runtime Error (port is ZERO)"));
     LM_TRANSACTION_END();
-    return "error";
+
+    *outP = "error";
+    return -1;
   }
 
   if (ip.empty())
   {
     LM_E(("Runtime Error (ip is empty)"));
     LM_TRANSACTION_END();
-    return "error";
+
+    *outP = "error";
+    return -2;
   }
 
   if (verb.empty())
   {
     LM_E(("Runtime Error (verb is empty)"));
     LM_TRANSACTION_END();
-    return "error";
+
+    *outP = "error";
+    return -3;
   }
 
   if (resource.empty())
   {
     LM_E(("Runtime Error (resource is empty)"));
     LM_TRANSACTION_END();
-    return "error";
+
+    *outP = "error";
+    return -4;
   }
 
   if ((content_type.empty()) && (!content.empty()))
   {
     LM_E(("Runtime Error (Content-Type is empty but there is actual content)"));
     LM_TRANSACTION_END();
-    return "error";
+
+    *outP = "error";
+    return -5;
   }
 
   if ((!content_type.empty()) && (content.empty()))
   {
     LM_E(("Runtime Error (Content-Type non-empty but there is no content)"));
     LM_TRANSACTION_END();
-    return "error";
+
+    *outP = "error";
+    return -6;
   }
 
 
@@ -270,7 +292,9 @@ std::string httpRequestSendWithCurl
   // Also, a few HTTP headers for rush must be setup.
   //
   if ((rushPort == 0) || (rushHost == ""))
+  {
     useRush = false;
+  }
 
   if (useRush)
   {
@@ -279,8 +303,8 @@ std::string httpRequestSendWithCurl
     std::string  rushHeaderIP       = ip;
     std::string  headerRushHttp;
 
-    ip             = rushHost;
-    port           = rushPort;
+    ip    = rushHost;
+    port  = rushPort;
 
     snprintf(rushHeaderPortAsString, sizeof(rushHeaderPortAsString), "%d", rushHeaderPort);
     headerRushHttp = "X-relayer-host: " + rushHeaderIP + ":" + rushHeaderPortAsString;
@@ -377,7 +401,8 @@ std::string httpRequestSendWithCurl
     delete httpResponse;
 
     LM_TRANSACTION_END();
-    return "error";
+    *outP = "error";
+    return -7;
   }
 
   // Contents
@@ -432,13 +457,13 @@ std::string httpRequestSendWithCurl
     //       So, this line should not be removed/altered, at least not without also modifying the functests.
     //
     LM_W(("Notification failure for %s:%s (curl_easy_perform failed: %s)", ip.c_str(), portAsString, curl_easy_strerror(res)));
-    result = "";
+    *outP = "invalid context provider response";
   }
   else
   {
     // The Response is here
     LM_I(("Notification Successfully Sent to %s", url.c_str()));
-    result.assign(httpResponse->memory, httpResponse->size);
+    outP->assign(httpResponse->memory, httpResponse->size);
   }
 
   // Cleanup curl environment
@@ -450,10 +475,27 @@ std::string httpRequestSendWithCurl
 
   LM_TRANSACTION_END();
 
-  return result;
+  return 0;
 }
 
-std::string httpRequestSend
+
+
+/* ****************************************************************************
+*
+* httpRequestSend - 
+*
+* RETURN VALUES
+*   httpRequestSend return 0 on success and a negative number on failure:
+*     -1: Invalid port
+*     -2: Invalid IP
+*     -3: Invalid verb
+*     -4: Invalid resource
+*     -5: No Content-Type BUT content present
+*     -6: Content-Type present but there is no content
+*     -7: Total outgoing message size is too big
+*     -8: Unable to initialize libcurl
+*/
+int httpRequestSend
 (
    const std::string&     _ip,
    unsigned short         port,
@@ -467,12 +509,13 @@ std::string httpRequestSend
    const std::string&     content,
    bool                   useRush,
    bool                   waitForResponse,
+   std::string*           outP,
    const std::string&     acceptFormat,
    long                   timeoutInMilliseconds
 )
 {
-  struct curl_context cc;
-  std::string         resp;
+  struct curl_context  cc;
+  int                  response;
 
   get_curl_context(_ip, &cc);
   if (cc.curl == NULL)
@@ -480,12 +523,27 @@ std::string httpRequestSend
     release_curl_context(&cc);
     LM_E(("Runtime Error (could not init libcurl)"));
     LM_TRANSACTION_END();
-    return "error";
+
+    *outP = "error";
+    return -8;
   }
-  resp = httpRequestSendWithCurl(cc.curl, _ip, port, protocol, verb, tenant, servicePath, xauthToken,
-                                             resource, orig_content_type, content, useRush, waitForResponse,
-                                             acceptFormat, timeoutInMilliseconds
-        );
+
+  response = httpRequestSendWithCurl(cc.curl,
+                                     _ip,
+                                     port,
+                                     protocol,
+                                     verb,
+                                     tenant,
+                                     servicePath,
+                                     xauthToken,
+                                     resource,
+                                     orig_content_type,
+                                     content,
+                                     useRush,
+                                     waitForResponse,
+                                     outP,
+                                     acceptFormat,
+                                     timeoutInMilliseconds);
   release_curl_context(&cc);
-  return resp;
+  return response;
 }

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -154,17 +154,13 @@ static char* curlVersionGet(char* buf, int bufLen)
 * The waitForResponse arguments specifies if the method has to wait for response
 * before return. If this argument is false, the return string is ""
 *
-* FIXME: I don't like too much "reusing" natural output to return "error" in the
-* case of error. I think it would be smarter to use "std::string* error" in the
-* arguments or (even better) an exception. To be solved in the future in a hardening
-* period.
-*
-* Note, we are using a hybrid approach, consisting in a static thread-local buffer of
+* NOTE
+* We are using a hybrid approach, consisting in a static thread-local buffer of a
 * small size that copes with most notifications to avoid expensive
 * calloc/free syscalls if the notification payload is not very large.
 *
 * RETURN VALUES
-*   httpRequestSendWithCurl return 0 on success and a negative number on failure:
+*   httpRequestSendWithCurl returns 0 on success and a negative number on failure:
 *     -1: Invalid port
 *     -2: Invalid IP
 *     -3: Invalid verb
@@ -457,7 +453,7 @@ int httpRequestSendWithCurl
     //       So, this line should not be removed/altered, at least not without also modifying the functests.
     //
     LM_W(("Notification failure for %s:%s (curl_easy_perform failed: %s)", ip.c_str(), portAsString, curl_easy_strerror(res)));
-    *outP = "invalid context provider response";
+    *outP = "notification failure";
   }
   else
   {
@@ -485,7 +481,7 @@ int httpRequestSendWithCurl
 * httpRequestSend - 
 *
 * RETURN VALUES
-*   httpRequestSend return 0 on success and a negative number on failure:
+*   httpRequestSend returns 0 on success and a negative number on failure:
 *     -1: Invalid port
 *     -2: Invalid IP
 *     -3: Invalid verb
@@ -494,6 +490,8 @@ int httpRequestSendWithCurl
 *     -6: Content-Type present but there is no content
 *     -7: Total outgoing message size is too big
 *     -8: Unable to initialize libcurl
+*
+*   [ error codes -1 to -7 comes from httpRequestSendWithCurl ]
 */
 int httpRequestSend
 (

--- a/src/lib/rest/httpRequestSend.h
+++ b/src/lib/rest/httpRequestSend.h
@@ -1,5 +1,5 @@
-#ifndef CLIENT_SOCKET_HTTP_H
-#define CLIENT_SOCKET_HTTP_H
+#ifndef SRC_LIB_REST_HTTPREQUESTSEND_H_
+#define SRC_LIB_REST_HTTPREQUESTSEND_H_
 
 /*
 *
@@ -57,7 +57,7 @@ extern int httpRequestConnect(const std::string& host, unsigned short port);
 *
 * httpRequestSend - 
 */
-extern std::string httpRequestSend
+extern int httpRequestSend
 (
   const std::string&     ip,
   unsigned short         port, 
@@ -71,15 +71,18 @@ extern std::string httpRequestSend
   const std::string&     content,
   bool                   useRush,
   bool                   waitForResponse,
+  std::string*           outP,
   const std::string&     acceptFormat          = "",
   long                   timeoutInMilliseconds = -1
 );
+
+
 
 /* ****************************************************************************
 *
 * httpRequestSendWithCurl -
 */
-extern std::string httpRequestSendWithCurl
+extern int httpRequestSendWithCurl
 (
   CURL                   *curl,
   const std::string&     ip,
@@ -94,10 +97,9 @@ extern std::string httpRequestSendWithCurl
   const std::string&     content,
   bool                   useRush,
   bool                   waitForResponse,
+  std::string*           outP,
   const std::string&     acceptFormat          = "",
   long                   timeoutInMilliseconds = -1
-
 );
 
-
-#endif
+#endif  // SRC_LIB_REST_HTTPREQUESTSEND_H_

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -134,30 +134,33 @@ static void queryForward(ConnectionInfo* ciP, QueryContextRequest* qcrP, Format 
   // 3. Send the request to the Context Provider (and await the reply)
   // FIXME P7: Should Rush be used?
   //
-  std::string     out;
   std::string     verb         = "POST";
   std::string     resource     = prefix + "/queryContext";
   std::string     tenant       = ciP->tenant;
   std::string     servicePath  = (ciP->httpHeaders.servicePathReceived == true)? ciP->httpHeaders.servicePath : "";
   std::string     mimeType     = (format == XML)? "application/xml" : "application/json";
+  std::string     out;
+  int             r;
 
-  out = httpRequestSend(ip,
-                        port,
-                        protocol,
-                        verb,
-                        tenant,
-                        servicePath,
-                        ciP->httpHeaders.xauthToken,
-                        resource,
-                        mimeType,
-                        payload,
-                        false,
-                        true,
-                        mimeType);
+  r = httpRequestSend(ip,
+                      port,
+                      protocol,
+                      verb,
+                      tenant,
+                      servicePath,
+                      ciP->httpHeaders.xauthToken,
+                      resource,
+                      mimeType,
+                      payload,
+                      false,
+                      true,
+                      &out,
+                      mimeType);
 
-  if ((out == "error") || (out == ""))
+
+  if (r != 0)
   {
-    qcrsP->errorCode.fill(SccContextElementNotFound, "");
+    qcrsP->errorCode.fill(SccContextElementNotFound, "invalid context provider response");
     LM_W(("Runtime Error (error forwarding 'Query' to providing application)"));
     return;
   }

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -160,7 +160,7 @@ static void queryForward(ConnectionInfo* ciP, QueryContextRequest* qcrP, Format 
 
   if (r != 0)
   {
-    qcrsP->errorCode.fill(SccContextElementNotFound, "invalid context provider response");
+    qcrsP->errorCode.fill(SccContextElementNotFound, "notification failure");
     LM_W(("Runtime Error (error forwarding 'Query' to providing application)"));
     return;
   }

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -168,30 +168,32 @@ static void updateForward(ConnectionInfo* ciP, UpdateContextRequest* upcrP, Upda
   // 3. Send the request to the Context Provider (and await the reply)
   // FIXME P7: Should Rush be used?
   //
-  std::string     out;
   std::string     verb         = "POST";
   std::string     resource     = prefix + "/updateContext";
   std::string     tenant       = ciP->tenant;
   std::string     servicePath  = (ciP->httpHeaders.servicePathReceived == true)? ciP->httpHeaders.servicePath : "";
   std::string     mimeType     = (format == XML)? "application/xml" : "application/json";
+  std::string     out;
+  int             r;
 
-  out = httpRequestSend(ip,
-                        port,
-                        protocol,
-                        verb,
-                        tenant,
-                        servicePath,
-                        ciP->httpHeaders.xauthToken,
-                        resource,
-                        mimeType,
-                        cleanPayload,
-                        false,
-                        true,
-                        mimeType);
+  r = httpRequestSend(ip,
+                      port,
+                      protocol,
+                      verb,
+                      tenant,
+                      servicePath,
+                      ciP->httpHeaders.xauthToken,
+                      resource,
+                      mimeType,
+                      cleanPayload,
+                      false,
+                      true,
+                      &out,
+                      mimeType);
 
-  if ((out == "error") || (out == ""))
+  if (r != 0)
   {
-    upcrsP->errorCode.fill(SccContextElementNotFound, "");
+    upcrsP->errorCode.fill(SccContextElementNotFound, "invalid context provider response");
     LM_E(("Runtime Error (error forwarding 'Update' to providing application)"));
     return;
   }

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -193,7 +193,7 @@ static void updateForward(ConnectionInfo* ciP, UpdateContextRequest* upcrP, Upda
 
   if (r != 0)
   {
-    upcrsP->errorCode.fill(SccContextElementNotFound, "invalid context provider response");
+    upcrsP->errorCode.fill(SccContextElementNotFound, "notification failure");
     LM_E(("Runtime Error (error forwarding 'Update' to providing application)"));
     return;
   }

--- a/test/functionalTest/cases/0880_timeout_for_forward_and_notifications/forward_that_times_out.test
+++ b/test/functionalTest/cases/0880_timeout_for_forward_and_notifications/forward_that_times_out.test
@@ -155,13 +155,14 @@ Date: REGEX(.*)
 02. Update/UPDATE E1/T1/A1 on CB (provoking forward to accumulator)
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 94
+Content-Length: 147
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "errorCode": {
-        "code": "404", 
+        "code": "404",
+        "details": "invalid context provider response",
         "reasonPhrase": "No context element found"
     }
 }
@@ -179,13 +180,14 @@ Date: REGEX(.*)
 05. Query E1/T1/A1 on CB (provoking forward to accumulator)
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 94
+Content-Length: 147
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "errorCode": {
-        "code": "404", 
+        "code": "404",
+        "details": "invalid context provider response",
         "reasonPhrase": "No context element found"
     }
 }


### PR DESCRIPTION
Changed the signature of httpRequestSend and httpRequestSendWithCurl, to return an integer and not a string. The string is now an output-parameter to the function instead of the return value.

Fixes issue #1380 
