### PR TITLE
[FEATURE] content type is not accepted in delete request (log traces)

### DIFF
--- a/test/acceptance/behave/components/ngsiv2/entities/remove_entity/remove_entity_traces_in_log.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/remove_entity/remove_entity_traces_in_log.feature
@@ -70,6 +70,10 @@ Feature: verify fields in log traces with remove entity request using NGSI v2.
       | entity | prefix |
       | id     | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value           |
+      | Fiware-Service     | test_log_traces |
+      | Fiware-ServicePath | /test           |
     When delete an entity with id "room_1"
     Then verify that receive a "No Content" http code
     And verify that entities are not stored in mongo


### PR DESCRIPTION
```
                    SUMMARY:
-------------------------------------------------
  - components\ngsiv2\entities\remove_entity\remove_entity_traces_in_log.feature >> passed: 1, failed: 0, skipped: 0 and total: 1 with duration: 4.781 seconds.
-------------------------------------------------
  Date: Friday, July 15, 2016 15:36:29
-------------------------------------------------
1 feature passed, 0 failed, 0 skipped
1 scenario passed, 0 failed, 0 skipped
11 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m4.781s
```
@fgalan @kzangeli @crbrox 