### PR TITLE
Fix for subscription case in  API Walkthrough (v2)

### DIFF
--- a/doc/manuals/user/walkthrough_apiv2.md
+++ b/doc/manuals/user/walkthrough_apiv2.md
@@ -669,7 +669,7 @@ curl -v localhost:1026/v2/subscriptions -s -S --header 'Content-Type: applicatio
     ],
     "condition": {
       "attrs": [
-        "temperature"
+        "pressure"
       ]
     }
   },


### PR DESCRIPTION
In the example it is said that:
"For example, in this case, when Room1 `pressure` changes, the Room1 temperature value is notified"
But the temperature of the object is being used as a condition attribute.