### PR TITLE
[FEATURE] attrs resources using ngsi v2

### DIFF
--- a/test/acceptance/behave/components/ngsiv2/attributes/remove_a_single_attribute/remove_a_single_attribute.feature
+++ b/test/acceptance/behave/components/ngsiv2/attributes/remove_a_single_attribute/remove_a_single_attribute.feature
@@ -633,7 +633,7 @@ Feature: delete an attribute request using NGSI v2 API. "DELETE" - /v2/entities/
       | room_11   | house_/         |
       | room_12   | house_#         |
 
-  @attribute_name_empty
+  @attribute_name_empty @ISSUE_2078 @skip
   Scenario:  try to delete an attribute by entity ID using NGSI v2 API with empty attribute name
     Given  a definition of headers
       | parameter          | value                            |
@@ -641,11 +641,11 @@ Feature: delete an attribute request using NGSI v2 API. "DELETE" - /v2/entities/
       | Fiware-ServicePath | /test                            |
       | Content-Type       | application/json                 |
     When delete an attribute "" in the entity with id "room"
-    Then verify that receive a "Bad Request" http code
+    Then verify that receive an "Method not allowed" http code
     And verify an error response
-      | parameter   | value             |
-      | error       | BadRequest        |
-      | description | service not found |
+      | parameter   | value            |
+      | error       | MethodNotAllowed |
+      | description | No defined yet   |
 
    #   -------------- queries parameters ------------------------------------------
    #   ---  type query parameter ---

--- a/test/acceptance/behave/components/ngsiv2/attributes/update_attribute_data/update_attribute_data.feature
+++ b/test/acceptance/behave/components/ngsiv2/attributes/update_attribute_data/update_attribute_data.feature
@@ -654,7 +654,7 @@ Feature: update an attribute by entity ID and attribute name if it exists using 
       | error       | BadRequest        |
       | description | service not found |
 
-  @entity_id_update_invalid @BUG_1351
+  @entity_id_update_invalid @BUG_1351 @ISSUE_2080 @skip
   Scenario:  try to update an attribute by entity ID and attribute name using NGSI v2 with invalid entity id values
     Given  a definition of headers
       | parameter          | value                 |
@@ -983,30 +983,31 @@ Feature: update an attribute by entity ID and attribute name if it exists using 
       | Content-Type       | application/json                 |
    # These properties below are used in create request
     And properties to entities
-      | parameter        | value       |
-      | entities_type    | house       |
-      | entities_id      | room        |
-      | attributes_name  | temperature |
-      | attributes_value | 34          |
-      | attributes_type  | celsius     |
-      | metadatas_number | 2           |
-      | metadatas_name   | very_hot    |
-      | metadatas_type   | alarm       |
-      | metadatas_value  | hot         |
-    And create entity group with "3" entities in "normalized" mode
+      | parameter         | value       |
+      | entities_type     | house       |
+      | entities_id       | room        |
+      | attributes_number | 4           |
+      | attributes_name   | temperature |
+      | attributes_value  | 34          |
+      | attributes_type   | celsius     |
+      | metadatas_number  | 2           |
+      | metadatas_name    | very_hot    |
+      | metadatas_type    | alarm       |
+      | metadatas_value   | hot         |
+    And create entity group with "1" entities in "normalized" mode
       | entity | prefix |
       | id     | true   |
     And verify that receive several "Created" http code
     # These properties below are used in update request
     And properties to entities
-      | parameter        | value |
-      | attributes_value | 25    |
-    When update an attribute by ID "room_1" and attribute name "" if it exists
+      | parameter        | value     |
+      | attributes_value | 25        |
+    When update an attribute by ID "room" and attribute name "" if it exists
     Then verify that receive an "Bad Request" http code
     And verify an error response
-      | parameter   | value             |
-      | error       | BadRequest        |
-      | description | service not found |
+      | parameter   | value                                                            |
+      | error       | BadRequest                                                       |
+      | description | attribute must be a JSON object, unless keyValues option is used |
 
  # --------------------- attribute type  ------------------------------------
 

--- a/test/acceptance/behave/components/ngsiv2/attributes_values/update_attribute_value/update_attribute_value.feature
+++ b/test/acceptance/behave/components/ngsiv2/attributes_values/update_attribute_value/update_attribute_value.feature
@@ -695,7 +695,7 @@ Feature: update an attribute value by entity ID and attribute name if it exists 
       | house_&             |
       | my house            |
 
-  @entity_id_update_invalid @BUG_1351
+  @entity_id_update_invalid_2 @BUG_1351 @ISSUE_2083 @skip
   Scenario:  try to update an attribute value by entity ID and attribute name using NGSI v2 with invalid entity id values
     Given  a definition of headers
       | parameter          | value                 |
@@ -707,11 +707,11 @@ Feature: update an attribute value by entity ID and attribute name if it exists 
       | parameter        | value |
       | attributes_value | 80    |
     When update an attribute value by ID "house_#" and attribute name "temperature_0" if it exists
-    Then verify that receive an "Unsupported Media Type" http code
+    Then verify that receive an "Method not allowed" http code
     And verify an error response
-      | parameter   | value                                  |
-      | error       | UnsupportedMediaType                   |
-      | description | not supported content type: text/plain |
+      | parameter   | value            |
+      | error       | MethodNotAllowed |
+      | description | No defined yet   |
 
   @entity_id_update_invalid @BUG_1351
   Scenario:  try to update an attribute value by entity ID and attribute name using NGSI v2 with invalid entity id values

--- a/test/acceptance/behave/components/ngsiv2/entities/replace_all_entity_attributes/replace_all_entity_attributes_part2.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/replace_all_entity_attributes/replace_all_entity_attributes_part2.feature
@@ -173,7 +173,7 @@ Feature: replace attributes by entity ID using NGSI v2. "PUT" - /v2/entities/<en
       | my house            |
 
   @entity_id_replace_invalid @BUG_1782
-  Scenario Outline:  try to replace attributes by entity ID using NGSI v2 with invalid entity id values
+  Scenario:  try to replace attributes by entity ID using NGSI v2 with invalid entity id values
     Given  a definition of headers
       | parameter          | value                  |
       | Fiware-Service     | test_replace_entity_id |
@@ -184,17 +184,50 @@ Feature: replace attributes by entity ID using NGSI v2. "PUT" - /v2/entities/<en
       | parameter        | value    |
       | attributes_name  | pressure |
       | attributes_value | 80       |
-    When replace attributes by ID "<entity_id>" if it exists and with "normalized" mode
-    Then verify that receive an "Not Found" http code
+    When replace attributes by ID "house_?" if it exists and with "normalized" mode
+    Then verify that receive an "Bad Request" http code
     And verify an error response
-      | parameter   | value                    |
-      | error       | NotFound                 |
-      | description | No context element found |
-    Examples:
-      | entity_id |
-      | house_?   |
-      | house_/   |
-      | house_#   |
+      | parameter   | value                                        |
+      | error       | BadRequest                                   |
+      | description | Empty right-hand-side for URI param //attrs/ |
+
+  @entity_id_replace_invalid @BUG_1782
+  Scenario:  try to replace attributes by entity ID using NGSI v2 with invalid entity id values
+    Given  a definition of headers
+      | parameter          | value                  |
+      | Fiware-Service     | test_replace_entity_id |
+      | Fiware-ServicePath | /test                  |
+      | Content-Type       | application/json       |
+    # These properties below are used in update request
+    And properties to entities
+      | parameter        | value    |
+      | attributes_name  | pressure |
+      | attributes_value | 80       |
+    When replace attributes by ID "house_/" if it exists and with "normalized" mode
+    Then verify that receive an "Bad Request" http code
+    And verify an error response
+      | parameter   | value             |
+      | error       | BadRequest        |
+      | description | service not found |
+
+  @entity_id_replace_invalid @BUG_1782 @ISSUE_2075 @skip
+  Scenario:  try to replace attributes by entity ID using NGSI v2 with invalid entity id values
+    Given  a definition of headers
+      | parameter          | value                  |
+      | Fiware-Service     | test_replace_entity_id |
+      | Fiware-ServicePath | /test                  |
+      | Content-Type       | application/json       |
+    # These properties below are used in update request
+    And properties to entities
+      | parameter        | value    |
+      | attributes_name  | pressure |
+      | attributes_value | 80       |
+    When replace attributes by ID "house_/" if it exists and with "normalized" mode
+    Then verify that receive an "Method not allowed" http code
+    And verify an error response
+      | parameter   | value            |
+      | error       | MethodNotAllowed |
+      | description | No defined yet   |
 
   # --------------------- attribute name  ------------------------------------
 

--- a/test/acceptance/behave/components/ngsiv2/entities/update_existing_entity_attributes/update_existing_entity_attributes.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/update_existing_entity_attributes/update_existing_entity_attributes.feature
@@ -630,7 +630,6 @@ Feature: update attributes by entity ID if it exists using NGSI v2. "PATCH" - /v
       | error       | NotFound                 |
       | description | No context element found |
 
-  @entity_id_update_invalid.row<row.id>
   @entity_id_update_invalid @BUG_1280
   Scenario Outline:  try to update attributes by entity ID using NGSI v2 with invalid entity id values
     Given  a definition of headers
@@ -664,7 +663,7 @@ Feature: update attributes by entity ID if it exists using NGSI v2. "PATCH" - /v
       | my house            |
 
   @entity_id_update_invalid @BUG_1280 @BUG_1782
-  Scenario Outline:  try to update attributes by entity ID using NGSI v2 with invalid entity id values
+  Scenario:  try to update attributes by entity ID using NGSI v2 with invalid entity id values
     Given  a definition of headers
       | parameter          | value                 |
       | Fiware-Service     | test_update_entity_id |
@@ -676,17 +675,52 @@ Feature: update attributes by entity ID if it exists using NGSI v2. "PATCH" - /v
       | attributes_number | 2           |
       | attributes_name   | temperature |
       | attributes_value  | 80          |
-    When update attributes by ID "<entity_id>" if it exists and with "normalized" mode
-    Then verify that receive an "Not Found" http code
+    When update attributes by ID "house_?" if it exists and with "normalized" mode
+    Then verify that receive an "Bad Request" http code
     And verify an error response
-      | parameter   | value                    |
-      | error       | NotFound                 |
-      | description | No context element found |
-    Examples:
-      | entity_id |
-      | house_?   |
-      | house_/   |
-      | house_#   |
+      | parameter   | value                                        |
+      | error       | BadRequest                                   |
+      | description | Empty right-hand-side for URI param //attrs/ |
+
+  @entity_id_update_invalid @BUG_1280 @BUG_1782
+  Scenario:  try to update attributes by entity ID using NGSI v2 with invalid entity id values
+    Given  a definition of headers
+      | parameter          | value                 |
+      | Fiware-Service     | test_update_entity_id |
+      | Fiware-ServicePath | /test                 |
+      | Content-Type       | application/json      |
+   # These properties below are used in update request
+    And properties to entities
+      | parameter         | value       |
+      | attributes_number | 2           |
+      | attributes_name   | temperature |
+      | attributes_value  | 80          |
+    When update attributes by ID "house_/" if it exists and with "normalized" mode
+    Then verify that receive an "Bad Request" http code
+    And verify an error response
+      | parameter   | value             |
+      | error       | BadRequest        |
+      | description | service not found |
+
+  @entity_id_update_invalid @BUG_1280 @BUG_1782 @ISSUE_2075 @skip
+  Scenario:  try to update attributes by entity ID using NGSI v2 with invalid entity id values
+    Given  a definition of headers
+      | parameter          | value                 |
+      | Fiware-Service     | test_update_entity_id |
+      | Fiware-ServicePath | /test                 |
+      | Content-Type       | application/json      |
+   # These properties below are used in update request
+    And properties to entities
+      | parameter         | value       |
+      | attributes_number | 2           |
+      | attributes_name   | temperature |
+      | attributes_value  | 80          |
+    When update attributes by ID "house_#" if it exists and with "normalized" mode
+    Then verify that receive an "Method not allowed" http code
+    And verify an error response
+      | parameter   | value            |
+      | error       | MethodNotAllowed |
+      | description | No defined yet   |
 
   @entity_id_update_empty @BUG_1783 @skip
   Scenario:  try to update attributes by entity ID using NGSI v2 with empty entity id values

--- a/test/acceptance/behave/components/ngsiv2/entities/update_or_append_entity_attributes/update_or_append_entity_attributes.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/update_or_append_entity_attributes/update_or_append_entity_attributes.feature
@@ -814,7 +814,7 @@ Feature: update or append an attribute by entity ID using NGSI v2. "POST" - /v2/
       | my house            |
 
   @entity_id_update_invalid @BUG_1782 @BUG_1817
-  Scenario Outline:  try to update or append attributes by entity ID using NGSI v2 with invalid entity id values
+  Scenario:  try to update or append attributes by entity ID using NGSI v2 with invalid entity id values
     Given  a definition of headers
       | parameter          | value                 |
       | Fiware-Service     | test_update_entity_id |
@@ -825,17 +825,50 @@ Feature: update or append an attribute by entity ID using NGSI v2. "POST" - /v2/
       | parameter        | value    |
       | attributes_name  | humidity |
       | attributes_value | 80       |
-    When update or append attributes by ID "<entity_id>" and with "normalized" mode
-    Then verify that receive an "Not Found" http code
+    When update or append attributes by ID "house_?" and with "normalized" mode
+    Then verify that receive an "Bad Request" http code
     And verify an error response
-      | parameter   | value                 |
-      | error       | NotFound              |
-      | description | Entity does not exist |
-    Examples:
-      | entity_id |
-      | house_?   |
-      | house_/   |
-      | house_#   |
+      | parameter   | value                                        |
+      | error       | BadRequest                                   |
+      | description | Empty right-hand-side for URI param //attrs/ |
+
+  @entity_id_update_invalid @BUG_1782 @BUG_1817
+  Scenario:  try to update or append attributes by entity ID using NGSI v2 with invalid entity id values
+    Given  a definition of headers
+      | parameter          | value                 |
+      | Fiware-Service     | test_update_entity_id |
+      | Fiware-ServicePath | /test                 |
+      | Content-Type       | application/json      |
+   # These properties below are used in update request
+    And properties to entities
+      | parameter        | value    |
+      | attributes_name  | humidity |
+      | attributes_value | 80       |
+    When update or append attributes by ID "house_/" and with "normalized" mode
+    Then verify that receive an "Bad Request" http code
+    And verify an error response
+      | parameter   | value             |
+      | error       | BadRequest        |
+      | description | service not found |
+
+  @entity_id_update_invalid @BUG_1782 @BUG_1817 @ISSUE_2075 @skip
+  Scenario:  try to update or append attributes by entity ID using NGSI v2 with invalid entity id values
+    Given  a definition of headers
+      | parameter          | value                 |
+      | Fiware-Service     | test_update_entity_id |
+      | Fiware-ServicePath | /test                 |
+      | Content-Type       | application/json      |
+   # These properties below are used in update request
+    And properties to entities
+      | parameter        | value    |
+      | attributes_name  | humidity |
+      | attributes_value | 80       |
+    When update or append attributes by ID "house_#" and with "normalized" mode
+    Then verify that receive an "Method not allowed" http code
+    And verify an error response
+      | parameter   | value            |
+      | error       | MethodNotAllowed |
+      | description | No defined yet   |
 
   # ----------------------- attributes ---------------------------------------
 


### PR DESCRIPTION
@kzangeli @crbrox 

**WARNING: verify that the PR: https://github.com/telefonicaid/iotqatools/pull/78 has been merged**

#### Regression Tests:
```
                    SUMMARY:
-------------------------------------------------
  - components/ngsiv2/entities/create_entity/create_entity.feature >> passed: 142, failed: 0, skipped: 6 and total: 148 with duration: 18.738 seconds.
  - components/ngsiv2/entities/create_entity/create_entity_part2.feature >> passed: 235, failed: 0, skipped: 0 and total: 235 with duration: 32.492 seconds.
  - components/ngsiv2/entities/create_entity/create_entity_part3.feature >> passed: 294, failed: 0, skipped: 16 and total: 310 with duration: 33.819 seconds.
  - components/ngsiv2/entities/create_entity/create_entity_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/attributes/update_attribute_data/update_attribute_data.feature >> passed: 160, failed: 0, skipped: 8 and total: 168 with duration: 35.057 seconds.
  - components/ngsiv2/attributes/update_attribute_data/update_attribute_data_part2.feature >> passed: 195, failed: 0, skipped: 6 and total: 201 with duration: 51.646 seconds.
  - components/ngsiv2/attributes/update_attribute_data/update_attribute_data_part3.feature >> passed: 246, failed: 0, skipped: 17 and total: 263 with duration: 63.463 seconds.
  - components/ngsiv2/attributes/update_attribute_data/update_attribute_data_part4.feature >> passed: 11, failed: 0, skipped: 7 and total: 18 with duration: 2.741 seconds.
  - components/ngsiv2/attributes/update_attribute_data/update_attribute_data_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/entities/retrieve_entity/retrieve_entity.feature >> passed: 200, failed: 0, skipped: 0 and total: 200 with duration: 52.330 seconds.
  - components/ngsiv2/entities/retrieve_entity/retrieve_entity_queries_parameters.feature >> passed: 19, failed: 0, skipped: 1 and total: 20 with duration: 5.404 seconds.
  - components/ngsiv2/entities/retrieve_entity/retrieve_entity_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/api_entry_point/retrieve_api_resource.feature >> passed: 18, failed: 0, skipped: 1 and total: 19 with duration: 0.123 seconds.
  - components/ngsiv2/attributes/remove_a_single_attribute/remove_a_single_attribute.feature >> passed: 109, failed: 0, skipped: 12 and total: 121 with duration: 15.819 seconds.
  - components/ngsiv2/attributes/remove_a_single_attribute/remove_a_single_attribute_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/attributes/get_attribute_data/get_attribute_data.feature >> passed: 238, failed: 0, skipped: 6 and total: 244 with duration: 47.256 seconds.
  - components/ngsiv2/attributes/get_attribute_data/get_attribute_data_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/entities/update_or_append_entity_attributes/update_or_append_entity_attributes.feature >> passed: 212, failed: 0, skipped: 1 and total: 213 with duration: 36.471 seconds.
  - components/ngsiv2/entities/update_or_append_entity_attributes/update_or_append_entity_attributes_part2.feature >> passed: 269, failed: 0, skipped: 0 and total: 269 with duration: 70.697 seconds.
  - components/ngsiv2/entities/update_or_append_entity_attributes/update_or_append_entity_attributes_part3.feature >> passed: 268, failed: 0, skipped: 8 and total: 276 with duration: 50.098 seconds.
  - components/ngsiv2/entities/update_or_append_entity_attributes/update_or_append_entity_attributes_part4.feature >> passed: 67, failed: 0, skipped: 0 and total: 67 with duration: 7.464 seconds.
  - components/ngsiv2/entities/update_or_append_entity_attributes/update_or_append_entity_attributes_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/entities/remove_entity/remove_entity.feature >> passed: 85, failed: 0, skipped: 7 and total: 92 with duration: 11.996 seconds.
  - components/ngsiv2/entities/remove_entity/remove_entity_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/attributes_values/update_attribute_value/update_attribute_value.feature >> passed: 118, failed: 0, skipped: 5 and total: 123 with duration: 22.661 seconds.
  - components/ngsiv2/attributes_values/update_attribute_value/update_attribute_value_part2.feature >> passed: 207, failed: 0, skipped: 7 and total: 214 with duration: 60.230 seconds.
  - components/ngsiv2/attributes_values/update_attribute_value/update_attribute_value_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/attributes_values/get_attribute_value/get_attribute_value.feature >> passed: 173, failed: 0, skipped: 17 and total: 190 with duration: 31.367 seconds.
  - components/ngsiv2/attributes_values/get_attribute_value/get_attribute_value_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/entities/replace_all_entity_attributes/replace_all_entity_attributes.feature >> passed: 262, failed: 0, skipped: 0 and total: 262 with duration: 70.226 seconds.
  - components/ngsiv2/entities/replace_all_entity_attributes/replace_all_entity_attributes_part2.feature >> passed: 221, failed: 0, skipped: 1 and total: 222 with duration: 45.209 seconds.
  - components/ngsiv2/entities/replace_all_entity_attributes/replace_all_entity_attributes_part3.feature >> passed: 97, failed: 0, skipped: 8 and total: 105 with duration: 26.440 seconds.
  - components/ngsiv2/entities/replace_all_entity_attributes/replace_all_entity_attributes_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/entities/list_entities/list_entities.feature >> passed: 188, failed: 0, skipped: 0 and total: 188 with duration: 52.428 seconds.
  - components/ngsiv2/entities/list_entities/list_entities_queries_parameters_part_1.feature >> passed: 141, failed: 0, skipped: 4 and total: 145 with duration: 49.525 seconds.
  - components/ngsiv2/entities/list_entities/list_entities_queries_parameters_part_2.feature >> passed: 13, failed: 0, skipped: 152 and total: 165 with duration: 4.894 seconds.
  - components/ngsiv2/entities/list_entities/list_entities_queries_parameters_part_3.feature >> passed: 13, failed: 0, skipped: 0 and total: 13 with duration: 5.078 seconds.
  - components/ngsiv2/entities/list_entities/list_entities_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
  - components/ngsiv2/entities/update_existing_entity_attributes/update_existing_entity_attributes.feature >> passed: 107, failed: 0, skipped: 5 and total: 112 with duration: 17.206 seconds.
  - components/ngsiv2/entities/update_existing_entity_attributes/update_existing_entity_attributes_part2.feature >> passed: 304, failed: 0, skipped: 1 and total: 305 with duration: 87.806 seconds.
  - components/ngsiv2/entities/update_existing_entity_attributes/update_existing_entity_attributes_part3.feature >> passed: 188, failed: 0, skipped: 34 and total: 222 with duration: 31.501 seconds.
  - components/ngsiv2/entities/update_existing_entity_attributes/update_existing_entity_attributes_part4.feature >> passed: 2, failed: 0, skipped: 0 and total: 2 with duration: 0.511 seconds.
  - components/ngsiv2/entities/update_existing_entity_attributes/update_existing_entity_attributes_traces_in_log.feature >> passed: 0, failed: 0, skipped: 1 and total: 1 with duration: 0.000 seconds.
-------------------------------------------------
  Date: Monday, April 25, 2016 19:31:00
-------------------------------------------------
31 features passed, 0 failed, 12 skipped
4802 scenarios passed, 0 failed, 342 skipped
34390 steps passed, 0 failed, 5342 skipped, 0 undefined
Took 17m20.696s
```