### PR TITLE
createTag.sh

### DIFF
--- a/scripts/build/createTag.sh
+++ b/scripts/build/createTag.sh
@@ -30,7 +30,7 @@ function usage()
   echo "$empty [--changelog <changelog file to flush into .spec, default is CHANGES_NEXT_RELEASE>"
   echo
   echo "Modes:"
-  echo "* 'files', only modify files (bu don't commit changes)"
+  echo "* 'files', only modify files (but don't commit changes)"
   echo "* 'commit', modify files and commit changes (but don't tag)"
   echo "* 'tag', modify files, commit and tag (but don't push)"
   echo "* 'push', modify files, commit, tag and push to origin"

--- a/scripts/build/createTag.sh
+++ b/scripts/build/createTag.sh
@@ -1,0 +1,230 @@
+# Copyright 2015 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# FIXME: this script assumes that it is run from the fiware-orion repository run
+PROJECT_DIR="."
+
+function usage()
+{
+  sfile="Usage: "$(basename $0)
+  empty=$(echo $sfile | tr 'a-zA-z/0-9.:' ' ')
+  echo "$sfile [-u (usage)]"
+  echo "$empty [--mode <files|commit|tag|push>"
+  echo "$empty [--changelog <changelog file to flush into .spec, default is CHANGES_NEXT_RELEASE>"
+  echo
+  echo "Modes:"
+  echo "* 'files', only modify files (bu don't commit changes)"
+  echo "* 'commit', modify files and commit changes (but don't tag)"
+  echo "* 'tag', modify files, commit and tag (but don't push)"
+  echo "* 'push', modify files, commit, tag and push to origin"
+  echo
+  exit $1
+}
+
+function checkValidInteger()
+{
+  if [ "$1" == "" ]; then
+    echo $0: at least one of the three tag tokens is empty
+    exit 1
+  fi
+
+  if ! [[ $1 =~ ^[0-9]+$ ]]; then
+    echo $0: tag token '"'${$1}'"' is not a number
+    exit 1
+  fi
+}
+
+#
+# Modify rpm/SPECS/contextBroker.spec only when step to a non-dev release
+# 
+# FIXME: unify this code with the same one in resease.sh into a commmon lib
+#
+function flushCNRToSpec()
+{
+  #
+  # Edit rpm/SPECS/contextBroker.spec, adding the new changes from CHANGELOG_FILE
+  #
+  # 1. Find the line in rpm/SPECS/contextBroker.spec, where to add the content of CHANGELOG_FILE plus the info-line for the changes.
+  #    o LINES:       number of lines before the insertion
+  # 2. Get the total number of lines in rpm/SPECS/contextBroker.spec
+  # 3. Get the number of lines in rpm/SPECS/contextBroker.spec after the insertion
+  #    o LAST_LINES:  number of lines after the insertion
+  # 4. To a temporal file, add the four 'chunks':
+  #    1. LINES
+  #    2. the info-line for the changes
+  #    3. the content of CHANGELOG_FILE
+  #    4. LAST_LINES
+  # 5. Replace using the temporal file
+
+  #
+  # 1. Find the line in rpm/SPECS/contextBroker.spec, where to add the content of CHANGELOG_FILE
+  #    The for is because these is more than one oceuurence of '%changelog'. We are only
+  #    interested in the last one.
+  #
+  for line in $(grep -n '%changelog' rpm/SPECS/contextBroker.spec | awk -F: '{ print $1 }')
+  do
+    LINE=$line
+  done
+
+  #
+  # 2. Get the total number of lines in rpm/SPECS/contextBroker.spec
+  #
+  LINES=$(wc -l rpm/SPECS/contextBroker.spec | awk '{ print $1 }')
+
+  #
+  # 3. Get the number of lines in rpm/SPECS/contextBroker.spec after the insertion
+  #
+  typeset -i LAST_LINES
+  LAST_LINES=$LINES-$LINE
+
+  #
+  # 4. To a temporal file, add the four 'chunks'
+  #
+  head -$LINE rpm/SPECS/contextBroker.spec        >  /tmp/contextBroker.spec
+
+  echo -n '* '                                    >> /tmp/contextBroker.spec
+  echo $dateLine                                  >> /tmp/contextBroker.spec
+
+  cat $changelog                                  >> /tmp/contextBroker.spec
+  echo                                            >> /tmp/contextBroker.spec
+
+  tail -$LAST_LINES rpm/SPECS/contextBroker.spec  >> /tmp/contextBroker.spec
+    
+  # 5. Replace using the temporal file
+  mv /tmp/contextBroker.spec rpm/SPECS/contextBroker.spec 
+
+  rm $changelog; touch $changelog
+}
+
+
+
+# ------------------------------------------------------------------------------
+#
+# Argument parsing
+#
+files=off
+commit=off
+tag=off
+push=off
+
+changelog=CHANGES_NEXT_RELEASE
+
+mode=""
+
+while [ "$#" != 0 ]
+do
+  if   [ "$1" == "-u" ];            then usage 0;
+  elif [ "$1" == "--mode" ];        then mode="$2"; shift;
+  elif [ "$1" == "--changelog" ];   then changelog="$2"; shift;
+  else
+    echo $0: bad parameter/option: "'"${1}"'";
+    echo
+    usage 1
+  fi
+  shift
+done
+
+if [ "$mode" == "" ]; then
+  echo $0: missing mode
+  echo
+  usage 1
+fi
+
+if [ "$mode" == "files" ]; then
+  files=on  # not actually used, but included for "symetry"
+elif [ "$mode" == "commit" ]; then
+  commit=on  
+elif [ "$mode" == "tag" ]; then
+  commit=on
+  tag=on
+elif [ "$mode" == "push" ]; then
+  commit=on
+  tag=on
+  push=on
+else
+  echo $0: wrong mode: "'"${mode}"'";
+  echo
+  usage 1
+fi
+
+# Check we are in a release/X.Y.Z branch
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ $branch != release/* ]]; then
+  echo $0: you are not in a release branch but in "'"${branch}"'"
+  exit 1
+fi
+
+
+# Get current tag
+currentTag=$(grep "define ORION_VERSION" $PROJECT_DIR/src/app/contextBroker/version.h  | awk -F\" '{ print $2 }')
+echo $0: current tag is: "'"${currentTag}"'"
+
+# Check tag structure
+X=$(echo $currentTag | awk -F '.' '{print $1}')
+Y=$(echo $currentTag | awk -F '.' '{print $2}')
+Z=$(echo $currentTag | awk -F '.' '{print $3}')
+checkValidInteger $X
+checkValidInteger $Y
+checkValidInteger $Z
+
+# Check branch match base version
+baseVersion=$X.$Y.0
+echo $0: base version is: "'"${baseVersion}"'"
+versionFromBranch=$(echo $branch | awk -F '/' '{print $2'})
+if [ "$baseVersion" != "$versionFromBranch" ]; then
+  echo $0: wrong base version in this release branch: "'"${versionFromBranch}"'"
+  exit 1
+fi
+
+# Calculate next tag
+Z=$((Z+1))
+nextTag=$X.$Y.$Z
+echo $0: next tag is: "'"${nextTag}"'"
+
+# Modify src/app/contextBroker/version.h
+sed "s/$currentTag/$nextTag/" src/app/contextBroker/version.h > /tmp/version.h
+mv /tmp/version.h src/app/contextBroker/version.h
+
+# Flush CNR into .spec
+DATE=$(LANG=C date +"%a %b %d %Y")
+export dateLine="$DATE Fermin Galan <fermin.galanmarquez@telefonica.com> ${nextTag}-1"
+flushCNRToSpec
+
+# Modify ENV GIT_REV_ORION at docker/Dockerfile
+sed "s/ENV GIT_REV_ORION $currentTag/ENV GIT_REV_ORION $nextTag/" docker/Dockerfile > /tmp/Dockerfile
+mv /tmp/Dockerfile docker/Dockerfile
+
+# Commit all files
+if [ "$commit" == "on" ]; then
+  git add src/app/contextBroker/version.h $changelog Docker/Dockerfile rpm/SPECS/contextBroker.spec
+  git commit -m "Step: $currentTag -> $nextTag"
+fi
+
+# Create tag
+if [ "$tag" == "on" ]; then
+  git tag $nextTag
+fi
+
+# Push
+if [ "$push" == "on" ]; then
+  git push --tags origin release/$baseVersion
+fi
+
+exit 0

--- a/scripts/build/createTag.sh
+++ b/scripts/build/createTag.sh
@@ -196,9 +196,10 @@ if [ "$baseVersion" != "$versionFromBranch" ]; then
 fi
 
 # Check dockerfile has the right tag
-grep $PROJECT_DIR/docker/Dockerfile "ENV GIT_REV_ORION $currentTag"
+grep "ENV GIT_REV_ORION $currentTag" $PROJECT_DIR/docker/Dockerfile
 if [ "$?" != "0" ]; then
-  echo $0: GIT_REV_ORION does not use current tag in Dockerfile"
+  echo $0: GIT_REV_ORION does not use current tag in Dockerfile
+  exit 1
 fi
 
 # Calculate next tag
@@ -217,7 +218,7 @@ flushCNRToSpec
 
 # Modify ENV GIT_REV_ORION at docker/Dockerfile
 sed "s/ENV GIT_REV_ORION $currentTag/ENV GIT_REV_ORION $nextTag/" $PROJECT_DIR/docker/Dockerfile > /tmp/Dockerfile
-mv /tmp/Dockerfile $PROJEC_DIR/docker/Dockerfile
+mv /tmp/Dockerfile $PROJECT_DIR/docker/Dockerfile
 
 # Commit all files
 if [ "$commit" == "on" ]; then

--- a/scripts/build/createTag.sh
+++ b/scripts/build/createTag.sh
@@ -141,7 +141,7 @@ do
       exit 0
       ;;
     *)
-      echo $0: bad parameter/option: "'"${1}"'"
+      echo $0: bad parameter/option: "'"${OPTARG}"'"
       echo
       usage
       exit 1


### PR DESCRIPTION
Tested in the 'files' mode ('push' mode will be tested next time we need a tag).

Files seems to be correctly modified. After running script on release/1.2.0 branch git diff shows the following:

```
fermin@trantor:~/src/fiware-orion$ git diff
diff --git a/CHANGES_NEXT_RELEASE b/CHANGES_NEXT_RELEASE
index f8aec1c..e69de29 100644
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,6 +0,0 @@
-- Fix: UTC as time in log file (Issue #2232)
-- Fix: Removed capping in NGSIv2 update forwarding (Issue #2193)
-- Fix: In some cases, compound attribute values were forwarded as empty strings (Issue #2237)
-- Fix: attribute overwritten when JSON value used in PUT /v2/entities/<eId>/attr/<attrName>/values (Issues #2246 and #2248)
-- Fix: subscription equal filter evaluation on update context logic (#2222)
-- Fix: capturing invalid id patterns at json parse time for v2 subscriptions - this bug made the broker crash when receiving invalid id-patterns (Issue #2257)
diff --git a/docker/Dockerfile b/docker/Dockerfile
index 59f534e..67a0c84 100644
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:centos6.6
 MAINTAINER FIWARE Orion Context Broker Team. Telefónica I+D

 ENV ORION_USER orion
-ENV GIT_REV_ORION 1.2.0
+ENV GIT_REV_ORION 1.2.1
 ENV CLEAN_DEV_TOOLS 1

 RUN adduser --comment "${ORION_USER}" ${ORION_USER}
diff --git a/rpm/SPECS/contextBroker.spec b/rpm/SPECS/contextBroker.spec
index e489f73..57743dc 100644
--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -164,6 +164,14 @@ if [ "$1" == "0" ]; then
 fi

 %changelog
+* Fri Jun 10 2016 Fermin Galan <fermin.galanmarquez@telefonica.com> 1.2.1-1
+- Fix: UTC as time in log file (Issue #2232)
+- Fix: Removed capping in NGSIv2 update forwarding (Issue #2193)
+- Fix: In some cases, compound attribute values were forwarded as empty strings (Issue #2237)
+- Fix: attribute overwritten when JSON value used in PUT /v2/entities/<eId>/attr/<attrName>/values (Issues #2246 and #2248)
+- Fix: subscription equal filter evaluation on update context logic (#2222)
+- Fix: capturing invalid id patterns at json parse time for v2 subscriptions - this bug made the broker crash when receiving invalid id-patterns (Issue #2257)
+
 * Thu Jun 02 2016 Fermin Galan <fermin.galanmarquez@telefonica.com> 1.2.0-1
 - Add: notification attributes blacklist for NGSIv2 notifications (#2064)
 - Add: NGSIv2 custom notifications (#2015)
diff --git a/src/app/contextBroker/version.h b/src/app/contextBroker/version.h
index c6bd698..3b14d75 100644
--- a/src/app/contextBroker/version.h
+++ b/src/app/contextBroker/version.h
@@ -28,6 +28,6 @@



-#define ORION_VERSION "1.2.0"
+#define ORION_VERSION "1.2.1"

 #endif  // SRC_APP_CONTEXTBROKER_VERSION_H_
```