### PR TITLE
Fix ccpcheck

### DIFF
--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -129,7 +129,7 @@ std::string Entity::render(ConnectionInfo* ciP, RequestType requestType, bool co
 */
 std::string Entity::check(ConnectionInfo* ciP, RequestType requestType)
 {
-  size_t len;
+  ssize_t len;
   char errorMsg[128];
 
   if ((requestType == EntitiesRequest) && (id == ""))

--- a/src/lib/cache/subCache.cpp
+++ b/src/lib/cache/subCache.cpp
@@ -71,8 +71,8 @@ volatile SubCacheState subCacheState = ScsIdle;
 */
 EntityInfo::EntityInfo(const std::string& _entityId, const std::string& _entityType, const std::string& _isPattern)
 {
-  entityId     = _entityId;
-  entityType   = _entityType;
+  const std::string entityId     = _entityId;
+  const std::string entityType   = _entityType;
   isPattern    = (_isPattern == "true") || (_isPattern == "TRUE") || (_isPattern == "True");
 
   if (isPattern)

--- a/src/lib/cache/subCache.cpp
+++ b/src/lib/cache/subCache.cpp
@@ -69,10 +69,9 @@ volatile SubCacheState subCacheState = ScsIdle;
 *
 * EntityInfo::EntityInfo - 
 */
-EntityInfo::EntityInfo(const std::string& _entityId, const std::string& _entityType, const std::string& _isPattern)
+EntityInfo::EntityInfo(const std::string& _entityId, const std::string& _entityType, const std::string& _isPattern) : entityId(_entityId), entityType(_entityType) 
 {
-  const std::string entityId     = _entityId;
-  const std::string entityType   = _entityType;
+  
   isPattern    = (_isPattern == "true") || (_isPattern == "TRUE") || (_isPattern == "True");
 
   if (isPattern)

--- a/src/lib/ngsi/ParseData.h
+++ b/src/lib/ngsi/ParseData.h
@@ -118,7 +118,7 @@ typedef struct DiscoverContextAvailabilityResponseData
 */
 struct QueryContextData
 {
-  QueryContextData(): entityIdP(NULL), scopeP(NULL), vertexP(NULL) {}
+  QueryContextData(): entityIdP(NULL), scopeP(NULL), vertexP(NULL),pointNo(0), coords(0) {}
   QueryContextRequest  res;
   EntityId*            entityIdP;
   Scope*               scopeP;

--- a/src/lib/orionTypes/areas.cpp
+++ b/src/lib/orionTypes/areas.cpp
@@ -66,7 +66,7 @@ Point::Point(::std::string latitude, ::std::string longitude): valid(true)
 *
 * Point::Point - 
 */
-Point::Point(double _lat, double _lon)
+Point::Point(double _lat, double _lon): valid(true)
 {
   lat = _lat;
   lon = _lon;


### PR DESCRIPTION
Tested using the following command
```
cppcheck --quiet --enable=warning,performance,portability  --inline-suppr -Isrc/lib/ -Isrc/app -DLM_ON  src/
```

```
[src/lib/rest/ConnectionInfo.h:55]: (warning) Member variable 'ConnectionInfo::requestType' is not initialized in the constructor.
[src/lib/rest/ConnectionInfo.h:77]: (warning) Member variable 'ConnectionInfo::requestType' is not initialized in the constructor.
[src/lib/rest/ConnectionInfo.h:99]: (warning) Member variable 'ConnectionInfo::requestType' is not initialized in the constructor.
[src/lib/apiTypesV2/Entity.cpp:128]: (warning) %zd in format string (no. 1) requires a signed integer given in the argument list.
[src/lib/apiTypesV2/Entity.cpp:141]: (warning) %zd in format string (no. 1) requires a signed integer given in the argument list.
[src/lib/cache/subCache.cpp:74]: (performance) Variable 'entityId' is assigned in constructor body. Consider performing initialization in initialization list.
[src/lib/cache/subCache.cpp:75]: (performance) Variable 'entityType' is assigned in constructor body. Consider performing initialization in initialization list.
[src/lib/ngsi/ParseData.h:121]: (warning) Member variable 'QueryContextData::pointNo' is not initialized in the constructor.
[src/lib/ngsi/ParseData.h:121]: (warning) Member variable 'QueryContextData::coords' is not initialized in the constructor.
[src/lib/logMsg/logMsg.cpp:2834] -> [src/lib/logMsg/logMsg.cpp:2835]: (performance) Variable 'nada' is reassigned a value before the old one has been used.
[src/lib/logMsg/logMsg.cpp:2835] -> [src/lib/logMsg/logMsg.cpp:2836]: (performance) Variable 'nada' is reassigned a value before the old one has been used.
[src/lib/logMsg/logMsg.cpp:2836] -> [src/lib/logMsg/logMsg.cpp:2837]: (performance) Variable 'nada' is reassigned a value before the old one has been used.
[src/lib/orionTypes/areas.cpp:69]: (warning) Member variable 'Point::valid' is not initialized in the constructor.
[src/lib/parseArgs/baStd.cpp:169]: (portability) scanf without field width limits can crash with huge input data on some versions of libc.
[src/lib/parseArgs/baStd.cpp:184]: (portability) scanf without field width limits can crash with huge input data on some versions of libc.

```