### PR TITLE
Changed attrName example value  in order to be consistent with the payload.

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
@@ -1350,7 +1350,7 @@ Response:
     + entityId: Bcn_Welt (required, string) - Id of the entity in question
     + type (optional, string) - Entity type, to avoid ambiguity in the case there are several
       entities with the same entity id.
-    + attrName: temperature (required, string) - Name of the attribute to be retrieved.
+    + attrName: address (required, string) - Name of the attribute to be retrieved.
 
 + Response 200 (application/json)
 
@@ -1389,7 +1389,7 @@ Response:
     + entityId: Bcn_Welt (required, string) - Id of the entity to be updated.
     + type (optional, string) - Entity type, to avoid ambiguity in the case there are several
       entities with the same entity id.
-    + attrName: temperature (required, string) - Attribute name.
+    + attrName: address (required, string) - Attribute name.
 
 + Request (application/json)
 

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -1461,7 +1461,7 @@ Response:
     + entityId: Bcn_Welt (required, string) - Id of the entity in question
     + type (optional, string) - Entity type, to avoid ambiguity in the case there are several
       entities with the same entity id.
-    + attrName: temperature (required, string) - Name of the attribute to be retrieved.
+    + attrName: address (required, string) - Name of the attribute to be retrieved.
 
 + Response 200 (application/json)
 
@@ -1500,7 +1500,7 @@ Response:
     + entityId: Bcn_Welt (required, string) - Id of the entity to be updated.
     + type (optional, string) - Entity type, to avoid ambiguity in the case there are several
       entities with the same entity id.
-    + attrName: temperature (required, string) - Attribute name.
+    + attrName: address (required, string) - Attribute name.
 
 + Request (application/json)
 


### PR DESCRIPTION
We suggest the `attrName` example value should be `address` instead of `temperature` because the payload is a JSON with `PostalAddress` format: 

```
{
  "address": "Ronda de la Comunicacion s/n",
  "zipCode": 28050,
  "city": "Madrid",
  "country": "Spain"
}
```