### PR TITLE
Hardening/functest failing

### DIFF
--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -153,6 +153,12 @@ Metadata::Metadata(const BSONObj& mdB)
 {
   name = getStringFieldF(mdB, ENT_ATTRS_MD_NAME);
   type = mdB.hasField(ENT_ATTRS_MD_TYPE) ? getStringFieldF(mdB, ENT_ATTRS_MD_TYPE) : "";
+
+  if (type != "")
+  {
+    typeGiven = true;
+  }
+
   switch (getFieldF(mdB, ENT_ATTRS_MD_VALUE).type())
   {
   case String:

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -154,10 +154,7 @@ Metadata::Metadata(const BSONObj& mdB)
   name = getStringFieldF(mdB, ENT_ATTRS_MD_NAME);
   type = mdB.hasField(ENT_ATTRS_MD_TYPE) ? getStringFieldF(mdB, ENT_ATTRS_MD_TYPE) : "";
 
-  if (type != "")
-  {
-    typeGiven = true;
-  }
+  typeGiven = (type == "")? false : true;
 
   switch (getFieldF(mdB, ENT_ATTRS_MD_VALUE).type())
   {


### PR DESCRIPTION
typeGiven was not initialized in one of the constructors of Metadata.

I wonder if perhaps a better implementation would be like this:

    if (mdB.hasField(ENT_ATTRS_MD_TYPE)
    {
      type      = getStringFieldF(mdB, ENT_ATTRS_MD_TYPE);
      typeGiven = true:
    }
    else
    {
      type      = "";
      typeGiven = false;
    }

The 'else' part could be initialized in the initialization list of the constructor.

This change would cover the case   "type": ""    (type given but empty)
Opinions?
 