### PR TITLE
Hardening/2232 utc in logfile (into release/1.2.0)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: UTC as time in log file (Issue #2232)

--- a/src/lib/logMsg/logMsg.cpp
+++ b/src/lib/logMsg/logMsg.cpp
@@ -895,15 +895,12 @@ static char* dateGet(int index, char* line, int lineSize)
   {
     struct timeb timebuffer;
     struct tm    tm;
-    char         line_tmp[80];
-    char         timeZone[20];
+    char         line_buf[80];
 
     ftime(&timebuffer);
-    localtime_r(&secondsNow, &tm);
-    strftime(line_tmp, 80, fds[index].timeFormat, &tm);
-    strftime(timeZone, sizeof(timeZone), "%Z", &tm);
-
-    snprintf(line, lineSize, "%s.%.3d%s", line_tmp, timebuffer.millitm, timeZone);
+    gmtime_r(&secondsNow, &tm);
+    strftime(line_buf, 80, fds[index].timeFormat, &tm);
+    snprintf(line, lineSize, "%s.%.3dZ", line_buf, timebuffer.millitm);
   }
 
   return line;


### PR DESCRIPTION
Twin PR (into release/1.2.0) of #2233

* UTC in logfile and not the nodes time-zone (which did not correspond to the times)
* gmtime_r seems to solve the problem
* CHANGES_NEXT_RELEASE