### PR TITLE
Hotfix: remove attribute detail in get types operations (only NGSIv2 API)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+Hotfix: remove attribute detail in get types operations (only NGSIv2 API) (hardwired solution for #2073)

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -52,6 +52,10 @@ static void getAttributeTypes
   std::vector<std::string>*             attrTypes
 )
 {
+  // Avoid attribute type detail, just ""
+  attrTypes->push_back("");
+
+#if 0
   std::string  idType         = std::string("_id.")    + ENT_ENTITY_TYPE;
   std::string  idServicePath  = std::string("_id.")    + ENT_SERVICE_PATH;
 
@@ -120,6 +124,7 @@ static void getAttributeTypes
 
   }
   releaseMongoConnection(connection);
+#endif
 }
 
 


### PR DESCRIPTION
Hardwired solution for #2073 (only in release/1.2.0 branch)