### PR TITLE
Feature/issue 2128 delete entity tests

### DIFF
--- a/test/acceptance/behave/README.md
+++ b/test/acceptance/behave/README.md
@@ -276,7 +276,7 @@ The log is stored in `logs` folder (if this folder does not exist it is created)
 | update_or_append_entity_attributes          |    823       | POST    | /v2/entities/`<entity_id>`                           | Yes       | Yes            |  
 | update_existing_entity_attributes           |    642       | PATCH   | /v2/entities/`<entity_id>`                           | Yes       | Yes            |
 | replace_all_entity_attributes               |    586       | PUT     | /v2/entities/`<entity_id>`                           | Yes       | Yes            |  
-| remove_entity                               |     92       | DELETE  | /v2/entities/`<entity_id>`                           | No        | Yes            |
+| remove_entity                               |    101       | DELETE  | /v2/entities/`<entity_id>`                           | No        | Yes            |
 |                                                                                                                                                          |
 |**attributes folder**                                                                                                                                     |
 | get_attribute_data                          |    244       | GET     | /v2/entities/`<entity_id>`/attrs/`<attr_name>`       | No        | Yes            |   

--- a/test/acceptance/behave/components/common_steps/entities/create_update_replace_steps.py
+++ b/test/acceptance/behave/components/common_steps/entities/create_update_replace_steps.py
@@ -57,6 +57,7 @@ def definition_of_headers(context):
     __logger__.info("Define header used in request...")
     context.cb.definition_headers(context)
 
+
 @step(u'modify headers and keep previous values "([^"]*)"')
 def definition_of_headers(context, prev):
     """
@@ -66,6 +67,7 @@ def definition_of_headers(context, prev):
     """
     __logger__.info("Modify or append headers used in new request...")
     context.cb.modification_headers(context, prev)
+
 
 @step(u'properties to entities')
 def properties_to_entities(context):

--- a/test/acceptance/behave/components/common_steps/general_steps.py
+++ b/test/acceptance/behave/components/common_steps/general_steps.py
@@ -114,6 +114,7 @@ def send_a_cache_statistics_request(context):
     context.resp = context.cb.get_cache_statistics_request()
     __logger__.info("..Sent a statistics request correctly")
 
+
 @step(u'delete database in mongo')
 def delete_database_in_mongo(context):
     """
@@ -162,8 +163,8 @@ def check_in_log_label_and_text(context, label, text):
     __logger__.info("...confirmed traces in log")
 
 
-
 # ------------------------------------- validations ----------------------------------------------
+
 
 @step(u'verify that receive a.? "([^"]*)" http code')
 def verify_that_receive_an_http_code(context, http_code):

--- a/test/acceptance/behave/components/ngsiv2/entities/remove_entity/remove_entity.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/remove_entity/remove_entity.feature
@@ -70,12 +70,64 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | id     | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value                  |
+      | Fiware-Service     | test_delete_happy_path |
+      | Fiware-ServicePath | /test                  |
     When delete an entity with id "room_1"
     Then verify that receive a "No Content" http code
     And verify that entities are not stored in mongo
 
-  # ------------------------ Service ----------------------------------------------
+  # ------------------------ Content-Type header ----------------------------------------------
+  @with_content_type @BUG_2128
+  Scenario Outline: try to delete an entity using NGSI v2 API with content type header
+    Given a definition of headers
+      | parameter          | value                  |
+      | Fiware-Service     | test_delete_happy_path |
+      | Fiware-ServicePath | /test                  |
+      | Content-Type       | application/json       |
+    # These properties below are used in create request
+    And properties to entities
+      | parameter         | value       |
+      | entities_type     | house       |
+      | entities_id       | room        |
+      | attributes_number | 3           |
+      | attributes_name   | temperature |
+      | attributes_value  | 45          |
+      | attributes_type   | celsius     |
+      | metadatas_number  | 2           |
+      | metadatas_name    | very_hot    |
+      | metadatas_type    | alarm       |
+      | metadatas_value   | hot         |
+    And create entity group with "3" entities in "normalized" mode
+      | entity | prefix |
+      | id     | true   |
+    And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value                  |
+      | Fiware-Service     | test_delete_happy_path |
+      | Fiware-ServicePath | /test                  |
+      | Content-Type       | <content_type>         |
+    When delete an entity with id "room_1"
+    Then verify that receive a "Bad Request" http code
+    And verify an error response
+      | parameter   | value                                                                                        |
+      | error       | BadRequest                                                                                   |
+      | description | Orion accepts no payload for GET/DELETE requests. HTTP header Content-Type is thus forbidden |
+    Examples:
+      | content_type                      |
+      | application/json                  |
+      | application/xml                   |
+      | application/x-www-form-urlencoded |
+      | multipart/form-data               |
+      | text/plain                        |
+      | text/html                         |
+      | dsfsdfsdf                         |
+      | <sdsd>                            |
+      | (eeqweqwe)                        |
+      |                                   |
 
+  # ------------------------ Service header ----------------------------------------------
   @service_delete
   Scenario Outline: Delete entities by ID using NGSI v2 with several service header values
     Given a definition of headers
@@ -100,6 +152,10 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | id     | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value                                  |
+      | Fiware-Service     | the same value of the previous request |
+      | Fiware-ServicePath | /test                                  |
     When delete an entity with id "room_1"
     Then verify that receive an "No Content" http code
     And verify that entities are not stored in mongo
@@ -135,6 +191,9 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | id     | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value |
+      | Fiware-ServicePath | /test |
     When delete an entity with id "room_1"
     Then verify that receive a "No Content" http code
     And verify that entities are not stored in mongo
@@ -142,10 +201,9 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
   @service_delete_error @BUG_1873
   Scenario Outline: Try to delete entities by ID using NGSI v2 with wrong service header values
     Given a definition of headers
-      | parameter          | value            |
-      | Fiware-Service     | <service>        |
-      | Fiware-ServicePath | /test            |
-      | Content-Type       | application/json |
+      | parameter          | value     |
+      | Fiware-Service     | <service> |
+      | Fiware-ServicePath | /test     |
     When delete an entity with id "room_1"
     Then verify that receive a "Bad Request" http code
     And verify an error response
@@ -170,7 +228,6 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | parameter          | value                           |
       | Fiware-Service     | greater than max length allowed |
       | Fiware-ServicePath | /test                           |
-      | Content-Type       | application/json                |
     When delete an entity with id "room_1"
     Then verify that receive a "Bad Request" http code
     And verify an error response
@@ -179,7 +236,6 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | description | bad length - a tenant name can be max 50 characters long |
 
   # ------------------------ Service path ----------------------------------------------
-
   @service_path_delete @BUG_1423
   Scenario Outline: Delete entities by ID using NGSI v2 with several service path header values
     Given a definition of headers
@@ -204,6 +260,10 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | id     | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value                                  |
+      | Fiware-Service     | test_delete_service_path               |
+      | Fiware-ServicePath | the same value of the previous request |
     When delete an entity with id "room_1"
     Then verify that receive an "No Content" http code
     And verify that entities are not stored in mongo
@@ -242,6 +302,9 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | id     | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter      | value                    |
+      | Fiware-Service | test_delete_service_path |
     When delete an entity with id "room_1"
     Then verify that receive an "No Content" http code
     And verify that entities are not stored in mongo
@@ -252,7 +315,6 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | parameter          | value                          |
       | Fiware-Service     | test_delete_service_path_error |
       | Fiware-ServicePath | <service_path>                 |
-      | Content-Type       | application/json               |
     When delete an entity with id "room_1"
     Then verify that receive a "Bad Request" http code
     And verify an error response
@@ -274,7 +336,6 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | parameter          | value                          |
       | Fiware-Service     | test_delete_service_path_error |
       | Fiware-ServicePath | <service_path>                 |
-      | Content-Type       | application/json               |
     When delete an entity with id "room_1"
     Then verify that receive a "Bad Request" http code
     And verify an error response
@@ -292,7 +353,6 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | parameter          | value                           |
       | Fiware-Service     | test_replace_service_path_error |
       | Fiware-ServicePath | <service_path>                  |
-      | Content-Type       | application/json                |
     When delete an entity with id "room_1"
     Then verify that receive a "Bad Request" http code
     And verify an error response
@@ -310,7 +370,6 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | parameter          | value                                |
       | Fiware-Service     | test_replace_service_path_error      |
       | Fiware-ServicePath | max length allowed and eleven levels |
-      | Content-Type       | application/json                     |
     When delete an entity with id "room_1"
     Then verify that receive a "Bad Request" http code
     And verify an error response
@@ -341,6 +400,10 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | metadatas_value  | hot           |
     And create entity group with "1" entities in "normalized" mode
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value                 |
+      | Fiware-Service     | test_delete_entity_id |
+      | Fiware-ServicePath | /test                 |
     When delete an entity with id "the same value of the previous request"
     Then verify that receive an "No Content" http code
     And verify that entities are not stored in mongo
@@ -369,7 +432,6 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | parameter          | value                 |
       | Fiware-Service     | test_delete_entity_id |
       | Fiware-ServicePath | /test                 |
-      | Content-Type       | application/json      |
     When delete an entity with id "<entity_id>"
     Then verify that receive an "Bad Request" http code
     And verify an error response
@@ -385,10 +447,10 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
   @entity_not_exists
   Scenario: Try to delete an entity by ID but it does not exist using NGSI v2
     Given a definition of headers
-      | parameter          | value                  |
-      | Fiware-Service     | test_delete_happy_path |
-      | Fiware-ServicePath | /test                  |
-      | Content-Type       | application/json       |
+      | parameter          | value                 |
+      | Fiware-Service     | test_delete_entity_id |
+      | Fiware-ServicePath | /test                 |
+      | Content-Type       | application/json      |
    # These properties below are used in create request
     And properties to entities
       | parameter        | value       |
@@ -403,6 +465,10 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | metadatas_value  | hot         |
     And create entity group with "1" entities in "normalized" mode
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value                 |
+      | Fiware-Service     | test_delete_entity_id |
+      | Fiware-ServicePath | /test                 |
     When delete an entity with id "tdsfsdfds"
     Then verify that receive a "Not Found" http code
     And verify an error response
@@ -410,13 +476,13 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | error       | NotFound                                                   |
       | description | The requested entity has not been found. Check type and id |
 
-  @more_entities_delete @BUG_1346 @skip
+  @more_entities_delete @BUG_1346
   Scenario: Try to delete an entity by ID using NGSI v2 with more than one entity with the same id
     Given a definition of headers
-      | parameter          | value                  |
-      | Fiware-Service     | test_delete_happy_path |
-      | Fiware-ServicePath | /test                  |
-      | Content-Type       | application/json       |
+      | parameter          | value                 |
+      | Fiware-Service     | test_delete_entity_id |
+      | Fiware-ServicePath | /test                 |
+      | Content-Type       | application/json      |
    # These properties below are used in create request
     And properties to entities
       | parameter        | value       |
@@ -428,20 +494,23 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | type   | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value                 |
+      | Fiware-Service     | test_delete_entity_id |
+      | Fiware-ServicePath | /test                 |
     When delete an entity with id "room"
     Then verify that receive a "Conflict" http code
     And verify an error response
-      | parameter   | value                                                                          |
-      | error       | TooManyResults                                                                 |
-      | description | There is more than one entity that match the delete. Please refine your query. |
+      | parameter   | value                                                   |
+      | error       | TooManyResults                                          |
+      | description | More than one matching entity. Please refine your query |
 
   @entity_id_delete_invalid
-  Scenario Outline: Try to delete entity by ID using NGSI v2 with invalid entity id values
+  Scenario Outline: Try to delete an entity by ID using NGSI v2 with invalid entity id values
     Given a definition of headers
       | parameter          | value                  |
       | Fiware-Service     | test_replace_entity_id |
       | Fiware-ServicePath | /test                  |
-      | Content-Type       | application/json       |
     When delete an entity with id "<entity_id>"
     Then verify that receive a "Bad Request" http code
     And verify an error response
@@ -462,12 +531,11 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | my house            |
 
   @entity_id_delete_invalid
-  Scenario Outline: Try to delete entity by ID using NGSI v2 with invalid entity id values
+  Scenario Outline: Try to delete an entity by ID using NGSI v2 with invalid entity id values
     Given a definition of headers
       | parameter          | value                  |
       | Fiware-Service     | test_replace_entity_id |
       | Fiware-ServicePath | /test                  |
-      | Content-Type       | application/json       |
     When delete an entity with id "<entity_id>"
     Then verify that receive a "Not Found" http code
     And verify an error response
@@ -479,10 +547,8 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | house_?   |
       | house_/   |
       | house_#   |
-
    #   -------------- queries parameters ------------------------------------------
    #   ---  type query parameter ---
-
   @qp_type
   Scenario Outline:  delete an entity using NGSI v2 with "type" query parameter
     Given  a definition of headers
@@ -501,6 +567,10 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | type   | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value             |
+      | Fiware-Service     | test_attr_type_qp |
+      | Fiware-ServicePath | /test             |
     When delete an entity with id "room"
       | parameter | value   |
       | type      | <types> |
@@ -530,6 +600,10 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | type   | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value             |
+      | Fiware-Service     | test_attr_type_qp |
+      | Fiware-ServicePath | /test             |
     When delete an entity with id "room"
       | parameter | value |
       | type      |       |
@@ -557,6 +631,10 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | type   | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value             |
+      | Fiware-Service     | test_attr_type_qp |
+      | Fiware-ServicePath | /test             |
     When delete an entity with id "room"
       | parameter   | value   |
       | <parameter> | house_1 |
@@ -592,6 +670,10 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | entity | prefix |
       | type   | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value             |
+      | Fiware-Service     | test_attr_type_qp |
+      | Fiware-ServicePath | /test             |
     When delete an entity with id "room"
       | parameter   | value   |
       | <parameter> | house_1 |
@@ -611,4 +693,3 @@ Feature: delete an entity request using NGSI v2 API. "DELETE" - /v2/entities/
       | p(flat)             |
       | {\'a\':34}          |
       | [\'34\', \'a\', 45] |
-


### PR DESCRIPTION
```
                    SUMMARY:
-------------------------------------------------
  - components\ngsiv2\entities\remove_entity\remove_entity.feature >> passed: 95, failed: 0, skipped: 6 and total: 101 with duration: 33.430 seconds.
-------------------------------------------------
  Date: Friday, July 15, 2016 11:13:37
-------------------------------------------------
1 feature passed, 0 failed, 0 skipped
95 scenarios passed, 0 failed, 6 skipped
612 steps passed, 0 failed, 48 skipped, 0 undefined
Took 0m33.430s
```
@kzangeli @crbrox 