### PR TITLE
FIX overloging false Runtime Error

### DIFF
--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -258,7 +258,7 @@ HttpStatusCode mongoEntityTypes
     // nullId true means that the "cumulative" entityType for both no-type and type "" has to be used. This happens
     // when the results item has the field "" and at the same time the value of that field is JSON null or when
     // the value of the field "_id" is ""
-    bool nullId = ((resultItem.hasField("")) && (getFieldF(resultItem, "").isNull())) || (getStringFieldF(resultItem, "_id") == "");
+    bool nullId = ((resultItem.hasField("")) && (getFieldF(resultItem, "").isNull())) || getFieldF(resultItem, "_id").isNull() || (getStringFieldF(resultItem, "_id") == "");
 
     if (nullId)
     {


### PR DESCRIPTION
This fixes loging the following ERROR traces (which is not actually an ERROR):

```
Runtime Error (field '_id' was supposed to be a string but type=10 in BSONObj
```

**DO NOT DELETE BRANCH AFTER MERGE**. We would need it to merge this also in develop