### PR TITLE
FIX query filter regex crashes

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Add: notification attributes blacklist for NGSIv2 notifications (#2064)
 - Add: 'values' option for GET /v2/types operation (#1170)
 - Add: ':' as alias for '==' in the NGSIv2 Simple Query Language (#1903)
 - Fix: several fixes related with 'attrsFormat' subscription field in NGSIv2 API (#2133, #2163)
@@ -9,4 +10,5 @@
 - Fix: total count return in GET /v2/types operation (#2115)
 - Fix: -noCache now avoids populating cache on create/update subscription operations (#2147)
 - Fix: accessing to csub cache in update subscription logic to update count and lastNotification without taking semaphore (#2146)
+- Fix: crash in multi-token query string when attribute value regex comes in first place (#2164)
 - Deprecated: /ngsi10 and /ngsi9 as URL path prefixes

--- a/src/lib/rest/StringFilter.cpp
+++ b/src/lib/rest/StringFilter.cpp
@@ -934,7 +934,7 @@ bool StringFilter::parse(const char* q, std::string* errorStringP)
     }
     else
     {
-      free(item);
+      delete item;
       free(toFree);
       return false;
     }

--- a/src/lib/rest/StringFilter.h
+++ b/src/lib/rest/StringFilter.h
@@ -190,8 +190,8 @@ class ContextElementResponse;
 class StringFilter
 {
 public:
-  std::vector<StringFilterItem>  filters;
-  std::vector<BSONObj>           mongoFilters;
+  std::vector<StringFilterItem*>  filters;
+  std::vector<BSONObj>            mongoFilters;
 
   StringFilter();
   ~StringFilter();

--- a/test/functionalTest/cases/2164_regex_filter_crash/regex_filter_crash.test
+++ b/test/functionalTest/cases/2164_regex_filter_crash/regex_filter_crash.test
@@ -1,0 +1,59 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Get using regex as first token in the query causes crash
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. GET using regex as first token in the query
+#
+
+
+echo "01. GET using regex as first token in the query"
+echo "==============================================="
+orionCurl --url '/v2/entities?q=humidity~=100;temperature>10'
+echo
+echo
+
+
+
+--REGEXPECT--
+01. GET using regex as first token in the query
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fixes #2164. In addition, it includes the CNR line for #2064, that we missed to include in a past PR.

Please, pay special attention to memory management logic (i.e. `new`s and `delete`s) in order to be sure that this PR is not introducing any leakage.

@kzangeli 
@crbrox 