### PR TITLE
FIX missing mq field in csubs documents makes Orion to crash

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - Fix: crash when creating entity with metadata when subscription is in place with "mq" on a different metadata (#2496)
 - Fix: supporting DateTime filters for metadata (#2443, #2445)
 - Fix: wrong matching in metadata existence and not existence filters with compounds
+- Fix: missing mq field in csubs documents (due to migrations mainly) makes Orion to crash

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -116,11 +116,11 @@ static void setSubject(Subscription* s, const BSONObj& r)
   if (r.hasField(CSUB_EXPR))
   {
     mongo::BSONObj expression = getFieldF(r, CSUB_EXPR).Obj();
-    std::string    q          = getFieldF(expression, CSUB_EXPR_Q).String();
-    std::string    mq         = getFieldF(expression, CSUB_EXPR_MQ).String();
-    std::string    geo        = getFieldF(expression, CSUB_EXPR_GEOM).String();
-    std::string    coords     = getFieldF(expression, CSUB_EXPR_COORDS).String();
-    std::string    georel     = getFieldF(expression, CSUB_EXPR_GEOREL).String();
+    std::string    q          = getStringFieldF(expression, CSUB_EXPR_Q);
+    std::string    mq         = getStringFieldF(expression, CSUB_EXPR_MQ);
+    std::string    geo        = getStringFieldF(expression, CSUB_EXPR_GEOM);
+    std::string    coords     = getStringFieldF(expression, CSUB_EXPR_COORDS);
+    std::string    georel     = getStringFieldF(expression, CSUB_EXPR_GEOREL);
 
     s->subject.condition.expression.q        = q;
     s->subject.condition.expression.mq       = mq;


### PR DESCRIPTION
The pattern `getFielfF(...).String()` (or `.Number()`, etc.) should be avoided, in favour of `getStringFieldF()` (or similar ones for other data types). This PR fixes that in a particular "severe" case, but an overall review of all them (around ~100 ocurrences of `getFieldF()` in the code) should be done. However, not in this PR.