### PR TITLE
FIX mongo driver legacy-1.0.2 -> legacy-1.0.7

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -18,3 +18,4 @@
 - Fix: subscription service path is lost at update subscription time (Issue #1693)
 - Add: Enable log summary traces using -logSummary CLI (Issue #1585)
 - Add: New CLI parameter '-relogAlarms' to see ALL possible alarm-provoking failures in the log-file
+- Fix: Mongo driver migrated to legacy-1.0.7 (to get the fix for https://jira.mongodb.org/browse/CXX-699) (Issue #1568)

--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -9,7 +9,7 @@ The Orion Context Broker uses the following libraries as build dependencies:
 * boost: 1.41 (the one that comes in EPEL6 repository)
 * libmicrohttpd: 0.9.22 (the one that comes in EPEL6 repository)
 * libcurl: 7.19.7
-* Mongo Driver: legacy-1.0.2 (from source)
+* Mongo Driver: legacy-1.0.7 (from source)
 * rapidjson: 1.0.2
 * gtest (only for `make unit_test` building target): 1.5 (from sources)
 * gmock (only for `make unit_test` building target): 1.5 (from sources)
@@ -30,9 +30,9 @@ commands that require root privilege):
 
 * Install the Mongo Driver from source:
 
-        wget https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.0.2.tar.gz
-        tar xfvz legacy-1.0.2.tar.gz
-        cd mongo-cxx-driver-legacy-1.0.2
+        wget https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.0.7.tar.gz
+        tar xfvz legacy-1.0.7.tar.gz
+        cd mongo-cxx-driver-legacy-1.0.7
         scons                                         # The build/linux2/normal/libmongoclient.a library is generated as outcome
         sudo scons install --prefix=/usr/local        # This puts .h files in /usr/local/include/mongo and libmongoclient.a in /usr/local/lib
 

--- a/src/lib/mongoBackend/MongoCommonRegister.cpp
+++ b/src/lib/mongoBackend/MongoCommonRegister.cpp
@@ -232,7 +232,7 @@ static bool addTriggeredSubscriptions
   if (!collectionQuery(connection, getSubscribeContextAvailabilityCollectionName(tenant), query, &cursor, &err))
   {
     TIME_STAT_MONGO_READ_WAIT_STOP();
-    releaseMongoConnection(connection, &cursor);
+    releaseMongoConnection(connection);
     return false;
   }
   TIME_STAT_MONGO_READ_WAIT_STOP();
@@ -277,7 +277,7 @@ static bool addTriggeredSubscriptions
       subs.insert(std::pair<string, TriggeredSubscription*>(subIdStr, trigs));
     }
   }
-  releaseMongoConnection(connection, &cursor);
+  releaseMongoConnection(connection);
 
   return true;
 }

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -115,7 +115,7 @@ extern DBClientBase* getMongoConnection(void);
 *
 * releaseMongoConnection - 
 */
-extern void releaseMongoConnection(DBClientBase* connection, std::auto_ptr<DBClientCursor>*  cursor = NULL);
+extern void releaseMongoConnection(DBClientBase* connection);
 
 /*****************************************************************************
 *

--- a/src/lib/mongoBackend/connectionOperations.cpp
+++ b/src/lib/mongoBackend/connectionOperations.cpp
@@ -131,7 +131,7 @@ extern bool collectionRangedQuery
     return false;
   }
 
-  LM_T(LmtMongo, ("query() in '%s' collection: '%s'", col.c_str(), q.toString().c_str()));
+  LM_T(LmtMongo, ("query() in '%s' collection limit=%d, offset=%d: '%s'", col.c_str(), limit, offset, q.toString().c_str()));
 
   try
   {

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -65,13 +65,14 @@ static std::string attributeType
   DBClientBase* connection = getMongoConnection();
   if (!collectionQuery(connection, getEntitiesCollectionName(tenant), query, &cursor, &err))
   {
-    releaseMongoConnection(connection, &cursor);
+    releaseMongoConnection(connection);
     TIME_STAT_MONGO_READ_WAIT_STOP();
     return "";
   }
   TIME_STAT_MONGO_READ_WAIT_STOP();
 
-  std::string ret = "";
+  std::string   ret  = "";
+  unsigned int  docs = 0;
   while (moreSafe(cursor))
   {
     BSONObj r;
@@ -80,7 +81,8 @@ static std::string attributeType
       LM_E(("Runtime Error (exception in nextSafe(): %s", err.c_str()));
       continue;
     }
-    LM_T(LmtMongo, ("retrieved document: '%s'", r.toString().c_str()));
+    docs++;
+    LM_T(LmtMongo, ("retrieved document [%d]: '%s'", docs, r.toString().c_str()));
 
     /* It could happen that different entities within the same entity type may have attributes with the same name
      * but different types. In that case, one type (at random) is returned. A list could be returned but the
@@ -90,7 +92,7 @@ static std::string attributeType
     ret = getStringField(attr, ENT_ATTRS_TYPE);
     break;
   }
-  releaseMongoConnection(connection, &cursor);
+  releaseMongoConnection(connection);
 
   return ret;
 }

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -410,7 +410,7 @@ void mongoSubCacheRefresh(const std::string& database)
   if (collectionQuery(connection, collection, query, &cursor, &errorString) != true)
   {
     alarmMgr.dbError(errorString);
-    releaseMongoConnection(connection, &cursor);
+    releaseMongoConnection(connection);
     TIME_STAT_MONGO_READ_WAIT_STOP();
     return;
   }
@@ -435,7 +435,7 @@ void mongoSubCacheRefresh(const std::string& database)
       ++subNo;
     }
   }
-  releaseMongoConnection(connection, &cursor);
+  releaseMongoConnection(connection);
 
   LM_T(LmtSubCache, ("Added %d subscriptions for database '%s'", subNo, database.c_str()));
 }


### PR DESCRIPTION
Upgrading driver hasn't impact in the code (it has impact in the system that builts the RPMs, i.e. jenkins, that will be upgraded after this PR got merged) but this PR includes some changes in the `LmtMongo` traces that were used the bug that motivates this upgrade and that can be useful in the future.

@kzangeli 
@crbrox 