### PR TITLE
hardening/no_cache_in_test_harness

### DIFF
--- a/test/functionalTest/cases/1048_subscription_cache/three_subscriptions.test
+++ b/test/functionalTest/cases/1048_subscription_cache/three_subscriptions.test
@@ -25,7 +25,7 @@ notifyFormat_ngsi10
 
 --SHELL-INIT--
 dbInit CB
-brokerStart CB 38,101 IPv4 -statSemWait
+brokerStart CB 38,101 IPv4 -statSemWait --cache
 accumulatorStart
 
 --SHELL--

--- a/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpirationAfterRefresh.test
+++ b/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpirationAfterRefresh.test
@@ -26,7 +26,7 @@ Subscription Cache Throttling and expiration after Refresh
 --SHELL-INIT--
 dbInit CB
 dbInit CB t1
-brokerStart CB 38,101 IPv4 -multiservice -subCacheIval 10
+brokerStart CB 38,101 IPv4 -multiservice -subCacheIval 10 --cache
 accumulatorStart
 
 --SHELL--

--- a/test/functionalTest/cases/1308_subscription_cache/sub_expired_and_updated_then_cache_refresh.test
+++ b/test/functionalTest/cases/1308_subscription_cache/sub_expired_and_updated_then_cache_refresh.test
@@ -25,7 +25,7 @@ notifyFormat_ngsi10
 
 --SHELL-INIT--
 dbInit CB
-brokerStart CB 38,101,102 IPv4 -subCacheIval 8
+brokerStart CB 38,101,102 IPv4 -subCacheIval 8 --cache
 accumulatorStart
 
 --SHELL--

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -518,7 +518,26 @@ function brokerStart()
   shift
   shift
 
-  extraParams=$*
+  # Check for --noCache and --cache options in 'extraParams'
+  xParams=""
+  while [ "$#" != 0 ]
+  do
+    if   [ "$1" == "--noCache" ];            then noCache=ON;
+    elif [ "$1" == "--cache" ];              then noCache=OFF;
+    elif [ "$1" == "-noCache" ];             then noCache=ON;
+    elif [ "$1" == "-cache" ];               then noCache=OFF;
+    else xParams=$xParams' '$1
+    fi
+    shift
+  done
+
+  if [ "$noCache" != "OFF" ]
+  then
+    if [ "$CB_NO_CACHE" == "ON" ] || [ "$noCache"  == "ON" ]
+    then
+      xParams=$xParams' -noCache'
+    fi
+  fi
 
   if [ "$role" == "" ]
   then
@@ -532,7 +551,7 @@ function brokerStart()
   fi
 
   localBrokerStop $role
-  localBrokerStart $role $traceLevels $ipVersion $extraParams
+  localBrokerStart $role $traceLevels $ipVersion $xParams
 }
 
 

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -28,7 +28,6 @@ MAX_TRIES=${CB_MAX_TRIES:-3}
 echo $testStartTime > /tmp/brokerStartCounter
 
 
-
 # ------------------------------------------------------------------------------
 #
 # Find out in which directory this script resides
@@ -97,6 +96,8 @@ function usage()
   echo "$empty [--ixList <list of test indexes>]"
   echo "$empty [--stopOnError (stop at first error encountered)]"
   echo "$empty [--no-duration (removes duration mark on successful tests)]"
+  echo "$empty [--noCache (force broker to be started with the option --noCache)]"
+  echo "$empty [--cache (force broker to be started without the option --noCache)]"
   echo "$empty [ <directory or file> ]*"
   echo
   echo "* Please note that if a directory is passed as parameter, its entire path must be given, not only the directory-name"
@@ -194,6 +195,7 @@ filterGiven=no
 showDuration=on
 fromIx=0
 ixList=""
+noCache=""
 
 vMsg "parsing options"
 while [ "$#" != 0 ]
@@ -209,6 +211,8 @@ do
   elif [ "$1" == "--fromIx" ];      then fromIx=$2; shift;
   elif [ "$1" == "--ixList" ];      then ixList=$2; shift;
   elif [ "$1" == "--no-duration" ]; then showDuration=off;
+  elif [ "$1" == "--noCache" ];     then noCache=ON;
+  elif [ "$1" == "--cache" ];       then noCache=OFF;
   else
     if [ "$dirOrFile" == "" ]
     then
@@ -223,6 +227,18 @@ do
 done
 
 vMsg "options parsed"
+
+
+
+# -----------------------------------------------------------------------------
+#
+# The function brokerStart looks at the env var CB_NO_CACHE to decide
+# whether to start the broker with the --noCache option or not
+#
+if [ "$noCache" != "" ]
+then
+  export CB_NO_CACHE=$noCache
+fi
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
New options for harness test script and brokerStart function: --noCache and --cache