### PR TITLE
FIX service path persistence at subscription creation (along with some refactoring)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -8,6 +8,6 @@
 - Fix: csub cache at mongoBackend update context subscription logic wrongly setting expiration with current time, ignoring actual expires/duration in the request
 - Fix: GET /v2/types response payload, from key-map to array (#1832)
 - Fix: GET /v2/types response payload, now using array for attribute types (#1636)
-- Fix: using "/#" as default service path instead of "/" in subscriptiobns (#1961)
+- Fix: using "/#" as default service path instead of "/" in subscriptiobns (#1961, #2024)
 - Fix: POST /v2/subscriptions, attributes in notification are optional (#1952)
 - Add: Correlator as HTTP header and in log file (Issue #1916)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -8,6 +8,6 @@
 - Fix: csub cache at mongoBackend update context subscription logic wrongly setting expiration with current time, ignoring actual expires/duration in the request
 - Fix: GET /v2/types response payload, from key-map to array (#1832)
 - Fix: GET /v2/types response payload, now using array for attribute types (#1636)
-- Fix: using "/#" as default service path instead of "/" in subscriptiobns (#1961, #2024)
+- Fix: using "/#" as default service path instead of "/" in subscriptions (#1961, #2024)
 - Fix: POST /v2/subscriptions, attributes in notification are optional (#1952)
 - Add: Correlator as HTTP header and in log file (Issue #1916)

--- a/src/lib/common/string.cpp
+++ b/src/lib/common/string.cpp
@@ -687,7 +687,7 @@ void strReplace(char* to, int toLen, const char* from, const char* oldString, co
 std::string servicePathCheck(const char* servicePath)
 {
   if (servicePath  == NULL)      return "No Service Path";
-  if (*servicePath == 0)         return "Empty Service Path";
+  if (*servicePath == 0)         return "OK";   // Special case, default service path
 
   //
   // A service-path contains only alphanumeric characters, plus underscore

--- a/src/lib/mongoBackend/MongoCommonRegister.cpp
+++ b/src/lib/mongoBackend/MongoCommonRegister.cpp
@@ -35,6 +35,7 @@
 #include "common/globals.h"
 #include "common/statistics.h"
 #include "common/sem.h"
+#include "common/defaultValues.h"
 #include "alarmMgr/alarmMgr.h"
 
 #include "mongoBackend/MongoCommonRegister.h"
@@ -335,7 +336,7 @@ HttpStatusCode processRegisterContext
   }
   reg.append("_id", oid);
   reg.append(REG_EXPIRATION, expiration);
-  reg.append(REG_SERVICE_PATH, servicePath);
+  reg.append(REG_SERVICE_PATH, servicePath == "" ? DEFAULT_SERVICE_PATH_UPDATES : servicePath);
   reg.append(REG_FORMAT, format);
 
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -2196,16 +2196,7 @@ static bool createEntity
     bsonId.append(ENT_ENTITY_TYPE, eP->type);
   }
 
-  if (servicePathV.size() > 0)
-  {
-    LM_T(LmtServicePath, ("Service path string: %s", servicePathV[0].c_str()));
-    bsonId.append(ENT_SERVICE_PATH, servicePathV[0]);
-  }
-  else
-  {
-    LM_T(LmtServicePath, ("Empty service path string, using default servicepath"));
-    bsonId.append(ENT_SERVICE_PATH, DEFAULT_SERVICE_PATH_UPDATES);
-  }
+  bsonId.append(ENT_SERVICE_PATH, servicePathV[0] == ""? DEFAULT_SERVICE_PATH_UPDATES : servicePathV[0]);
 
   BSONObjBuilder insertedDoc;
 
@@ -2625,20 +2616,8 @@ static void updateEntity
     query.append(typeString, entityType);
   }
 
-  // The servicePath of THIS object is entitySPath
-  char espath[SERVICE_PATH_MAX_TOTAL];
-  slashEscape(entitySPath.c_str(), espath, sizeof(espath));
-  const std::string servicePathValue  = std::string("^") + espath + "$";
-
-  // servicePathString from earlier in this function
-  if (servicePathV.size() == 0)
-  {
-    query.append(servicePathString, BSON("$exists" << false));
-  }
-  else
-  {
-    query.appendRegex(servicePathString, servicePathValue);
-  }
+  // Servicepath
+  query.append(servicePathString, fillQueryServicePath(servicePathV));
 
   std::string err;
   if (!collectionUpdate(getEntitiesCollectionName(tenant), query.obj(), updatedEntityObj, false, &err))
@@ -2798,27 +2777,8 @@ void processContextElement
     bob.append(typeString, enP->type);
   }
 
-  if (servicePathV.size() == 0)
-  {
-    bob.append(servicePathString, BSON("$exists" << false));
-    LM_T(LmtServicePath, ("Updating entity '%s' (no Service Path), action '%s'",
-                          ceP->entityId.id.c_str(),
-                          action.c_str()));
-  }
-  else
-  {
-    LM_T(LmtServicePath, ("Updating entity '%s' for Service Path: '%s', action '%s'",
-                          ceP->entityId.id.c_str(),
-                          servicePathV[0].c_str(),
-                          action.c_str()));
-
-    char               path[SERVICE_PATH_MAX_TOTAL];
-    slashEscape(servicePathV[0].c_str(), path, sizeof(path));
-
-    const std::string  servicePathValue  = std::string("^") + path + "$";
-    bob.appendRegex(servicePathString, servicePathValue);
-  }
-
+  // Service path
+  bob.append(servicePathString, fillQueryServicePath(servicePathV));
 
   // FIXME P7: we build the filter for '?!exist=entity::type' directly at mongoBackend layer given that
   // Restriction is not a valid field in updateContext according to the NGSI specification. In the

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -629,62 +629,61 @@ BSONObj fillQueryServicePath(const std::vector<std::string>& servicePath)
    *
    * More information on: http://stackoverflow.com/questions/24243276/include-regex-elements-in-bsonarraybuilder
    *
-   */
+   */  
 
-  std::string servicePathValue = "";
-
-  if (servicePath.size() > 0)
+  // Note that by construction servicePath vector must have at least one element. Note that the
+  // case in which first element is "" is special, it means that the SP were not provided and
+  // we have to apply the default
+  if (servicePath[0] == "")
   {
-    bool nullAdded = false;
+    LM_T(LmtServicePath, ("Service Path JSON string: '{$in: [ /^\\/.*/, null] }'"));
+    return fromjson("{$in: [ /^\\/.*/, null] }");
+  }
 
-    servicePathValue += "{ $in: [ ";
+  std::string servicePathValue = "{ $in: [ ";
+  bool nullAdded = false;
 
-    for (unsigned int ix = 0 ; ix < servicePath.size(); ++ix)
+  for (unsigned int ix = 0 ; ix < servicePath.size(); ++ix)
+  {
+
+    //
+    // Add "null" in the following service path cases: / or /#. In order to avoid adding null
+    // several times, the nullAdded flag is used
+    //
+    if (!nullAdded && ((servicePath[ix] == "/") || (servicePath[ix] == "/#")))
     {
-
-      //
-      // Add "null" in the following service path cases: / or /#. In order to avoid adding null
-      // several times, the nullAdded flag is used
-      //
-      if (!nullAdded && ((servicePath[ix] == "/") || (servicePath[ix] == "/#")))
-      {
-        servicePathValue += "null, ";
-        nullAdded = true;
-      }
-
-      char path[SERVICE_PATH_MAX_TOTAL * 2];
-      slashEscape(servicePath[ix].c_str(), path, sizeof(path));
-
-      if (path[strlen(path) - 1] == '#')
-      {
-        /* Remove '\/#' trailing part of the string */
-        int l = strlen(path);
-
-        path[l - 3] = 0;
-        servicePathValue += std::string("/^") + path + "$/, " + std::string("/^") + path + "\\/.*/";
-      }
-      else
-      {
-        servicePathValue += std::string("/^") + path + "$/";
-      }
-
-      /* Prepare concatenation for next token in regex */
-      if (ix < servicePath.size() - 1)
-      {
-        servicePathValue += std::string(", ");
-      }
+      servicePathValue += "null, ";
+      nullAdded = true;
     }
 
-    servicePathValue += " ] }";
-    LM_T(LmtServicePath, ("Service Path JSON string: '%s'", servicePathValue.c_str()));
-  }
-  else
-  {
-    /* In this case, servicePath match any path, including the case of "null" */
-    servicePathValue = "{$in: [ /^\\/.*/, null] }";
+    char path[SERVICE_PATH_MAX_TOTAL * 2];
+    slashEscape(servicePath[ix].c_str(), path, sizeof(path));
+
+    if (path[strlen(path) - 1] == '#')
+    {
+      /* Remove '\/#' trailing part of the string */
+      int l = strlen(path);
+
+      path[l - 3] = 0;
+      servicePathValue += std::string("/^") + path + "$/, " + std::string("/^") + path + "\\/.*/";
+    }
+    else
+    {
+      servicePathValue += std::string("/^") + path + "$/";
+    }
+
+    /* Prepare concatenation for next token in regex */
+    if (ix < servicePath.size() - 1)
+    {
+      servicePathValue += std::string(", ");
+    }
   }
 
+  servicePathValue += " ] }";
+  LM_T(LmtServicePath, ("Service Path JSON string: '%s'", servicePathValue.c_str()));
+
   return fromjson(servicePathValue);
+
 }
 
 /* *****************************************************************************
@@ -1969,7 +1968,8 @@ bool processAvailabilitySubscription
 {
   std::string                       err;
   NotifyContextAvailabilityRequest  ncar;
-  const std::vector<std::string>    servicePathV;  // FIXME P5: servicePath for NGSI9 Subscriptions
+  std::vector<std::string>          servicePathV;  // FIXME P5: servicePath for NGSI9 Subscriptions
+  servicePathV.push_back("");                      // While this gets implemented, "" default is used.
 
   if (!registrationsQuery(enV, attrL, &ncar.contextRegistrationResponseVector, &err, tenant, servicePathV))
   {

--- a/src/lib/mongoBackend/mongoRegisterContext.cpp
+++ b/src/lib/mongoBackend/mongoRegisterContext.cpp
@@ -62,16 +62,11 @@ HttpStatusCode mongoRegisterContext
   const std::string&                   servicePath
 )
 {
-    std::string        sPath         = servicePath;    
     bool               reqSemTaken;    
 
     reqSemTake(__FUNCTION__, "ngsi9 register request", SemWriteOp, &reqSemTaken);
 
-    // Default value for service-path is "/"
-    if (sPath == "")
-    {
-      sPath = DEFAULT_SERVICE_PATH_UPDATES;
-    }
+    std::string sPath = servicePath == "" ? DEFAULT_SERVICE_PATH_UPDATES : servicePath;
 
     /* Check if new registration */
     if (requestP->registrationId.isEmpty())

--- a/src/lib/mongoBackend/mongoSubscribeContext.cpp
+++ b/src/lib/mongoBackend/mongoSubscribeContext.cpp
@@ -58,8 +58,8 @@ HttpStatusCode mongoSubscribeContext
   const std::string&                   fiwareCorrelator
 )
 {
-    std::string        servicePath           = (servicePathV.size() == 0)? DEFAULT_SERVICE_PATH_QUERIES : servicePathV[0];
-    bool               reqSemTaken           = false;    
+    std::string servicePath = servicePathV[0] == ""? DEFAULT_SERVICE_PATH_QUERIES : servicePathV[0];
+    bool        reqSemTaken = false;
 
     reqSemTake(__FUNCTION__, "ngsi10 subscribe request", SemWriteOp, &reqSemTaken);
 

--- a/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
@@ -198,7 +198,7 @@ HttpStatusCode mongoUpdateContextSubscription
   LM_T(LmtMongo, ("New subscription expiration: %ld", (long) expiration));
 
   /* ServicePath update */
-  newSub.append(CSUB_SERVICE_PATH, (servicePathV.size() == 0)? DEFAULT_SERVICE_PATH_QUERIES : servicePathV[0]);
+  newSub.append(CSUB_SERVICE_PATH, servicePathV[0] == "" ? DEFAULT_SERVICE_PATH_QUERIES : servicePathV[0]);
 
   /* Throttling update */
   if (!requestP->throttling.isEmpty())

--- a/src/lib/ngsiNotify/Notifier.cpp
+++ b/src/lib/ngsiNotify/Notifier.cpp
@@ -39,15 +39,6 @@
 
 /* ****************************************************************************
 *
-* Select 'method' to send notifications - only one can be uncommented
-*/
-//#define SEND_BLOCKING
-#define SEND_IN_NEW_THREAD
-
-
-
-/* ****************************************************************************
-*
 * ~Notifier -
 */
 Notifier::~Notifier (void)
@@ -121,42 +112,6 @@ void Notifier::sendNotifyContextRequest
     /* Set Content-Type */
     std::string content_type = "application/json";
 
-#ifdef SEND_BLOCKING
-    int r;
-
-    r = httpRequestSend(host,
-                        port,
-                        protocol,
-                        "POST",
-                        tenant,
-                        spathList,
-                        xauthToken,
-                        uriPath,
-                        content_type,
-                        payload,
-                        fiwareCorrelator,
-                        true,
-                        NOTIFICATION_WAIT_MODE);
-
-    char portV[STRING_SIZE_FOR_INT];
-    snprintf(portV, sizeof(portV), "%d", port);
-    std::string url = host + ":" + portV + params->resource;
-
-    if (r == 0)
-    {
-      statisticsUpdate(NotifyContextSent, format);
-      QueueStatistics::incSentOK();
-      alarmMgr.notificationErrorReset(url);
-    }
-    else
-    {
-      QueueStatistics::incSentError();
-      alarmMgr.notificationError(url, "notification failure for Notifier::sendNotifyContextRequest");
-    }
-
-#endif
-
-#ifdef SEND_IN_NEW_THREAD
     /* Send the message (no wait for response), in a separate thread to avoid blocking */
     pthread_t tid;
     SenderThreadParams* params = new SenderThreadParams();
@@ -182,7 +137,6 @@ void Notifier::sendNotifyContextRequest
       return;
     }
     pthread_detach(tid);
-#endif
 }
 
 

--- a/src/lib/ngsiNotify/Notifier.cpp
+++ b/src/lib/ngsiNotify/Notifier.cpp
@@ -178,23 +178,6 @@ void Notifier::sendNotifyContextAvailabilityRequest
     std::string content_type = "application/json";
 
     /* Send the message (without awaiting response, in a separate thread to avoid blocking) */
-#ifdef SEND_BLOCKING
-    int r = httpRequestSend(host, port, protocol, "POST", tenant, "", "", uriPath, content_type, payload, fiwareCorrelator, true, NOTIFICATION_WAIT_MODE);
-
-    if (r == 0)
-    {
-      statisticsUpdate(NotifyContextSent, format);
-      QueueStatistics::incSentOK();
-      alarmMgr.notificationErrorReset(url);
-    }
-    else
-    {
-      QueueStatistics::incSentError();
-      alarmMgr.notificationError(url, "notification failure for Notifier::sendNotifyContextRequest");      
-    }
-#endif
-
-#ifdef SEND_IN_NEW_THREAD
     pthread_t tid;
     SenderThreadParams* params = new SenderThreadParams();
 
@@ -216,5 +199,4 @@ void Notifier::sendNotifyContextAvailabilityRequest
       return;
     }
     pthread_detach(tid);
-#endif
 }

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -574,6 +574,13 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
     return 0;
   }
 
+  if (servicePath[0] == 0)
+  {
+    // Special case, corresponding to default service path
+    return 0;
+  }
+
+
   if (servicePath[0] != '/')
   {
     OrionError e(SccBadRequest, "Only /absolute/ Service Paths allowed [a service path must begin with /]");
@@ -670,7 +677,8 @@ int servicePathSplit(ConnectionInfo* ciP)
 
   if (servicePaths == 0)
   {
-    /* In this case the result is a 0 length vector */
+    /* In this case the result is a vector with an empty string */
+    ciP->servicePathV.push_back("");
     return 0;
   }
 
@@ -801,72 +809,6 @@ bool urlCheck(ConnectionInfo* ciP, const std::string& url)
   }
 
   return true;
-}
-
-
-
-/* ****************************************************************************
-*
-* defaultServicePath
-*
-* Returns a default servicePath (to be used in the case Fiware-servicePath header
-* is not found in the request) depending on the RequestCheck
-*/
-std::string defaultServicePath(const char* url, const char* method)
-{
-  /* Look for standard operation (based on the URL). Given that some operations are
-   * a substring of other, we search first for the longest ones
-   *
-   *  updateContextAvailabilitySubscription
-   *  unsubscribeContextAvailability
-   *  subscribeContextAvailability
-   *  discoverContextAvailability
-   *  updateContextSubscription
-   *  unsubscribeContext
-   *  subscribeContext
-   *  registerContext
-   *  updateContext
-   *  queryContext
-   *
-   * Note that in the case of unsubscribeContext and unsubscribeContextAvailability doesn't
-   * actually use a servicePath, but we also provide a default in that case for the sake of
-   * completeness
-   */
-
-  //
-  // FIXME P5: this strategy can be improved taking into account full URL. Otherwise, it is
-  // ambiguous (e.g. entity which id is "queryContext" and are using a conv op). However, it is
-  // highly improbable that the user uses entities which id (or type) match the name of a
-  // standard operation.
-  // Also, if we wait (if we can) until we know what service it is, this whole string-search will come for free
-  // Don't think strcasestr is a 'simple' function ...
-  //
-  if (strcasestr(url, "updateContextAvailabilitySubscription") != NULL) return DEFAULT_SERVICE_PATH_QUERIES;
-  if (strcasestr(url, "unsubscribeContextAvailability") != NULL)        return DEFAULT_SERVICE_PATH_QUERIES;
-  if (strcasestr(url, "subscribeContextAvailability") != NULL)          return DEFAULT_SERVICE_PATH_QUERIES;
-  if (strcasestr(url, "discoverContextAvailability") != NULL)           return DEFAULT_SERVICE_PATH_QUERIES;
-  if (strcasestr(url, "notifyContextAvailability") != NULL)             return DEFAULT_SERVICE_PATH_UPDATES;
-  if (strcasestr(url, "updateContextSubscription") != NULL)             return DEFAULT_SERVICE_PATH_QUERIES;
-  if (strcasestr(url, "unsubscribeContext") != NULL)                    return DEFAULT_SERVICE_PATH_QUERIES;
-  if (strcasestr(url, "subscribeContext") != NULL)                      return DEFAULT_SERVICE_PATH_QUERIES;
-  if (strcasestr(url, "registerContext") != NULL)                       return DEFAULT_SERVICE_PATH_UPDATES;
-  if (strcasestr(url, "updateContext") != NULL)                         return DEFAULT_SERVICE_PATH_UPDATES;
-  if (strcasestr(url, "notifyContext") != NULL)                         return DEFAULT_SERVICE_PATH_UPDATES;
-  if (strcasestr(url, "queryContext") != NULL)                          return DEFAULT_SERVICE_PATH_QUERIES;
-
-  /* Look for convenience operation. Subscription-related operations are special, all the other depend on
-   * the method
-   */
-  if (strcasestr(url, "contextAvailabilitySubscriptions") != NULL)      return DEFAULT_SERVICE_PATH_QUERIES;
-  if (strcasestr(url, "contextSubscriptions") != NULL)                  return DEFAULT_SERVICE_PATH_QUERIES;
-
-  if (strcasecmp(method, "POST")   == 0)                                return DEFAULT_SERVICE_PATH_UPDATES;
-  if (strcasecmp(method, "PUT")    == 0)                                return DEFAULT_SERVICE_PATH_UPDATES;
-  if (strcasecmp(method, "DELETE") == 0)                                return DEFAULT_SERVICE_PATH_UPDATES;
-  if (strcasecmp(method, "GET")    == 0)                                return DEFAULT_SERVICE_PATH_QUERIES;
-  if (strcasecmp(method, "PATCH")  == 0)                                return DEFAULT_SERVICE_PATH_UPDATES;
-
-  return DEFAULT_SERVICE_PATH_UPDATES;
 }
 
 
@@ -1031,10 +973,6 @@ static int connectionTreat
     ciP->uriParam[URI_PARAM_PAGINATION_DETAILS] = DEFAULT_PAGINATION_DETAILS;
     
     MHD_get_connection_values(connection, MHD_HEADER_KIND, httpHeaderGet, &ciP->httpHeaders);
-    if (!ciP->httpHeaders.servicePathReceived)
-    {
-      ciP->httpHeaders.servicePath = defaultServicePath(url, method);
-    }
 
     char correlator[CORRELATOR_ID_SIZE + 1];
     if (ciP->httpHeaders.correlator == "")

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -442,7 +442,8 @@ std::string postUpdateContext
   // 01. Check service-path consistency
   //
   // If more than ONE service-path is input, an error is returned as response.
-  // If NO service-path is issued, then the default service-path "/" is used.
+  // If ONE service-path is issued and that service path is "", then the default service-path is used.
+  // Note that by construction servicePath cannot have 0 elements
   // After these checks, the service-path is checked to be 'correct'.
   //
   if (ciP->servicePathV.size() > 1)
@@ -454,9 +455,9 @@ std::string postUpdateContext
 
     return answer;
   }
-  else if (ciP->servicePathV.size() == 0)
+  else if (ciP->servicePathV[0] == "")
   {
-    ciP->servicePathV.push_back(DEFAULT_SERVICE_PATH_UPDATES);
+    ciP->servicePathV[0] = DEFAULT_SERVICE_PATH_UPDATES;
   }
 
   std::string res = servicePathCheck(ciP->servicePathV[0].c_str());

--- a/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
@@ -374,7 +374,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationDetails)
   uriParams[URI_PARAM_PAGINATION_DETAILS]  = "on";
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -477,7 +477,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationAll)
   uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -582,7 +582,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationOnlyFirst)
   uriParams[URI_PARAM_PAGINATION_LIMIT]  = "1";
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -631,7 +631,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationOnlySecond)
   uriParams[URI_PARAM_PAGINATION_LIMIT]  = "1";
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -680,7 +680,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationRange)
   uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -757,7 +757,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationNonExisting)
   uriParams[URI_PARAM_PAGINATION_LIMIT]  = "2";
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -793,7 +793,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationNonExistingOverlap)
   uriParams[URI_PARAM_PAGINATION_LIMIT]  = "4";
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -842,7 +842,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationNonExistingDetails)
   uriParams[URI_PARAM_PAGINATION_LIMIT]    = "2";
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -877,7 +877,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrsAll)
   req.entityIdVector.push_back(&en);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+  ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -938,7 +938,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrOneSingle)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1000,7 +1000,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrOneMulti)
     req.attributeList.push_back("A1");
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1072,7 +1072,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrsSubset)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1131,7 +1131,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternSeveralCREs)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1209,7 +1209,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternSeveralRegistrations)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1286,7 +1286,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternNoEntity)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1330,7 +1330,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternNoAttribute)
     req.attributeList.push_back("A5");
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1375,7 +1375,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternMultiEntity)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1475,7 +1475,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternMultiAttr)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1550,7 +1550,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternMultiEntityAttrs)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1642,7 +1642,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternNoType)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1744,7 +1744,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, pattern0Attr)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1826,7 +1826,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, pattern1AttrSingle)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1883,7 +1883,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, pattern1AttrMulti)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1959,7 +1959,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, patternNAttr)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2048,7 +2048,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, patternFail)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2097,7 +2097,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, patternNoType)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2202,7 +2202,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, mixPatternAndNotPattern)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2311,7 +2311,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, mongoDbQueryFail)
     req.entityIdVector.push_back(&en);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathV);
+    ms = mongoDiscoverContextAvailability(&req, &res, "", uriParams, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);

--- a/test/unittests/mongoBackend/mongoNotifyContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoNotifyContext_test.cpp
@@ -36,6 +36,7 @@
 #include "mongo/client/dbclient.h"
 
 #include "commonMocks.h"
+#include "unittest.h"
 
 using ::testing::_;
 using ::testing::Throw;
@@ -47,7 +48,7 @@ extern void setMongoConnectionForUnitTest(DBClientBase*);
 *
 * servicePathV - empty service path vector used for these tests 
 */
-static const std::vector<std::string> servicePathV;
+//static const std::vector<std::string> servicePathV;
 
 
 
@@ -177,6 +178,8 @@ static bool findAttr(std::vector<BSONElement> attrs, std::string name)
 */
 TEST(mongoNotifyContextRequest, Ent1Attr1)
 {
+    utInit();
+
     HttpStatusCode         ms;
     NotifyContextRequest   req;
     NotifyContextResponse  res;
@@ -201,7 +204,7 @@ TEST(mongoNotifyContextRequest, Ent1Attr1)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContext(&req, &res, "", "", servicePathV);
+    ms = mongoNotifyContext(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -312,8 +315,8 @@ TEST(mongoNotifyContextRequest, Ent1Attr1)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release mock */
     delete timerMock;
+    utExit();
 }
 
 /* ****************************************************************************
@@ -325,6 +328,8 @@ TEST(mongoNotifyContextRequest, Ent1AttrN)
     HttpStatusCode         ms;
     NotifyContextRequest   req;
     NotifyContextResponse  res;
+
+    utInit();
 
     /* Prepare database */
     prepareDatabase();
@@ -348,7 +353,7 @@ TEST(mongoNotifyContextRequest, Ent1AttrN)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContext(&req, &res, "", "", servicePathV);
+    ms = mongoNotifyContext(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -459,8 +464,8 @@ TEST(mongoNotifyContextRequest, Ent1AttrN)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release mock */
     delete timerMock;
+    utExit();
 }
 
 /* ****************************************************************************
@@ -472,6 +477,8 @@ TEST(mongoNotifyContextRequest, EntNAttr1)
     HttpStatusCode         ms;
     NotifyContextRequest   req;
     NotifyContextResponse  res;
+
+    utInit();
 
     /* Prepare database */
     prepareDatabase();
@@ -498,7 +505,7 @@ TEST(mongoNotifyContextRequest, EntNAttr1)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContext(&req, &res, "", "", servicePathV);
+    ms = mongoNotifyContext(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -609,8 +616,8 @@ TEST(mongoNotifyContextRequest, EntNAttr1)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release mock */
     delete timerMock;
+    utExit();
 }
 
 /* ****************************************************************************
@@ -622,6 +629,8 @@ TEST(mongoNotifyContextRequest, EntNAttrN)
     HttpStatusCode         ms;
     NotifyContextRequest   req;
     NotifyContextResponse  res;
+
+    utInit();
 
     /* Prepare database */
     prepareDatabase();
@@ -652,7 +661,7 @@ TEST(mongoNotifyContextRequest, EntNAttrN)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContext(&req, &res, "", "", servicePathV);
+    ms = mongoNotifyContext(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -763,8 +772,8 @@ TEST(mongoNotifyContextRequest, EntNAttrN)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release mock */
     delete timerMock;
+    utExit();
 }
 
 /* ****************************************************************************
@@ -776,6 +785,8 @@ TEST(mongoNotifyContextRequest, createEntity)
     HttpStatusCode         ms;
     NotifyContextRequest   req;
     NotifyContextResponse  res;
+
+    utInit();
 
     /* Prepare database */
     prepareDatabase();
@@ -797,7 +808,7 @@ TEST(mongoNotifyContextRequest, createEntity)
     setTimer(timerMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoNotifyContext(&req, &res, "", "", servicePathV);
+    ms = mongoNotifyContext(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -924,7 +935,7 @@ TEST(mongoNotifyContextRequest, createEntity)
     EXPECT_FALSE(a2.hasField("value"));
     EXPECT_FALSE(a2.hasField("modDate"));
 
-    /* Release mock */
     delete timerMock;
+    utExit();
 }
 

--- a/test/unittests/mongoBackend/mongoQueryContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_test.cpp
@@ -1111,6 +1111,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_2levels)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "T", "true");
   req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
   servicePathVector.push_back("/home/kz/#");
 
   /* Invoke the function in mongoBackend library */
@@ -1183,6 +1184,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_1level)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "T", "true");
   req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
   servicePathVector.push_back("/home/#");
 
   /* Invoke the function in mongoBackend library */
@@ -1376,6 +1378,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternType_1levelbis)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "T", "true");
   req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
   servicePathVector.push_back("/home2/#");
 
   /* Invoke the function in mongoBackend library */
@@ -1651,6 +1654,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_2levels)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
   servicePathVector.push_back("/home/kz/#");
 
   /* Invoke the function in mongoBackend library */
@@ -1735,6 +1739,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_1level)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
   servicePathVector.push_back("/home/#");
 
   /* Invoke the function in mongoBackend library */
@@ -1940,6 +1945,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntPatternNoType_1levelbis)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
   servicePathVector.push_back("/home2/#");
 
   /* Invoke the function in mongoBackend library */
@@ -2000,6 +2006,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntNoPatternTypeFail)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E3", "T", "false");
   req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
   servicePathVector.push_back("/home/kz");
 
   /* Invoke the function in mongoBackend library */
@@ -2036,6 +2043,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntNoPatternTypeOk)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E3", "T", "false");
   req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
   servicePathVector.push_back("/home/fg");
 
   /* Invoke the function in mongoBackend library */
@@ -2084,6 +2092,7 @@ TEST(mongoQueryContextRequest, queryWithServicePathEntNoPatternNoType)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E3", "", "false");
   req.entityIdVector.push_back(&en);
+  servicePathVector.clear();
   servicePathVector.push_back("/home/fg/#");
 
   /* Invoke the function in mongoBackend library */
@@ -2200,6 +2209,8 @@ TEST(mongoQueryContextRequest, queryWithSeveralServicePaths)
 */
 TEST(mongoQueryContextRequest, query1Ent0Attr)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2212,7 +2223,6 @@ TEST(mongoQueryContextRequest, query1Ent0Attr)
     req.entityIdVector.push_back(&en);
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams, options);
 
     /* Check response is as expected */
@@ -2240,6 +2250,8 @@ TEST(mongoQueryContextRequest, query1Ent0Attr)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2251,6 +2263,8 @@ TEST(mongoQueryContextRequest, query1Ent0Attr)
 */
 TEST(mongoQueryContextRequest, query1Ent1Attr)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2285,6 +2299,8 @@ TEST(mongoQueryContextRequest, query1Ent1Attr)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2297,6 +2313,8 @@ TEST(mongoQueryContextRequest, query1Ent1Attr)
 */
 TEST(mongoQueryContextRequest, queryNEnt0Attr)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2352,7 +2370,9 @@ TEST(mongoQueryContextRequest, queryNEnt0Attr)
     EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
-    res.contextElementResponseVector.release();    
+    res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2364,6 +2384,8 @@ TEST(mongoQueryContextRequest, queryNEnt0Attr)
 */
 TEST(mongoQueryContextRequest, queryNEnt1AttrSingle)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2403,6 +2425,8 @@ TEST(mongoQueryContextRequest, queryNEnt1AttrSingle)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2415,6 +2439,9 @@ TEST(mongoQueryContextRequest, queryNEnt1AttrSingle)
 */
 TEST(mongoQueryContextRequest, queryNEnt1AttrMulti)
 {
+
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;  
@@ -2466,6 +2493,8 @@ TEST(mongoQueryContextRequest, queryNEnt1AttrMulti)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2478,6 +2507,8 @@ TEST(mongoQueryContextRequest, queryNEnt1AttrMulti)
 */
 TEST(mongoQueryContextRequest, queryNEntNAttr)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2493,8 +2524,7 @@ TEST(mongoQueryContextRequest, queryNEntNAttr)
     req.attributeList.push_back("A1");
     req.attributeList.push_back("A3");
 
-    /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
+    /* Invoke the function in mongoBackend library */    
     ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams, options);
 
     /* Check response is as expected */
@@ -2531,6 +2561,8 @@ TEST(mongoQueryContextRequest, queryNEntNAttr)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2542,6 +2574,8 @@ TEST(mongoQueryContextRequest, queryNEntNAttr)
 */
 TEST(mongoQueryContextRequest, query1Ent0AttrFail)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2566,6 +2600,8 @@ TEST(mongoQueryContextRequest, query1Ent0AttrFail)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2577,6 +2613,8 @@ TEST(mongoQueryContextRequest, query1Ent0AttrFail)
 */
 TEST(mongoQueryContextRequest, query1Ent1AttrFail)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2589,8 +2627,7 @@ TEST(mongoQueryContextRequest, query1Ent1AttrFail)
     req.entityIdVector.push_back(&en);
     req.attributeList.push_back("A3");
 
-    /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
+    /* Invoke the function in mongoBackend library */    
     ms = mongoQueryContext(&req, &res, "", servicePathVector, uriParams, options);
 
     /* Check response is as expected */
@@ -2603,6 +2640,8 @@ TEST(mongoQueryContextRequest, query1Ent1AttrFail)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 
@@ -2615,6 +2654,8 @@ TEST(mongoQueryContextRequest, query1Ent1AttrFail)
 */
 TEST(mongoQueryContextRequest, query1EntWA0AttrFail)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2640,6 +2681,8 @@ TEST(mongoQueryContextRequest, query1EntWA0AttrFail)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2651,6 +2694,8 @@ TEST(mongoQueryContextRequest, query1EntWA0AttrFail)
 */
 TEST(mongoQueryContextRequest, query1EntWA1Attr)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2684,6 +2729,8 @@ TEST(mongoQueryContextRequest, query1EntWA1Attr)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2696,6 +2743,8 @@ TEST(mongoQueryContextRequest, query1EntWA1Attr)
 */
 TEST(mongoQueryContextRequest, queryNEntWA0Attr)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2746,6 +2795,8 @@ TEST(mongoQueryContextRequest, queryNEntWA0Attr)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2757,6 +2808,8 @@ TEST(mongoQueryContextRequest, queryNEntWA0Attr)
 */
 TEST(mongoQueryContextRequest, queryNEntWA1Attr)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2793,6 +2846,8 @@ TEST(mongoQueryContextRequest, queryNEntWA1Attr)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2810,6 +2865,8 @@ TEST(mongoQueryContextRequest, queryNEntWA1Attr)
 */
 TEST(mongoQueryContextRequest, queryNoType)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2868,6 +2925,8 @@ TEST(mongoQueryContextRequest, queryNoType)
     EXPECT_EQ(SccOk, RES_CER_STATUS(2).code);
     EXPECT_EQ("OK", RES_CER_STATUS(2).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(2).details.size());
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2877,6 +2936,8 @@ TEST(mongoQueryContextRequest, queryNoType)
 */
 TEST(mongoQueryContextRequest, queryIdMetadata)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2922,6 +2983,8 @@ TEST(mongoQueryContextRequest, queryIdMetadata)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -2931,6 +2994,8 @@ TEST(mongoQueryContextRequest, queryIdMetadata)
 */
 TEST(mongoQueryContextRequest, queryCustomMetadata)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -2972,6 +3037,8 @@ TEST(mongoQueryContextRequest, queryCustomMetadata)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+    utExit();
 }
 
 
@@ -2982,6 +3049,8 @@ TEST(mongoQueryContextRequest, queryCustomMetadata)
 */
 TEST(mongoQueryContextRequest, queryCustomMetadataNative)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3032,6 +3101,8 @@ TEST(mongoQueryContextRequest, queryCustomMetadataNative)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+    utExit();
 }
 
 
@@ -3049,6 +3120,8 @@ TEST(mongoQueryContextRequest, queryCustomMetadataNative)
 */
 TEST(mongoQueryContextRequest, queryPattern0Attr)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3100,6 +3173,8 @@ TEST(mongoQueryContextRequest, queryPattern0Attr)
     EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
     EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3111,6 +3186,8 @@ TEST(mongoQueryContextRequest, queryPattern0Attr)
 */
 TEST(mongoQueryContextRequest, queryPattern1AttrSingle)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3145,6 +3222,8 @@ TEST(mongoQueryContextRequest, queryPattern1AttrSingle)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3157,6 +3236,8 @@ TEST(mongoQueryContextRequest, queryPattern1AttrSingle)
 */
 TEST(mongoQueryContextRequest, queryPattern1AttrMulti)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3203,6 +3284,8 @@ TEST(mongoQueryContextRequest, queryPattern1AttrMulti)
     EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
     EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3215,6 +3298,8 @@ TEST(mongoQueryContextRequest, queryPattern1AttrMulti)
 */
 TEST(mongoQueryContextRequest, queryPatternNAttr)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3265,6 +3350,8 @@ TEST(mongoQueryContextRequest, queryPatternNAttr)
     EXPECT_EQ(SccOk, RES_CER_STATUS(1).code);
     EXPECT_EQ("OK", RES_CER_STATUS(1).reasonPhrase);
     EXPECT_EQ(0, RES_CER_STATUS(1).details.size());
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3276,6 +3363,8 @@ TEST(mongoQueryContextRequest, queryPatternNAttr)
 */
 TEST(mongoQueryContextRequest, queryPatternFail)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3298,6 +3387,7 @@ TEST(mongoQueryContextRequest, queryPatternFail)
     EXPECT_EQ("", res.errorCode.details);
     EXPECT_EQ(0,res.contextElementResponseVector.size());
 
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3311,6 +3401,8 @@ TEST(mongoQueryContextRequest, queryPatternFail)
 */
 TEST(mongoQueryContextRequest, queryMixPatternAndNotPattern)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3376,6 +3468,8 @@ TEST(mongoQueryContextRequest, queryMixPatternAndNotPattern)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3394,6 +3488,8 @@ TEST(mongoQueryContextRequest, queryMixPatternAndNotPattern)
 */
 TEST(mongoQueryContextRequest, queryNoTypePattern)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3475,6 +3571,8 @@ TEST(mongoQueryContextRequest, queryNoTypePattern)
 
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3484,6 +3582,8 @@ TEST(mongoQueryContextRequest, queryNoTypePattern)
 */
 TEST(mongoQueryContextRequest, queryIdMetadataPattern)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3556,6 +3656,8 @@ TEST(mongoQueryContextRequest, queryIdMetadataPattern)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3565,6 +3667,8 @@ TEST(mongoQueryContextRequest, queryIdMetadataPattern)
 */
 TEST(mongoQueryContextRequest, queryCustomMetadataPattern)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3625,6 +3729,8 @@ TEST(mongoQueryContextRequest, queryCustomMetadataPattern)
     EXPECT_EQ(SccOk, RES_CER_STATUS(0).code);
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3637,6 +3743,8 @@ TEST(mongoQueryContextRequest, queryCustomMetadataPattern)
 */
 TEST(mongoQueryContextRequest, queryNativeTypes)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3711,9 +3819,10 @@ TEST(mongoQueryContextRequest, queryNativeTypes)
     EXPECT_EQ("OK", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("", RES_CER_STATUS(0).details);
 
-
     /* Release dynamic memory used by response (mongoBackend allocates it) */
     res.contextElementResponseVector.release();
+
+    utExit();
 }
 
 /* ****************************************************************************
@@ -3723,6 +3832,8 @@ TEST(mongoQueryContextRequest, queryNativeTypes)
 */
 TEST(mongoQueryContextRequest, mongoDbQueryFail)
 {
+    utInit();
+
     HttpStatusCode         ms;
     QueryContextRequest   req;
     QueryContextResponse  res;
@@ -3760,6 +3871,6 @@ TEST(mongoQueryContextRequest, mongoDbQueryFail)
     /* Restore real DB connection */
     setMongoConnectionForUnitTest(connectionDb);
 
-    /* Release mock */
     delete connectionMock;
+    utExit();
 }

--- a/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
@@ -2256,6 +2256,8 @@ TEST(mongoRegisterContextRequest, ceN_EnNnt_AtNnt_Ok)
 */
 TEST(mongoRegisterContextRequest, NotifyContextAvailability1)
 {
+  utInit();
+
   HttpStatusCode           ms;
   RegisterContextRequest   req;
   RegisterContextResponse  res;
@@ -2307,8 +2309,9 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability1)
    * testbed by other unit tests, so we don't include checking in the present unit test */
 
   /* Delete mock */
-  delete timerMock;
   delete notifierMock;
+  delete timerMock;
+  utExit();
 }
 
 /* ****************************************************************************
@@ -2317,6 +2320,8 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability1)
 */
 TEST(mongoRegisterContextRequest, NotifyContextAvailability2)
 {
+  utInit();
+
   HttpStatusCode           ms;
   RegisterContextRequest   req;
   RegisterContextResponse  res;
@@ -2375,8 +2380,9 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability2)
    * testbed by other unit tests, so we don't include checking in the present unit test */
 
   /* Delete mock */
-  delete timerMock;
   delete notifierMock;
+  delete timerMock;
+  utExit();
 }
 
 /* ****************************************************************************
@@ -2385,6 +2391,8 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability2)
 */
 TEST(mongoRegisterContextRequest, NotifyContextAvailability3)
 {
+  utInit();
+
   HttpStatusCode           ms;
   RegisterContextRequest   req;
   RegisterContextResponse  res;
@@ -2440,9 +2448,9 @@ TEST(mongoRegisterContextRequest, NotifyContextAvailability3)
    * testbed by other unit tests, so we don't include checking in the present unit test */
 
   /* Delete mock */
-  delete timerMock;
   delete notifierMock;
-
+  delete timerMock;
+  utExit();
 }
 
 /* ****************************************************************************

--- a/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
@@ -39,15 +39,6 @@
 
 extern void setMongoConnectionForUnitTest(DBClientBase*);
 
-/* ****************************************************************************
-*
-* emptyServicePathV -
-*
-* Empty vector of service paths, sent to mongoSubscribeContext during tests.
-*/
-static std::vector<std::string> emptyServicePathV;
-
-
 
 /* ****************************************************************************
 *
@@ -315,7 +306,7 @@ TEST(mongoSubscribeContext, Ent1_Attr0_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -402,7 +393,7 @@ TEST(mongoSubscribeContext, Ent1_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -492,7 +483,7 @@ TEST(mongoSubscribeContext, Ent1_Attr0_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -584,7 +575,7 @@ TEST(mongoSubscribeContext, Ent1_Attr0_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -676,7 +667,7 @@ TEST(mongoSubscribeContext, Ent1_AttrN_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -774,7 +765,7 @@ TEST(mongoSubscribeContext, Ent1_AttrN_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -867,7 +858,7 @@ TEST(mongoSubscribeContext, EntN_Attr0_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -960,7 +951,7 @@ TEST(mongoSubscribeContext, EntN_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1056,7 +1047,7 @@ TEST(mongoSubscribeContext, EntN_Attr0_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1154,7 +1145,7 @@ TEST(mongoSubscribeContext, EntN_Attr0_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1251,7 +1242,7 @@ TEST(mongoSubscribeContext, EntN_AttrN_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1353,7 +1344,7 @@ TEST(mongoSubscribeContext, EntN_AttrN_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1459,7 +1450,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1556,7 +1547,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_C1_JSON)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */    
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1652,7 +1643,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1751,7 +1742,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_C1_disjoint)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1864,7 +1855,7 @@ TEST(mongoSubscribeContext, matchEnt1NoType_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1977,7 +1968,7 @@ TEST(mongoSubscribeContext, matchEnt1NoType_AttrN_C1_disjoint)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2083,7 +2074,7 @@ TEST(mongoSubscribeContext, matchEnt1Pattern_AttrN_C1)
     prepareDatabasePatternTrue();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2189,7 +2180,7 @@ TEST(mongoSubscribeContext, matchEnt1Pattern_AttrN_C1_disjoint)
     prepareDatabasePatternTrue();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2307,7 +2298,7 @@ TEST(mongoSubscribeContext, matchEnt1PatternNoType_AttrN_C1)
     prepareDatabasePatternTrue();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2425,7 +2416,7 @@ TEST(mongoSubscribeContext, matchEnt1PatternNoType_AttrN_C1_disjoint)
     prepareDatabasePatternTrue();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2527,7 +2518,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2633,7 +2624,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_CN_partial)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2738,7 +2729,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2838,7 +2829,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_disjoint)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2946,7 +2937,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_partial)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3054,7 +3045,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_partial_disjoint)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3160,7 +3151,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3265,7 +3256,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3382,7 +3373,7 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3491,7 +3482,7 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3607,7 +3598,7 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3725,7 +3716,7 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3838,7 +3829,7 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3954,7 +3945,7 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -4048,7 +4039,7 @@ TEST(mongoSubscribeContext, defaultDuration)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -4140,7 +4131,7 @@ TEST(mongoSubscribeContext, MongoDbInsertFail)
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", emptyServicePathV);
+    ms = mongoSubscribeContext(&req, &res, "", uriParams, "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);

--- a/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
@@ -138,14 +138,6 @@ extern void setMongoConnectionForUnitTest(DBClientBase*);
 
 /* ****************************************************************************
 *
-* emptyServicePathV -
-*
-* Empty vector of service paths, sent to mongoSubscribeContext during tests.
-*/
-std::vector<std::string> emptyServicePathV;
-
-/* ****************************************************************************
-*
 * prepareDatabase -
 */
 static void prepareDatabase(void) {
@@ -496,7 +488,7 @@ TEST(mongoUpdateContextSubscription, subscriptionNotFound)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -517,6 +509,8 @@ TEST(mongoUpdateContextSubscription, subscriptionNotFound)
 */
 TEST(mongoUpdateContextSubscription, updateDuration)
 {
+    utInit();
+
     HttpStatusCode                    ms;
     UpdateContextSubscriptionRequest  req;
     UpdateContextSubscriptionResponse res;
@@ -541,7 +535,7 @@ TEST(mongoUpdateContextSubscription, updateDuration)
     /* Invoke the function in mongoBackend library */
     std::string tenant      = "";
     std::string servicePath = "";
-    ms = mongoUpdateContextSubscription(&req, &res, tenant, servicePath, emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, tenant, servicePath, servicePathVector);
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
     EXPECT_EQ("PT5H",res.subscribeResponse.duration.get());
@@ -589,9 +583,9 @@ TEST(mongoUpdateContextSubscription, updateDuration)
     EXPECT_EQ("AX1", condValues[0].String());
     EXPECT_EQ("AY1", condValues[1].String());
 
-    /* Release mock */
     delete notifierMock;
     delete timerMock;
+    utExit();
 }
 
 /* ****************************************************************************
@@ -632,7 +626,7 @@ TEST(mongoUpdateContextSubscription, updateThrottling)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -708,7 +702,7 @@ TEST(mongoUpdateContextSubscription, clearThrottling)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -791,7 +785,7 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -874,7 +868,7 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -961,7 +955,7 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1051,7 +1045,7 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1139,7 +1133,7 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1231,7 +1225,7 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1319,7 +1313,7 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1406,7 +1400,7 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1498,7 +1492,7 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1588,7 +1582,7 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1677,7 +1671,7 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1770,7 +1764,7 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1871,7 +1865,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1965,7 +1959,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_C1_JSON)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2056,7 +2050,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2148,7 +2142,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_C1_disjoint)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2255,7 +2249,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1NoType_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2361,7 +2355,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1NoType_AttrN_C1_disjoint)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2461,7 +2455,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1Pattern_AttrN_C1)
     prepareDatabasePatternTrue();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2561,7 +2555,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1Pattern_AttrN_C1_disjoint)
     prepareDatabasePatternTrue();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2673,7 +2667,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1PatternNoType_AttrN_C1)
     prepareDatabasePatternTrue();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2785,7 +2779,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1PatternNoType_AttrN_C1_disjoint)
     prepareDatabasePatternTrue();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2883,7 +2877,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2985,7 +2979,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_CN_partial)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3086,7 +3080,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3181,7 +3175,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN_disjoint)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3283,7 +3277,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN_partial)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3385,7 +3379,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN_partial_disjoint)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3485,7 +3479,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3584,7 +3578,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3695,7 +3689,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3796,7 +3790,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_C1)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -3906,7 +3900,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -4018,7 +4012,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -4123,7 +4117,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_CN)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -4231,7 +4225,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_CNbis)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -4321,7 +4315,7 @@ TEST(mongoUpdateContextSubscription, updateDurationAndNotifyConditions)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -4404,7 +4398,7 @@ TEST(mongoUpdateContextSubscription, MongoDbFindOneFail)
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -4470,7 +4464,7 @@ TEST(mongoUpdateContextSubscription, MongoDbUpdateFail)
     setMongoConnectionForUnitTest(connectionMock);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContextSubscription(&req, &res, "", "", emptyServicePathV);
+    ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -458,7 +458,6 @@ TEST(mongoUpdateContextRequest, update1Ent1Attr)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();   
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -612,7 +611,6 @@ TEST(mongoUpdateContextRequest, update1Ent1AttrNoType)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -766,7 +764,6 @@ TEST(mongoUpdateContextRequest, update1EntNoType1Attr)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();   
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -946,7 +943,6 @@ TEST(mongoUpdateContextRequest, update1EntNoType1AttrNoType)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -1130,7 +1126,6 @@ TEST(mongoUpdateContextRequest, updateNEnt1Attr)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -1298,7 +1293,6 @@ TEST(mongoUpdateContextRequest, update1EntNAttr)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();   
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -1464,7 +1458,6 @@ TEST(mongoUpdateContextRequest, updateNEntNAttr)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -1638,7 +1631,6 @@ TEST(mongoUpdateContextRequest, append1Ent1Attr)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -1796,7 +1788,6 @@ TEST(mongoUpdateContextRequest, append1Ent1AttrNoType)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -1954,7 +1945,6 @@ TEST(mongoUpdateContextRequest, append1EntNoType1Attr)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -2148,7 +2138,6 @@ TEST(mongoUpdateContextRequest, append1EntNoType1AttrNoType)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();   
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -2346,7 +2335,6 @@ TEST(mongoUpdateContextRequest, appendNEnt1Attr)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -2524,7 +2512,6 @@ TEST(mongoUpdateContextRequest, append1EntNAttr)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -2699,7 +2686,6 @@ TEST(mongoUpdateContextRequest, appendNEntNAttr)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -2892,7 +2878,6 @@ TEST(mongoUpdateContextRequest, delete1Ent0Attr)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();   
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -3021,7 +3006,6 @@ TEST(mongoUpdateContextRequest, delete1Ent1Attr)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -3168,7 +3152,6 @@ TEST(mongoUpdateContextRequest, delete1Ent1AttrNoType)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -3314,7 +3297,6 @@ TEST(mongoUpdateContextRequest, delete1EntNoType0Attr)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -3428,7 +3410,6 @@ TEST(mongoUpdateContextRequest, delete1EntNoType1Attr)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -3597,7 +3578,6 @@ TEST(mongoUpdateContextRequest, delete1EntNoType1AttrNoType)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -3770,7 +3750,6 @@ TEST(mongoUpdateContextRequest, deleteNEnt1Attr)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -3927,7 +3906,6 @@ TEST(mongoUpdateContextRequest, delete1EntNAttr)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -4082,7 +4060,6 @@ TEST(mongoUpdateContextRequest, deleteNEntNAttr)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();   
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -4237,7 +4214,6 @@ TEST(mongoUpdateContextRequest, updateEntityFails)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -4396,7 +4372,6 @@ TEST(mongoUpdateContextRequest, createEntity)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -4567,7 +4542,6 @@ TEST(mongoUpdateContextRequest, createEntityWithId)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -4743,7 +4717,6 @@ TEST(mongoUpdateContextRequest, createEntityMixIdNoIdFails)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -4907,7 +4880,6 @@ TEST(mongoUpdateContextRequest, createEntityMd)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -5090,7 +5062,6 @@ TEST(mongoUpdateContextRequest, updateEmptyValueOk)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -5243,7 +5214,6 @@ TEST(mongoUpdateContextRequest, appendEmptyValueOk)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -5402,7 +5372,6 @@ TEST(mongoUpdateContextRequest, updateAttrNotFoundFail)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -5560,7 +5529,6 @@ TEST(mongoUpdateContextRequest, deleteAttrNotFoundFail)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();   
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -5717,7 +5685,6 @@ TEST(mongoUpdateContextRequest, mixUpdateAndCreate)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -5899,7 +5866,6 @@ TEST(mongoUpdateContextRequest, appendExistingAttr)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -6054,7 +6020,6 @@ TEST(mongoUpdateContextRequest, updateAttrWithId)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -6237,7 +6202,6 @@ TEST(mongoUpdateContextRequest, updateAttrWithAndWithoutId)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -6422,7 +6386,6 @@ TEST(mongoUpdateContextRequest, appendAttrWithId)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -6609,7 +6572,6 @@ TEST(mongoUpdateContextRequest, appendAttrWithAndWithoutId)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -6803,7 +6765,6 @@ TEST(mongoUpdateContextRequest, appendAttrWithIdFails)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -6982,7 +6943,6 @@ TEST(mongoUpdateContextRequest, appendAttrWithoutIdFails)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -7160,7 +7120,6 @@ TEST(mongoUpdateContextRequest, deleteAttrWithId)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -7338,7 +7297,6 @@ TEST(mongoUpdateContextRequest, deleteAttrWithAndWithoutId)
     req.updateActionType.set("DELETE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -7516,7 +7474,6 @@ TEST(mongoUpdateContextRequest, appendCreateEntWithMd)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -7610,7 +7567,6 @@ TEST(mongoUpdateContextRequest, appendMdAllExisting)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -7701,7 +7657,6 @@ TEST(mongoUpdateContextRequest, updateMdAllExisting)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -7792,7 +7747,6 @@ TEST(mongoUpdateContextRequest, appendMdAllNew)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -7886,7 +7840,6 @@ TEST(mongoUpdateContextRequest, updateMdAllNew)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -7982,7 +7935,6 @@ TEST(mongoUpdateContextRequest, appendMdSomeNew)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -8081,7 +8033,6 @@ TEST(mongoUpdateContextRequest, updateMdSomeNew)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -8178,7 +8129,6 @@ TEST(mongoUpdateContextRequest, appendValueAndMd)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -8269,7 +8219,6 @@ TEST(mongoUpdateContextRequest, updateValueAndMd)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -8361,7 +8310,6 @@ TEST(mongoUpdateContextRequest, appendMdNoActualChanges)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -8452,7 +8400,6 @@ TEST(mongoUpdateContextRequest, updateMdNoActualChanges)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();   
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -8546,7 +8493,6 @@ TEST(mongoUpdateContextRequest, patternUnsupported)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -8712,7 +8658,6 @@ TEST(mongoUpdateContextRequest, notExistFilter)
     uriParams[URI_PARAM_NOT_EXIST] = "entity::type";
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -8872,7 +8817,6 @@ TEST(mongoUpdateContextRequest, createNativeTypes)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -9081,7 +9025,6 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", "v2");
 
     /* Check response is as expected */
@@ -9254,7 +9197,6 @@ TEST(mongoUpdateContextRequest, preservingNativeTypes)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -9365,7 +9307,6 @@ TEST(mongoUpdateContextRequest, createMdNativeTypes)
     req.updateActionType.set("APPEND");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -9569,7 +9510,6 @@ TEST(mongoUpdateContextRequest, updateMdNativeTypes)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -9673,7 +9613,6 @@ TEST(mongoUpdateContextRequest, preservingMdNativeTypes)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -9769,7 +9708,6 @@ TEST(mongoUpdateContextRequest, replace)
     req.updateActionType.set("REPLACE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -9933,7 +9871,6 @@ TEST(mongoUpdateContextRequest, tooManyEntitiesNGSIv2)
   req.updateActionType.set("UPDATE");
 
   /* Invoke the function in mongoBackend library (note the "v2" to activate NGSIv2 special behaviours) */
-  servicePathVector.clear();
   ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", "v2");
 
   /* Check response is as expected */
@@ -10084,7 +10021,6 @@ TEST(mongoUpdateContextRequest, onlyOneEntityNGSIv2)
   req.updateActionType.set("UPDATE");
 
   /* Invoke the function in mongoBackend library (note the "v2" to activate NGSIv2 special behaviours) */
-  servicePathVector.clear();
   ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", "v2");
 
   /* Check response is as expected */
@@ -10287,7 +10223,6 @@ TEST(mongoUpdateContextRequest, mongoDbUpdateFail)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -10311,7 +10246,7 @@ TEST(mongoUpdateContextRequest, mongoDbUpdateFail)
     EXPECT_EQ("Internal Server Error", RES_CER_STATUS(0).reasonPhrase);
 
     EXPECT_EQ("Database Error (collection: utest.entities "
-              "- update(): <{ _id.id: \"E1\", _id.type: \"T1\", _id.servicePath: { $exists: false } },{ $set: { attrs.A1: { value: \"new_val\", type: \"TA1\", modDate: 1360232700 }, modDate: 1360232700 }, $unset: { location: 1 } }> "
+              "- update(): <{ _id.id: \"E1\", _id.type: \"T1\", _id.servicePath: { $in: [ /^/.*/, null ] } },{ $set: { attrs.A1: { value: \"new_val\", type: \"TA1\", modDate: 1360232700 }, modDate: 1360232700 }, $unset: { location: 1 } }> "
               "- exception: boom!!)", RES_CER_STATUS(0).details);
 
     /* Restore real DB connection */
@@ -10356,7 +10291,6 @@ TEST(mongoUpdateContextRequest, mongoDbQueryFail)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    servicePathVector.clear();    
     ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "");
 
     /* Check response is as expected */
@@ -10375,7 +10309,7 @@ TEST(mongoUpdateContextRequest, mongoDbQueryFail)
     EXPECT_EQ(SccReceiverInternalError, RES_CER_STATUS(0).code);
     EXPECT_EQ("Internal Server Error", RES_CER_STATUS(0).reasonPhrase);
     EXPECT_EQ("Database Error (collection: utest.entities "
-              "- query(): { _id.id: \"E1\", _id.type: \"T1\", _id.servicePath: { $exists: false } } "
+              "- query(): { _id.id: \"E1\", _id.type: \"T1\", _id.servicePath: { $in: [ /^/.*/, null ] } } "
               "- exception: boom!!)", RES_CER_STATUS(0).details);
 
     /* Restore real DB connection */
@@ -10411,6 +10345,7 @@ TEST(mongoUpdateContextRequest, servicePathEntityUpdate_3levels)
   ce.contextAttributeVector.push_back(&ca);
   req.contextElementVector.push_back(&ce);
   req.updateActionType.set("UPDATE");
+  servicePathVector.clear();
   servicePathVector.push_back("/home/kz/01");
 
   /* Invoke the function in mongoBackend library */
@@ -10502,6 +10437,7 @@ TEST(mongoUpdateContextRequest, servicePathEntityAppend_3levels)
   ce.contextAttributeVector.push_back(&ca);
   req.contextElementVector.push_back(&ce);
   req.updateActionType.set("APPEND");
+  servicePathVector.clear();
   servicePathVector.push_back("/home/kz/01");
 
   /* Invoke the function in mongoBackend library */
@@ -10599,6 +10535,7 @@ TEST(mongoUpdateContextRequest, servicePathEntityCreation_2levels)
     ce.contextAttributeVector.push_back(&ca);
     req.contextElementVector.push_back(&ce);
     req.updateActionType.set("APPEND");
+    servicePathVector.clear();
     servicePathVector.push_back("/home/fg");
 
     /* Invoke the function in mongoBackend library */
@@ -10706,6 +10643,7 @@ TEST(mongoUpdateContextRequest, servicePathEntityCreation_3levels)
     ce.contextAttributeVector.push_back(&ca);
     req.contextElementVector.push_back(&ce);
     req.updateActionType.set("APPEND");
+    servicePathVector.clear();
     servicePathVector.push_back("/home/fg/01");
 
     /* Invoke the function in mongoBackend library */
@@ -10811,6 +10749,7 @@ TEST(mongoUpdateContextRequest, servicePathEntityDeletion_3levels)
     ce.entityId.fill("E1", "T1", "false");
     req.contextElementVector.push_back(&ce);
     req.updateActionType.set("DELETE");
+    servicePathVector.clear();
     servicePathVector.push_back("/home/kz/01");
 
     /* Invoke the function in mongoBackend library */

--- a/test/unittests/rest/RestService_test.cpp
+++ b/test/unittests/rest/RestService_test.cpp
@@ -121,6 +121,8 @@ TEST(RestService, payloadParse)
 TEST(RestService, noSuchServiceAndNotFound)
 {
   ConnectionInfo ci("/ngsi9/discoverContextAvailability",  "POST", "1.1");
+  ci.servicePathV.push_back("");
+
   const char*    infile    = "ngsi9.discoverContextAvailabilityRequest.ok.valid.json";
   const char*    outfile1  = "ngsi9.discoverContextAvailabilityRsponse.serviceNotRecognized.valid.json";
   const char*    outfile2  = "ngsi9.discoverContextAvailabilityRsponse.notFound.valid.json";

--- a/test/unittests/serviceRoutines/putIndividualContextEntityAttribute_test.cpp
+++ b/test/unittests/serviceRoutines/putIndividualContextEntityAttribute_test.cpp
@@ -52,6 +52,8 @@ static RestService rs[] =
 TEST(putIndividualContextEntityAttribute, json)
 {
   ConnectionInfo ci("/ngsi10/contextEntities/entity11/attributes/temperature",  "PUT", "1.1");
+  ci.servicePathV.push_back("");
+
   const char*    infile      = "ngsi10.updateContextAttributeRequest.putAttribute.valid.json";
   const char*    outfile     = "ngsi10.updateContextAttributeResponse.notFound.valid.json";
   std::string    out;

--- a/test/unittests/unittest.cpp
+++ b/test/unittests/unittest.cpp
@@ -73,14 +73,6 @@ std::map<std::string, std::string> uriParams;
 */
 std::map<std::string, bool> options;
 
-
-
-/* ****************************************************************************
-*
-* servicePathV - 
-*/
-std::vector<std::string> servicePathV;
-
  
 
 /* ****************************************************************************
@@ -142,6 +134,7 @@ void utInit(void)
   // Resetting servicePathVector
   //
   servicePathVector.clear();
+  servicePathVector.push_back("");
 
   // Init subs cache (this initialization is overridden in tests that use csubs)
   subCacheInit();

--- a/test/unittests/unittest.h
+++ b/test/unittests/unittest.h
@@ -62,14 +62,6 @@ extern std::map<std::string, bool> options;
 
 /* ****************************************************************************
 *
-* servicePathV - 
-*/
-extern std::vector<std::string> servicePathV;
-
- 
-
-/* ****************************************************************************
-*
 * servicePathVector - 
 */
 extern std::vector<std::string> servicePathVector;


### PR DESCRIPTION
"No .test was harmed in the making of this PR" :)

Apart of fixing #2024 itself, this PR moves the SP defaulting logic to mongoBackend, thus allowing to simplify removing defaultServicePath() funtion. In addition, some refactors has been include to make centralize SP filtering functionality across mongoBackend in the fillQueryServicePath() function.

Finally, unit test code has been optimized, removing duplicated copies of the "mock" service path.

Test done to check that #2024 has been solved with this PR:

```
$  curl -v -H "Content-Type: application/json" -H "Fiware-Service: test_service_path" http://localhost:1026/v2/subscriptions -d '{"notification": {"callback": "http://localhost:1234", "attributes": ["temperature"]}, "expires": "2016-04-05T14:00:00.00Z", "subject": {"entities": [{"idPattern": ".*", "type": "room"}], "condition": {"attributes": ["temperature"]}}}' 
* Hostname was NOT found in DNS cache
*   Trying ::1...
* Connected to localhost (::1) port 1026 (#0)
> POST /v2/subscriptions HTTP/1.1
> User-Agent: curl/7.38.0
> Host: localhost:1026
> Accept: */*
> Content-Type: application/json
> Fiware-Service: test_service_path
> Content-Length: 234
> 
* upload completely sent off: 234 out of 234 bytes
< HTTP/1.1 201 Created
< Connection: Keep-Alive
< Content-Length: 0
< Location: /v2/subscriptions/570d2a54fd070d4aad115e79
< Fiware-Correlator: 732925b2-00d0-11e6-9a87-000c29173617
< Date: Tue, 12 Apr 2016 17:03:16 GMT
< 
* Connection #0 to host localhost left intact
```

mongo result:

```
> db.csubs.find({},{servicePath:1})
{ "_id" : ObjectId("570d2a54fd070d4aad115e79"), "servicePath" : "/#" }
```

No CNR changes needed (as #2024 is a consecuence of a change already included in CNR).

@kzangeli 
@crbrox 