### PR TITLE
Hardening/1368 cppcheck parse args

### DIFF
--- a/makefile
+++ b/makefile
@@ -68,6 +68,17 @@ all: prepare_release release
 
 di: install_debug
 
+#
+# The 'dix' build target must only be used when fiddling with style_check.
+# It is necessary to be able to check that style_check modifications don't 
+# break the compilation.
+#
+# FIXME: As soon as all the source code is incorporated into style_check, this
+#        build target (dix) must be removed.
+#
+dix: prepare_debug
+	cd BUILD_DEBUG && make -j$(CPU_COUNT)
+
 compile_info:
 	./scripts/build/compileInfo.sh
 

--- a/makefile
+++ b/makefile
@@ -93,10 +93,14 @@ prepare_unit_test: compile_info
 	@echo '------------------------------- prepare_unit_test ended ---------------------------------'
 
 
-release: prepare_release
+style_check_included_in_make_steps:
+	./scripts/style_check_in_makefile.sh
+
+
+release: style_check_included_in_make_steps prepare_release
 	cd BUILD_RELEASE && make -j$(CPU_COUNT)
 
-debug: prepare_debug
+debug: style_check_included_in_make_steps prepare_debug
 	cd BUILD_DEBUG && make -j$(CPU_COUNT)
 
 # Requires root access, i.e. use 'sudo make install' to install

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -2685,7 +2685,7 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension, include_state,
   if Search(r'\bsprintf\b', line):
     error(filename, linenum, 'runtime/printf', 5,
           'Never use sprintf.  Use snprintf instead.')
-  match = Search(r'\b(strcpy|strcat)\b', line)
+  match = Search(r'\b(strcat)\b', line)  # KZ removed strcpy from the 'verboten list'
   if match:
     error(filename, linenum, 'runtime/printf', 4,
           'Almost always, snprintf is better than %s' % match.group(1))

--- a/scripts/style_check_in_makefile.sh
+++ b/scripts/style_check_in_makefile.sh
@@ -1,3 +1,28 @@
+#!/bin/bash
+# -*- coding: latin-1 -*-
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+#
+# Author: Ken Zangelin
+
+
 
 # -----------------------------------------------------------------------------
 #
@@ -18,3 +43,6 @@ function style_check
 }
 
 style_check src/lib/logMsg
+
+# style_check src/lib/parseArgs
+# FIXME: Just keep adding directories here until all of them are included ...

--- a/scripts/style_check_in_makefile.sh
+++ b/scripts/style_check_in_makefile.sh
@@ -23,8 +23,9 @@
 # Author: Ken Zangelin
 
 # NOTE: this script is designed to be launched from makefile targets. Thus,
-# the call to style_check.sh may break if you attemp to use it from a
+# the call to style_check.sh may break if you attempt to use it from a
 # different place. 
+
 
 # -----------------------------------------------------------------------------
 #

--- a/scripts/style_check_in_makefile.sh
+++ b/scripts/style_check_in_makefile.sh
@@ -1,0 +1,20 @@
+
+# -----------------------------------------------------------------------------
+#
+# style_check
+#
+function style_check
+{
+  style_check.sh -d src/lib/logMsg
+  if [ "$?" != 0 ]
+  then
+    echo Lint Errors:
+    cat LINT_ERRORS
+    echo "================================================================="
+    cat LINT | grep -v "Done processing"
+    echo 
+    exit 1
+  fi
+}
+
+style_check src/lib/logMsg

--- a/scripts/style_check_in_makefile.sh
+++ b/scripts/style_check_in_makefile.sh
@@ -45,4 +45,24 @@ function style_check
 style_check src/lib/logMsg
 style_check src/lib/parseArgs
 
-# FIXME: Just keep adding directories here until all of them are included ...
+# FIXME: Just keep adding directories here until all of them are included:
+#
+# style_check src/lib/alarmMgr
+# style_check src/lib/apiTypesV2
+# style_check src/lib/cache
+# style_check src/lib/common
+# style_check src/lib/convenience
+# style_check src/lib/jsonParse
+# style_check src/lib/jsonParseV2
+# style_check src/lib/logSummary
+# style_check src/lib/mongoBackend
+# style_check src/lib/ngsi
+# style_check src/lib/ngsi10
+# style_check src/lib/ngsi9
+# style_check src/lib/ngsiNotify
+# style_check src/lib/orionTypes
+# style_check src/lib/parse
+# style_check src/lib/rest
+# style_check src/lib/serviceRoutines
+# style_check src/lib/serviceRoutinesV2
+# style_check src/app/contextBroker

--- a/scripts/style_check_in_makefile.sh
+++ b/scripts/style_check_in_makefile.sh
@@ -30,7 +30,7 @@
 #
 function style_check
 {
-  style_check.sh -d src/lib/logMsg
+  style_check.sh -d "$1"
   if [ "$?" != 0 ]
   then
     echo Lint Errors:

--- a/scripts/style_check_in_makefile.sh
+++ b/scripts/style_check_in_makefile.sh
@@ -43,6 +43,6 @@ function style_check
 }
 
 style_check src/lib/logMsg
+style_check src/lib/parseArgs
 
-# style_check src/lib/parseArgs
 # FIXME: Just keep adding directories here until all of them are included ...

--- a/src/lib/logMsg/logMsg.cpp
+++ b/src/lib/logMsg/logMsg.cpp
@@ -438,8 +438,8 @@ const char* lmSemGet(void)
   {
     return "taken";
   }
-  
-  return "free";  
+
+  return "free";
 }
 
 

--- a/src/lib/parseArgs/baStd.cpp
+++ b/src/lib/parseArgs/baStd.cpp
@@ -166,7 +166,7 @@ float baStof(char* string)
 {
   float f;
 
-  sscanf(string, "%f", &f);
+  f = strtod(string, NULL);
 
   return f;
 }
@@ -181,7 +181,7 @@ double baStod(char* string)
 {
   double f;
 
-  sscanf(string, "%lf", &f);
+  f = strtod(string, NULL);
 
   return f;
 }

--- a/src/lib/parseArgs/paBuiltin.cpp
+++ b/src/lib/parseArgs/paBuiltin.cpp
@@ -78,6 +78,8 @@ char            paLogLevel[256];
 #define PAI_REST         PafUnchanged, { 'N', 'a', 'm', 'e', 0 }, 0, 0, false, false, false, true, false, false, 0
 #define PAI_REST_U       PafUnchanged, { 'N', 'a', 'm', 'e', 0 }, 0, 0, false, false, false, true, false, true,  0
 #define PAI_END_OF_ARGS  { "^D", NULL, "NADA", PaLastArg, PaReq, 0, 0, 0, "", PAI_REST }
+#define LOGLEVEL_DESC    "initial log level (NONE, ERROR, WARNING, INFO, DEBUG)"
+
 /* ****************************************************************************
 *
 * paBuiltin - 
@@ -120,7 +122,7 @@ PaiArgument paBuiltin[] =
   { "",           paVisual,        "!VISUAL",     PaStr,  PaHid,  0, PaNL, PaNL, "visual",              PAI_REST   },
   { "-t",         paTraceV,        "TRACE",       PaStr,  PaOpt,  0, PaNL, PaNL, "trace level",         PAI_REST_U },
   { "--silent",   &paSilent,       "SILENT",      PaBool, PaHid,  F,    T,    F, "silent mode",         PAI_REST_U },
-  { "-logLevel",  &paLogLevel,     "LOG_LEVEL",   PaStr,  PaOpt,  0, PaNL, PaNL, "initial log level (NONE, ERROR, WARNING, INFO, DEBUG)", PAI_REST_U },
+  { "-logLevel",  &paLogLevel,     "LOG_LEVEL",   PaStr,  PaOpt,  0, PaNL, PaNL, LOGLEVEL_DESC,         PAI_REST_U },
   { "-v",         &paVerbose,      "VERBOSE",     PaBool, PaOpt,  F,    T,    F, "verbose mode",        PAI_REST_U },
   { "-vv",        &paVerbose2,     "VERBOSE2",    PaBool, PaOpt,  F,    T,    F, "verbose2 mode",       PAI_REST_U },
   { "-vvv",       &paVerbose3,     "VERBOSE3",    PaBool, PaOpt,  F,    T,    F, "verbose3 mode",       PAI_REST_U },

--- a/src/lib/parseArgs/paConfig.cpp
+++ b/src/lib/parseArgs/paConfig.cpp
@@ -277,7 +277,7 @@ void paConfigCleanup(void)
 
   if (paManExitStatus)
   {
-    //LM_T(LmtParse,("Freeing paManExitStatus"));
+    // LM_T(LmtParse,("Freeing paManExitStatus"));
     PA_M(("Freeing paManExitStatus"));
     free(paManExitStatus);
     paManExitStatus = NULL;
@@ -285,7 +285,7 @@ void paConfigCleanup(void)
 
   if (paManAuthor)
   {
-    //LM_T(LmtParse,("Freeing paManAuthor"));
+    // LM_T(LmtParse,("Freeing paManAuthor"));
     PA_M(("Freeing paManAuthor"));
     free(paManAuthor);
     paManAuthor = NULL;
@@ -969,7 +969,7 @@ int paConfigActions(bool preTreat)
       {
         ok = validLogLevelCheck(paValidLogLevels, paLogLevel);
       }
-      
+
       if (ok == true)
       {
         lmLevelMaskSetString(paLogLevel);

--- a/src/lib/parseArgs/paOptionsParse.cpp
+++ b/src/lib/parseArgs/paOptionsParse.cpp
@@ -363,7 +363,8 @@ int paOptionsParse(PaiArgument* paList, char* argV[], int argC)
         if (paBoolWithValueIsUnrecognized == true)
           snprintf(w, sizeof(w), "'%s' not recognized",  argV[argNo]);
         else
-          snprintf(w, sizeof(w), "%s is a boolean option - cannot have a value (%s)", aP->name, &argV[argNo][strlen(aP->option)]);
+          snprintf(w, sizeof(w), "%s is a boolean option - cannot have a value (%s)",
+                   aP->name, &argV[argNo][strlen(aP->option)]);
 
         PA_W(("Warning: '%s'", w));
         PA_WARNING(PasNoSuchOption, w);

--- a/src/lib/parseArgs/paParse.cpp
+++ b/src/lib/parseArgs/paParse.cpp
@@ -467,7 +467,6 @@ int paParse
       {
         break;
       }
-
     }
   }
 


### PR DESCRIPTION
Style guide checks incorporated in make targets `di` and `release`.
For now, only `logMsg` and `parseArgs` libraries are included in the style checks.
