### PR TITLE
Hardening/1751 syntax for uri param q and exists

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,6 @@
 - Fix: wrong over-logging at error level updating attributes having metadata without type 
 - Fix: libmicrohttpd 0.9.48 included in contextBroker as static lib (previous Orion versions used 0.9.22 as dynamic library) (Issue #1675)
 - Fix: list of attribute names in URI param 'type' (Issue #1749)
+- Fix: syntax change in string query 'q' for exist and not-exist (Issue #1751)
+- Fix: sanity check for string query 'q' - detect 'left-hand-side missing' (Issue #1754)
+- Fix: more sanity checks for string query 'q' (q empty, parts of 'q' empty - parts of 'q' are separated by ';')

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -24,7 +24,7 @@ context information including updates, queries, registrations and subscriptions.
 ## Acknowledgements
 
 The editors would like to express their gratitude to the following people who actively contributed to this specification:
-Juan José Hierro, Marcos Reyes, Ken Gunnar, Antonio López, ... 
+Juan José Hierro, Marcos Reyes, Ken Zangelin, Antonio López, ... 
   
 ## Status
 
@@ -506,12 +506,14 @@ The list of operators (and the format of the values they use) is as follows:
 In the case of equal or unequal, if the value to match include a `,`, you can use simple quote
 (`'`), e.g: `color=='light,green','deep,blue'`.
 
-Unary statements are composed of a unary operator (either `+`or `-`) and are used in two situations:
+Unary negatory statements use the unary operator `!`, while affirmative unary statements use no operator at all.
+The unary statements are used in two situations:
 
-+ To check for attribute existence. E.g. `+temperature`matches entities which have
-  a temperature attribute (no matter its value), while `-temperature` matches entities which do not have
++ To check for attribute existence. E.g. `temperature` matches entities that have
+  a temperature attribute (no matter its value), while `!temperature` matches entities that do not have
   a temperature attribute.
-+ To check for entity type existence, with the `type`keyword. E.g, `-type`   matches entities which do not have a type.
++ To check for entity type existence, with the `type` keyword. E.g, `-type` matches entities which do not have a type,
+  while `type` matches entities with a type..
   
  
 ## Geographical Queries

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -510,10 +510,10 @@ Unary negatory statements use the unary operator `!`, while affirmative unary st
 The unary statements are used in two situations:
 
 + To check for attribute existence. E.g. `temperature` matches entities that have
-  a temperature attribute (no matter its value), while `!temperature` matches entities that do not have
+  an attribute called 'temperature' (no matter its value), while `!temperature` matches entities that do not have
   a temperature attribute.
-+ To check for entity type existence, with the `type` keyword. E.g, `-type` matches entities which do not have a type,
-  while `type` matches entities with a type..
++ To check for entity type existence, with the `type` keyword. E.g, `!type` matches entities which do not have a type,
+  while `type` matches entities having a type.
   
  
 ## Geographical Queries

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -80,6 +80,7 @@ static unsigned int              maxConns;
 static unsigned int              threadPoolSize;
 
 
+
 /* ****************************************************************************
 *
 * uriArgumentGet - 
@@ -89,6 +90,14 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
   ConnectionInfo*  ciP   = (ConnectionInfo*) cbDataP;
   std::string      key   = ckey;
   std::string      value = (val == NULL)? "" : val;
+
+  if (*val == 0)
+  {
+    OrionError error(SccBadRequest, std::string("Empty right-hand-side for URI param /") + ckey + "/");
+    ciP->httpStatusCode = SccBadRequest;
+    ciP->answer         = error.render(ciP, "");
+    return MHD_YES;
+  }
 
   if (key == URI_PARAM_NOTIFY_FORMAT)
   {

--- a/test/functionalTest/cases/1316_create_subscription/post_subs_expr_q_exist_attr.test
+++ b/test/functionalTest/cases/1316_create_subscription/post_subs_expr_q_exist_attr.test
@@ -31,15 +31,15 @@ accumulatorStart
 --SHELL--
 
 #
-# 01. Create subscription with q: +A
+# 01. Create subscription with q:A (attribute A exists)
 # 02. Create entity E1 with A (notif)
 # 03. Create entity E2 without A (not notif)
 # 04. Append attribute A to E2 (notif)
 # 05. Dump accumulator (2 notifications)
 #
 
-echo "01. Create subscription with q: +A"
-echo "=================================="
+echo "01. Create subscription with q:A (attribute A exists)"
+echo "====================================================="
 payload='
 {
     "subject": {
@@ -52,7 +52,7 @@ payload='
         "condition": {
             "attributes": [ ],
             "expression": {
-               "q": "+A"
+               "q": "A"
             }
          }
     },
@@ -112,8 +112,8 @@ echo
 
 
 --REGEXPECT--
-01. Create subscription with q: +A
-==================================
+01. Create subscription with q:A (attribute A exists)
+=====================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Location: /v2/subscriptions/REGEX([0-9a-f]{24})

--- a/test/functionalTest/cases/1316_create_subscription/post_subs_expr_q_not_exist_attr.test
+++ b/test/functionalTest/cases/1316_create_subscription/post_subs_expr_q_not_exist_attr.test
@@ -31,14 +31,14 @@ accumulatorStart
 --SHELL--
 
 #
-# 01. Create subscription with q: -A
+# 01. Create subscription with q:!A (attribute A does not exist)
 # 02. Create entity E1 with A (not notif)
 # 03. Create entity E2 without A (notif)
 # 04. Dump accumulator (1 notifications)
 #
 
-echo "01. Create subscription with q: -A"
-echo "=================================="
+echo "01. Create subscription with q:!A (attribute A does not exist)"
+echo "=============================================================="
 payload='
 {
     "subject": {
@@ -51,7 +51,7 @@ payload='
         "condition": {
             "attributes": [ ],
             "expression": {
-               "q": "-A"
+               "q": "!A"
             }
          }
     },
@@ -101,8 +101,8 @@ echo
 
 
 --REGEXPECT--
-01. Create subscription with q: -A
-==================================
+01. Create subscription with q:!A (attribute A does not exist)
+==============================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Location: /v2/subscriptions/REGEX([0-9a-f]{24})

--- a/test/functionalTest/cases/1592_query_with_q_op_greater_or_equal/query_with_all_q_ops_without_right_hand_side.test
+++ b/test/functionalTest/cases/1592_query_with_q_op_greater_or_equal/query_with_all_q_ops_without_right_hand_side.test
@@ -30,27 +30,35 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. Operation +
-# 02. Operation -
+# 01. Empty q
+# 02. Operation NOT EXIST
 # 03. Operation ==
 # 04. Operation !=
 # 05. Operation >
 # 06. Operation <
 # 07. Operation >=
 # 08. Operation <=
+# 09. Q-part empty I
+# 10. Q-part empty II
+# 11. Operation == without left-hand-side
+# 12. Operation != without left-hand-side
+# 13. Operation > without left-hand-side
+# 14. Operation < without left-hand-side
+# 15. Operation >= without left-hand-side
+# 16. Operation <= without left-hand-side
 #
 
 
-echo "01. Operation +"
-echo "==============="
-orionCurl --url '/v2/entities?q=+' --json
+echo "01. Empty q"
+echo "==========="
+orionCurl --url '/v2/entities?q=' --json
 echo
 echo
 
 
-echo "02. Operation -"
-echo "==============="
-orionCurl --url '/v2/entities?q=-' --json
+echo "02. Operation NOT EXIST"
+echo "======================="
+orionCurl --url '/v2/entities?q=!' --json
 echo
 echo
 
@@ -97,22 +105,79 @@ echo
 echo
 
 
+echo "09. Q-part empty I"
+echo "=================="
+orionCurl --url '/v2/entities?q=;' --json
+echo
+echo
+
+
+echo "10. Q-part empty II"
+echo "==================="
+orionCurl --url '/v2/entities?q=type;;' --json
+echo
+echo
+
+
+echo "11. Operation == without left-hand-side"
+echo "======================================="
+orionCurl --url '/v2/entities?q===12' --json
+echo
+echo
+
+
+echo "12. Operation != without left-hand-side"
+echo "======================================="
+orionCurl --url '/v2/entities?q===12' --json
+echo
+echo
+
+
+echo "13. Operation > without left-hand-side"
+echo "======================================="
+orionCurl --url '/v2/entities?q=>12' --json
+echo
+echo
+
+
+echo "14. Operation < without left-hand-side"
+echo "======================================="
+orionCurl --url '/v2/entities?q=<12' --json
+echo
+echo
+
+
+echo "15. Operation >= without left-hand-side"
+echo "======================================="
+orionCurl --url '/v2/entities?q=>=12' --json
+echo
+echo
+
+
+echo "16. Operation <= without left-hand-side"
+echo "======================================="
+orionCurl --url '/v2/entities?q=<=12' --json
+echo
+echo
+
+
+
 --REGEXPECT--
-01. Operation +
-===============
+01. Empty q
+===========
 HTTP/1.1 400 Bad Request
-Content-Length: 63
+Content-Length: 78
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "description": "invalid query expression",
+    "description": "Empty right-hand-side for URI param /q/",
     "error": "BadRequest"
 }
 
 
-02. Operation -
-===============
+02. Operation NOT EXIST
+=======================
 HTTP/1.1 400 Bad Request
 Content-Length: 63
 Content-Type: application/json
@@ -191,6 +256,110 @@ Date: REGEX(.*)
 
 08. Operation <=
 ================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "invalid query expression",
+    "error": "BadRequest"
+}
+
+
+09. Q-part empty I
+==================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "invalid query expression",
+    "error": "BadRequest"
+}
+
+
+10. Q-part empty II
+===================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "invalid query expression",
+    "error": "BadRequest"
+}
+
+
+11. Operation == without left-hand-side
+=======================================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "invalid query expression",
+    "error": "BadRequest"
+}
+
+
+12. Operation != without left-hand-side
+=======================================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "invalid query expression",
+    "error": "BadRequest"
+}
+
+
+13. Operation > without left-hand-side
+=======================================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "invalid query expression",
+    "error": "BadRequest"
+}
+
+
+14. Operation < without left-hand-side
+=======================================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "invalid query expression",
+    "error": "BadRequest"
+}
+
+
+15. Operation >= without left-hand-side
+=======================================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "description": "invalid query expression",
+    "error": "BadRequest"
+}
+
+
+16. Operation <= without left-hand-side
+=======================================
 HTTP/1.1 400 Bad Request
 Content-Length: 63
 Content-Type: application/json

--- a/test/unittests/mongoBackend/mongoQueryContext_filters_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_filters_test.cpp
@@ -949,7 +949,7 @@ TEST(mongoQueryContextRequest_filters, withAttribute)
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en(".*", "", "true");
-  Scope sc(SCOPE_TYPE_SIMPLE_QUERY, "+S");
+  Scope sc(SCOPE_TYPE_SIMPLE_QUERY, "S");
   req.entityIdVector.push_back(&en);
   req.restriction.scopeVector.push_back(&sc);
 
@@ -992,7 +992,7 @@ TEST(mongoQueryContextRequest_filters, withoutAttribute)
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en(".*", "", "true");
-  Scope sc(SCOPE_TYPE_SIMPLE_QUERY, "-S");
+  Scope sc(SCOPE_TYPE_SIMPLE_QUERY, "!S");
   req.entityIdVector.push_back(&en);
   req.restriction.scopeVector.push_back(&sc);
 
@@ -1036,7 +1036,7 @@ TEST(mongoQueryContextRequest_filters, withEntityType)
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en(".*", "", "true");
-  Scope sc(SCOPE_TYPE_SIMPLE_QUERY, "+type");
+  Scope sc(SCOPE_TYPE_SIMPLE_QUERY, "type");
   req.entityIdVector.push_back(&en);
   req.restriction.scopeVector.push_back(&sc);
 
@@ -1083,7 +1083,7 @@ TEST(mongoQueryContextRequest_filters, withoutEntityType)
 
   /* Forge the request (from "inside" to "outside") */
   EntityId en(".*", "", "true");
-  Scope sc(SCOPE_TYPE_SIMPLE_QUERY, "-type");
+  Scope sc(SCOPE_TYPE_SIMPLE_QUERY, "!type");
   req.entityIdVector.push_back(&en);
   req.restriction.scopeVector.push_back(&sc);
 


### PR DESCRIPTION
Changed +attr/-attr   for attr/!attr in q-string
Added lots of sanity checks for q and q-parts.

Fixes issues #1751 and #1754 
Apart from these two issues, q is inspected not to:
- be empty
- contain only a ';'
- contain two consecutive ';'s

These two last checks had to be made before the strtok-loop as strtok doesn't return empty tokens, it just eats them ...  