### PR TITLE
FIX unittest cmake file for Debian 8.3

### DIFF
--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -291,8 +291,8 @@ MESSAGE("unitTest distro: '${DISTRO}'")
 
 IF(${DISTRO} MATCHES "CentOS_6.*")
   TARGET_LINK_LIBRARIES(unitTest ${STATIC_LIBS} ${BOOST_MT} ${DYNAMIC_LIBS})
-ELSEIF(${DISTRO} MATCHES "Debian_8.2")
-  # It seems that Debian 8.2 doesn't like -mt libraries for unit tests... not sure about other Debian versions
+ELSEIF(${DISTRO} MATCHES "Debian_8.*")
+  # It seems that Debian 8.x doesn't like -mt libraries for unit tests... not sure about other Debian versions
   TARGET_LINK_LIBRARIES(unitTest ${STATIC_LIBS} ${BOOST} ${DYNAMIC_LIBS})
 ELSEIF(${DISTRO} MATCHES "Debian_.*")
   TARGET_LINK_LIBRARIES(unitTest ${STATIC_LIBS} ${BOOST_MT} ${DYNAMIC_LIBS})


### PR DESCRIPTION
Small fix on the Debian 8.3 unit test building cmake files.