### PR TITLE
REMOVE /opt/libmicrohttpd-0.9.48 in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,6 +75,7 @@ RUN \
     rm -rf /opt/libmicrohttpd-0.9.48.tar.gz \
            /usr/local/include/microhttpd.h \
            /usr/local/lib/libmicrohttpd.* \
+           /opt/libmicrohttpd-0.9.48 \
            /opt/legacy-1.0.7.tar.gz \
            /opt/mongo-cxx-driver-legacy-1.0.7 \
            /usr/local/include/mongo \


### PR DESCRIPTION
Related with #2063 

Remove unneded stuff in Dockefile in order to reduce docker images footprint.