### PR TITLE
FIX change log level to uppercase in log API doc

### DIFF
--- a/doc/manuals/admin/management_api.md
+++ b/doc/manuals/admin/management_api.md
@@ -8,7 +8,7 @@ API for management that allows to change the log level and the trace levels
 To change the log level:
 
 ```
-curl --request PUT <host>:<port>/admin/log?level=<fatal|error|warning|warn|info|debug|none>
+curl --request PUT <host>:<port>/admin/log?level=<FATAL|ERROR|WARNING|WARN|INFO|DEBUG|NONE>
 ```
 
 


### PR DESCRIPTION
It has been recently decided that the standard codification for log levels is in upper case. Thus, documentation should use upper case.

(Anyway, it is ok to supporr also lowercase in the implementation, as a "convenience" alternative flavour of the API).