### PR TITLE
Functest for hash in URI as entityId or attribute name

### DIFF
--- a/src/lib/parse/forbiddenChars.cpp
+++ b/src/lib/parse/forbiddenChars.cpp
@@ -97,6 +97,7 @@ bool forbiddenIdChars(const std::string& api, const char* s, const char* excepti
   {
     return forbiddenChars(s, exceptions);  // old behavior
   }
+
   return forbiddenIdCharsV2(s, exceptions);
 }
 
@@ -120,10 +121,12 @@ bool forbiddenIdCharsV2(const char* s, const char* exceptions)
       ++s;
       continue;
     }
+
     if (*s >= 127 || *s <= 32)
     {
       return true;
     }
+
     switch (*s)
     {
     case '?':

--- a/test/functionalTest/cases/1887_hash_in_url_gives_strange_results/hash_in_url_gives_strange_results.test
+++ b/test/functionalTest/cases/1887_hash_in_url_gives_strange_results/hash_in_url_gives_strange_results.test
@@ -32,6 +32,8 @@ brokerStart CB
 #
 # 01. GET /v2/entities/E1_#/attrs/A1/value
 # 02. GET /v2/entities/E1/attrs/A1_#/value
+# 03. GET /v2/entities/E1_#/attrs/A1/value, Accept text/plain
+# 04. GET /v2/entities/E1/attrs/A1_#/value, Accept text/plain
 #
 
 echo '01. GET /v2/entities/E1_#/attrs/A1/value'
@@ -44,6 +46,20 @@ echo
 echo '02. GET /v2/entities/E1/attrs/A1_#/value'
 echo '========================================'
 orionCurl --url '/v2/entities/E1/attrs/A1_#/value'
+echo
+echo
+
+
+echo '03. GET /v2/entities/E1_#/attrs/A1/value, Accept text/plain'
+echo '==========================================================='
+orionCurl --url '/v2/entities/E1_#/attrs/A1/value' --out text/plain
+echo
+echo
+
+
+echo '04. GET /v2/entities/E1/attrs/A1_#/value, Accept text/plain'
+echo '==========================================================='
+orionCurl --url '/v2/entities/E1/attrs/A1_#/value' --out text/plain
 echo
 echo
 
@@ -75,6 +91,28 @@ Date: REGEX(.*)
     "description": "invalid character in URI",
     "error": "BadRequest"
 }
+
+
+03. GET /v2/entities/E1_#/attrs/A1/value, Accept text/plain
+===========================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: text/plain
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{"error":"BadRequest","description":"invalid character in URI"}
+
+
+04. GET /v2/entities/E1/attrs/A1_#/value, Accept text/plain
+===========================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: text/plain
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{"error":"BadRequest","description":"invalid character in URI"}
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/1887_hash_in_url_gives_strange_results/hash_in_url_gives_strange_results.test
+++ b/test/functionalTest/cases/1887_hash_in_url_gives_strange_results/hash_in_url_gives_strange_results.test
@@ -1,0 +1,82 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Hash sign in URL gives strange results
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. GET /v2/entities/E1_#/attrs/A1/value
+# 02. GET /v2/entities/E1/attrs/A1_#/value
+#
+
+echo '01. GET /v2/entities/E1_#/attrs/A1/value'
+echo '========================================'
+orionCurl --url '/v2/entities/E1_#/attrs/A1/value'
+echo
+echo
+
+
+echo '02. GET /v2/entities/E1/attrs/A1_#/value'
+echo '========================================'
+orionCurl --url '/v2/entities/E1/attrs/A1_#/value'
+echo
+echo
+
+
+--REGEXPECT--
+01. GET /v2/entities/E1_#/attrs/A1/value
+========================================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "invalid character in URI",
+    "error": "BadRequest"
+}
+
+
+02. GET /v2/entities/E1/attrs/A1_#/value
+========================================
+HTTP/1.1 400 Bad Request
+Content-Length: 63
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "invalid character in URI",
+    "error": "BadRequest"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Functest for the Issue #1887 (part about house_# as EntityId or attrName).
No source code has been changed (except for a few empty lines for readability). It seems to be working.

Note that for the test cases with text/plain, the broker returns JSON.
This is something I believe we have discussed in the past and we've said "Good enough, after all, JSON is plain text ..."
Could be better, but it might be good enough.

Still unable to reproduce the strange error response that is described in issue #1887.