### PR TITLE
Bug/2419 log level

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -49,6 +49,7 @@
 - Fix: Better error returned on invalid geoquery (Issue #2174)
 - Fix: Better error returned on attribute not found in GET /v2/entities/<entity-id>/attrs/<attr-name>/value (Issue #2220)
 - Fix: Metadata identification based on just name instead of name+type (metadata representation at DB changed from vector to object)  (#1112)
+- Fix: Bug in log level configuration via REST fixed (Issue #2419)
 - Fix: Distinguish between strings and numbers in q string filter (Issue #1129)
 - Fix: proper response for 'GET /v2/entities/<id>?attrs=<attrName>' and 'GET /v2/entities/<id>/attrs?attrs=<attrName>' when <attrName> doesn't exist (#2241)
 - Fix: In error responses for ngsi9 registrations, the duration is no longer rendered.

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -207,7 +207,9 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
       ciP->uriParamTypes.push_back(val);
     }
   }
-  else if ((key != URI_PARAM_Q) && (key != URI_PARAM_MQ))  // FIXME P1: possible more known options here ...
+  else if ((key != URI_PARAM_Q)       &&
+           (key != URI_PARAM_MQ)      &&
+           (key != URI_PARAM_LEVEL))  // FIXME P1: possible more known options here ...
   {
     LM_T(LmtUriParams, ("Received unrecognized URI parameter: '%s'", key.c_str()));
   }

--- a/src/lib/serviceRoutinesV2/logLevelTreat.cpp
+++ b/src/lib/serviceRoutinesV2/logLevelTreat.cpp
@@ -78,11 +78,11 @@ std::string changeLogLevel
   {
     if (strcasecmp(levelP, "fatal") == 0)
     {
-      level = "None";
+      level = "NONE";
     }
-    else if (strcasecmp(levelP, "warn") == 0)
+    else if (strcasecmp(levelP, "warning") == 0)
     {
-      level = "Warning";
+      level = "WARN";
     }
 
     lmLevelMaskSetString((char*) level.c_str());
@@ -112,6 +112,15 @@ std::string getLogLevel
 )
 {
   std::string  level = lmLevelMaskStringGet();
+
+  if (level == "NONE")
+  {
+    level = "FATAL";
+  }
+  else if (level == "Warning")
+  {
+    level = "WARN";
+  }
 
   return "{\"level\":\"" + level + "\"}";
 }

--- a/src/lib/serviceRoutinesV2/logLevelTreat.cpp
+++ b/src/lib/serviceRoutinesV2/logLevelTreat.cpp
@@ -117,10 +117,6 @@ std::string getLogLevel
   {
     level = "FATAL";
   }
-  else if (level == "Warning")
-  {
-    level = "WARN";
-  }
 
   return "{\"level\":\"" + level + "\"}";
 }

--- a/test/functionalTest/cases/2419_log_level/log_level.test
+++ b/test/functionalTest/cases/2419_log_level/log_level.test
@@ -31,9 +31,9 @@ brokerStart CB
 
 #
 # 01. Set log level to FATAL (which the broker does not really support)
-# 02. GET log level
+# 02. GET log level, see FATAL
 # 03. Set log level to WARN
-# 04. GET log level
+# 04. GET log level, see WARN
 #
 
 echo "01. Set log level to FATAL (which the broker does not really support)"
@@ -43,8 +43,8 @@ echo
 echo
 
 
-echo "02. GET log level"
-echo "================="
+echo "02. GET log level, see FATAL"
+echo "============================"
 orionCurl --url /admin/log
 echo
 echo
@@ -57,8 +57,8 @@ echo
 echo
 
 
-echo "04. GET log level"
-echo "================="
+echo "04. GET log level, see WARN"
+echo "==========================="
 orionCurl --url /admin/log
 echo
 echo
@@ -74,8 +74,8 @@ Date: REGEX(.*)
 
 
 
-02. GET log level
-=================
+02. GET log level, see FATAL
+============================
 HTTP/1.1 200 OK
 Content-Length: 17
 Content-Type: application/json
@@ -96,8 +96,8 @@ Date: REGEX(.*)
 
 
 
-04. GET log level
-=================
+04. GET log level, see WARN
+===========================
 HTTP/1.1 200 OK
 Content-Length: 16
 Content-Type: application/json

--- a/test/functionalTest/cases/2419_log_level/log_level.test
+++ b/test/functionalTest/cases/2419_log_level/log_level.test
@@ -1,0 +1,115 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Log level via REST
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Set log level to FATAL (which the broker does not really support)
+# 02. GET log level
+# 03. Set log level to WARN
+# 04. GET log level
+#
+
+echo "01. Set log level to FATAL (which the broker does not really support)"
+echo "====================================================================="
+orionCurl --url /admin/log?level=FATAL -X PUT
+echo
+echo
+
+
+echo "02. GET log level"
+echo "================="
+orionCurl --url /admin/log
+echo
+echo
+
+
+echo "03. Set log level to WARN"
+echo "========================="
+orionCurl --url /admin/log?level=WARN -X PUT
+echo
+echo
+
+
+echo "04. GET log level"
+echo "================="
+orionCurl --url /admin/log
+echo
+echo
+
+
+--REGEXPECT--
+01. Set log level to FATAL (which the broker does not really support)
+=====================================================================
+HTTP/1.1 200 OK
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. GET log level
+=================
+HTTP/1.1 200 OK
+Content-Length: 17
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "level": "FATAL"
+}
+
+
+03. Set log level to WARN
+=========================
+HTTP/1.1 200 OK
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. GET log level
+=================
+HTTP/1.1 200 OK
+Content-Length: 16
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "level": "WARN"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+


### PR DESCRIPTION
Fixed the response for modifying log levels, issue #2419.
Everything worked the way it should internally, but the broker didn't respond the way it should.
Also, removed the annoying trace line about 'URI param not recognized' for logLevel requests.