### PR TITLE
Bug/2221 invalid error updating non existing attribute

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -22,3 +22,4 @@
 - Fix: Error payload returned on encountering non-existing entity/attribute in PUT /v2/entities/<entity-id>/attrs/<attr-name> (Issue #1360)
 - Fix: invalid regex patterns detection (#968)
 - Fix: Better error returned on invalid geoquery (Issue #2174)
+- Fix: Correct error returned when trying to replace a non-existing attribute (Issue #2221)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -23,4 +23,4 @@
 - Fix: invalid regex patterns detection (#968)
 - Fix: Better error returned on invalid geoquery (Issue #2174)
 - Fix: Better error returned on attribute not found in GET /v2/entities/<entity-id>/attrs/<attr-name>/value (Issue #2220)
-- Fix: Correct error returned when trying to replace a non-existing attribute (Issue #2221)
+- Fix: Correct error returned when trying to replace a non-existing attribute in PUT /v2/entities/<entity-id>/attrs/<attr-name> (Issue #2221)

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -3056,7 +3056,7 @@ void processContextElement
 
         if (apiVersion == "v1")
         {
-          responseP->oe.fill(SccContextElementNotFound, "Entity not found. Check type and id", "NotFound");
+          responseP->oe.fill(SccContextElementNotFound, "No context element found", "NotFound");
         }
         else
         {

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -659,6 +659,7 @@ static bool updateAttribute
 {
   actualUpdate = false;
 
+  LM_W(("KZ: In updateAttribute for '%s'", caP->name.c_str()));
   /* Attributes with metadata ID are stored as <attrName>__<ID> in the attributes embedded document */
   std::string effectiveName = dbDotEncode(caP->name);
   if (caP->getId() != "")
@@ -1823,9 +1824,10 @@ static bool updateContextAttributeItem
                             " - entity: [" + eP->toString() + "]" +
                             " - offending attribute: " + targetAttr->getName();
       cerP->statusCode.fill(SccInvalidParameter, details);
-      oe->fill(SccContextElementNotFound, "No context element found", "NotFound");
+      LM_W(("KZ: Setting error text to 'The entity does not have such an attribute'"));
+      oe->fill(SccContextElementNotFound, "The entity does not have such an attribute", "NotFound");
 
-      /* Although ca has been already pushed into cerP, it can be used */
+      /* Although 'ca' has been already pushed into cerP, the pointer is still valid, of course */
       ca->found = false;
     }
   }
@@ -3053,6 +3055,7 @@ void processContextElement
       if (forwardsPending(responseP) == false)
       {
         cerP->statusCode.fill(SccContextElementNotFound);
+        LM_W(("KZ: Setting error text to 'No context element found'"));
         responseP->oe.fill(SccContextElementNotFound, "No context element found", "NotFound");
       }
     }

--- a/src/lib/rest/HttpStatusCode.cpp
+++ b/src/lib/rest/HttpStatusCode.cpp
@@ -22,9 +22,14 @@
 *
 * Author: developer
 */
-
 #include "HttpStatusCode.h"
 
+
+
+/* ****************************************************************************
+*
+* httpStatusCodeString - 
+*/
 std::string httpStatusCodeString(HttpStatusCode code)
 {
   switch (code)

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -953,6 +953,7 @@ static int connectionTreat
     LM_T(LmtRequest, (""));
     // WARNING: This log message below is crucial for the correct function of the Behave tests - CANNOT BE REMOVED
     LM_T(LmtRequest, ("--------------------- Serving request %s %s -----------------", method, url));
+    LM_W(("KZ: --------------------- Serving request %s %s -----------------", method, url));
     *con_cls     = (void*) ciP; // Pointer to ConnectionInfo for subsequent calls
     ciP->port    = port;
     ciP->ip      = ip;

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -953,7 +953,6 @@ static int connectionTreat
     LM_T(LmtRequest, (""));
     // WARNING: This log message below is crucial for the correct function of the Behave tests - CANNOT BE REMOVED
     LM_T(LmtRequest, ("--------------------- Serving request %s %s -----------------", method, url));
-    LM_W(("KZ: --------------------- Serving request %s %s -----------------", method, url));
     *con_cls     = (void*) ciP; // Pointer to ConnectionInfo for subsequent calls
     ciP->port    = port;
     ciP->ip      = ip;

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -690,6 +690,7 @@ std::string postUpdateContext
     if (fails == response.contextElementResponseVector.size())
     {
       // If all CER result in error, then it isn't a partial update, but a regular NotFound
+      LM_W(("KZ: Setting error text to 'No context element found'"));
       parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, "No context element found", "NotFound");
     }
     else if (fails > 0)

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -690,8 +690,14 @@ std::string postUpdateContext
     if (fails == response.contextElementResponseVector.size())
     {
       // If all CER result in error, then it isn't a partial update, but a regular NotFound
-      LM_W(("KZ: Setting error text to 'No context element found'"));
-      parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, "No context element found", "NotFound");
+      if (ciP->apiVersion == "v1")
+      {
+        parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, "No context element found", "NotFound");
+      }
+      else
+      {
+        parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, "The requested entity has not been found. Check type and id", "NotFound");
+      }
     }
     else if (fails > 0)
     {

--- a/test/functionalTest/cases/0787_cprs_full_functional_v2/ngsiv2_update_false_registration.test
+++ b/test/functionalTest/cases/0787_cprs_full_functional_v2/ngsiv2_update_false_registration.test
@@ -97,13 +97,13 @@ Date: REGEX(.*)
 02. Update/UPDATE E1/T1/A1 in CB, using NGSIv2
 ==============================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/0979_patch_v2_entities_eid/patch_v2_entities_eid.test
+++ b/test/functionalTest/cases/0979_patch_v2_entities_eid/patch_v2_entities_eid.test
@@ -88,13 +88,13 @@ echo
 01. Intent to patch a non-existing entity - error, of course
 ============================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 
@@ -169,13 +169,13 @@ Date: REGEX(.*)
 06. PATCH /v2/entities/E1 attr3=6, to see the error (attr3 doesn't exist)
 =========================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The entity does not have such an attribute",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/0980_patch_entity_v2_wihth_param_type/patch_entity_with_param_type.test
+++ b/test/functionalTest/cases/0980_patch_entity_v2_wihth_param_type/patch_entity_with_param_type.test
@@ -167,13 +167,13 @@ Date: REGEX(.*)
 05. PATCH /v2/entities/E1 T1 (error, attribute not exist)
 =========================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The entity does not have such an attribute",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/0987_put_attributes/put_entity_error.test
+++ b/test/functionalTest/cases/0987_put_attributes/put_entity_error.test
@@ -87,13 +87,13 @@ echo
 01. Modify non-existing entity E1
 =================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/0987_put_attributes/put_entity_error_01.test
+++ b/test/functionalTest/cases/0987_put_attributes/put_entity_error_01.test
@@ -45,13 +45,13 @@ echo
 01. Modify non-existing entity E1
 =================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/0999_update_single_attr_value_by_eid/update_single_attr_by_eid.test
+++ b/test/functionalTest/cases/0999_update_single_attr_value_by_eid/update_single_attr_by_eid.test
@@ -163,13 +163,13 @@ echo
 01. PUT /v2/entities/E1/attrs/A1/value and see it fail
 ======================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1259_new_json_for_v2/put_v2_entities_eid_attrs_attr.test
+++ b/test/functionalTest/cases/1259_new_json_for_v2/put_v2_entities_eid_attrs_attr.test
@@ -117,13 +117,13 @@ echo
 01. PUT /v2/entities/E1/attrs/A1 and see it fail
 ================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1260_v2_update_patch_error_description/update_patch_error_description.test
+++ b/test/functionalTest/cases/1260_v2_update_patch_error_description/update_patch_error_description.test
@@ -91,13 +91,13 @@ Date: REGEX(.*)
 03. PATCH /v2/entities/Eno/attrs (not found)
 ============================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1278_patch_unknown_attribute/patch_unknown_attribute.test
+++ b/test/functionalTest/cases/1278_patch_unknown_attribute/patch_unknown_attribute.test
@@ -72,13 +72,13 @@ Date: REGEX(.*)
 02. PATCH /v2/entities/E1/attrs (A2 unknown)
 ============================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The entity does not have such an attribute",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1320_v2_error_put_attributes/error_put_attributes.test
+++ b/test/functionalTest/cases/1320_v2_error_put_attributes/error_put_attributes.test
@@ -107,13 +107,13 @@ Date: REGEX(.*)
 04. PUT /v2/entities/fgg (entity not found)
 ===========================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1360_error_response_for_entity_not_found/error_response_for_entity_not_found.test
+++ b/test/functionalTest/cases/1360_error_response_for_entity_not_found/error_response_for_entity_not_found.test
@@ -70,13 +70,13 @@ echo
 01. Attempt to update an entity that does not exist
 ===================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 
@@ -94,13 +94,13 @@ Date: REGEX(.*)
 03. Attempt to update attribute dfgdfgdf of entity room_2 (the attribute does not exist)
 ========================================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The entity does not have such an attribute",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1682_ngsiv2_entity_id/ngsiv2_entity_id_revisited.test
+++ b/test/functionalTest/cases/1682_ngsiv2_entity_id/ngsiv2_entity_id_revisited.test
@@ -113,13 +113,13 @@ echo
 01. POST /v2/entities/E1 A (and check 404 Not Found)
 ====================================================
 HTTP/1.1 404 Not Found
-Content-Length: 58
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "Entity does not exist",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1715_batch_update/batch_update_UPDATE.test
+++ b/test/functionalTest/cases/1715_batch_update/batch_update_UPDATE.test
@@ -188,13 +188,13 @@ Date: REGEX(.*)
 05. Try to UPDATE non-existing attribute A3, see error
 ======================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The entity does not have such an attribute",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1715_batch_update/batch_update_error_entity_not_found.test
+++ b/test/functionalTest/cases/1715_batch_update/batch_update_error_entity_not_found.test
@@ -87,13 +87,13 @@ echo
 01. Batch Update with actionType UPDATE on non-existing entity, see error
 =========================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 
@@ -115,13 +115,13 @@ Date: REGEX(.*)
 03. Batch Update with actionType REPLACE on non-existing entity, see error
 ==========================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1784_patch_non_existing_attribute/patch_non_existing_attribute.test
+++ b/test/functionalTest/cases/1784_patch_non_existing_attribute/patch_non_existing_attribute.test
@@ -86,13 +86,13 @@ Date: REGEX(.*)
 02. PATCH E1/A1+A2, see error (error due to A2 not existing, but A1 is modified)
 ================================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The entity does not have such an attribute",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/2193_entity_not_found_when_forwarding/entity_not_found_when_forwarding_all_attrs.test
+++ b/test/functionalTest/cases/2193_entity_not_found_when_forwarding/entity_not_found_when_forwarding_all_attrs.test
@@ -84,13 +84,13 @@ Date: REGEX(.*)
 02. Modify E1/A1 in CP1 via CB, using PUT /v2/entities/E1/attrs/A1?type=T1, see error
 =====================================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/2193_entity_not_found_when_forwarding/entity_not_found_when_forwarding_specific_attr.test
+++ b/test/functionalTest/cases/2193_entity_not_found_when_forwarding/entity_not_found_when_forwarding_specific_attr.test
@@ -91,13 +91,13 @@ Date: REGEX(.*)
 02. Modify E1/A1 in CP1 via CB, using PUT /v2/entities/E1/attrs/A1?type=T1, see error
 =====================================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/2221_invalid_error_updating_non_existing_attribute/invalid_error_updating_non_existing_attribute.test
+++ b/test/functionalTest/cases/2221_invalid_error_updating_non_existing_attribute/invalid_error_updating_non_existing_attribute.test
@@ -94,13 +94,13 @@ Date: REGEX(.*)
 03. Attempt to replace E2/A2, see another error, about the entity 
 =================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/2221_invalid_error_updating_non_existing_attribute/invalid_error_updating_non_existing_attribute.test
+++ b/test/functionalTest/cases/2221_invalid_error_updating_non_existing_attribute/invalid_error_updating_non_existing_attribute.test
@@ -1,0 +1,110 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Replacing non existing attribute
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create E1/A1
+# 02. Attempt to replace E1/A2, see error about attribute not found
+# 03. Attempt to replace E2/A2, see another error, about the entity
+#
+
+echo "01. Create E1/A1"
+echo "================"
+payload='{
+  "id": "E1",
+  "type": "T1",
+  "A1": {
+    "type": "at1",
+    "value": "01"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Attempt to replace E1/A2, see error about attribute not found"
+echo "================================================================="
+payload='{ "value": false }'
+orionCurl --url /v2/entities/E1/attrs/A2 --payload "$payload" -X PUT
+echo
+echo
+
+
+echo "03. Attempt to replace E2/A2, see another error, about the entity"
+echo "================================================================="
+payload='{ "value": false }'
+orionCurl --url /v2/entities/E2/attrs/A2 --payload "$payload" -X PUT
+echo
+echo
+
+
+--REGEXPECT--
+01. Create E1/A1
+================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=T1
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Attempt to replace E1/A2, see error about attribute not found
+=================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 79
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "The entity does not have such an attribute",
+    "error": "NotFound"
+}
+
+
+03. Attempt to replace E2/A2, see another error, about the entity 
+=================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 61
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "No context element found",
+    "error": "NotFound"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/2248_forwarding_updates_overwrite_the_types_of_attributes/attribute_type_converted_to_string_on_forward.test
+++ b/test/functionalTest/cases/2248_forwarding_updates_overwrite_the_types_of_attributes/attribute_type_converted_to_string_on_forward.test
@@ -98,13 +98,13 @@ Date: REGEX(.*)
 Note: we get 404 Not Found, but is ok. It is due to accumulator-server.py doesn't answers in NGSIv1
 ==========================================================================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/2248_forwarding_updates_overwrite_the_types_of_attributes/forwarding_updates_overwrite_the_types_of_attributes.test
+++ b/test/functionalTest/cases/2248_forwarding_updates_overwrite_the_types_of_attributes/forwarding_updates_overwrite_the_types_of_attributes.test
@@ -144,13 +144,13 @@ Date: REGEX(.*)
 Note: we get 404 Not Found, but is ok. It is due to accumulator-server.py doesn't answers in NGSIv1
 =============================================================================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 
@@ -180,13 +180,13 @@ Date: REGEX(.*)
 Note: we get 404 Not Found, but is ok. It is due to accumulator-server.py doesn't answers in NGSIv1
 =============================================================================================================================
 HTTP/1.1 404 Not Found
-Content-Length: 61
+Content-Length: 95
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "No context element found",
+    "description": "The requested entity has not been found. Check type and id",
     "error": "NotFound"
 }
 


### PR DESCRIPTION
Fixed issue #2221 
Now, the issue is describing an older behavior of the broker, part of the issue has been fixed by another PR. In this PR, the request in #2221 is made receive a 'Attribute Not Found' instead of the former 'Entity Not Found'  (the entity exists but doesn't have the attribute that issue #2221 tries to replace).

Also, plenty of older 'context element not found' texts replaced for the nicer message 'The requested entity has not been found. Check type and id', and 'Attribute Not Found' is also used in more places than before.
