### PR TITLE
Bug/2527 crash with empty uri path

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - Fix: crash when creating entity with metadata when subscription is in place with "mq" on a different metadata (#2496)
+- Fix: crash with request with empty URI PATH (Issue #2527)
 - Fix: supporting DateTime filters for metadata (#2443, #2445)
 - Fix: wrong matching in metadata existence and not existence filters with compounds

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -493,7 +493,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
   //
   std::string apiVersion = "v1";
 
-  if (strcasecmp(compV[0].c_str(), "v2") == 0)
+  if ((compV.size() != 0) && strcasecmp(compV[0].c_str(), "v2") == 0)
   {
     apiVersion = "v2";
   }

--- a/test/functionalTest/cases/2527_crash_with_empty_uri_path/crash_with_empty_uri_path.test
+++ b/test/functionalTest/cases/2527_crash_with_empty_uri_path/crash_with_empty_uri_path.test
@@ -1,0 +1,63 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Broker crash with empty URI PATH
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Request with empty URL - see Bad Request
+#
+
+echo "01. Request with empty URL - see Bad Request"
+echo "============================================"
+orionCurl --url /
+echo
+echo
+
+
+--REGEXPECT--
+01. Request with empty URL - see Bad Request
+============================================
+HTTP/1.1 400 Bad Request
+Content-Length: 119
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "orionError": {
+        "code": "400",
+        "details": "service not found",
+        "reasonPhrase": "Bad Request"
+    }
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fixes #2527 

Checking that URI PATH vector is not empty before using it.
This avoids a crash for empty URI PATH.