### PR TITLE
hardening/1583_log_levels_tracelevel_problem_in_functests

### DIFF
--- a/src/lib/logMsg/logMsg.h
+++ b/src/lib/logMsg/logMsg.h
@@ -981,11 +981,14 @@ do                                                                       \
 /* ****************************************************************************
 *
 * LM_T - log trace message
+*
+* FIXME: temporal change, just for Orion contextBroker, use LogLevelDebug for LM_T
+*        instead of its correct level LogLevelTrace.
 */
 #define LM_T(tLev, s)                                                         \
 do                                                                            \
 {                                                                             \
-  if (LM_MASK(LogLevelTrace) && lmOk('T', tLev) == LmsOk)                     \
+  if (LM_MASK(LogLevelDebug) && lmOk('T', tLev) == LmsOk)                     \
   {                                                                           \
     char* text;                                                               \
                                                                               \


### PR DESCRIPTION
Change for Orion to use LogLevelDebug for LM_T instead of its 'correct' level LogLevelTrace.
This was a bug introduced in my previous PR #1590

