### PR TITLE
Align csub pyaload description in NGSIv2 spec with latest changes in implementation

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -1361,7 +1361,7 @@ A `notification` object contains the following subfields:
 + `attrs`: List of attributes to be included in the notification message. If not specified (or empty), all attributes are included
   in the notification. It also defines the order in which attributes will appear in notifications when `attrsFormat` `value` is used
   (see "Notification messages" section).
-+ `http`: Information about the HTTP transport.
++ `http`: It is used to convey parameters for notifications delivered through the HTTP protocol.
 + `attrsFormat` (optional): specifies how the entities will be represented in notifications. Accepted values are
   `normalized` (the one used if the field is omitted), `keyValues` or `values`. If `attrsFormat` takes any value different
   than those an error will be raised. See detail in "Notification messages" section.
@@ -1370,10 +1370,10 @@ A `notification` object contains the following subfields:
 
 An `http` object contains the following subfields:
 
-+ `url` : URL pointing to the service which will be invoked when a notification is generated. A NGSIv2
++ `url` : URL referencing the service which is invoked when a notification is generated. A NGSIv2
   compliant server must support `http` URL schema, other schemas could also be supported.
-+ `headers` (optional): a key-map of HTTP headers that will be included in the notification messages-
-+ `qs` (optional): a key-map of URL query parameters that will be included in the notification message.
++ `headers` (optional): a key-map of HTTP headers that are included in the notification messages.
++ `qs` (optional): a key-map of URL query parameters that are included in the notification message.
 + `method` (optional): the method to use for sending the notification (default is POST)
 + `payload` (optional): the payload to be used in the notification. If omitted, the default payload (see
   "Notification messages" sections) is used.

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -712,7 +712,7 @@ so notification receiver can know the format used without needing processing not
 ### Notification templates
 
 Based on the "template" field defined as part of the subscription and in a macro replacement language
-that could be used in "template" "callback", "headers" and "query". Details TBD.
+that could be used in "payload", "url", "headers", "method" and "qs". Details TBD.
 
 ## Group API Entry Point
 
@@ -1343,6 +1343,8 @@ A subscription is represented by a JSON object with the following fields:
   If this field is not provided at subscription creation time, new subscriptions are created with
   the `active` status, which can be changed by clients afterwards. For expired subscriptions this
   attribute is set to `expired` value (no matter if the client updates it to `active`/`inactive`).
++ `throttling`: Minimal period of time in seconds which must elapse between two consecutive notifications. It
+  is optional.
 
 A `subject` contains the following subfields:
 
@@ -1350,36 +1352,40 @@ A `subject` contains the following subfields:
     + `id` or `idPattern`: Id or pattern of the affected entities. Both cannot be used at the same time, but at least one of them must be set.
     + `type`: Type of the affected entities (optional).
 + `condition`: Condition that will trigger the notification. It can have two optional properties:
-    + `attributes`: array of attribute names
+    + `attrs`: array of attribute names
     + `expression`: an expression composed of `q`, `georel`, `geometry` and `coords` (see "List entities" operation above
    about this field).
 
 A `notification` object contains the following subfields:
 
-+ `attributes`: List of attributes to be included in the notification message. If not specified (or empty), all attributes are included
++ `attrs`: List of attributes to be included in the notification message. If not specified (or empty), all attributes are included
   in the notification. It also defines the order in which attributes will appear in notifications when `attrsFormat` `value` is used
   (see "Notification messages" section).
-+ `callback` : URL pointing to the service which will be invoked when a notification is generated. A NGSIv2
-  compliant server must support `http` URL schema, other schemas (e.g. schemas for web sockets) could also be supported.
-+ `headers` (optional): a key-map of HTTP headers that will be included in the notification messages. Note that this cannot be used
-  to override headers that make the notification inconsistent (e.g. `Content-Type: application/json`).
-+ `query` (optional): a key-map of URL query parameters that will be included in the notification message.
++ `http`: Information about the HTTP transport.
 + `attrsFormat` (optional): specifies how the entities will be represented in notifications. Accepted values are
   `normalized` (the one used if the field is omitted), `keyValues` or `values`. If `attrsFormat` takes any value different
   than those an error will be raised. See detail in "Notification messages" section.
-+ `throttling`: Minimal period of time in seconds which must elapse between two consecutive notifications. It
-  is optional.
 + `timesSent` (not editable, only in GET operations): Number of notifications sent due to this subscription.
 + `lastNotification`: Last notification date in ISO8601 format.
 
+An `http` object contains the following subfields:
+
++ `url` : URL pointing to the service which will be invoked when a notification is generated. A NGSIv2
+  compliant server must support `http` URL schema, other schemas could also be supported.
++ `headers` (optional): a key-map of HTTP headers that will be included in the notification messages-
++ `qs` (optional): a key-map of URL query parameters that will be included in the notification message.
++ `method` (optional): the method to use for sending the notification (default is POST)
++ `payload` (optional): the payload to be used in the notification. If omitted, the default payload (see
+  "Notification messages" sections) is used.
+
 Notification rules are as follow:
 
-* If `attributes` and `expression` are used, a notification is sent whenever one of the attributes in the `attributes` list changes and
+* If `attrs` and `expression` are used, a notification is sent whenever one of the attributes in the `attrs` list changes and
   at the same time `expression` matches.
-* If `attributes` is used and `expression` is not used, a notification is sent whenever one of the attributes in the `attributes` list changes-
-* If `attributes` is not used and `expression` is used, a notification is sent whenever any of the attributes of the entity changes and
+* If `attrs` is used and `expression` is not used, a notification is sent whenever one of the attributes in the `attrs` list changes-
+* If `attrs` is not used and `expression` is used, a notification is sent whenever any of the attributes of the entity changes and
   at the same time `expression` matches.
-* If neither `attributes` or `expression` are used, a notification is sent whenever any of the attributes of the entity changes.
+* If neither `attrs` or `expression` are used, a notification is sent whenever any of the attributes of the entity changes.
 
 ## Subscription List [/v2/subscriptions]
 
@@ -1420,21 +1426,23 @@ Response:
                     }
                 },
                 "notification": {
-                    "callback": "http://localhost:1234",
-                    "headers": {
-                      "X-MyHeader": "foo"
-                    },
-                    "query": {
-                      "authToken": "bar"
+                    "http": {
+                      "url": "http://localhost:1234",
+                      "headers": {
+                        "X-MyHeader": "foo"
+                      },
+                      "qs": {
+                        "authToken": "bar"
+                      }
                     },
                     "attrsFormat": "keyValues",
-                    "attributes": ["temperature", "humidity"],
-                    "throttling": 5,
-                    "count": 12,
+                    "attrs": ["temperature", "humidity"],
+                    "timesSent": 12,
                     "lastNotification": "2015-10-05T16:00:00.00Z"
                 },
                 "expires": "2016-04-05T14:00:00.00Z",
-                "status": "active"
+                "status": "active",
+                "throttling": 5
             }
         ]
 
@@ -1461,18 +1469,20 @@ Response:
                     }
                 ],
                 "condition": {
-                    "attributes": [ "temperature" ],
+                    "attrs": [ "temperature" ],
                     "expression": {
                        "q": "temperature>40"
                     }
                  }
             },
             "notification": {
-                "callback": "http://localhost:1234",
-                "attributes": ["temperature", "humidity"],
-                "throttling": 5
+                "http": {
+                  "url": "http://localhost:1234"
+                },
+                "attrs": ["temperature", "humidity"]
             },            
-            "expires": "2016-04-05T14:00:00.00Z"
+            "expires": "2016-04-05T14:00:00.00Z",
+            "throttling": 5
         }
 
 + Response 201
@@ -1509,21 +1519,23 @@ Response:
                     }
                 ],
                 "condition": {
-                    "attributes": [ "temperature " ],
+                    "attrs": [ "temperature " ],
                     "expression": {
                        "q": "temperature>40"
                     }
                  }
             },
             "notification": {
-                "callback": "http://localhost:1234",
-                "attributes": ["temperature", "humidity"],
-                "throttling": 5,
-                "count": 12,
+                "http": {
+                  "url": "http://localhost:1234"
+                },
+                "attrs": ["temperature", "humidity"],
+                "timesSent": 12,
                 "lastNotification": "2015-10-05T16:00:00.00Z"
             },
             "expires": "2016-04-05T14:00:00.00Z",
-            "status": "active"
+            "status": "active",
+            "throttling": 5,
         }
 
 


### PR DESCRIPTION
This PR fixes the NGSIv2 spec .apib in order to align with the latest changes in CB implementation (related with issues #2014, #2042 and #2043).

People that may be insterested in having a look to this:

@iariasleon 
@anabelengp 
@kzangeli 
@crbrox 
@jmcanterafonseca 