### PR TITLE
Temporary: not deleting compounds in Metadata::release - to avoid crashes

### DIFF
--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -368,7 +368,7 @@ void Metadata::release(void)
 {
   if (compoundValueP != NULL)
   {
-    delete compoundValueP;
+    // delete compoundValueP;
     compoundValueP = NULL;
   }
 }

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -115,11 +115,11 @@ CompoundValueNode::CompoundValueNode
 }
 
 
+
 /* ****************************************************************************
 *
 * CompoundValueNode - constructor for all nodes except toplevel (char*)
 */
-
 CompoundValueNode::CompoundValueNode
 (
   CompoundValueNode*  _container,
@@ -183,6 +183,8 @@ CompoundValueNode::CompoundValueNode
                           orion::valueTypeName(valueType),
                           this));
 }
+
+
 
 /* ****************************************************************************
 *


### PR DESCRIPTION
Simply commented the call to `delete compoundValueP`in Metadata::release().
All tests in 1156_* run OK,

This is very temporary, a real fix is needed ASAP.