### PR TITLE
[FIX] regression test in get attribute data - trace in log test suite

### DIFF
--- a/test/acceptance/behave/components/ngsiv2/attributes/get_attribute_data/get_attribute_data_traces_in_log.feature
+++ b/test/acceptance/behave/components/ngsiv2/attributes/get_attribute_data/get_attribute_data_traces_in_log.feature
@@ -70,6 +70,10 @@ Feature: verify fields in log traces with get attribute data request using NGSI 
       | entity | prefix |
       | id     | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value           |
+      | Fiware-Service     | test_log_traces |
+      | Fiware-ServicePath | /test           |
     When get an attribute "temperature_0" by ID "room_1"
     Then verify that receive an "OK" http code
     And verify that the attribute by ID is returned


### PR DESCRIPTION
```
                    SUMMARY:
-------------------------------------------------
  - components\ngsiv2\attributes\get_attribute_data\get_attribute_data_traces_in_log.feature >> passed: 1, failed: 0, skipped: 0 and total: 1 with duration: 5.043 seconds.
-------------------------------------------------
  Date: Tuesday, July 26, 2016 10:34:26
-------------------------------------------------
1 feature passed, 0 failed, 0 skipped
1 scenario passed, 0 failed, 0 skipped
11 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m5.043s
```