### PR TITLE
Final fixes for the NGSIv2 release candidate May 2016

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
@@ -1,7 +1,7 @@
 FORMAT: 1A
 HOST: http://orion.lab.fiware.org
 TITLE: FIWARE-NGSI v2 Specification
-DATE: 31 May 21016
+DATE: 31 May 2016
 VERSION: 2.0-rc-2016_05
 PREVIOUS_VERSION: 2.0-latest
 APIARY_PROJECT: fiware-ngsi-v2

--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
@@ -33,8 +33,11 @@ Sergio García Gómez (Telefónica I+D), Martin Bauer (NEC).
 ## Status
 
 This specification is the May 2016 release candidate of the NGSIv2 API specification (RC-2016.05).
-By "release candidate" we mean that the specification is quite stable, but changes may occur with
-regard to new release candidates or the final version. In particular changes may be of two types:
+By "release candidate" we mean that only Minor Changes are expected to the API described by this document.
+Nonetheless new functionalities will be added in the near future, particularly JSON-LD and
+NGSI9 (context registration) support
+
+In particular, Minor Changes may be of two types:
 
 * Extensions to the functionality currently specified by this document. Note that in this case
   there isn't any risk of breaking backward compatibility on existing software implementations.

--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
@@ -39,7 +39,7 @@ candidates or the final version. In particular changes may be of two types:
 * Extensions to the functionality currently specified by this document. Note that in this case
   there isn't any risk of breaking backward compatibility on existing software implementations.
 * Slight modifications in the functionality currently specified by this document, as a consequence
-  of outgoing discussions. Backward compatibility will be taken into account in this case, trying
+  of ongoing discussions. Backward compatibility will be taken into account in this case, trying
   to minimize the impact on existing software implementations. In particular, only completely
   justified changes impacting backward compatibility will be allowed and "matter of taste"
   changes will not be allowed.

--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
@@ -32,9 +32,9 @@ Sergio García Gómez (Telefónica I+D), Martin Bauer (NEC).
   
 ## Status
 
-This specification is a release candidate of the NGSIv2 API specification. By "release candidate"
-we mean that the specification is quite stable, but changes may occur with regard to new release
-candidates or the final version. In particular changes may be of two types:
+This specification is the May 2016 release candidate of the NGSIv2 API specification (RC-2016.05).
+By "release candidate" we mean that the specification is quite stable, but changes may occur with
+regard to new release candidates or the final version. In particular changes may be of two types:
 
 * Extensions to the functionality currently specified by this document. Note that in this case
   there isn't any risk of breaking backward compatibility on existing software implementations.
@@ -45,7 +45,7 @@ candidates or the final version. In particular changes may be of two types:
   changes will not be allowed.
 
 The work in progress draft of the specification can be found at
-[the following link](https://telefonicaid.github.io/fiware-orion/api/v2/latest).
+[the following link](http://fiware.github.io/specifications/ngsiv2/latest).
 
 ## Copyright
 

--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
@@ -1,11 +1,11 @@
 FORMAT: 1A
 HOST: http://orion.lab.fiware.org
 TITLE: FIWARE-NGSI v2 Specification
-DATE: 30 September 2015
-VERSION: 2.0-latest
-PREVIOUS_VERSION: <placeholder>
+DATE: 31 May 21016
+VERSION: 2.0-rc-2016_05
+PREVIOUS_VERSION: 2.0-latest
 APIARY_PROJECT: fiware-ngsi-v2
-SPEC_URL: https://telefonicaid.github.io/fiware-orion/api/v2/
+SPEC_URL: https://telefonicaid.github.io/fiware-orion/api/v2/stable
 GITHUB_SOURCE: http://github.com/telefonicaid/fiware-orion.git
 
 # FIWARE-NGSI v2 Specification
@@ -32,16 +32,20 @@ Sergio García Gómez (Telefónica I+D), Martin Bauer (NEC).
   
 ## Status
 
-This is a work in progress and is changing on a daily basis.
-Please send your comments to fiware-ngsi@lists.fiware.org.
-You can trace the discussions checking the archives of the mailing list:
-https://lists.fiware.org/private/fiware-ngsi/ (list subscription required).
+This specification is a release candidate of the NGSIv2 API specification. By "release candidate"
+we mean that the specification is quite stable, but changes may occur with regard to new release
+candidates or the final version. In particular changes may be of two types:
 
-In addition, note that a list of currently open discussions is available at
+* Extensions to the functionality currently specified by this document. Note that in this case
+  there isn't any risk of breaking backward compatibility on existing software implementations.
+* Slight modifications in the functionality currently specified by this document, as a consequence
+  of outgoing discussions. Backward compatibility will be taken into account in this case, trying
+  to minimize the impact on existing software implementations. In particular, only completely
+  justified changes impacting backward compatibility will be allowed and "matter of taste"
+  changes will not be allowed.
 
-* https://github.com/telefonicaid/fiware-orion/issues/1022
-* https://github.com/telefonicaid/fiware-orion/issues/1034
-* https://github.com/telefonicaid/fiware-orion/issues/1035
+The work in progress draft of the specification can be found at
+[the following link](https://telefonicaid.github.io/fiware-orion/api/v2/latest).
 
 ## Copyright
 
@@ -62,6 +66,11 @@ NGSI version 2 uses camel case (camelCase) syntax for naming properties and rela
 by the API. When  referring to URIs, as part of HATEOAS patterns, and to mark them appropriately,
 the suffix `_url` is added.
 
+## Reference Implementations
+
+* NGISv2 servers
+  * [Orion Context Broker](http://catalogue.fiware.org/enablers/publishsubscribe-context-broker-orion-context-broker) - [Implementation Notes](https://fiware-orion.readthedocs.io/en/develop/user/ngsiv2_implementation_notes/index.html)
+
 # Specification
 
 ## Introduction
@@ -74,7 +83,6 @@ The FIWARE NGSI (Next Generation Service Interface) API defines
   update operations
 * a **context availability interface** for exchanging information on how to obtain context
   information (whether to separate the two interfaces is currently under discussion).
-* a set of typical **roles** played by NGSI-compliant components
 
 ## Terminology
 
@@ -98,28 +106,6 @@ For example, a context entity with id *sensor-365* could have the
 type *temperatureSensor*.
 
 Each entity is uniquely identified by the combination of its id and type.
-
-#### Context Elements
-
-*(Note: the distinction between context entities and context elements 
-is still under discussion; therefore the notion of context elements
-currently only appears in this section.)*
-
-A context element is a data object (e.g. JSON object; see the section
-on JSON representation below) that contains information about a
-specific context entity. Consequently, a context element has a
-mandatory property `id` in order to identify the context entity it
-refers to. It furthermore can contain an optional property `type`
-to describe the type of the entity. Further properties can be used
-to represent more information about the entity (see the **context
-attributes** section below).
-
-It is important to understand that the relationship between entities and context elements is
-one-to-many.
-This means that:
-* each context element refers to exactly one entity
-* there can be several context elements referring to the same entity. 
-The context elements can for example contain different pieces of information about the entity.
 
 #### Context Attributes 
 
@@ -152,48 +138,6 @@ above. Similar to attributes, each piece of metadata has:
  * a **metadata value** containing the actual metadata
 
 Note that in NGSI it is not foreseen that metadata may contain nested metadata.
-
-#### Restrictions and Operation Scopes
-
-(placeholder to describe restrictions and operation scopes)
-
-#### Context Queries
-
-(placeholder for describing what a context query is, and some hints on how this
-is typically done in the REST interface)
-
-#### Context Subscriptions
-
-(placeholder for describing the concept of context subscriptions)
-
-#### Context Updates
-
-(placeholder for describing updates)
-
-### Exchanging Context Availability Information
-
-(placeholder on some introduction of what context availability information is)
-
-#### Context Registrations
-
-(placeholder for describing what a context registration is and what it is used for)
-
-#### Context Discovery
-
-(placehoder for describing what discovery does)
-
-#### Context Availability Subscription
-
-(placeholder for describing context availability subscriptions)
-
-#### Registering Context Availability Information
-
-(placeholder for describing the operation of registering context)
-
-### Roles of FIWARE NGSI components
-
-(placeholder to describe roles like context provider, context producer,
-context broker, context registry, context consumer)
 
 ## MIME Types
 
@@ -297,17 +241,11 @@ Some operations use partial representation of entities:
 
 * `id` and `type` are not allowed in update operations, as they are immutable properties.
 
-* In requests where entity `type` is allowed, it may be omitted. When omitted in entity
-  creation operations, the default string value `none` is used for the type.
-
 * In some cases, not all the attributes of the entity are shown, e.g. a query selecting a subset
   of the entity attributes.
 
 * Attribute/metadata `value` may be omitted in requests, meaning that the attribute/metadata has
   `null` value. In responses, the value is always present.
-
-* Attribute/metadata `type` may be omitted in requests. When omitted in attribute/metadata creation
-  or in update operations, the default string value `none` is used for the type.
 
 * Attribute `metadata` may be omitted in requests, meaning that there are no metadata elements
   associated to the attribute. In responses, this property is set to
@@ -407,8 +345,6 @@ If present, the error payload is a JSON object including the following fields:
 
 + `error` (required, string): a textual description of the error.
 + `description` (optional, string): additional information about the error.
-+ `affectedItems` (optional, array[string]): a list of elements affected by the error.
-  Depending on the operation, it may refer to entities, registrations or subscriptions.
 
 All NGSIv2 server implementations must use the following HTTP response codes and `error` texts.
 However, the particular text used for `description` field is an implementation specific aspect.
@@ -458,9 +394,6 @@ need special indexes which can be under resource constraints imposed by backend 
 Thus, implementations may raise errors when spatial index limits are exceeded.
 The recommended HTTP status code for those situations is ``413``, *Request entity too large*, and
 the reported error on the response payload must be ``NoResourcesAvailable``.
-
-*Note: At the time of writing it is still under discussion whether supporting both syntaxes is
-really needed* 
 
 ### Simple Location Format
 
@@ -747,7 +680,7 @@ is used:
       "type": "Room",
       "temperature": {
         "value": 23,
-        "type": "none",
+        "type": "Number",
         "metadata": {}
       },
       "humidity": {
@@ -761,7 +694,7 @@ is used:
       "type": "Room",
       "temperature": {
         "value": 24,
-        "type": "none",
+        "type": "Number",
         "metadata": {}
       }
     }
@@ -894,8 +827,6 @@ to keep your client decoupled from implementation details.
         + types_url: /v2/types (required, string) - URL which points to the types resource
         + subscriptions_url: /v2/subscriptions (required, string) - URL which points to the
           subscriptions resource
-        + registrations_url: /v2/registrations (required, string) - URL which points to the
-          registrations resource
 
 # Group Entities
 
@@ -973,7 +904,7 @@ Response code:
            "id": "DC_S1-D41",
            "temperature": {
              "value": 35.6,
-             "type": "none",
+             "type": "Number",
              "metadata": {}
            }
          },
@@ -982,7 +913,7 @@ Response code:
            "id": "Boe-Idearium",
            "temperature": {
              "value": 22.5,
-             "type": "none",
+             "type": "Number",
              "metadata": {}
            }
          },
@@ -995,7 +926,7 @@ Response code:
              "metadata": {
                "accuracy": {
                  "value": 2,
-                 "type": "none"
+                 "type": "Number"
                },
                "timestamp": {
                  "value": "2015-06-04T07:20:27.378Z",
@@ -1095,11 +1026,11 @@ Response:
           "id": "Bcn_Welt",
           "temperature": {
             "value": 21.7,
-            "type": "none"
+            "type": "Number"
           },
           "humidity": {
             "value": 60,
-            "type": "none"
+            "type": "Number"
           },
           "location": {
             "value": "41.3763726, 2.1864475",
@@ -1107,7 +1038,7 @@ Response:
             "metadata": {
               "crs": {
                 "value": "WGS84",
-                "type": "none"
+                "type": "Text"
               }
             }
           }
@@ -1153,11 +1084,11 @@ Response:
         {
           "temperature": {
             "value": 21.7,
-            "type": "none"
+            "type": "Number"
           },
           "humidity": {
             "value": 60,
-            "type": "none"
+            "type": "Number"
           },
           "location": {
             "value": "41.3763726, 2.1864475",
@@ -1165,7 +1096,7 @@ Response:
             "metadata": {
               "crs": {
                 "value": "WGS84",
-                "type": "none"
+                "type": "Text"
               }
             }
           }
@@ -1331,7 +1262,7 @@ Response:
 
         {
           "value": 21.7,
-          "type": "none",
+          "type": "Number",
           "metadata": {}
         }
 
@@ -1509,7 +1440,7 @@ Response code:
             "type": "Car",
             "attrs": {
               "speed": {
-                "types": [ "none" ]
+                "types": [ "Number" ]
               },
               "fuel": {
                 "types": [ "gasoline", "diesel" ]
@@ -1524,7 +1455,7 @@ Response code:
             "type": "Room",
             "attrs": {
               "pressure": {
-                "types": [ "none" ]
+                "types": [ "Number" ]
               },
               "humidity": {
                 "types": [ "percentage" ]
@@ -1563,7 +1494,7 @@ Response code:
           {
             "attrs": {
               "pressure": {
-                "types": [ "none" ]
+                "types": [ "Number" ]
               },
               "humidity": {
                 "types": [ "percentage" ]
@@ -1848,188 +1779,6 @@ Response:
 
 + Response 204
 
-# Group Registrations
-
-Context Registration allows to associate external services to context data. One of the main
-use cases of this functionality is the association of Context Providers.
-
-A context registration is represented by a JSON object with the following fields:
-
-+ `id`       : Unique identifier assigned to the registration. Automatically generated at creation
-  time.
-+ `subject`  : Object that describes the subject of the registration.
-+ `callback` : URL which denotes the end-point of the registered service. It is optional, as it can
-  be undefined under certain conditions, for instance, transient unavailability of the provider.
-+ `metadata` : An optional JSON object which allows to associate extra metadata properties to the
-  registration.
-  It must follow the same representation conventions as context attribute metadata
-  (See JSON Attribute Representation). 
-+ `duration` : Duration of the registration in ISO8601 format. Default duration is infinite.
-
-A `subject` contains the following subfields:
-
-+ `entities`: A list of objects, each one composed of the following subfields (`id`/`idPattern` or
-  type must be present):
-    + `id` or `idPattern`: Id or pattern of the affected entities. Both cannot be set at the same
-      time, but one of them must be set.
-    + `type`: Type of the affected entities (optional).
-+ `attributes`: List of attributes to be provided (if not specified, all attributes).
-
-## Registration list [/v2/registrations]
-
-### Retrieve registrations [GET /v2/registrations]
-
-Lists all the registrations present in the system.
-
-Response:
-
-* Successful operation uses 200 OK
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Response 200
-
-        [
-          {
-            "id": "abcdefg",
-            "subject": {
-              "entities": [
-                {
-                  "id": "Bcn_Welt",
-                  "type": "Room"
-                }
-              ],
-              "attributes": [
-                "temperature"
-              ]
-            },
-            "callback": "http://weather.example.com/ngsi",
-            "metadata": {
-              "providingService": {
-                 "value": "weather.example.com",
-                 "type": "none"
-               },
-              "providingAuthority": {
-                 "value": "AEMET - Spain",
-                 "type": "none"
-               }
-            },
-            "duration": "PT1M"
-          }
-        ]
-
-### Create a new context provider registration [POST /v2/registrations]
-
-Creates a new registration. This is typically used for associating context providers
-to certain data.
-The registration is represented by a JSON object as described at the beginning of this section.
-
-Response:
-
-* Successful operation uses 201 Created
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Request (application/json)
-
-        {
-          "subject": {
-            "entities": [
-              {
-                "id": "room2",
-                "type": "Room"
-              }
-            ],
-            "attributes": [
-              "humidity"
-            ]
-          },
-          "callback":  "http://localhost:1234",
-          "metadata" : {
-            "provider": {
-              "value": "example.com"
-            }
-          },
-          "duration": "PT1M"
-        }
-
-+ Response 201
-
-    + Headers
-
-            Location: /v2/registrations/abcde98765
-
-## Registration By ID [/v2/registrations/{registrationId}]
-
-### Retrieve context provider registration [GET /v2/registrations/{registrationId}]
-
-The response is the registration represented by a JSON object as described at the beginning of this
-section.
-
-Response:
-
-* Successful operation uses 200 OK
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Parameters
-    + registrationId: abcdef (required, string) - registration Id.
-
-+ Response 200 (application/json)
-
-        {
-          "id": "abcde",
-          "subject": {
-            "entities": [
-              {
-                "id": "room2",
-                "type": "Room"
-              }
-            ],
-            "attributes": [
-              "humidity"
-            ]
-          },
-          "callback":  "http://localhost:1234",
-          "duration": "PT1M"
-        }
-
-### Update context provider registration [PATCH /v2/registrations/{registrationId}]
-
-Only the fields included in the request are updated in the registration.
-
-Response:
-
-* Successful operation uses 204 No Content
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Parameters
-    + registrationId: abcdef (required, string) - registration Id.
-
-+ Request (application/json)
-
-        {
-          "duration": "PT1M"
-        }
-
-+ Response 204
-
-### Delete context provider registration [DELETE /v2/registrations/{registrationId}]
-
-Cancels registration.
-
-Response:
-
-* Successful operation uses 204 No Content
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Parameters
-    + registrationId: abcdef (required, string) - registration Id.
-
-+ Response 204
-
 # Group Batch Operations
 
 ### Update [POST /v2/op/update]
@@ -2100,10 +1849,6 @@ The payload may contain the following elements (all of them optional):
     + `type`: specifies the type of the entities to search for. If omitted, it means
       "any entity type".
 + `attributes`: a list of attribute names to search for. If omitted, it means "all attributes".
-+ `scopes`: a list of scopes to restrict the result of the query. Each scope is represented by a
-   JSON object with a `type` (a JSON string) and `value` (whose type depends on the `type`
-   property).
-   The different available scopes are described elsewhere.
 
 Response code:
 
@@ -2144,12 +1889,6 @@ Response code:
           "attributes": [
             "temperature",
             "humidity"
-          ],
-          "scopes": [
-            {
-              "type": "FIWARE::...",
-              "value": "..."
-            }
           ]
         }
 
@@ -2161,7 +1900,7 @@ Response code:
             "id": "DC_S1-D41",
             "temperature": {
               "value": 35.6,
-              "type": "none"
+              "type": "Number"
             }
           },
           {
@@ -2169,7 +1908,7 @@ Response code:
             "id": "Boe-Idearium",
             "temperature": {
               "value": 22.5,
-              "type": "none"
+              "type": "Number"
             }
           },
           {
@@ -2186,200 +1925,3 @@ Response code:
             }
           }
         ]
-
-
-### Register [POST /v2/op/register]
-
-This operation allows to create, update and/or delete several registrations in a single batch
-operation. The payload is an object with two properties:
-
-+ `actionType`, to specify the kind of register action to do: either CREATE, UPDATE, or DELETE.
-+ `registrations`, an array of registrations, each one specified using the JSON registration 
-  representation format (described above). In the case of CREATE operation, the registration `id`
-  must not be included.
-
-Response:
-
-* Successful operation uses 200 OK. In addition, in the case of successful CREATE, a list of IDs is
-  returned, each one corresponding to the ID of the element in the request payload and in that same
-  order.
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Request (application/json)
-
-        {
-          "actionType": "CREATE",
-          "registrations": [
-            {
-              "subject": {
-                "entities": [
-                  {
-                    "type": "Room"
-                  }
-                ],
-                "attributes": [
-                  "humidity"
-                ]
-              },
-              "callback": "http://localhost:1234",
-              "duration": "PT1M"
-            },
-            {
-              "subject": {
-                "entities": [
-                  {
-                    "type": "Car"
-                  }
-                ],
-                "attributes": [
-                  "speed"
-                ]
-              },
-              "callback": "http://localhost:5678",
-              "duration": "PT1M"
-            }
-          ]
-        }
-
-+ Response 200
-
-        [
-          "abcd",
-          "efgh"
-        ]
-
-
-### Discover [POST /v2/op/discover/{?limit,offset,options}]
-
-The response payload is an Array that contains one object per matching registration.
-The registrations follow the JSON registration representation format (described in a section above).
-
-The payload may contain the following elements (all of them optional):
-
-+ `entities`: a list of entites to search for. Each entity is represented by a JSON object with the
-  following elements:
-    + `id` or `idPattern`: Id or pattern of the affected entities. Both cannot be present at the
-      same time, but one of them must be.
-    + `type`: specifies the type of the entities to search for. If omitted, it means
-      "any entity type".
-+ `attributes`: a list of attribute names to search for. If omitted, it means "all attributes".
-+ `scopes`: a list of scopes to restrict the results of the query. Each scope is represented by a
-  JSON object with a `type` (a JSON string) and a `value` (whose type depends on the `type`
-  property). The different available scopes are described elsewhere.
-
-Response code:
-
-* Successful operation uses 200 OK
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Parameters
-    + limit: 10 (optional, number) - Limit the number of registrations to be retrieved.
-    + offset: 22 (optional, number) - Skip a number of registrations.
-    + options (optional, string) - Options dictionary.
-        + Members
-          + count - when used, the total number of registrations is returned in the response as the
-            HTTP header `Fiware-Total-Count`.
-
-
-+ Request (application/json)
-
-        {
-          "entities": [
-            {
-              "idPattern": ".*",
-              "type": "myFooType"
-            },
-            {
-              "id": "myBar",
-              "type": "myBarType"
-            }
-          ],
-          "attributes": [
-            "temperature",
-            "humidity"
-          ],
-          "scopes": [
-            {
-              "type": "FIWARE::Filter::Foo",
-              "value": "Bar"
-            }
-          ]
-        }
-
-+ Response 200 (application/json)
-
-        [
-          {
-            "id": "abcde",
-            "subject": {
-              "entities": [
-                {
-                  "id": "Foo",
-                  "type": "myFooType"
-                }
-              ],
-              "attributes": [
-                "humidity"
-              ]
-            },
-            "callback": "http://localhost:1234",
-            "duration": "PT1M"
-          },
-          {
-            "id": "efgh",
-            "subject": {
-              "entities": [
-                {
-                  "id": "myBar",
-                  "type": "myBarType"
-                }
-              ],
-              "attributes": [
-                "speed"
-              ]
-            },
-            "callback": "http://localhost:5678",
-            "duration": "PT1M"
-          }
-        ]
-
-# Group OMA-NGSI Operations
-
-(The need/usefulness of these operations is currently under discussion)
-
-For the sake of completeness here is an enumeration of the OMA-NGSI (9 & 10) operations. These
-operations will be supported under the 'v2' resource as well.
-
-### subscribeContext [POST /v2/subscribeContext]
-
-(Not needed, as it is covered by the RESTful POST /v2/subscriptions operation)
-
-### updateContextSubscription [POST /v2/updateContextSubscription]
-
-(Not needed, as it is covered by the RESTful PATCH /v2/subscriptions operation)
-
-### unsubscribeContext [POST /v2/unsubscribeContext]
-
-(Not needed, as it is covered by the RESTful DELETE /v2/subscriptions operation)
-
-### notifyContext [POST /v2/notifyContext]
-
-(The payload of the v2 notifyContext should be described)
-
-### subscribeContextAvailability [POST /v2/subscribeContextAvailability]
-
-(Not needed as POJ RPC, but we need to define a RESTful operation for this, analogous to the NGSI10 one)
-
-### updateContextAvailabilitySubscription [POST /v2/updateContextAvailabilitySubscription]
-
-(Not needed as POJ RPC, but we need to define a RESTful operation for this, analogous to the NGSI10 one)
-
-### unsubscribeContextAvailability [POST /v2/unsubscribeContextAvailability]
-
-(Not needed as POJ RPC, but we need to define a RESTful operation for this, analogous to the NGSI10 one)
-
-### notifyContextAvailability [POST /v2/notifyContextAvailability]
-
-(The payload of the v2 notifyContextAvailability should be described)


### PR DESCRIPTION
This PR finished the work to prepare the NGSIv2 specification release candidate May 2016.

Summary of changes:

* Rewritten "Status" section (with the Status corresponding to Release Candidates)
* Added section on "Reference Implementations"
* Removed references to "role" concept
* Removed empty placeholders "Terminology" subsections 
* Removed Context Element section (as it has not been yet decided if this concetp will be part of the final version of the API)
* Removed "pending discussion" notes.
* Removed "registration_url" removed from GET /v2 operation (as context management availability as not been yet defined in NGSIv2 specification)
* Removed "# Group Registrations" (as context management availability as not been yet defined in NGSIv2 specification)
* Removed "scopes" in POST /v2/op/query (as scopes has not been yet crearly defined)
* Removed POST /v2/op/register and POST /v2/op/discover (as context management availability as not been yet defined in NGSIv2 specification)
* Removed "# Group OMA-NGSI Operations" (only empty placeholders there)
* Removed references (and examples) to default entity/attribute/netadata type to "none" (this requires more disucssion, see https://github.com/telefonicaid/fiware-orion/issues/2223)
* Removed affectedItem field in "Error Responses" (not clear enougth)

Note that alghough many sections has been removed in this document, they remain in the latest version of the specification (fiware-ngsiv2-reference.apib file) so discussion can continue on them and, eventually, be added to next release candidates.

Merging deadline: **June 7th EoB.**