### PR TITLE
FIX crash on missing csub expr q + dockerfile fixes for release/1.2.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: missing expression sub-fields (q, etc.) in csubs makes Orion to crash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,15 +47,6 @@ RUN \
     curl -kOL https://github.com/miloyip/rapidjson/archive/v1.0.2.tar.gz && \
     tar xfz v1.0.2.tar.gz && \
     mv rapidjson-1.0.2/include/rapidjson/ /usr/local/include && \
-    # Install Google Test/Mock from source
-    curl -kOL http://googlemock.googlecode.com/files/gmock-1.5.0.tar.bz2 && \
-    tar xfj gmock-1.5.0.tar.bz2 && \
-    cd gmock-1.5.0 && \
-    ./configure && \
-    make && \
-    make install && \
-    ldconfig && \
-    cd /opt && \
     # Install orion from source
     git clone https://github.com/telefonicaid/fiware-orion && \
     cd fiware-orion && \
@@ -83,15 +74,6 @@ RUN \
            /opt/rapidjson-1.0.2 \
            /opt/v1.0.2.tar.gz \
            /usr/local/include/rapidjson \
-           /opt/gmock-1.5.0.tar.bz2 \
-           /opt/gmock-1.5.0 \
-           /usr/local/bin/gmock* \
-           /usr/local/bin/gtest* \
-           /usr/local/include/gmock \
-           /usr/local/include/gtest \
-           /usr/local/lib/libgmock* \
-           /usr/local/lib/libgtest* \
-           /usr/local/share/aclocal/gtest* \
            /opt/fiware-orion \
            && \
     yum -y erase git perl rsync \

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -112,10 +112,10 @@ static void setSubject(Subscription* s, const BSONObj& r)
   }
   if (r.hasField(CSUB_EXPR)) {
     mongo::BSONObj expression = getFieldF(r, CSUB_EXPR).Obj();
-    std::string    q          = getFieldF(expression, CSUB_EXPR_Q).String();
-    std::string    geo        = getFieldF(expression, CSUB_EXPR_GEOM).String();
-    std::string    coords     = getFieldF(expression, CSUB_EXPR_COORDS).String();
-    std::string    georel     = getFieldF(expression, CSUB_EXPR_GEOREL).String();
+    std::string    q          = getStringFieldF(expression, CSUB_EXPR_Q);
+    std::string    geo        = getStringFieldF(expression, CSUB_EXPR_GEOM);
+    std::string    coords     = getStringFieldF(expression, CSUB_EXPR_COORDS);
+    std::string    georel     = getStringFieldF(expression, CSUB_EXPR_GEOREL);
 
     s->subject.condition.expression.q = q;
     s->subject.condition.expression.geometry = geo;


### PR DESCRIPTION
This PR contains two commits:

* The same fix than in PR https://github.com/telefonicaid/fiware-orion/pull/2525
* Some fixes needed to enable next Orion 1.2.3 building at dockerhub (note that 1.2.2 got broken in dockerhub).

Reviews required:

* @dmoranj (docker stuff)
* Somebody in the CB dev team