### PR TITLE
Hardening/metadata compound liberation

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1862,8 +1862,15 @@ static void updateAttrInNotifyCer
             }
 
             // Steal compound value from targetMdP
-            mdP->compoundValueP       = targetMdP->compoundValueP;
-            targetMdP->compoundValueP = NULL;
+            // mdP->compoundValueP       = targetMdP->compoundValueP;
+            // targetMdP->compoundValueP = NULL;
+
+            // Clone compound value of targetMdP
+            if (targetMdP->compoundValueP != NULL)
+            {
+              mdP->compoundValueP       = targetMdP->compoundValueP->clone();
+            }
+
 
             if (targetMdP->type != "")
             {

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1862,15 +1862,8 @@ static void updateAttrInNotifyCer
             }
 
             // Steal compound value from targetMdP
-            // mdP->compoundValueP       = targetMdP->compoundValueP;
-            // targetMdP->compoundValueP = NULL;
-
-            // Clone compound value of targetMdP
-            if (targetMdP->compoundValueP != NULL)
-            {
-              mdP->compoundValueP       = targetMdP->compoundValueP->clone();
-            }
-
+            mdP->compoundValueP       = targetMdP->compoundValueP;
+            targetMdP->compoundValueP = NULL;
 
             if (targetMdP->type != "")
             {

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -80,7 +80,7 @@ Metadata::Metadata(Metadata* mP, bool useDefaultType)
   numberValue     = mP->numberValue;
   boolValue       = mP->boolValue;
   typeGiven       = mP->typeGiven;
-  compoundValueP  = mP->compoundValueP;
+  compoundValueP  = (mP->compoundValueP != NULL)? mP->compoundValueP->clone() : NULL;
 
   if (useDefaultType && !typeGiven)
   {
@@ -368,7 +368,7 @@ void Metadata::release(void)
 {
   if (compoundValueP != NULL)
   {
-    // delete compoundValueP;
+    delete compoundValueP;
     compoundValueP = NULL;
   }
 }
@@ -476,7 +476,7 @@ std::string Metadata::toJson(bool isLastElement)
       compoundValueP->name  = "value";
       compoundValueP->rootP = NULL;
 
-      out += compoundValueP->toJson(true);
+      out += compoundValueP->toJson(isLastElement, false);
     }
     else if (compoundValueP->isVector())
     {

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -456,7 +456,7 @@ std::string Metadata::toJson(bool isLastElement)
   }
   else if (valueType == orion::ValueTypeObject)
   {
-    if (compoundValueP->isObject())
+    if ((compoundValueP->isObject()) || (compoundValueP->isVector()))
     {
       std::string out2;
 
@@ -478,10 +478,6 @@ std::string Metadata::toJson(bool isLastElement)
 
       out += compoundValueP->toJson(isLastElement, false);
     }
-    else if (compoundValueP->isVector())
-    {
-      out += std::string("\"value\"") + ":[" + compoundValueP->toJson(true) + "]";
-    }    
   }
   else
   {

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -742,15 +742,17 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, const std::string& in
 /* ****************************************************************************
 *
 * toJson -
+*
+* FIXME P3: isLastElement is not used and should be removed
 */
-std::string CompoundValueNode::toJson(bool isLastElement)
+std::string CompoundValueNode::toJson(bool isLastElement, bool comma)
 {
   std::string  out       = "";
   bool         jsonComma = siblingNo < (int) container->childV.size() - 1;
   std::string  key       = (container->valueType == orion::ValueTypeVector)? "item" : name;
 
   // No "comma after" if toplevel
-  if (container == this)
+  if ((container == this) || (comma == false))
   {
     jsonComma = false;
   }

--- a/src/lib/parse/CompoundValueNode.h
+++ b/src/lib/parse/CompoundValueNode.h
@@ -160,7 +160,7 @@ class CompoundValueNode
   std::string         check(void);
   std::string         finish(void);
   std::string         render(ConnectionInfo* ciP, const std::string& indent);
-  std::string         toJson(bool isLastElement);
+  std::string         toJson(bool isLastElement, bool comma = true);
 
   void                shortShow(const std::string& indent);
   void                show(const std::string& indent);


### PR DESCRIPTION
Fixed the problems with calling delete on compound pointer in Metadata::release.
Also, fixed a bug about commas in metadata compound values