### PR TITLE
Hardening/badverb errors

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -24,3 +24,4 @@
 - Add: scope FIWARE::Location::NGSIv2 to allow using NGSIv2 geo-queries also with NGSIv1 (Issue #1677)
 - Fix: segfault caused by parameter without value in query string (Issue #1805)
 - Add: options=values mode for entity queries in NGSIV2 (Issue #1049)
+- Fix: some of the operations reported an incorrect 'Allow' HTTP Header on Bad Verb, now fixed

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -476,10 +476,6 @@ static const char* validLogLevels[] =
 #define BQR_COMPS_V2            3, { "v2", "op", "query" }
 #define BQR_COMPS_WORD          ""
 
-#define BUR                     BatchUpdateRequest
-#define BUR_COMPS_V2            3, { "v2", "op", "update" }
-#define BUR_COMPS_WORD          ""
-
 //
 // NGSI9
 //

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -173,6 +173,7 @@
 #include "serviceRoutines/badVerbGetOnly.h"
 #include "serviceRoutines/badVerbGetDeleteOnly.h"
 #include "serviceRoutinesV2/badVerbGetPutOnly.h"
+#include "serviceRoutinesV2/badVerbGetDeletePatchOnly.h"
 #include "serviceRoutines/badNgsi9Request.h"
 #include "serviceRoutines/badNgsi10Request.h"
 #include "serviceRoutines/badRequest.h"
@@ -475,6 +476,9 @@ static const char* validLogLevels[] =
 #define BQR_COMPS_V2            3, { "v2", "op", "query" }
 #define BQR_COMPS_WORD          ""
 
+#define BUR                     BatchUpdateRequest
+#define BUR_COMPS_V2            3, { "v2", "op", "update" }
+#define BUR_COMPS_WORD          ""
 
 //
 // NGSI9
@@ -725,7 +729,7 @@ static const char* validLogLevels[] =
 
 #define API_V2                                                                                         \
   { "GET",    EPS,          EPS_COMPS_V2,         ENT_COMPS_WORD,          entryPointsTreat         }, \
-  { "*",      EPS,          EPS_COMPS_V2,         ENT_COMPS_WORD,          badVerbAllFour           }, \
+  { "*",      EPS,          EPS_COMPS_V2,         ENT_COMPS_WORD,          badVerbGetOnly           }, \
                                                                                                        \
   { "GET",    ENT,          ENT_COMPS_V2,         ENT_COMPS_WORD,          getEntities              }, \
   { "POST",   ENT,          ENT_COMPS_V2,         ENT_COMPS_WORD,          postEntities             }, \
@@ -755,12 +759,12 @@ static const char* validLogLevels[] =
                                                                                                        \
   { "GET",    SSR,          SSR_COMPS_V2,         SSR_COMPS_WORD,          getAllSubscriptions      }, \
   { "POST",   SSR,          SSR_COMPS_V2,         SSR_COMPS_WORD,          postSubscriptions        }, \
-  { "*",      SSR,          SSR_COMPS_V2,         SSR_COMPS_WORD,          badVerbGetOnly           }, \
+  { "*",      SSR,          SSR_COMPS_V2,         SSR_COMPS_WORD,          badVerbGetPostOnly       }, \
                                                                                                        \
   { "GET",    ISR,          ISR_COMPS_V2,         ISR_COMPS_WORD,          getSubscription          }, \
   { "DELETE", ISR,          ISR_COMPS_V2,         ISR_COMPS_WORD,          deleteSubscription       }, \
   { "PATCH",  ISR,          ISR_COMPS_V2,         ISR_COMPS_WORD,          patchSubscription        }, \
-  { "*",      ISR,          ISR_COMPS_V2,         ISR_COMPS_WORD,          badVerbGetOnly           }, \
+  { "*",      ISR,          ISR_COMPS_V2,         ISR_COMPS_WORD,          badVerbGetDeletePatchOnly}, \
                                                                                                        \
   { "POST",   BQR,          BQR_COMPS_V2,         BQR_COMPS_WORD,          postBatchQuery           }, \
   { "*",      BQR,          BQR_COMPS_V2,         BQR_COMPS_WORD,          badVerbPostOnly          }
@@ -801,7 +805,7 @@ static const char* validLogLevels[] =
 
 
 #define STANDARD_REQUESTS_V0                                                                             \
-  { "POST",   UPCR,  UPCR_COMPS_V0,        UPCR_POST_WORD,  (RestTreat)postUpdateContext                         }, \
+  { "POST",   UPCR,  UPCR_COMPS_V0,        UPCR_POST_WORD,  (RestTreat) postUpdateContext             }, \
   { "*",      UPCR,  UPCR_COMPS_V0,        UPCR_POST_WORD,  badVerbPostOnly                           }, \
   { "POST",   QCR,   QCR_COMPS_V0,         QCR_POST_WORD,   postQueryContext                          }, \
   { "*",      QCR,   QCR_COMPS_V0,         QCR_POST_WORD,   badVerbPostOnly                           }, \
@@ -817,7 +821,7 @@ static const char* validLogLevels[] =
 
 
 #define STANDARD_REQUESTS_V1                                                                               \
-  { "POST",   UPCR,  UPCR_COMPS_V1,          UPCR_POST_WORD,  (RestTreat)postUpdateContext                         }, \
+  { "POST",   UPCR,  UPCR_COMPS_V1,          UPCR_POST_WORD,  (RestTreat) postUpdateContext             }, \
   { "*",      UPCR,  UPCR_COMPS_V1,          UPCR_POST_WORD,  badVerbPostOnly                           }, \
   { "POST",   QCR,   QCR_COMPS_V1,           QCR_POST_WORD,   postQueryContext                          }, \
   { "*",      QCR,   QCR_COMPS_V1,           QCR_POST_WORD,   badVerbPostOnly                           }, \
@@ -917,7 +921,7 @@ static const char* validLogLevels[] =
   { "PUT",    ICEAA, ICEAA_COMPS_V0,       ICEAA_PUT_WORD,  putIndividualContextEntityAttribute       }, \
   { "POST",   ICEAA, ICEAA_COMPS_V0,       ICEAA_POST_WORD, postIndividualContextEntityAttribute      }, \
   { "DELETE", ICEAA, ICEAA_COMPS_V0,       "",              deleteIndividualContextEntityAttribute    }, \
-  { "*",      ICEAA, ICEAA_COMPS_V0,       "",              badVerbGetPostDeleteOnly                  }, \
+  { "*",      ICEAA, ICEAA_COMPS_V0,       "",              badVerbAllFour                            }, \
                                                                                                          \
   { "GET",    AVI,   AVI_COMPS_V0,         "",              getAttributeValueInstance                 }, \
   { "PUT",    AVI,   AVI_COMPS_V0,         AVI_PUT_WORD,    putAttributeValueInstance                 }, \
@@ -959,7 +963,7 @@ static const char* validLogLevels[] =
   { "PUT",    ICEAA, ICEAA_COMPS_V1,         ICEAA_PUT_WORD,  putIndividualContextEntityAttribute       }, \
   { "POST",   ICEAA, ICEAA_COMPS_V1,         ICEAA_POST_WORD, postIndividualContextEntityAttribute      }, \
   { "DELETE", ICEAA, ICEAA_COMPS_V1,         "",              deleteIndividualContextEntityAttribute    }, \
-  { "*",      ICEAA, ICEAA_COMPS_V1,         "",              badVerbGetPostDeleteOnly                  }, \
+  { "*",      ICEAA, ICEAA_COMPS_V1,         "",              badVerbAllFour                            }, \
                                                                                                            \
   { "GET",    AVI,   AVI_COMPS_V1,           "",              getAttributeValueInstance                 }, \
   { "PUT",    AVI,   AVI_COMPS_V1,           AVI_PUT_WORD,    putAttributeValueInstance                 }, \
@@ -984,12 +988,13 @@ static const char* validLogLevels[] =
                                                                                                            \
   { "GET",    ET,    ET_COMPS_V1,            "",              getEntityTypes                            }, \
   { "*",      ET,    ET_COMPS_V1,            "",              badVerbGetOnly                            }, \
+                                                                                                           \
   { "GET",    AFET,  AFET_COMPS_V1,          "",              getAttributesForEntityType                }, \
   { "*",      AFET,  AFET_COMPS_V1,          "",              badVerbGetOnly                            }, \
                                                                                                            \
   { "GET",    ACE,   ACE_COMPS_V1,           "",              getAllContextEntities                     }, \
   { "POST",   ACE,   ACE_COMPS_V1,           ACE_POST_WORD,   postIndividualContextEntity               }, \
-  { "*",      ACE,   ACE_COMPS_V1,           "",              badVerbGetOnly                            }, \
+  { "*",      ACE,   ACE_COMPS_V1,           "",              badVerbGetPostOnly                        }, \
                                                                                                            \
   { "GET",    ACET,  ACET_COMPS_V1,          "",              getAllEntitiesWithTypeAndId               }, \
   { "POST",   ACET,  ACET_COMPS_V1,          ACET_POST_WORD,  postAllEntitiesWithTypeAndId              }, \
@@ -1028,30 +1033,30 @@ static const char* validLogLevels[] =
 #define LOG_REQUESTS_V0                                                              \
   { "GET",    LOG,  LOGT_COMPS_V0,    "",  logTraceTreat                          }, \
   { "DELETE", LOG,  LOGT_COMPS_V0,    "",  logTraceTreat                          }, \
-  { "*",      LOG,  LOGT_COMPS_V0,    "",  badVerbAllFour                         }, \
+  { "*",      LOG,  LOGT_COMPS_V0,    "",  badVerbGetDeleteOnly                   }, \
   { "PUT",    LOG,  LOGTL_COMPS_V0,   "",  logTraceTreat                          }, \
   { "DELETE", LOG,  LOGTL_COMPS_V0,   "",  logTraceTreat                          }, \
-  { "*",      LOG,  LOGTL_COMPS_V0,   "",  badVerbAllFour                         }, \
+  { "*",      LOG,  LOGTL_COMPS_V0,   "",  badVerbPutDeleteOnly                   }, \
   { "GET",    LOG,  LOG2T_COMPS_V0,   "",  logTraceTreat                          }, \
   { "DELETE", LOG,  LOG2T_COMPS_V0,   "",  logTraceTreat                          }, \
-  { "*",      LOG,  LOG2T_COMPS_V0,   "",  badVerbAllFour                         }, \
+  { "*",      LOG,  LOG2T_COMPS_V0,   "",  badVerbGetDeleteOnly                   }, \
   { "PUT",    LOG,  LOG2TL_COMPS_V0,  "",  logTraceTreat                          }, \
   { "DELETE", LOG,  LOG2TL_COMPS_V0,  "",  logTraceTreat                          }, \
-  { "*",      LOG,  LOG2TL_COMPS_V0,  "",  badVerbAllFour                         }
+  { "*",      LOG,  LOG2TL_COMPS_V0,  "",  badVerbPutDeleteOnly                   }
 
 #define LOG_REQUESTS_V1                                                              \
   { "GET",    LOG,  LOGT_COMPS_V1,    "",  logTraceTreat                          }, \
   { "DELETE", LOG,  LOGT_COMPS_V1,    "",  logTraceTreat                          }, \
-  { "*",      LOG,  LOGT_COMPS_V1,    "",  badVerbAllFour                         }, \
+  { "*",      LOG,  LOGT_COMPS_V1,    "",  badVerbGetDeleteOnly                   }, \
   { "PUT",    LOG,  LOGTL_COMPS_V1,   "",  logTraceTreat                          }, \
   { "DELETE", LOG,  LOGTL_COMPS_V1,   "",  logTraceTreat                          }, \
-  { "*",      LOG,  LOGTL_COMPS_V1,   "",  badVerbAllFour                         }, \
+  { "*",      LOG,  LOGTL_COMPS_V1,   "",  badVerbPutDeleteOnly                   }, \
   { "GET",    LOG,  LOG2T_COMPS_V1,   "",  logTraceTreat                          }, \
   { "DELETE", LOG,  LOG2T_COMPS_V1,   "",  logTraceTreat                          }, \
-  { "*",      LOG,  LOG2T_COMPS_V1,   "",  badVerbAllFour                         }, \
+  { "*",      LOG,  LOG2T_COMPS_V1,   "",  badVerbGetDeleteOnly                   }, \
   { "PUT",    LOG,  LOG2TL_COMPS_V1,  "",  logTraceTreat                          }, \
   { "DELETE", LOG,  LOG2TL_COMPS_V1,  "",  logTraceTreat                          }, \
-  { "*",      LOG,  LOG2TL_COMPS_V1,  "",  badVerbAllFour                         }
+  { "*",      LOG,  LOG2TL_COMPS_V1,  "",  badVerbPutDeleteOnly                   }
 
 #define STAT_REQUESTS_V0                                                             \
   { "GET",    STAT, STAT_COMPS_V0,    "",  statisticsTreat                        }, \

--- a/src/lib/serviceRoutinesV2/CMakeLists.txt
+++ b/src/lib/serviceRoutinesV2/CMakeLists.txt
@@ -42,6 +42,7 @@ postSubscriptions.cpp
 deleteSubscription.cpp
 patchSubscription.cpp
 postBatchQuery.cpp
+badVerbGetDeletePatchOnly.cpp
 )
 
 SET (HEADERS
@@ -66,6 +67,7 @@ postSubscriptions.h
 deleteSubscription.h
 patchSubscription.h
 postBatchQuery.h
+badVerbGetDeletePatchOnly.h
 )
 
 

--- a/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
@@ -1,0 +1,59 @@
+/*
+*
+* Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Ken Zangelin
+*/
+#include <string>
+#include <vector>
+
+#include "logMsg/logMsg.h"
+#include "logMsg/traceLevels.h"
+
+#include "alarmMgr/alarmMgr.h"
+#include "ngsi/ParseData.h"
+#include "rest/ConnectionInfo.h"
+#include "rest/restReply.h"
+#include "serviceRoutinesV2/badVerbGetDeletePatchOnly.h"
+
+
+
+/* ****************************************************************************
+*
+* badVerbGetDeletePatchOnly - 
+*/
+std::string badVerbGetDeletePatchOnly
+(
+  ConnectionInfo*            ciP,
+  int                        components,
+  std::vector<std::string>&  compV,
+  ParseData*                 parseDataP
+)
+{
+  ciP->httpHeader.push_back("Allow");
+  ciP->httpHeaderValue.push_back("GET, DELETE, PATCH");
+  ciP->httpStatusCode = SccBadVerb;
+
+  std::string details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
+  alarmMgr.badInput(clientIp, details);
+
+  return "";
+}

--- a/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.h
+++ b/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.h
@@ -1,0 +1,48 @@
+#ifndef SRC_LIB_SERVICEROUTINES_BADVERBGETDELETEPATCHONLY_H_
+#define SRC_LIB_SERVICEROUTINES_BADVERBGETDELETEPATCHONLY_H_
+
+/*
+*
+* Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Ken Zangelin
+*/
+#include <string>
+#include <vector>
+
+#include "rest/ConnectionInfo.h"
+#include "ngsi/ParseData.h"
+
+
+
+/* ****************************************************************************
+*
+* badVerbGetDeletePatchOnly - 
+*/
+extern std::string badVerbGetDeletePatchOnly
+(
+  ConnectionInfo*            ciP,
+  int                        components,
+  std::vector<std::string>&  compV,
+  ParseData*                 parseDataP
+);
+
+#endif  // SRC_LIB_SERVICEROUTINES_BADVERBGETDELETEPATCHONLY_H_

--- a/test/functionalTest/cases/0000_log_operation/log_rest.test
+++ b/test/functionalTest/cases/0000_log_operation/log_rest.test
@@ -135,7 +135,7 @@ Date: REGEX(.*)
 === 4. POST trace level
 HTTP/1.1 405 Method Not Allowed
 Content-Length: 0
-Allow: POST, GET, PUT, DELETE
+Allow: PUT, DELETE
 Date: REGEX(.*)
 
 

--- a/test/functionalTest/cases/0559_new_url_paths/ngsi10_new_url_paths.test
+++ b/test/functionalTest/cases/0559_new_url_paths/ngsi10_new_url_paths.test
@@ -977,7 +977,7 @@ Date: REGEX(.*)
 ================================================
 HTTP/1.1 405 Method Not Allowed
 Content-Length: 0
-Allow: GET, POST, DELETE
+Allow: POST, GET, PUT, DELETE
 Date: REGEX(.*)
 
 

--- a/test/functionalTest/cases/0559_new_url_paths/v1.test
+++ b/test/functionalTest/cases/0559_new_url_paths/v1.test
@@ -977,7 +977,7 @@ Date: REGEX(.*)
 ==============================================
 HTTP/1.1 405 Method Not Allowed
 Content-Length: 0
-Allow: GET, POST, DELETE
+Allow: POST, GET, PUT, DELETE
 Date: REGEX(.*)
 
 


### PR DESCRIPTION
Fixed the erroneous "Allow: verb1,verb2, ..." HTTP Headers.

No functest added.
Perhaps we should create a 'mega functest' exercising each and every operation with a bad verb and checking the Allow header. Seemed a little too much for this quick fix. 