### PR TITLE
FIX accumulator-server.py able to accumulate query params

### DIFF
--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -167,7 +167,20 @@ def record():
     #
     #  request.url = request.scheme + '://' + request.host + request.path
     #
-    s += request.method + ' ' + request.scheme + '://' + request.host + request.path + '\n'
+    s += request.method + ' ' + request.scheme + '://' + request.host + request.path
+
+    # Check for query params
+    params = ''
+    for k in request.args:
+        if (params == ''):
+            params = k + '=' + request.args[k]
+        else:
+            params += '&' + k + '=' + request.args[k]
+
+    if (params == ''):
+        s += '\n'
+    else:
+        s += '?' + params + '\n'
 
     # Store headers
     for h in request.headers.keys():


### PR DESCRIPTION
I haven't tested extensively but after a quick chec it seems to work as expected:

```
POST http://localhost:1028/accumulate?x=1&b=2
Content-Length: 
User-Agent: curl/7.38.0
Host: localhost:1028
Accept: */*
Content-Type: 
=======================================

::1 - - [18/May/2016 12:50:20] "POST /accumulate?x=1&b=2 HTTP/1.1" 200 -
```
