### PR TITLE
Fixed 2419

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -50,7 +50,7 @@
 - Fix: Better error returned on invalid geoquery (Issue #2174)
 - Fix: Better error returned on attribute not found in GET /v2/entities/<entity-id>/attrs/<attr-name>/value (Issue #2220)
 - Fix: Metadata identification based on just name instead of name+type (metadata representation at DB changed from vector to object)  (#1112)
-- Fix: Bug in log level configuration via REST fixed (Issue #2419)
+- Fix: Bug in log level configuration via REST fixed, and log levels in broker modified (Issue #2419)
 - Fix: Distinguish between strings and numbers in q string filter (Issue #1129)
 - Fix: proper response for 'GET /v2/entities/<id>?attrs=<attrName>' and 'GET /v2/entities/<id>/attrs?attrs=<attrName>' when <attrName> doesn't exist (#2241)
 - Fix: correct error response for missing value in URI param in /admin/ requests (Issue #2420)

--- a/doc/manuals/admin/cli.md
+++ b/doc/manuals/admin/cli.md
@@ -86,7 +86,8 @@ The list of available options is the following:
 -   **-logAppend**. If used, the log lines are appended to the existing
     contextBroker log file, instead of starting with an empty log file.
 -   **-logLevel**. Select initial logging level, supported levels:
-    - NONE    (suppress ALL log output, including errors),
+    - NONE    (suppress ALL log output, including fatal error messages),
+    - FATAL   (show only fatal error messages),
     - ERROR   (show only error messages),
     - WARN    (show error and warning messages - this is the default setting),
     - INFO    (show error, warning and informational messages),

--- a/doc/manuals/admin/logs.md
+++ b/doc/manuals/admin/logs.md
@@ -18,6 +18,7 @@ When starting the Orion context broker, if a previous log file exists:
 The `-logLevel` option allows to choose which error messages are printed in the log:
 
 - NONE: no log at all
+- FATAL: only FATAL ERROR messages are logged
 - ERROR: only ERROR messages are logged
 - WARN (default): WARN and ERROR messages are logged
 - INFO: INFO, WARN and ERROR messages are logged
@@ -62,12 +63,12 @@ The different fields in each line are as follows:
 -   **time**. A timestamp corresponding to the moment in which the log
     line was generated in [ISO8601](https://es.wikipedia.org/wiki/ISO_8601) format.
     Orion prints timestamps in UTC format.
--   **lvl (level)**. There are five levels:
-    -   ERROR: This level designates error events. There is a severe
-        problem that should be fixed. A subclass of ERROR is FATAL,
-        which designates very severe error events that will
-        presumably lead the application to abort. The process can no
-        longer work.
+-   **lvl (level)**. There are six levels:
+    -   FATAL: This level designates severe error events
+        that lead the application to exit.
+        The process can no longer work.
+    -   ERROR: This level designates error events.
+        There is a severe problem that must be fixed.
     -   WARN: This level designates potentially harmful situations.
         There is a minor problem that should be fixed.
     -   INFO: This level designates informational messages that

--- a/doc/manuals/admin/management_api.md
+++ b/doc/manuals/admin/management_api.md
@@ -8,7 +8,7 @@ API for management that allows to change the log level and the trace levels
 To change the log level:
 
 ```
-curl -X PUT <host>:<port>/admin/log?level=<FATAL|ERROR|WARN|INFO|DEBUG|NONE>
+curl -X PUT <host>:<port>/admin/log?level=<NONE|FATAL|ERROR|WARN|INFO|DEBUG>
 ```
 
 To retrieve the log level:

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -407,6 +407,7 @@ PaArgument paArgs[] =
 static const char* validLogLevels[] = 
 {
   "NONE",
+  "FATAL",
   "ERROR",
   "WARN",
   "INFO",

--- a/src/lib/logMsg/logMsg.cpp
+++ b/src/lib/logMsg/logMsg.cpp
@@ -557,6 +557,10 @@ void lmLevelMaskSetString(char* level)
   {
     lmLevelMask = 0;
   }
+  else if (strcasecmp(level, "FATAL") == 0)
+  {
+    lmLevelMask  = LogLevelExit;
+  }
   else if (strcasecmp(level, "ERROR") == 0)
   {
     lmLevelMask  = LogLevelExit;
@@ -648,6 +652,10 @@ std::string lmLevelMaskStringGet(void)
   else if (lmLevelMask & LogLevelError)
   {
     return "ERROR";
+  }
+  else if (lmLevelMask & LogLevelExit)
+  {
+    return "FATAL";
   }
   else
   {

--- a/src/lib/parseArgs/paBuiltin.cpp
+++ b/src/lib/parseArgs/paBuiltin.cpp
@@ -78,7 +78,7 @@ char            paLogLevel[256];
 #define PAI_REST         PafUnchanged, { 'N', 'a', 'm', 'e', 0 }, 0, 0, false, false, false, true, false, false, 0
 #define PAI_REST_U       PafUnchanged, { 'N', 'a', 'm', 'e', 0 }, 0, 0, false, false, false, true, false, true,  0
 #define PAI_END_OF_ARGS  { "^D", NULL, "NADA", PaLastArg, PaReq, 0, 0, 0, "", PAI_REST }
-#define LOGLEVEL_DESC    "initial log level (NONE, ERROR, WARN, INFO, DEBUG)"
+#define LOGLEVEL_DESC    "initial log level (NONE, FATAL, ERROR, WARN, INFO, DEBUG)"
 
 /* ****************************************************************************
 *

--- a/src/lib/serviceRoutinesV2/logLevelTreat.cpp
+++ b/src/lib/serviceRoutinesV2/logLevelTreat.cpp
@@ -76,11 +76,7 @@ std::string changeLogLevel
       (strcasecmp(levelP, "info")    == 0) ||
       (strcasecmp(levelP, "debug")   == 0))
   {
-    if (strcasecmp(levelP, "fatal") == 0)
-    {
-      level = "NONE";
-    }
-    else if (strcasecmp(levelP, "warning") == 0)
+    if (strcasecmp(levelP, "warning") == 0)
     {
       level = "WARN";
     }
@@ -112,11 +108,6 @@ std::string getLogLevel
 )
 {
   std::string  level = lmLevelMaskStringGet();
-
-  if (level == "NONE")
-  {
-    level = "FATAL";
-  }
 
   return "{\"level\":\"" + level + "\"}";
 }

--- a/test/functionalTest/cases/0000_cli/bool_option_with_value.test
+++ b/test/functionalTest/cases/0000_cli/bool_option_with_value.test
@@ -43,7 +43,7 @@ Usage: contextBroker  [option '-U' (extended usage)]
                       [option '--version' (show version)]
                       [option '-logDir' <log file directory>]
                       [option '-t' <trace level>]
-                      [option '-logLevel' <initial log level (NONE, ERROR, WARN, INFO, DEBUG)>]
+                      [option '-logLevel' <initial log level (NONE, FATAL, ERROR, WARN, INFO, DEBUG)>]
                       [option '-logAppend' (append to log-file)]
                      
                       [option '-fg' (don't start as daemon)]

--- a/test/functionalTest/cases/0000_cli/command_line_options.test
+++ b/test/functionalTest/cases/0000_cli/command_line_options.test
@@ -32,7 +32,7 @@ Usage: contextBroker  [option '-U' (extended usage)]
                       [option '--version' (show version)]
                       [option '-logDir' <log file directory>]
                       [option '-t' <trace level>]
-                      [option '-logLevel' <initial log level (NONE, ERROR, WARN, INFO, DEBUG)>]
+                      [option '-logLevel' <initial log level (NONE, FATAL, ERROR, WARN, INFO, DEBUG)>]
                       [option '-logAppend' (append to log-file)]
                      
                       [option '-fg' (don't start as daemon)]

--- a/test/functionalTest/cases/0000_cli/tracelevel_without_logLevel_as_DEBUG.test
+++ b/test/functionalTest/cases/0000_cli/tracelevel_without_logLevel_as_DEBUG.test
@@ -33,7 +33,7 @@ Usage:                [option '-U' (extended usage)]
                       [option '--version' (show version)]
                       [option '-logDir' <log file directory>]
                       [option '-t' <trace level>]
-                      [option '-logLevel' <initial log level (NONE, ERROR, WARN, INFO, DEBUG)>]
+                      [option '-logLevel' <initial log level (NONE, FATAL, ERROR, WARN, INFO, DEBUG)>]
                       [option '-logAppend' (append to log-file)]
                      
                       [option '-fg' (don't start as daemon)]

--- a/test/functionalTest/cases/2419_log_level/log_level.test
+++ b/test/functionalTest/cases/2419_log_level/log_level.test
@@ -30,43 +30,125 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. Set log level to FATAL (which the broker does not really support)
-# 02. GET log level, see FATAL
-# 03. Set log level to WARN
-# 04. GET log level, see WARN
+# 01. Set log level to NONE
+# 02. GET log level, see NONE
+# 03. Set log level to FATAL
+# 04. GET log level, see FATAL
+# 05. Set log level to ERROR
+# 06. GET log level, see ERROR
+# 07. Set log level to WARN
+# 08. GET log level, see WARN
+# 09. Set log level to INFO
+# 10. GET log level, see INFO
+# 11. Set log level to DEBUG
+# 12. GET log level, see DEBUG
+# 13. Set log level to XYZ - see error
+# 14. GET log level, see DEBUG
 #
 
-echo "01. Set log level to FATAL (which the broker does not really support)"
-echo "====================================================================="
-orionCurl --url /admin/log?level=FATAL -X PUT
-echo
-echo
-
-
-echo "02. GET log level, see FATAL"
-echo "============================"
-orionCurl --url /admin/log
-echo
-echo
-
-
-echo "03. Set log level to WARN"
+echo "01. Set log level to NONE"
 echo "========================="
-orionCurl --url /admin/log?level=WARN -X PUT
+orionCurl --url /admin/log?level=NONE -X PUT
 echo
 echo
 
 
-echo "04. GET log level, see WARN"
+echo "02. GET log level, see NONE"
 echo "==========================="
 orionCurl --url /admin/log
 echo
 echo
 
 
+echo "03. Set log level to FATAL"
+echo "=========================="
+orionCurl --url /admin/log?level=FATAL -X PUT
+echo
+echo
+
+
+echo "04. GET log level, see FATAL"
+echo "============================"
+orionCurl --url /admin/log
+echo
+echo
+
+
+echo "05. Set log level to ERROR"
+echo "=========================="
+orionCurl --url /admin/log?level=ERROR -X PUT
+echo
+echo
+
+
+echo "06. GET log level, see ERROR"
+echo "============================"
+orionCurl --url /admin/log
+echo
+echo
+
+
+echo "07. Set log level to WARN"
+echo "========================="
+orionCurl --url /admin/log?level=WARN -X PUT
+echo
+echo
+
+
+echo "08. GET log level, see WARN"
+echo "==========================="
+orionCurl --url /admin/log
+echo
+echo
+
+
+echo "09. Set log level to INFO"
+echo "========================="
+orionCurl --url /admin/log?level=INFO -X PUT
+echo
+echo
+
+
+echo "10. GET log level, see INFO"
+echo "==========================="
+orionCurl --url /admin/log
+echo
+echo
+
+
+echo "11. Set log level to DEBUG"
+echo "=========================="
+orionCurl --url /admin/log?level=DEBUG -X PUT
+echo
+echo
+
+
+echo "12. GET log level, see DEBUG"
+echo "============================"
+orionCurl --url /admin/log
+echo
+echo
+
+
+echo "13. Set log level to XYZ - see error"
+echo "===================================="
+orionCurl --url /admin/log?level=XYZ -X PUT
+echo
+echo
+
+
+echo "14. GET log level, see DEBUG"
+echo "============================"
+orionCurl --url /admin/log
+echo
+echo
+
+
+
+
 --REGEXPECT--
-01. Set log level to FATAL (which the broker does not really support)
-=====================================================================
+01. Set log level to NONE
+=========================
 HTTP/1.1 200 OK
 Content-Length: 0
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -74,7 +156,29 @@ Date: REGEX(.*)
 
 
 
-02. GET log level, see FATAL
+02. GET log level, see NONE
+===========================
+HTTP/1.1 200 OK
+Content-Length: 16
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "level": "NONE"
+}
+
+
+03. Set log level to FATAL
+==========================
+HTTP/1.1 200 OK
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. GET log level, see FATAL
 ============================
 HTTP/1.1 200 OK
 Content-Length: 17
@@ -87,7 +191,29 @@ Date: REGEX(.*)
 }
 
 
-03. Set log level to WARN
+05. Set log level to ERROR
+==========================
+HTTP/1.1 200 OK
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. GET log level, see ERROR
+============================
+HTTP/1.1 200 OK
+Content-Length: 17
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "level": "ERROR"
+}
+
+
+07. Set log level to WARN
 =========================
 HTTP/1.1 200 OK
 Content-Length: 0
@@ -96,7 +222,7 @@ Date: REGEX(.*)
 
 
 
-04. GET log level, see WARN
+08. GET log level, see WARN
 ===========================
 HTTP/1.1 200 OK
 Content-Length: 16
@@ -106,6 +232,76 @@ Date: REGEX(.*)
 
 {
     "level": "WARN"
+}
+
+
+09. Set log level to INFO
+=========================
+HTTP/1.1 200 OK
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+10. GET log level, see INFO
+===========================
+HTTP/1.1 200 OK
+Content-Length: 16
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "level": "INFO"
+}
+
+
+11. Set log level to DEBUG
+==========================
+HTTP/1.1 200 OK
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+12. GET log level, see DEBUG
+============================
+HTTP/1.1 200 OK
+Content-Length: 17
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "level": "DEBUG"
+}
+
+
+13. Set log level to XYZ - see error
+====================================
+HTTP/1.1 400 Bad Request
+Content-Length: 29
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "error": "invalid log level"
+}
+
+
+14. GET log level, see DEBUG
+============================
+HTTP/1.1 200 OK
+Content-Length: 17
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "level": "DEBUG"
 }
 
 


### PR DESCRIPTION
Fixed issue #2419, by changing the broker slightly.

The broker now accepts FATAL *and* NONE as different log levels.
All intents to justify for FATAL/NONE have been removed.

