### PR TITLE
[FIX] regression test in delete attribute data test suite

### DIFF
--- a/test/acceptance/behave/README.md
+++ b/test/acceptance/behave/README.md
@@ -281,7 +281,7 @@ The log is stored in `logs` folder (if this folder does not exist it is created)
 |**attributes folder**                                                                                                                                     |
 | get_attribute_data                          |    254       | GET     | /v2/entities/`<entity_id>`/attrs/`<attr_name>`       | No        | Yes            |   
 | update_attribute_data                       |    610       | PUT     | /v2/entities/`<entity_id>`/attrs/`<attr_name>`       | Yes       | Yes            |
-| remove_a_single_attribute                   |    121       | DELETE  | /v2/entities/`<entity_id>`/attrs/`<attr_name>`       | No        | Yes            |
+| remove_a_single_attribute                   |    132       | DELETE  | /v2/entities/`<entity_id>`/attrs/`<attr_name>`       | No        | Yes            |
 |                                                                                                                                                          |
 |**attributes_value folder**                                                                                                                               |
 | get_attribute_value                         |    190       | GET     | /v2/entities/`<entity_id>`/attrs/`<attr_name>`/value | No        | Yes            |  

--- a/test/acceptance/behave/components/ngsiv2/attributes/remove_a_single_attribute/remove_a_single_attribute.feature
+++ b/test/acceptance/behave/components/ngsiv2/attributes/remove_a_single_attribute/remove_a_single_attribute.feature
@@ -530,7 +530,7 @@ Feature: delete an attribute request using NGSI v2 API. "DELETE" - /v2/entities/
       | description | More than one matching entity. Please refine your query |
 
   @entity_id_delete_invalid
-  Scenario Outline: Try to delete an attribute by entity ID using NGSI v2with invalid entity id values
+  Scenario Outline: Try to delete an attribute by entity ID using NGSI v2 with invalid entity id values
     Given a definition of headers
       | parameter          | value                  |
       | Fiware-Service     | test_replace_entity_id |

--- a/test/acceptance/behave/components/ngsiv2/attributes/remove_a_single_attribute/remove_a_single_attribute_traces_in_log.feature
+++ b/test/acceptance/behave/components/ngsiv2/attributes/remove_a_single_attribute/remove_a_single_attribute_traces_in_log.feature
@@ -70,6 +70,10 @@ Feature: verify fields in log traces with remove a single attribute request usin
       | entity | prefix |
       | id     | true   |
     And verify that receive several "Created" http code
+    And modify headers and keep previous values "false"
+      | parameter          | value           |
+      | Fiware-Service     | test_log_traces |
+      | Fiware-ServicePath | /test           |
     When delete an attribute "temperature_0" in the entity with id "room_1"
     Then verify that receive an "No Content" http code
     And verify that the attribute is deleted into mongo in the defined entity


### PR DESCRIPTION
```

                    SUMMARY:
-------------------------------------------------
  - components\ngsiv2\attributes\remove_a_single_attribute\remove_a_single_attribute.feature >> passed: 124, failed: 0, skipped: 7 and total: 131 with duration: 41.426 seconds.
  - components\ngsiv2\attributes\remove_a_single_attribute\remove_a_single_attribute_traces_in_log.feature >> passed: 1, failed: 0, skipped: 0 and total: 1 with duration: 4.866 seconds.
-------------------------------------------------
  Date: Tuesday, July 26, 2016 11:19:57
-------------------------------------------------
2 features passed, 0 failed, 0 skipped
125 scenarios passed, 0 failed, 7 skipped
787 steps passed, 0 failed, 56 skipped, 0 undefined
Took 0m46.292s
```
@fgalan @kzangeli @crbrox 