### PR TITLE
New NGSIv2 JSON: part 8 (null support in mongoBackend)

### DIFF
--- a/src/lib/mongoBackend/compoundResponses.cpp
+++ b/src/lib/mongoBackend/compoundResponses.cpp
@@ -36,9 +36,9 @@ using namespace mongo;
 */
 static void addCompoundNode(orion::CompoundValueNode* cvP, const BSONElement& e)
 {
-  if ((e.type() != String) && (e.type() != Bool) && (e.type() != NumberDouble) && (e.type() != Object) && (e.type() != Array))
+  if ((e.type() != String) && (e.type() != Bool) && (e.type() != NumberDouble) && (e.type() != jstNULL) && (e.type() != Object) && (e.type() != Array))
   {
-    LM_T(LmtSoftError, ("unknown BSON type"));
+    LM_E(("Runtime Error (unknown BSON type: %d)", e.type()));
     return;
   }
 
@@ -60,6 +60,10 @@ static void addCompoundNode(orion::CompoundValueNode* cvP, const BSONElement& e)
   case NumberDouble:
     child->valueType  = orion::ValueTypeNumber;
     child->numberValue = e.Number();
+    break;
+
+  case jstNULL:
+    child->valueType  = orion::ValueTypeNone;
     break;
 
   case Object:

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -366,6 +366,13 @@ std::string ContextAttribute::renderAsJsonObject
         valueIsNumberOrBool = true;
         break;
 
+#if 0
+      // This may be useful for Ken's next PR (otherwise remove)
+      case ValueTypeNone:
+        effectiveValue = "null";
+        break;
+#endif
+
       default:
         LM_E(("Runtime Error (unknown value type: %d)", valueType));
       }
@@ -493,6 +500,13 @@ std::string ContextAttribute::render
         effectiveValue      = num;
         valueIsNumberOrBool = true;
         break;
+
+#if 0
+      // This may be useful for Ken's next PR (otherwise remove)
+      case ValueTypeNone:
+        effectiveValue = "null";
+        break;
+#endif
 
       default:
         LM_E(("Runtime Error (unknown value type: %d)", valueType));

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -207,6 +207,11 @@ ContextElementResponse::ContextElementResponse(const mongo::BSONObj& entityDoc, 
         caP = new ContextAttribute(ca.name, ca.type, ca.boolValue);
         break;
 
+      case jstNULL:
+        caP = new ContextAttribute(ca.name, ca.type, "");
+        caP->valueType = orion::ValueTypeNone;
+        break;
+
       case Object:
         caP = new ContextAttribute(ca.name, ca.type, "");
         caP->compoundValueP = new orion::CompoundValueNode(orion::ValueTypeObject);

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -161,6 +161,10 @@ Metadata::Metadata(const BSONObj& mdB)
     boolValue = getBoolField(mdB, ENT_ATTRS_MD_VALUE);
     break;
 
+  case jstNULL:
+    valueType = orion::ValueTypeNone;
+    break;
+
   default:
     valueType = orion::ValueTypeUnknown;
     LM_E(("Runtime Error (unknown metadata value value type in DB: %d)", getField(mdB, ENT_ATTRS_MD_VALUE).type()));

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -875,6 +875,12 @@ CompoundValueNode* CompoundValueNode::clone(void)
     case orion::ValueTypeBoolean:
       me = new CompoundValueNode(container, path, name, boolValue, siblingNo, valueType, level);
       break;
+
+    case orion::ValueTypeNone:
+      me = new CompoundValueNode(container, path, name, stringValue, siblingNo, valueType, level);
+      me->valueType = orion::ValueTypeNone;
+      break;
+
     default:
       me = NULL;
       LM_E(("Runtime Error (unknown compound node value type: %d)", valueType));

--- a/test/unittests/mongoBackend/mongoQueryContextCompoundValues_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContextCompoundValues_test.cpp
@@ -55,8 +55,8 @@
 * - CompoundValue1PlusSimpleValueNative
 * - CompoundValue2PlusSimpleValueNative
 *
-* Compound 1 is based on: [ 22, {x: [x1, x2], y: 3}, [z1, false] ]
-* Compound 2 is based on: { x: {x1: a, x2: true}, y: [ y1, y2 ] }
+* Compound 1 is based on: [ 22, {x: [x1, x2], y: 3, z: null}, [z1, false, null] ]
+* Compound 2 is based on: { x: {x1: a, x2: true}, y: [ y1, y2 ], z: null }
 *
 */
 
@@ -151,8 +151,9 @@ static void prepareDatabaseNative(void) {
                         "A1" << BSON("type" << "TA1" <<
                              "value" << BSON_ARRAY(22.0 <<
                                                    BSON("x" << BSON_ARRAY("x1" << "x2") <<
-                                                        "y" << 3.0) <<
-                                                   BSON_ARRAY("z1" << false)
+                                                        "y" << 3.0 <<
+                                                        "z" << BSONNULL) <<
+                                                   BSON_ARRAY("z1" << false << BSONNULL)
                                                    )
                              )
                         )
@@ -163,7 +164,8 @@ static void prepareDatabaseNative(void) {
                      "attrs" << BSON(
                         "A2" << BSON("type" << "TA2" <<
                              "value" << BSON("x" << BSON("x1" << "a" << "x2" << true) <<
-                                             "y" << BSON_ARRAY("y1" << "y2")
+                                             "y" << BSON_ARRAY("y1" << "y2" << BSONNULL) <<
+                                             "z" << BSONNULL
                                              )
                              )
                         )
@@ -175,8 +177,9 @@ static void prepareDatabaseNative(void) {
                         "A3" << BSON("type" << "TA3" <<
                              "value" << BSON_ARRAY(22.0 <<
                                                    BSON("x" << BSON_ARRAY("x1" << "x2") <<
-                                                        "y" << 3.0) <<
-                                                   BSON_ARRAY("z1" << false)
+                                                        "y" << 3.0 <<
+                                                        "z" << BSONNULL) <<
+                                                   BSON_ARRAY("z1" << false << BSONNULL)
                                                    )
                              ) <<
                         "A3bis" << BSON("type" << "TA3" << "value" << "val3")
@@ -188,7 +191,8 @@ static void prepareDatabaseNative(void) {
                      "attrs" << BSON(
                         "A4" << BSON("type" << "TA4" <<
                              "value" << BSON("x" << BSON("x1" << "a" << "x2" << true) <<
-                                             "y" << BSON_ARRAY("y1" << "y2")
+                                             "y" << BSON_ARRAY("y1" << "y2") <<
+                                             "z" << BSONNULL
                                              )
                              ) <<
                         "A4bis" << BSON("type" << "TA4" << "value" << "val4")
@@ -512,12 +516,15 @@ TEST(mongoQueryContextCompoundValuesRequest, CompoundValue1Native)
     EXPECT_EQ("x2", RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[0]->childV[1]->stringValue);
     EXPECT_EQ(orion::ValueTypeNumber, RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->valueType);
     EXPECT_EQ("y", RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->name);
-    EXPECT_EQ(3.0, RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->numberValue);
+    EXPECT_EQ(3.0, RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->numberValue);    
+    EXPECT_EQ(orion::ValueTypeNone, RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[2]->valueType);
+    EXPECT_EQ("z", RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[2]->name);
     EXPECT_EQ(orion::ValueTypeVector, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->valueType);
     EXPECT_EQ(orion::ValueTypeString, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[0]->valueType);
     EXPECT_EQ("z1", RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[0]->stringValue);
     EXPECT_EQ(orion::ValueTypeBoolean, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[1]->valueType);
-    EXPECT_FALSE(RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[1]->boolValue);
+    EXPECT_FALSE(RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[1]->boolValue);    
+    EXPECT_EQ(orion::ValueTypeNone, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[2]->valueType);
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
@@ -580,6 +587,8 @@ TEST(mongoQueryContextCompoundValuesRequest, CompoundValue2Native)
     EXPECT_EQ("y1", RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[0]->stringValue);
     EXPECT_EQ(orion::ValueTypeString, RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->valueType);
     EXPECT_EQ("y2", RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->stringValue);
+    EXPECT_EQ(orion::ValueTypeNone, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->valueType);
+    EXPECT_EQ("z", RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->name);
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
@@ -639,11 +648,14 @@ TEST(mongoQueryContextCompoundValuesRequest, CompoundValue1PlusSimpleValueNative
     EXPECT_EQ(orion::ValueTypeNumber, RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->valueType);
     EXPECT_EQ("y", RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->name);
     EXPECT_EQ(3.0, RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->numberValue);
+    EXPECT_EQ(orion::ValueTypeNone, RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[2]->valueType);
+    EXPECT_EQ("z", RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[2]->name);
     EXPECT_EQ(orion::ValueTypeVector, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->valueType);
     EXPECT_EQ(orion::ValueTypeString, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[0]->valueType);
     EXPECT_EQ("z1", RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[0]->stringValue);
     EXPECT_EQ(orion::ValueTypeBoolean, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[1]->valueType);
     EXPECT_FALSE(RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[1]->boolValue);
+    EXPECT_EQ(orion::ValueTypeNone, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->childV[2]->valueType);
     EXPECT_EQ("A3bis", RES_CER_ATTR(0, 1)->name);
     EXPECT_EQ("TA3", RES_CER_ATTR(0, 1)->type);
     EXPECT_EQ("val3", RES_CER_ATTR(0, 1)->stringValue);
@@ -709,6 +721,8 @@ TEST(mongoQueryContextCompoundValuesRequest, CompoundValue2PlusSimpleValueNative
     EXPECT_EQ("y1", RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[0]->stringValue);
     EXPECT_EQ(orion::ValueTypeString, RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->valueType);
     EXPECT_EQ("y2", RES_CER_ATTR(0, 0)->compoundValueP->childV[1]->childV[1]->stringValue);
+    EXPECT_EQ(orion::ValueTypeNone, RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->valueType);
+    EXPECT_EQ("z", RES_CER_ATTR(0, 0)->compoundValueP->childV[2]->name);
     EXPECT_EQ("A4bis", RES_CER_ATTR(0, 1)->name);
     EXPECT_EQ("TA4", RES_CER_ATTR(0, 1)->type);
     EXPECT_EQ("val4", RES_CER_ATTR(0, 1)->stringValue);

--- a/test/unittests/mongoBackend/mongoQueryContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_test.cpp
@@ -386,7 +386,8 @@ static void prepareDatabaseWithCustomMetadataNative(void) {
                           "A1" << BSON("type" << "TA1" << "value" << "A" <<
                                "md" << BSON_ARRAY(BSON("name" << "MD1" << "type" << "TMD1" << "value" << "val1") <<
                                                   BSON("name" << "MD2" << "type" << "TMD2" << "value" << 2.1) <<
-                                                  BSON("name" << "MD3" << "type" << "TMD3" << "value" << false)
+                                                  BSON("name" << "MD3" << "type" << "TMD3" << "value" << false) <<
+                                                  BSON("name" << "MD4" << "type" << "TMD4" << "value" << BSONNULL)
                                                  )
                                ) <<
                           "A2" << BSON("type" << "TA2" << "value" << "C" <<
@@ -559,17 +560,19 @@ static void prepareDatabaseDifferentNativeTypes(void) {
    *     A2: bool
    *     A3: vector
    *     A5: object
+   *     A6: null
    *
    */
 
   BSONObj en1 = BSON("_id" << BSON("id" << "E1" << "type" << "T1") <<
-                     "attrNames" << BSON_ARRAY("A1" << "A2" << "A3" << "A4" << "A5") <<
+                     "attrNames" << BSON_ARRAY("A1" << "A2" << "A3" << "A4" << "A5" << "A6") <<
                      "attrs" << BSON(
                         "A1" << BSON("type" << "T" << "value" << "s") <<
                         "A2" << BSON("type" << "T" << "value" << 42.0) <<
                         "A3" << BSON("type" << "T" << "value" << false) <<
                         "A4" << BSON("type" << "T" << "value" << BSON("x" << "a" << "y" << "b")) <<
-                        "A5" << BSON("type" << "T" << "value" << BSON_ARRAY("x1" << "x2"))
+                        "A5" << BSON("type" << "T" << "value" << BSON_ARRAY("x1" << "x2")) <<
+                        "A6" << BSON("type" << "T" << "value" << BSONNULL)
                         )
                     );
 
@@ -3010,7 +3013,7 @@ TEST(mongoQueryContextRequest, queryCustomMetadataNative)
     EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
     EXPECT_EQ("TA1", RES_CER_ATTR(0, 0)->type);
     EXPECT_EQ("A", RES_CER_ATTR(0, 0)->stringValue);
-    ASSERT_EQ(3, RES_CER_ATTR(0, 0)->metadataVector.size());
+    ASSERT_EQ(4, RES_CER_ATTR(0, 0)->metadataVector.size());
     EXPECT_EQ("MD1", RES_CER_ATTR(0, 0)->metadataVector[0]->name);
     EXPECT_EQ("TMD1", RES_CER_ATTR(0, 0)->metadataVector[0]->type);
     EXPECT_EQ("val1", RES_CER_ATTR(0, 0)->metadataVector[0]->stringValue);
@@ -3022,7 +3025,10 @@ TEST(mongoQueryContextRequest, queryCustomMetadataNative)
     EXPECT_EQ("MD3", RES_CER_ATTR(0, 0)->metadataVector[2]->name);
     EXPECT_EQ("TMD3", RES_CER_ATTR(0, 0)->metadataVector[2]->type);
     EXPECT_FALSE(RES_CER_ATTR(0, 0)->metadataVector[2]->boolValue);
-    EXPECT_EQ(orion::ValueTypeBoolean, RES_CER_ATTR(0, 0)->metadataVector[2]->valueType);
+    EXPECT_EQ(orion::ValueTypeBoolean, RES_CER_ATTR(0, 0)->metadataVector[2]->valueType);    
+    EXPECT_EQ("MD4", RES_CER_ATTR(0, 0)->metadataVector[3]->name);
+    EXPECT_EQ("TMD4", RES_CER_ATTR(0, 0)->metadataVector[3]->type);
+    EXPECT_EQ(orion::ValueTypeNone, RES_CER_ATTR(0, 0)->metadataVector[3]->valueType);
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
@@ -3658,7 +3664,7 @@ TEST(mongoQueryContextRequest, queryNativeTypes)
     EXPECT_EQ("E1", RES_CER(0).entityId.id);
     EXPECT_EQ("T1", RES_CER(0).entityId.type);
     EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
-    ASSERT_EQ(5, RES_CER(0).contextAttributeVector.size());
+    ASSERT_EQ(6, RES_CER(0).contextAttributeVector.size());
 
     EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
     EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
@@ -3695,6 +3701,11 @@ TEST(mongoQueryContextRequest, queryNativeTypes)
     EXPECT_EQ(orion::ValueTypeString, RES_CER_ATTR(0, 4)->compoundValueP->childV[1]->valueType);
     EXPECT_EQ("x2", RES_CER_ATTR(0, 4)->compoundValueP->childV[1]->stringValue);
     EXPECT_EQ(0, RES_CER_ATTR(0, 4)->metadataVector.size());
+
+    EXPECT_EQ("A6", RES_CER_ATTR(0, 5)->name);
+    EXPECT_EQ("T", RES_CER_ATTR(0, 5)->type);
+    EXPECT_EQ(ValueTypeNone, RES_CER_ATTR(0, 5)->valueType);
+    EXPECT_EQ(0, RES_CER_ATTR(0, 5)->metadataVector.size());
 
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);

--- a/test/unittests/mongoBackend/mongoUpdateContextCompoundValues_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextCompoundValues_test.cpp
@@ -86,10 +86,10 @@
     cv = new orion::CompoundValueNode(orion::ValueTypeVector);           \
                                                                          \
     cv->add(orion::ValueTypeString,         "",  "22");                  \
-    str  = cv->add(orion::ValueTypeObject,  "",  "");                    \
-    vec  = cv->add(orion::ValueTypeVector,  "",  "");                    \
+    str = cv->add(orion::ValueTypeObject,   "",  "");                    \
+    vec = cv->add(orion::ValueTypeVector,   "",  "");                    \
                                                                          \
-    x    = str->add(orion::ValueTypeVector, "x", "");                    \
+    x = str->add(orion::ValueTypeVector,    "x", "");                    \
     str->add(orion::ValueTypeString,        "y", "3");                   \
                                                                          \
     x->add(orion::ValueTypeString,          "",  "x1");                  \
@@ -110,14 +110,14 @@
                                                                          \
     cv = new orion::CompoundValueNode(orion::ValueTypeObject);           \
                                                                          \
-    x    = cv->add(orion::ValueTypeObject, "x",  "");                    \
-    y    = cv->add(orion::ValueTypeVector, "y",  "");                    \
+    x = cv->add(orion::ValueTypeObject, "x",  "");                       \
+    y = cv->add(orion::ValueTypeVector, "y",  "");                       \
                                                                          \
-    x->add(orion::ValueTypeString,  "x1", "a");                          \
-    x->add(orion::ValueTypeString,  "x2", "b");                          \
+    x->add(orion::ValueTypeString,      "x1", "a");                      \
+    x->add(orion::ValueTypeString,      "x2", "b");                      \
                                                                          \
-    y->add(orion::ValueTypeString,  "",   "y1");                         \
-    y->add(orion::ValueTypeString,  "",   "y2");                         \
+    y->add(orion::ValueTypeString,      "",   "y1");                     \
+    y->add(orion::ValueTypeString,      "",   "y2");                     \
                                                                          \
     cv->shortShow("shortShow2: ");                                       \
     cv->show("show2: ");
@@ -131,20 +131,20 @@
                                                                          \
     cv = new orion::CompoundValueNode(orion::ValueTypeVector);           \
                                                                          \
-    cv->add(orion::ValueTypeNumber,  "",  22.0);                         \
+    cv->add(orion::ValueTypeNumber,         "",  22.0);                  \
     str  = cv->add(orion::ValueTypeObject,  "",  "");                    \
     vec  = cv->add(orion::ValueTypeVector,  "",  "");                    \
                                                                          \
     x    = str->add(orion::ValueTypeVector, "x", "");                    \
-    str->add(orion::ValueTypeNumber, "y", 3.0);                          \
-    str->add(orion::ValueTypeNone, "z", "");                             \
+    str->add(orion::ValueTypeNumber,        "y", 3.0);                   \
+    str->add(orion::ValueTypeNone,          "z", "");                    \
                                                                          \
-    x->add(orion::ValueTypeString,   "",  "x1");                         \
-    x->add(orion::ValueTypeString,   "",  "x2");                         \
+    x->add(orion::ValueTypeString,          "",  "x1");                  \
+    x->add(orion::ValueTypeString,          "",  "x2");                  \
                                                                          \
-    vec->add(orion::ValueTypeString, "",  "z1");                         \
-    vec->add(orion::ValueTypeBoolean, "",  false);                       \
-    vec->add(orion::ValueTypeNone, "",  "");                             \
+    vec->add(orion::ValueTypeString,        "",  "z1");                  \
+    vec->add(orion::ValueTypeBoolean,       "",  false);                 \
+    vec->add(orion::ValueTypeNone,          "",  "");                    \
                                                                          \
     cv->shortShow("shortShow1: ");                                       \
     cv->show("show1: ");
@@ -159,13 +159,13 @@
                                                                          \
     x    = cv->add(orion::ValueTypeObject, "x",  "");                    \
     y    = cv->add(orion::ValueTypeVector, "y",  "");                    \
-    cv->add(orion::ValueTypeNone,   "z",  "");                           \
+    cv->add(orion::ValueTypeNone,          "z",  "");                    \
                                                                          \
-    x->add(orion::ValueTypeString,  "x1", "a");                          \
-    x->add(orion::ValueTypeBoolean, "x2", true);                         \
+    x->add(orion::ValueTypeString,         "x1", "a");                   \
+    x->add(orion::ValueTypeBoolean,        "x2", true);                  \
                                                                          \
-    y->add(orion::ValueTypeString,  "",   "y1");                         \
-    y->add(orion::ValueTypeString,  "",   "y2");                         \
+    y->add(orion::ValueTypeString,         "",   "y1");                  \
+    y->add(orion::ValueTypeString,         "",   "y2");                  \
                                                                          \
     cv->shortShow("shortShow2: ");                                       \
     cv->show("show2: ");

--- a/test/unittests/mongoBackend/mongoUpdateContextCompoundValues_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextCompoundValues_test.cpp
@@ -126,7 +126,7 @@
     cv->show("show2: ");
 
 
-// Compound1 native: [ 22.0, { x: [x1, x2], y: 3.0 }, [ z1, false ] ]
+// Compound1 native: [ 22.0, { x: [x1, x2], y: 3.0, z: null}, [ z1, false, null ] ]
 #define CREATE_COMPOUND1_NATIVE(cv)                                      \
     orion::CompoundValueNode*  str;                                      \
     orion::CompoundValueNode*  vec;                                      \
@@ -141,19 +141,21 @@
                                                                          \
     x    = str->add(orion::ValueTypeVector, "x", "");                    \
     leaf = str->add(orion::ValueTypeNumber, "y", 3.0);                   \
+    leaf = str->add(orion::ValueTypeNone, "z", "");                      \
                                                                          \
     leaf = x->add(orion::ValueTypeString,   "",  "x1");                  \
     leaf = x->add(orion::ValueTypeString,   "",  "x2");                  \
                                                                          \
     leaf = vec->add(orion::ValueTypeString, "",  "z1");                  \
     leaf = vec->add(orion::ValueTypeBoolean, "",  false);                \
+    leaf = vec->add(orion::ValueTypeNone, "",  "");                      \
                                                                          \
     leaf->check();                                                       \
     cv->shortShow("shortShow1: ");                                       \
     cv->show("show1: ");
 
 
-// Compound2 native: { x: { x1: a, x2: true }, y: [ y1, y2 ] }
+// Compound2 native: { x: { x1: a, x2: true }, y: [ y1, y2 ], z: null }
 #define CREATE_COMPOUND2_NATIVE(cv)                                      \
     orion::CompoundValueNode*  x;                                        \
     orion::CompoundValueNode*  y;                                        \
@@ -163,9 +165,10 @@
                                                                          \
     x    = cv->add(orion::ValueTypeObject, "x",  "");                    \
     y    = cv->add(orion::ValueTypeVector, "y",  "");                    \
+    leaf = cv->add(orion::ValueTypeNone,   "z",  "");                    \
                                                                          \
     leaf = x->add(orion::ValueTypeString,  "x1", "a");                   \
-    leaf = x->add(orion::ValueTypeBoolean,  "x2", true);                 \
+    leaf = x->add(orion::ValueTypeBoolean, "x2", true);                  \
                                                                          \
     leaf = y->add(orion::ValueTypeString,  "",   "y1");                  \
     leaf = y->add(orion::ValueTypeString,  "",   "y2");                  \
@@ -699,8 +702,10 @@ TEST(mongoUpdateContextCompoundValuesRequest, createCompoundValue1Native)
     EXPECT_EQ("x1", a1.getField("value").Array()[1].embeddedObject().getField("x").Array()[0].str());
     EXPECT_EQ("x2", a1.getField("value").Array()[1].embeddedObject().getField("x").Array()[1].str());
     EXPECT_EQ(3.0, a1.getField("value").Array()[1].embeddedObject().getField("y").Number());
+    EXPECT_TRUE(a1.getField("value").Array()[1].embeddedObject().getField("z").isNull());
     EXPECT_EQ("z1", a1.getField("value").Array()[2].Array()[0].str());
     EXPECT_FALSE(a1.getField("value").Array()[2].Array()[1].Bool());
+    EXPECT_TRUE(a1.getField("value").Array()[2].Array()[2].isNull());
     EXPECT_EQ(1360232700, a1.getIntField("modDate"));
     EXPECT_EQ(1360232700, a1.getIntField("creDate"));
 
@@ -782,6 +787,7 @@ TEST(mongoUpdateContextCompoundValuesRequest, createCompoundValue2Native)
     EXPECT_TRUE(a1.getField("value").embeddedObject().getField("x").embeddedObject().getField("x2").Bool());
     EXPECT_EQ("y1", a1.getField("value").embeddedObject().getField("y").Array()[0].str());
     EXPECT_EQ("y2", a1.getField("value").embeddedObject().getField("y").Array()[1].str());
+    EXPECT_TRUE(a1.getField("value").embeddedObject().getField("z").isNull());
     EXPECT_EQ(1360232700, a1.getIntField("modDate"));
     EXPECT_EQ(1360232700, a1.getIntField("creDate"));
 
@@ -871,8 +877,10 @@ TEST(mongoUpdateContextCompoundValuesRequest, createCompoundValue1PlusSimpleValu
     EXPECT_EQ("x1", a1.getField("value").Array()[1].embeddedObject().getField("x").Array()[0].str());
     EXPECT_EQ("x2", a1.getField("value").Array()[1].embeddedObject().getField("x").Array()[1].str());
     EXPECT_EQ(3.0, a1.getField("value").Array()[1].embeddedObject().getField("y").Number());
+    EXPECT_TRUE(a1.getField("value").Array()[1].embeddedObject().getField("z").isNull());
     EXPECT_EQ("z1", a1.getField("value").Array()[2].Array()[0].str());
     EXPECT_FALSE(a1.getField("value").Array()[2].Array()[1].Bool());
+    EXPECT_TRUE(a1.getField("value").Array()[2].Array()[2].isNull());
     EXPECT_EQ(1360232700, a1.getIntField("modDate"));
     EXPECT_EQ(1360232700, a1.getIntField("creDate"));
     EXPECT_STREQ("TA2",C_STR_FIELD(a2, "type"));
@@ -966,6 +974,7 @@ TEST(mongoUpdateContextCompoundValuesRequest, createCompoundValue2PlusSimpleValu
     EXPECT_TRUE(a1.getField("value").embeddedObject().getField("x").embeddedObject().getField("x2").Bool());
     EXPECT_EQ("y1", a1.getField("value").embeddedObject().getField("y").Array()[0].str());
     EXPECT_EQ("y2", a1.getField("value").embeddedObject().getField("y").Array()[1].str());
+    EXPECT_TRUE(a1.getField("value").embeddedObject().getField("z").isNull());
     EXPECT_EQ(1360232700, a1.getIntField("modDate"));
     EXPECT_EQ(1360232700, a1.getIntField("creDate"));
     EXPECT_STREQ("TA2",C_STR_FIELD(a2, "type"));

--- a/test/unittests/mongoBackend/mongoUpdateContextCompoundValues_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextCompoundValues_test.cpp
@@ -82,24 +82,22 @@
     orion::CompoundValueNode*  str;                                      \
     orion::CompoundValueNode*  vec;                                      \
     orion::CompoundValueNode*  x;                                        \
-    orion::CompoundValueNode*  leaf;                                     \
                                                                          \
     cv = new orion::CompoundValueNode(orion::ValueTypeVector);           \
                                                                          \
-    leaf = cv->add(orion::ValueTypeString,  "",  "22");                  \
+    cv->add(orion::ValueTypeString,         "",  "22");                  \
     str  = cv->add(orion::ValueTypeObject,  "",  "");                    \
     vec  = cv->add(orion::ValueTypeVector,  "",  "");                    \
                                                                          \
     x    = str->add(orion::ValueTypeVector, "x", "");                    \
-    leaf = str->add(orion::ValueTypeString, "y", "3");                   \
+    str->add(orion::ValueTypeString,        "y", "3");                   \
                                                                          \
-    leaf = x->add(orion::ValueTypeString,   "",  "x1");                  \
-    leaf = x->add(orion::ValueTypeString,   "",  "x2");                  \
+    x->add(orion::ValueTypeString,          "",  "x1");                  \
+    x->add(orion::ValueTypeString,          "",  "x2");                  \
                                                                          \
-    leaf = vec->add(orion::ValueTypeString, "",  "z1");                  \
-    leaf = vec->add(orion::ValueTypeString, "",  "z2");                  \
+    vec->add(orion::ValueTypeString,        "",  "z1");                  \
+    vec->add(orion::ValueTypeString,        "",  "z2");                  \
                                                                          \
-    leaf->check();                                                       \
     cv->shortShow("shortShow1: ");                                       \
     cv->show("show1: ");
     
@@ -115,13 +113,12 @@
     x    = cv->add(orion::ValueTypeObject, "x",  "");                    \
     y    = cv->add(orion::ValueTypeVector, "y",  "");                    \
                                                                          \
-    leaf = x->add(orion::ValueTypeString,  "x1", "a");                   \
-    leaf = x->add(orion::ValueTypeString,  "x2", "b");                   \
+    x->add(orion::ValueTypeString,  "x1", "a");                          \
+    x->add(orion::ValueTypeString,  "x2", "b");                          \
                                                                          \
-    leaf = y->add(orion::ValueTypeString,  "",   "y1");                  \
-    leaf = y->add(orion::ValueTypeString,  "",   "y2");                  \
+    y->add(orion::ValueTypeString,  "",   "y1");                         \
+    y->add(orion::ValueTypeString,  "",   "y2");                         \
                                                                          \
-    leaf->check();                                                       \
     cv->shortShow("shortShow2: ");                                       \
     cv->show("show2: ");
 
@@ -131,26 +128,24 @@
     orion::CompoundValueNode*  str;                                      \
     orion::CompoundValueNode*  vec;                                      \
     orion::CompoundValueNode*  x;                                        \
-    orion::CompoundValueNode*  leaf;                                     \
                                                                          \
     cv = new orion::CompoundValueNode(orion::ValueTypeVector);           \
                                                                          \
-    leaf = cv->add(orion::ValueTypeNumber,  "",  22.0);                  \
+    cv->add(orion::ValueTypeNumber,  "",  22.0);                         \
     str  = cv->add(orion::ValueTypeObject,  "",  "");                    \
     vec  = cv->add(orion::ValueTypeVector,  "",  "");                    \
                                                                          \
     x    = str->add(orion::ValueTypeVector, "x", "");                    \
-    leaf = str->add(orion::ValueTypeNumber, "y", 3.0);                   \
-    leaf = str->add(orion::ValueTypeNone, "z", "");                      \
+    str->add(orion::ValueTypeNumber, "y", 3.0);                          \
+    str->add(orion::ValueTypeNone, "z", "");                             \
                                                                          \
-    leaf = x->add(orion::ValueTypeString,   "",  "x1");                  \
-    leaf = x->add(orion::ValueTypeString,   "",  "x2");                  \
+    x->add(orion::ValueTypeString,   "",  "x1");                         \
+    x->add(orion::ValueTypeString,   "",  "x2");                         \
                                                                          \
-    leaf = vec->add(orion::ValueTypeString, "",  "z1");                  \
-    leaf = vec->add(orion::ValueTypeBoolean, "",  false);                \
-    leaf = vec->add(orion::ValueTypeNone, "",  "");                      \
+    vec->add(orion::ValueTypeString, "",  "z1");                         \
+    vec->add(orion::ValueTypeBoolean, "",  false);                       \
+    vec->add(orion::ValueTypeNone, "",  "");                             \
                                                                          \
-    leaf->check();                                                       \
     cv->shortShow("shortShow1: ");                                       \
     cv->show("show1: ");
 
@@ -159,21 +154,19 @@
 #define CREATE_COMPOUND2_NATIVE(cv)                                      \
     orion::CompoundValueNode*  x;                                        \
     orion::CompoundValueNode*  y;                                        \
-    orion::CompoundValueNode*  leaf;                                     \
                                                                          \
     cv = new orion::CompoundValueNode(orion::ValueTypeObject);           \
                                                                          \
     x    = cv->add(orion::ValueTypeObject, "x",  "");                    \
     y    = cv->add(orion::ValueTypeVector, "y",  "");                    \
-    leaf = cv->add(orion::ValueTypeNone,   "z",  "");                    \
+    cv->add(orion::ValueTypeNone,   "z",  "");                           \
                                                                          \
-    leaf = x->add(orion::ValueTypeString,  "x1", "a");                   \
-    leaf = x->add(orion::ValueTypeBoolean, "x2", true);                  \
+    x->add(orion::ValueTypeString,  "x1", "a");                          \
+    x->add(orion::ValueTypeBoolean, "x2", true);                         \
                                                                          \
-    leaf = y->add(orion::ValueTypeString,  "",   "y1");                  \
-    leaf = y->add(orion::ValueTypeString,  "",   "y2");                  \
+    y->add(orion::ValueTypeString,  "",   "y1");                         \
+    y->add(orion::ValueTypeString,  "",   "y2");                         \
                                                                          \
-    leaf->check();                                                       \
     cv->shortShow("shortShow2: ");                                       \
     cv->show("show2: ");
 

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -354,17 +354,19 @@ static void prepareDatabaseDifferentNativeTypes(void) {
    *     A3: bool
    *     A4: vector
    *     A5: object
+   *     A6: null
    *
    */
 
   BSONObj en1 = BSON("_id" << BSON("id" << "E1" << "type" << "T1") <<
-                     "attrNames" << BSON_ARRAY("A1" << "A2" << "A3" << "A4" << "A5") <<
+                     "attrNames" << BSON_ARRAY("A1" << "A2" << "A3" << "A4" << "A5" << "A6") <<
                      "attrs" << BSON(
                         "A1" << BSON("type" << "T" << "value" << "s") <<
                         "A2" << BSON("type" << "T" << "value" << 42) <<
                         "A3" << BSON("type" << "T" << "value" << false) <<
                         "A4" << BSON("type" << "T" << "value" << BSON("x" << "a" << "y" << "b")) <<
-                        "A5" << BSON("type" << "T" << "value" << BSON_ARRAY("x1" << "x2"))
+                        "A5" << BSON("type" << "T" << "value" << BSON_ARRAY("x1" << "x2")) <<
+                        "A6" << BSON("type" << "T" << "value" << BSONNULL)
                         )
                     );
 
@@ -390,6 +392,7 @@ static void prepareDatabaseDifferentMdNativeTypes(void) {
    *     MD1: string
    *     MD2: number
    *     MD3: bool
+   *     MD4: null
    *
    */
 
@@ -399,7 +402,8 @@ static void prepareDatabaseDifferentMdNativeTypes(void) {
                         "A1" << BSON("type" << "TA1" << "value" << "val1" <<
                              "md" << BSON_ARRAY(BSON("name" << "MD1" << "type" << "T" << "value" << "s") <<
                                                 BSON("name" << "MD2" << "type" << "T" << "value" << 55.5) <<
-                                                BSON("name" << "MD3" << "type" << "T" << "value" << false)
+                                                BSON("name" << "MD3" << "type" << "T" << "value" << false) <<
+                                                BSON("name" << "MD4" << "type" << "T" << "value" << BSONNULL)
                                                )
                              )
                         )
@@ -8857,9 +8861,12 @@ TEST(mongoUpdateContextRequest, createNativeTypes)
     ContextAttribute ca1("A1", "T", "myVal");
     ContextAttribute ca2("A2", "T", 42.5);
     ContextAttribute ca3("A3", "T", false);
+    ContextAttribute ca4("A4", "T", "");
+    ca4.valueType = orion::ValueTypeNone;
     ce.contextAttributeVector.push_back(&ca1);
     ce.contextAttributeVector.push_back(&ca2);
     ce.contextAttributeVector.push_back(&ca3);
+    ce.contextAttributeVector.push_back(&ca4);
     req.contextElementVector.push_back(&ce);
     req.updateActionType.set("APPEND");
 
@@ -8879,7 +8886,7 @@ TEST(mongoUpdateContextRequest, createNativeTypes)
     EXPECT_EQ("E4", RES_CER(0).entityId.id);
     EXPECT_EQ("T4", RES_CER(0).entityId.type);
     EXPECT_EQ("false", RES_CER(0).entityId.isPattern);
-    ASSERT_EQ(3, RES_CER(0).contextAttributeVector.size());
+    ASSERT_EQ(4, RES_CER(0).contextAttributeVector.size());
     EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
     EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->stringValue.size());
@@ -8892,6 +8899,10 @@ TEST(mongoUpdateContextRequest, createNativeTypes)
     EXPECT_EQ("T", RES_CER_ATTR(0, 2)->type);
     EXPECT_EQ(0, RES_CER_ATTR(0, 2)->stringValue.size());
     EXPECT_EQ(0, RES_CER_ATTR(0, 2)->metadataVector.size());
+    EXPECT_EQ("A4", RES_CER_ATTR(0, 3)->name);
+    EXPECT_EQ("T", RES_CER_ATTR(0, 3)->type);
+    EXPECT_EQ(0, RES_CER_ATTR(0, 3)->stringValue.size());
+    EXPECT_EQ(0, RES_CER_ATTR(0, 3)->metadataVector.size());
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
@@ -8985,11 +8996,12 @@ TEST(mongoUpdateContextRequest, createNativeTypes)
     EXPECT_EQ(1360232700, ent.getIntField("modDate"));
     attrs = ent.getField("attrs").embeddedObject();
     attrNames = ent.getField("attrNames").Array();
-    ASSERT_EQ(3, attrs.nFields());
-    ASSERT_EQ(3, attrNames.size());
+    ASSERT_EQ(4, attrs.nFields());
+    ASSERT_EQ(4, attrNames.size());
     a1 = attrs.getField("A1").embeddedObject();
     a2 = attrs.getField("A2").embeddedObject();
     a3 = attrs.getField("A3").embeddedObject();
+    a4 = attrs.getField("A4").embeddedObject();
     EXPECT_TRUE(findAttr(attrNames, "A1"));
     EXPECT_TRUE(findAttr(attrNames, "A2"));
     EXPECT_TRUE(findAttr(attrNames, "A3"));
@@ -9005,6 +9017,10 @@ TEST(mongoUpdateContextRequest, createNativeTypes)
     EXPECT_FALSE(a3.getBoolField("value"));
     EXPECT_EQ(1360232700, a3.getIntField("creDate"));
     EXPECT_EQ(1360232700, a3.getIntField("modDate"));
+    EXPECT_STREQ("T", C_STR_FIELD(a4, "type"));
+    EXPECT_TRUE(a4.getField("value").isNull());
+    EXPECT_EQ(1360232700, a4.getIntField("creDate"));
+    EXPECT_EQ(1360232700, a4.getIntField("modDate"));
 
 
     /* Note "_id.type: {$exists: false}" is a way for querying for entities without type */
@@ -9046,18 +9062,26 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
     prepareDatabase();
 
     /* Forge the request (from "inside" to "outside") */
-    ContextElement ce;
-    ce.entityId.fill("E1", "T1", "false");
+    ContextElement ce1;
+    ce1.entityId.fill("E1", "T1", "false");
     ContextAttribute ca1("A1", "T", 42.5);
     ContextAttribute ca2("A2", "T", false);
-    ce.contextAttributeVector.push_back(&ca1);
-    ce.contextAttributeVector.push_back(&ca2);
-    req.contextElementVector.push_back(&ce);
+    ce1.contextAttributeVector.push_back(&ca1);
+    ce1.contextAttributeVector.push_back(&ca2);
+    req.contextElementVector.push_back(&ce1);
+
+    ContextElement ce2;
+    ce2.entityId.fill("E2", "T2", "false");
+    ContextAttribute ca3("A3", "T", "");
+    ca3.valueType = orion::ValueTypeNone;
+    ce2.contextAttributeVector.push_back(&ca3);
+    req.contextElementVector.push_back(&ce2);
+
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
     servicePathVector.clear();
-    ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
+    ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "v2");
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -9066,7 +9090,7 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
     EXPECT_EQ("OK", res.errorCode.reasonPhrase);
     EXPECT_EQ(0, res.errorCode.details.size());
 
-    ASSERT_EQ(1, res.contextElementResponseVector.size());
+    ASSERT_EQ(2, res.contextElementResponseVector.size());
     /* Context Element response # 1 */
     EXPECT_EQ("E1", RES_CER(0).entityId.id);
     EXPECT_EQ("T1", RES_CER(0).entityId.type);
@@ -9083,6 +9107,19 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+    /* Context Element response # 2 */
+    EXPECT_EQ("E2", RES_CER(1).entityId.id);
+    EXPECT_EQ("T2", RES_CER(1).entityId.type);
+    EXPECT_EQ("false", RES_CER(1).entityId.isPattern);
+    ASSERT_EQ(1, RES_CER(1).contextAttributeVector.size());
+    EXPECT_EQ("A3", RES_CER_ATTR(1, 0)->name);
+    EXPECT_EQ("T", RES_CER_ATTR(1, 0)->type);
+    EXPECT_EQ(0, RES_CER_ATTR(1, 0)->stringValue.size());
+    EXPECT_EQ(0, RES_CER_ATTR(1, 0)->metadataVector.size());
+    EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
+    EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
+    EXPECT_EQ("", RES_CER_STATUS(1).details);
 
     /* Check that every involved collection at MongoDB is as expected */
     /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string
@@ -9117,7 +9154,7 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
     ent = connection->findOne(ENTITIES_COLL, BSON("_id.id" << "E2" << "_id.type" << "T2"));
     EXPECT_STREQ("E2", C_STR_FIELD(ent.getObjectField("_id"), "id"));
     EXPECT_STREQ("T2", C_STR_FIELD(ent.getObjectField("_id"), "type"));
-    EXPECT_FALSE(ent.hasField("modDate"));
+    EXPECT_EQ(1360232700, ent.getIntField("modDate"));
     attrs = ent.getField("attrs").embeddedObject();
     attrNames = ent.getField("attrNames").Array();
     ASSERT_EQ(2, attrs.nFields());
@@ -9125,10 +9162,10 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
     BSONObj a3 = attrs.getField("A3").embeddedObject();
     BSONObj a4 = attrs.getField("A4").embeddedObject();
     EXPECT_TRUE(findAttr(attrNames, "A3"));
-    EXPECT_TRUE(findAttr(attrNames, "A4"));
-    EXPECT_STREQ("TA3", C_STR_FIELD(a3, "type"));
-    EXPECT_STREQ("val3", C_STR_FIELD(a3, "value"));
-    EXPECT_FALSE(a3.hasField("modDate"));
+    EXPECT_TRUE(findAttr(attrNames, "A4"));    
+    EXPECT_STREQ("T",C_STR_FIELD(a3, "type"));
+    EXPECT_TRUE(a3.getField("value").isNull());
+    EXPECT_EQ(1360232700, a3.getIntField("modDate"));
     EXPECT_STREQ("TA4", C_STR_FIELD(a4, "type"));
     EXPECT_FALSE(a4.hasField("value"));
     EXPECT_FALSE(a4.hasField("modDate"));
@@ -9193,7 +9230,7 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
 *
 * preservingNativeTypes -
 *
-* Changing only one attribute (the string one), other weeks the same
+* Changing only one attribute (the string one), other keep the same
 */
 TEST(mongoUpdateContextRequest, preservingNativeTypes)
 {
@@ -9256,13 +9293,14 @@ TEST(mongoUpdateContextRequest, preservingNativeTypes)
     EXPECT_EQ(1360232700, ent.getIntField("modDate"));
     attrs = ent.getField("attrs").embeddedObject();
     attrNames = ent.getField("attrNames").Array();
-    ASSERT_EQ(5, attrs.nFields());
-    ASSERT_EQ(5, attrNames.size());
+    ASSERT_EQ(6, attrs.nFields());
+    ASSERT_EQ(6, attrNames.size());
     BSONObj a1 = attrs.getField("A1").embeddedObject();
     BSONObj a2 = attrs.getField("A2").embeddedObject();
     BSONObj a3 = attrs.getField("A3").embeddedObject();
     BSONObj a4 = attrs.getField("A4").embeddedObject();
     BSONObj a5 = attrs.getField("A5").embeddedObject();
+    BSONObj a6 = attrs.getField("A6").embeddedObject();
     EXPECT_TRUE(findAttr(attrNames, "A1"));
     EXPECT_TRUE(findAttr(attrNames, "A2"));
     EXPECT_TRUE(findAttr(attrNames, "A3"));
@@ -9284,7 +9322,10 @@ TEST(mongoUpdateContextRequest, preservingNativeTypes)
     EXPECT_STREQ("T", C_STR_FIELD(a5, "type"));
     EXPECT_EQ("x1", a5.getField("value").Array()[0].str());
     EXPECT_EQ("x2", a5.getField("value").Array()[1].str());
-    EXPECT_FALSE(a5.hasField("modDate"));
+    EXPECT_FALSE(a5.hasField("modDate"));    
+    EXPECT_STREQ("T", C_STR_FIELD(a6, "type"));
+    EXPECT_TRUE(a6.getField("value").isNull());
+    EXPECT_FALSE(a6.hasField("modDate"));
 
     utExit();
 }
@@ -9311,9 +9352,12 @@ TEST(mongoUpdateContextRequest, createMdNativeTypes)
     Metadata md1("MD1", "T", "s");
     Metadata md2("MD2", "T", 55.5);
     Metadata md3("MD3", "T", false);
+    Metadata md4("MD4", "T", "");
+    md4.valueType = orion::ValueTypeNone;
     ca.metadataVector.push_back(&md1);
     ca.metadataVector.push_back(&md2);
     ca.metadataVector.push_back(&md3);
+    ca.metadataVector.push_back(&md4);
     ce.contextAttributeVector.push_back(&ca);
     req.contextElementVector.push_back(&ce);
     req.updateActionType.set("APPEND");
@@ -9338,7 +9382,7 @@ TEST(mongoUpdateContextRequest, createMdNativeTypes)
     EXPECT_EQ("A1", RES_CER_ATTR(0, 0)->name);
     EXPECT_EQ("T", RES_CER_ATTR(0, 0)->type);
     EXPECT_EQ(0, RES_CER_ATTR(0, 0)->stringValue.size());
-    ASSERT_EQ(3, RES_CER_ATTR(0, 0)->metadataVector.size());
+    ASSERT_EQ(4, RES_CER_ATTR(0, 0)->metadataVector.size());
     EXPECT_EQ("MD1", RES_CER_ATTR(0, 0)->metadataVector[0]->name);
     EXPECT_EQ("T", RES_CER_ATTR(0, 0)->metadataVector[0]->type);
     EXPECT_EQ(orion::ValueTypeString, RES_CER_ATTR(0, 0)->metadataVector[0]->valueType);
@@ -9350,7 +9394,10 @@ TEST(mongoUpdateContextRequest, createMdNativeTypes)
     EXPECT_EQ("MD3", RES_CER_ATTR(0, 0)->metadataVector[2]->name);
     EXPECT_EQ("T", RES_CER_ATTR(0, 0)->metadataVector[2]->type);
     EXPECT_EQ(orion::ValueTypeBoolean, RES_CER_ATTR(0, 0)->metadataVector[2]->valueType);
-    EXPECT_FALSE(RES_CER_ATTR(0, 0)->metadataVector[2]->boolValue);
+    EXPECT_FALSE(RES_CER_ATTR(0, 0)->metadataVector[2]->boolValue);        
+    EXPECT_EQ("MD4", RES_CER_ATTR(0, 0)->metadataVector[3]->name);
+    EXPECT_EQ("T", RES_CER_ATTR(0, 0)->metadataVector[3]->type);
+    EXPECT_EQ(orion::ValueTypeNone, RES_CER_ATTR(0, 0)->metadataVector[3]->valueType);
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
@@ -9453,7 +9500,7 @@ TEST(mongoUpdateContextRequest, createMdNativeTypes)
     EXPECT_TRUE(a1.hasField("creDate"));
     EXPECT_TRUE(a1.hasField("modDate"));
     std::vector<BSONElement> mdV = a1.getField("md").Array();
-    ASSERT_EQ(3, mdV.size());
+    ASSERT_EQ(4, mdV.size());
     EXPECT_EQ("MD1", getStringField(mdV[0].embeddedObject(), "name"));
     EXPECT_EQ("T", getStringField(mdV[0].embeddedObject(), "type"));
     EXPECT_EQ("s", getStringField(mdV[0].embeddedObject(), "value"));
@@ -9462,7 +9509,10 @@ TEST(mongoUpdateContextRequest, createMdNativeTypes)
     EXPECT_EQ(55.5, mdV[1].embeddedObject().getField("value").Number());
     EXPECT_EQ("MD3", getStringField(mdV[2].embeddedObject(), "name"));
     EXPECT_EQ("T", getStringField(mdV[2].embeddedObject(), "type"));
-    EXPECT_FALSE(mdV[2].embeddedObject().getBoolField("value"));
+    EXPECT_FALSE(mdV[2].embeddedObject().getBoolField("value"));    
+    EXPECT_EQ("MD4", getStringField(mdV[3].embeddedObject(), "name"));
+    EXPECT_EQ("T", getStringField(mdV[3].embeddedObject(), "type"));
+    EXPECT_TRUE(mdV[3].embeddedObject().getField("value").isNull());
 
     /* Note "_id.type: {$exists: false}" is a way for querying for entities without type */
     ent = connection->findOne(ENTITIES_COLL, BSON("_id.id" << "E1" << "_id.type" << BSON("$exists" << false)));
@@ -9511,7 +9561,7 @@ TEST(mongoUpdateContextRequest, updateMdNativeTypes)
     Metadata md3("MD3", "T", true);
     ca.metadataVector.push_back(&md1);
     ca.metadataVector.push_back(&md2);
-    ca.metadataVector.push_back(&md3);
+    ca.metadataVector.push_back(&md3);    
     ce.contextAttributeVector.push_back(&ca);
     req.contextElementVector.push_back(&ce);
     req.updateActionType.set("UPDATE");
@@ -9578,7 +9628,7 @@ TEST(mongoUpdateContextRequest, updateMdNativeTypes)
     EXPECT_STREQ("new_val",C_STR_FIELD(a1, "value"));
     EXPECT_EQ(1360232700, a1.getIntField("modDate"));
     std::vector<BSONElement> mdV = a1.getField("md").Array();
-    ASSERT_EQ(3, mdV.size());
+    ASSERT_EQ(4, mdV.size());
     EXPECT_EQ("MD1", getStringField(mdV[0].embeddedObject(), "name"));
     EXPECT_EQ("T", getStringField(mdV[0].embeddedObject(), "type"));
     EXPECT_EQ("ss", getStringField(mdV[0].embeddedObject(), "value"));
@@ -9587,7 +9637,10 @@ TEST(mongoUpdateContextRequest, updateMdNativeTypes)
     EXPECT_EQ(44.4, mdV[1].embeddedObject().getField("value").Number());
     EXPECT_EQ("MD3", getStringField(mdV[2].embeddedObject(), "name"));
     EXPECT_EQ("T", getStringField(mdV[2].embeddedObject(), "type"));
-    EXPECT_TRUE(mdV[2].embeddedObject().getBoolField("value"));
+    EXPECT_TRUE(mdV[2].embeddedObject().getBoolField("value"));    
+    EXPECT_EQ("MD4", getStringField(mdV[3].embeddedObject(), "name"));
+    EXPECT_EQ("T", getStringField(mdV[3].embeddedObject(), "type"));
+    EXPECT_TRUE(mdV[3].embeddedObject().getField("value").isNull());
 
     utExit();
 }
@@ -9667,7 +9720,7 @@ TEST(mongoUpdateContextRequest, preservingMdNativeTypes)
     EXPECT_STREQ("new_s", C_STR_FIELD(a1, "value"));
     EXPECT_EQ(1360232700, a1.getIntField("modDate"));
     std::vector<BSONElement> mdV = a1.getField("md").Array();
-    ASSERT_EQ(3, mdV.size());
+    ASSERT_EQ(4, mdV.size());
     EXPECT_EQ("MD1", getStringField(mdV[0].embeddedObject(), "name"));
     EXPECT_EQ("T", getStringField(mdV[0].embeddedObject(), "type"));
     EXPECT_EQ("s", getStringField(mdV[0].embeddedObject(), "value"));
@@ -9677,6 +9730,9 @@ TEST(mongoUpdateContextRequest, preservingMdNativeTypes)
     EXPECT_EQ("MD3", getStringField(mdV[2].embeddedObject(), "name"));
     EXPECT_EQ("T", getStringField(mdV[2].embeddedObject(), "type"));
     EXPECT_FALSE(mdV[2].embeddedObject().getBoolField("value"));
+    EXPECT_EQ("MD4", getStringField(mdV[3].embeddedObject(), "name"));
+    EXPECT_EQ("T", getStringField(mdV[3].embeddedObject(), "type"));
+    EXPECT_TRUE(mdV[3].embeddedObject().getField("value").isNull());
 
     utExit();
 }


### PR DESCRIPTION
The following unit test has been extened in order to ensure support 

Related with query:

* CCompoundValue1Native
* CCompoundValue2Native
* CCompoundValue1PlusSimpleValueNative
* CompoundValue2PlusSimpleValueNative
* queryCustomMetadataNative
* queryNativeTypes

Related with update:

* createEntityCompoundValue1Native
* createEntityCompoundValue2Native
* createEntityCompoundValue1PlusSimpleValueNative
* createEntityCompoundValue2PlusSimpleValueNative
* createNativeTypes
* updateNativeTypes
* preservingNativeTypes
* createMdNativeTypes
* updateMdNativeTypes
* preservingMdNativeTypes

No new functional test added. It is expected (make ft running just now) that all will be working (except the 2 ones in 1164 and 1305 that are expected to fail).