### PR TITLE
Feature/1677 geo location for api v2

### DIFF
--- a/src/lib/common/limits.h
+++ b/src/lib/common/limits.h
@@ -62,8 +62,9 @@
 * Others -
 *
 */
-#define IP_LENGTH_MAX        15    // Based on xxx.xxx.xxx.xxx
-#define STRING_SIZE_FOR_INT  16    // Room enough for an integer
+#define IP_LENGTH_MAX           15    // Based on xxx.xxx.xxx.xxx
+#define STRING_SIZE_FOR_INT     16    // Room enough for an integer
+#define STRING_SIZE_FOR_DOUBLE  64    // Room enough for a double
 
 
 /* ****************************************************************************

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -71,69 +71,203 @@ Scope::Scope(const std::string& _type, const std::string& _value, const std::str
 
 /* ****************************************************************************
 *
+* pointVectorRelease - 
+*/
+static void pointVectorRelease(const std::vector<orion::Point*>& pointV)
+{
+  for (unsigned int ix = 0; ix < pointV.size(); ++ix)
+  {
+    delete(pointV[ix]);
+  }
+}
+
+
+
+/* ****************************************************************************
+*
 * Scope::fill - 
 */
 int Scope::fill
 (
-  orion::Geometry*                 geometry,
-  const std::vector<std::string>&  coordsV,
-  std::string*                     errorString
+  const std::string&  apiVersion,
+  const std::string&  geometryString,
+  const std::string&  coordsString,
+  const std::string&  georelString,
+  std::string*        errorStringP
 )
 {
-  if (geometry->areaType == "circle")
+  Geometry                    geometry;
+  Georel                      georel;
+  std::vector<std::string>    pointStringV;
+  int                         points;
+  std::vector<orion::Point*>  pointV;
+
+  //
+  // parse geometry
+  //
+  std::string errorString;
+  if (geometry.parse(geometryString.c_str(), &errorString) != 0)
   {
-    areaType = orion::CircleType;
+    *errorStringP = std::string("error parsing geometry: ") + errorString;
+    return -1;
+  }
 
-    circle.radiusSet(geometry->radius);
-    circle.invertedSet(geometry->external);
 
-    std::vector<std::string>  coords;
+  //
+  // Split coordsString into a vector of points, or pairs of coordinates
+  //
+  if (coordsString == "")
+  {
+    *errorStringP = "no coordinates for geometry";
+    return -1;
+  }
+  points = stringSplit(coordsString, ';', pointStringV);
 
-    if (stringSplit(coordsV[0], ',', coords) == 2)
+  if (points == 0)
+  {
+    *errorStringP = "erroneous coordinates for geometry";
+    return -1;
+  }
+
+
+  //
+  // Parse georel?
+  //
+  if (georelString != "")
+  {
+    if (georel.parse(georelString.c_str(), errorStringP) != 0)
     {
-      std::string latitude  = coords[0];
-      std::string longitude = coords[1];
-
-      Point p(latitude, longitude);
-      circle.centerSet(&p);
-    }
-    else
-    {
-      *errorString = "invalid coordinate-set for circle";
       return -1;
     }
   }
-  else if (geometry->areaType == "polygon")
+
+
+  //
+  // Convert point-strings into instances of the orion::Point class
+  //
+  for (int ix = 0; ix < points; ++ix)
+  {
+    std::vector<std::string>  coordV;
+    int                       coords;
+    double                    latitude;
+    double                    longitude;
+
+    coords = stringSplit(pointStringV[ix], ',', coordV);
+
+    if (coords != 2)
+    {
+      *errorStringP = "invalid point in URI param /coords/";
+      return -1;
+    }
+
+    if (!str2double(coordV[0].c_str(), &latitude))
+    {
+      *errorStringP = "non-numeric latitude-coordinate in URI param /coords/";
+      return -1;
+    }
+
+    if (!str2double(coordV[0].c_str(), &longitude))
+    {
+      *errorStringP = "non-numeric longitude-coordinate in URI param /coords/";
+      return -1;
+    }
+
+    orion::Point* pointP = new Point(latitude, longitude);
+    pointV.push_back(pointP);
+  }
+
+
+  if (geometry.areaType == "circle")
+  {
+#if 0
+    if (apiVersion == "v2")
+    {
+      *errorStringP = "circle geometry is not supported by Orion API v2";
+      pointVectorRelease(pointV);
+      pointV.clear();
+      return -1;
+    }
+    else
+#endif
+    {
+      if (pointV.size() != 1)
+      {
+        *errorStringP = "too many coordinates for circle";
+        pointVectorRelease(pointV);
+        pointV.clear();
+        return -1;
+      }
+
+      areaType = orion::CircleType;
+
+      LM_W(("KZ: setting radius: %f", geometry.radius));
+      circle.radiusSet(geometry.radius);
+      circle.invertedSet(geometry.external);
+      circle.centerSet(pointV[0]);
+      pointV.clear();
+    }
+  }
+  else if (geometry.areaType == "polygon")
   {
     areaType = orion::PolygonType;
     
-    polygon.invertedSet(geometry->external);
+    polygon.invertedSet(geometry.external);
 
-    for (unsigned int ix = 0; ix < coordsV.size(); ++ix)
+    for (unsigned int ix = 0; ix < pointV.size(); ++ix)
     {
-      std::vector<std::string>  coords;
-
-      if (stringSplit(coordsV[ix], ',', coords) == 2)
-      {
-        std::string latitude  = coords[0];
-        std::string longitude = coords[1];
-
-        // FIXME P1:  we should check 'valid number' of coords[0] and coords[1]
-        Point* p = new Point(latitude, longitude);
-        polygon.vertexAdd(p);
-      }
-      else
-      {
-        *errorString = "invalid coordinate-set for polygon";
-        return -1;
-      }
+      polygon.vertexAdd(pointV[ix]);
     }
+    pointV.clear();
+  }
+  else if (geometry.areaType == "line")
+  {
+    areaType = orion::LineType;
+
+    if (pointV.size() != 2)
+    {
+      *errorStringP = "invalid number of coordinates for /line/";
+      pointVectorRelease(pointV);
+      pointV.clear();
+      return -1;
+    }
+    line.fill(pointV[0], pointV[1]);
+    pointV.clear();
+  }
+  else if (geometry.areaType == "box")
+  {
+    areaType = orion::BoxType;
+
+    if (pointV.size() != 2)
+    {
+      *errorStringP = "invalid number of coordinates for /box/";
+      pointVectorRelease(pointV);
+      pointV.clear();
+      return -1;
+    }
+    box.fill(pointV[0], pointV[1]);
+    pointV.clear();
+  }
+  else if (geometry.areaType == "point")
+  {
+    areaType = orion::PointType;
+
+    if (pointV.size() != 1)
+    {
+      *errorStringP = "invalid number of coordinates for /point/";
+      pointVectorRelease(pointV);
+      pointV.clear();
+      return -1;
+    }
+    point.fill(pointV[0]);
+    pointV.clear();
   }
   else
   {
     areaType = orion::NoArea;
     
-    *errorString = "invalid area-type";
+    *errorStringP = "invalid area-type";
+    pointVectorRelease(pointV);
+    pointV.clear();
     return -1;
   }
 

--- a/src/lib/ngsi/Scope.h
+++ b/src/lib/ngsi/Scope.h
@@ -63,11 +63,19 @@ typedef struct Scope
   orion::AreaType     areaType;
   orion::Circle       circle;
   orion::Polygon      polygon;
+  orion::Point        point;
+  orion::Line         line;
+  orion::Box          box;
 
   Scope();
   Scope(const std::string& _type, const std::string& _value,  const std::string& _oper = "");
 
-  int          fill(orion::Geometry* geometry,  const std::vector<std::string>& coordsV, std::string* errorString);
+  int          fill(const std::string&  apiVersion,
+                    const std::string&  geometry,
+                    const std::string&  coords,
+                    const std::string&  georel,
+                    std::string*        errorString);
+
   std::string  render(Format format, const std::string& indent, bool notLastInVector);
   void         present(const std::string& indent, int ix);
   void         release(void);

--- a/src/lib/orionTypes/areas.cpp
+++ b/src/lib/orionTypes/areas.cpp
@@ -42,7 +42,7 @@ namespace orion
 *
 * Point::Point - 
 */
-Point::Point()
+Point::Point(): valid(true), lat(0), lon(0)
 {
 }
 
@@ -52,9 +52,12 @@ Point::Point()
 *
 * Point::Point - 
 */
-Point::Point(::std::string latitude, ::std::string longitude): _latitude(latitude), _longitude(longitude)
+Point::Point(::std::string latitude, ::std::string longitude): valid(true)
 {
-
+  if ((str2double(latitude.c_str(), &lat) == false) || (str2double(longitude.c_str(), &lon) == false))
+  {
+    valid = false;
+  }
 }
 
 
@@ -89,8 +92,7 @@ void Point::fill(Point* p)
 */
 double Point::latitude(void) const
 {
-  // NOTE: here we use atof and not str2double on purpose
-  return atof(_latitude.c_str());
+  return lat;
 }
 
 
@@ -100,8 +102,7 @@ double Point::latitude(void) const
 */
 double Point::longitude(void) const
 {
-  // NOTE: here we use atof and not str2double on purpose
-  return atof(_longitude.c_str());
+  return lon;
 }
 
 
@@ -111,7 +112,7 @@ double Point::longitude(void) const
 */
 void Point::latitudeSet(::std::string latitude)
 {
-  _latitude  = latitude;
+  valid = str2double(latitude.c_str(), &lat);
 }
 
 
@@ -122,7 +123,23 @@ void Point::latitudeSet(::std::string latitude)
 */
 void Point::longitudeSet(::std::string longitude)
 {
-  _longitude = longitude;
+  valid = str2double(longitude.c_str(), &lon);
+}
+
+
+
+/* ****************************************************************************
+*
+* Point::equals -
+*/
+bool Point::equals(Point* p)
+{
+  if ((p->lat != lat) || (p->lon != lon))
+  {
+    return false;
+  }
+
+  return true;
 }
 
 
@@ -133,7 +150,10 @@ void Point::longitudeSet(::std::string longitude)
 */
 ::std::string Point::latitudeString(void)
 {
-  return _latitude;
+  char cV[STRING_SIZE_FOR_DOUBLE]; 
+
+  snprintf(cV, sizeof(cV), "%f", lat);
+  return cV;
 }
 
 
@@ -143,7 +163,10 @@ void Point::longitudeSet(::std::string longitude)
 */
 ::std::string Point::longitudeString(void)
 {
-  return _longitude;
+  char cV[STRING_SIZE_FOR_DOUBLE]; 
+
+  snprintf(cV, sizeof(cV), "%f", lon);
+  return cV;
 }
 
 
@@ -239,7 +262,9 @@ bool Circle::inverted(void) const
 double Circle::radius(void) const
 {
   // NOTE: here we use atof and not str2double on purpose
-  return atof(_radius.c_str());
+  float r = atof(_radius.c_str());
+
+  return r;
 }
 
 
@@ -250,7 +275,7 @@ double Circle::radius(void) const
 */
 ::std::string Circle::radiusString(void) const
 {
-  return  _radius;
+  return _radius;
 }
 
 
@@ -318,9 +343,9 @@ void Circle::invertedSet(bool inverted)
 *
 * Circle::centerSet -
 */
-void Circle::centerSet(Point* _center)
+void Circle::centerSet(Point* centerP)
 {
-  center.fill(_center);
+  center.fill(centerP);
 }
 
 
@@ -553,7 +578,6 @@ int Geometry::parse(const char* in, std::string* errorString)
       }
 
       areaType = items[ix];
-      LM_W(("KZ: Got an areaType of %s", areaType.c_str()));
     }
     else if (strncmp(items[ix].c_str(), "radius", 6) == 0)
     {
@@ -564,12 +588,10 @@ int Geometry::parse(const char* in, std::string* errorString)
         *errorString = "Invalid value of /radius/";
         return -1;
       }
-      LM_W(("KZ: Got a radius of '%f'", radius));
     }
     else if (items[ix] == "external")
     {
       external = true;
-      LM_W(("KZ: Got an EXTERNAL"));
     }
     else
     {

--- a/src/lib/orionTypes/areas.h
+++ b/src/lib/orionTypes/areas.h
@@ -41,7 +41,10 @@ typedef enum AreaType
 {
   NoArea,
   CircleType,
-  PolygonType
+  PolygonType,
+  PointType,
+  LineType,
+  BoxType
 } AreaType;
 
 
@@ -55,10 +58,13 @@ class Point
  private:
   ::std::string _latitude;
   ::std::string _longitude;
+  double        lat;
+  double        lon;
 
  public:
   Point();
   Point(::std::string latitude, ::std::string longitude);
+  Point(double _lat, double _lon);
 
   void   fill(Point* p);
   double latitude(void) const;
@@ -67,6 +73,42 @@ class Point
   void   longitudeSet(::std::string longitude);
   ::std::string latitudeString(void);
   ::std::string longitudeString(void);
+};
+
+
+
+/* ****************************************************************************
+*
+* Line -
+*/
+class Line
+{
+public:
+  Point start;
+  Point end;
+
+  Line();
+  Line(Point* startP, Point* endP);
+
+  void fill(Point* startP, Point* endP);
+};
+
+
+
+/* ****************************************************************************
+*
+* Box -
+*/
+class Box
+{
+public:
+  Point lowerLeft;
+  Point upperRight;
+
+  Box();
+  Box(Point* lowerLeftP, Point* upperRightP);
+
+  void fill(Point* lowerLeftP, Point* upperRightP);
 };
 
 
@@ -114,6 +156,25 @@ class Polygon
   ::std::string         invertedString(void) const;
   void                  vertexAdd(Point* p);
   void                  release(void);
+};
+
+
+
+/* ****************************************************************************
+*
+* Georel - 
+*/
+class Georel
+{
+public:
+  Georel();
+
+  void         fill(Georel* georelP);         
+  int          parse(const char* in, std::string* errorString);
+
+  std::string  type;
+  double       maxDistance;
+  double       minDistance;
 };
 
 

--- a/src/lib/orionTypes/areas.h
+++ b/src/lib/orionTypes/areas.h
@@ -56,10 +56,9 @@ typedef enum AreaType
 class Point
 {
  private:
-  ::std::string _latitude;
-  ::std::string _longitude;
-  double        lat;
-  double        lon;
+  bool    valid;
+  double  lat;
+  double  lon;
 
  public:
   Point();
@@ -69,8 +68,12 @@ class Point
   void   fill(Point* p);
   double latitude(void) const;
   double longitude(void) const;
+  void   latitudeSet(double latitude);
   void   latitudeSet(::std::string latitude);
+  void   longitudeSet(double longitude);
   void   longitudeSet(::std::string longitude);
+  bool   equals(Point* p);
+
   ::std::string latitudeString(void);
   ::std::string longitudeString(void);
 };

--- a/src/lib/serviceRoutinesV2/getEntities.cpp
+++ b/src/lib/serviceRoutinesV2/getEntities.cpp
@@ -174,75 +174,12 @@ std::string getEntities
       return out;
     }
 
-    LM_W(("KZ: radius in scope: %f", scopeP->circle.radius()));
     parseDataP->qcr.res.restriction.scopeVector.push_back(scopeP);
   }
-
-#if 0
-  // Making sure geometry is valid (if present) - TAKEN CARE OF BY Scope::fill()
-  orion::Geometry           geo;
-  std::vector<std::string>  coordsV;
-
-  if (geometry != "")
-  {
-    std::string  errorString;
-
-    if (geo.parse(geometry.c_str(), &errorString) != 0)
-    {
-      OrionError oe(SccBadRequest, std::string("error parsing geometry: ") + errorString);
-
-      TIMED_RENDER(out = oe.render(ciP, ""));
-
-      return out;
-    }
-
-    if ((geo.areaType != "polygon") && (geo.areaType != "circle"))
-    {
-      OrionError oe(SccBadRequest, "URI param /geometry/ must be either /polygon/ or /circle/");
-
-      TIMED_RENDER(out = oe.render(ciP, ""));
-
-      return out;
-    }
-
-    //
-    // As 'geometry' is present, so is 'coords' - checking coords
-    //
-    int noOfCoords = stringSplit(coords, ';', coordsV);
-
-    if (noOfCoords == 0)
-    {
-      OrionError oe(SccBadRequest, "URI param /coords/ has no coordinates");
-
-      TIMED_RENDER(out = oe.render(ciP, ""));
-
-      return out;
-    }
-
-    if ((geo.areaType == "circle") && (noOfCoords != 1))
-    {
-      OrionError oe(SccBadRequest, "Too many coordinates for circle");
-
-      TIMED_RENDER(out = oe.render(ciP, ""));
-
-      return out;
-    }
-
-    if ((geo.areaType == "polygon") && (noOfCoords < 3))
-    {
-      OrionError oe(SccBadRequest, "Too few coordinates for polygon");
-
-      TIMED_RENDER(out = oe.render(ciP, ""));
-
-      return out;
-    }
-  }
-#endif
 
   //
   // 01. Fill in QueryContextRequest - type "" is valid for all types
   //
-
 
   // If URI param 'q' is given, its value must be put in a scope
   if (q != "")
@@ -252,31 +189,6 @@ std::string getEntities
     parseDataP->qcr.res.restriction.scopeVector.push_back(scopeP);
   }
 
-
-#if 0
-  // If URI params 'geometry' and 'coords' are given, another scope is to be created for this
-  if ((coords != "") && (geometry != ""))
-  {
-    //
-    // Sanity check of coords
-    //
-    for (unsigned int ix = 0; ix < coordsV.size(); ++ix)
-    {
-      double                    d;
-      std::string               copy = coordsV[ix];
-      std::vector<std::string>  cV;
-      
-      stringSplit(copy, ',', cV);
-
-      if ((cV.size() != 2) || (str2double(cV[0].c_str(), &d) == false) || (str2double(cV[1].c_str(), &d) == false))
-      {
-        OrionError oe(SccBadRequest, "invalid coordinates");
-        TIMED_RENDER(out = oe.render(ciP, ""));
-        return out;
-      }
-    }
-  }
-#endif
 
   //
   // URI param 'type', three options:

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -92,6 +92,8 @@ function usage()
   echo "$empty [--keep (don't remove output files)]"
   echo "$empty [--dryrun (don't execute any tests)]"
   echo "$empty [--dir <directory>]"
+  echo "$empty [--fromIx <index of test where to start>]"
+  echo "$empty [--ixList <list of test indexes>]"
   echo "$empty [--stopOnError (stop at first error encountered)]"
   echo "$empty [--no-duration (removes duration mark on successful tests)]"
   echo "$empty [ <directory or file> ]*"
@@ -177,6 +179,7 @@ vMsg "$ME, in directory $SCRIPT_HOME"
 #
 # Argument parsing
 #
+typeset -i fromIx
 verbose=off
 dryrun=off
 keep=off
@@ -188,6 +191,8 @@ dirOrFile=""
 dirGiven=no
 filterGiven=no
 showDuration=on
+fromIx=0
+ixList=""
 
 vMsg "parsing options"
 while [ "$#" != 0 ]
@@ -200,6 +205,8 @@ do
   elif [ "$1" == "--filter" ];      then testFilter="$2"; filterGiven=yes; shift;
   elif [ "$1" == "--match" ];       then match="$2"; shift;
   elif [ "$1" == "--dir" ];         then dir="$2"; dirGiven=yes; shift;
+  elif [ "$1" == "--fromIx" ];      then fromIx=$2; shift;
+  elif [ "$1" == "--ixList" ];      then ixList=$2; shift;
   elif [ "$1" == "--no-duration" ]; then showDuration=off;
   else
     if [ "$dirOrFile" == "" ]
@@ -765,6 +772,21 @@ do
   fi
 
   testNo=$testNo+1
+
+  if [ $fromIx != 0 ] && [ $testNo -lt $fromIx ]
+  then
+    continue;
+  fi
+
+  if [ "$ixList" != "" ]
+  then
+    hit=$(echo ' '$ixList' ' | grep ' '$testNo' ')
+    if [ "$hit" == "" ]
+    then
+      continue
+    fi
+  fi
+
   startDate=$(date)
   start=$(date --date="$startDate" +%s)
   endDate=""

--- a/test/unittests/ngsi10/SubscribeContextRequest_test.cpp
+++ b/test/unittests/ngsi10/SubscribeContextRequest_test.cpp
@@ -463,9 +463,9 @@ TEST(SubscribeContextRequest, scopeGeolocationPolygonInverted)
   result = xmlTreat(testBuf, &ci, &parseData, SubscribeContext, "subscribeContextRequest", NULL);
   EXPECT_STREQ("OK", result.c_str());
 
-  EXPECT_EQ("10",   parseData.scr.res.restriction.scopeVector[0]->polygon.vertexList[0]->longitudeString());
-  EXPECT_EQ("20",   parseData.scr.res.restriction.scopeVector[0]->polygon.vertexList[0]->latitudeString());
-  EXPECT_EQ("true", parseData.scr.res.restriction.scopeVector[0]->polygon.invertedString());
+  EXPECT_EQ("10.000000",   parseData.scr.res.restriction.scopeVector[0]->polygon.vertexList[0]->longitudeString());
+  EXPECT_EQ("20.000000",   parseData.scr.res.restriction.scopeVector[0]->polygon.vertexList[0]->latitudeString());
+  EXPECT_EQ("true",        parseData.scr.res.restriction.scopeVector[0]->polygon.invertedString());
 
   EXPECT_EQ(10,   parseData.scr.res.restriction.scopeVector[0]->polygon.vertexList[0]->longitude());
   EXPECT_EQ(20,   parseData.scr.res.restriction.scopeVector[0]->polygon.vertexList[0]->latitude());

--- a/test/valgrind/valgrindTestSuite.sh
+++ b/test/valgrind/valgrindTestSuite.sh
@@ -156,7 +156,7 @@ dryrun=off
 leakTest=off
 dryLeaks=off
 fromIx=0
-ixLists=""
+ixList=""
 
 vMsg "parsing options"
 while [ "$#" != 0 ]


### PR DESCRIPTION
Fixes part of the issue #1677.

The coords for polygons has changed in v2.
New rules: last point must be equal to first point, and the number of points must be >= 4.
These two rules are implemented but *ifdeffed out*. Perhaps this should be fixed within this PR.
Also, there is a comment or two about more detailed 'details' in errors.
Both these (two rules + details) give errors in functests and are disabled in this PR.
