### PR TITLE
[RENAME] response headers

### DIFF
--- a/test/acceptance/behave/components/common_steps/general_steps.py
+++ b/test/acceptance/behave/components/common_steps/general_steps.py
@@ -365,8 +365,8 @@ def verify_headers_in_response(context):
     verify headers in response
     Ex:
           | parameter          | value                |
-          | fiware-total-count | 5                    |
-          | location           | /v2/subscriptions/.* |
+          | Fiware-Total-Count | 5                    |
+          | Location           | /v2/subscriptions/.* |
     :param context: It’s a clever place where you and behave can store information to share around. It runs at three levels, automatically managed by behave.
     """
     __logger__.debug("Verifying headers in response...")

--- a/test/acceptance/behave/components/ngsiv2/entities/create_entity/create_entity_geospatial_properties_of_entities.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/create_entity/create_entity_geospatial_properties_of_entities.feature
@@ -50,7 +50,7 @@ Feature: create an entity with geospatial properties of entities using NGSIv2. "
 
   # -------------------- Simple Location Format ---------------
   @simple_location_wo_metadata
-  Scenario Outline:  create an entity with Simple Location Format to define location and to geo-query using NGSIv2 without metadata
+  Scenario Outline:  create an entity with Simple Location Format to define Location and to geo-query using NGSIv2 without metadata
     Given  a definition of headers
       | parameter          | value                |
       | Fiware-Service     | test_simple_location |

--- a/test/acceptance/behave/components/ngsiv2/entities/list_entities/list_entities_headers.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/list_entities/list_entities_headers.feature
@@ -121,7 +121,7 @@ Feature: list all entities with get request and queries parameters using NGSI v2
     And verify that "1" entities are returned
     And verify headers in response
       | parameter          | value |
-      | fiware-total-count | 1     |
+      | Fiware-Total-Count | 1     |
 
   @id_multiples @BUG_1720
   Scenario:  try to list all entities using NGSI v2 (3 entity groups with 15 entities in total) but with id query parameter used as regexp

--- a/test/acceptance/behave/components/ngsiv2/entities/list_entities/list_entities_queries_parameters_part_3.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/list_entities/list_entities_queries_parameters_part_3.feature
@@ -87,7 +87,7 @@ Feature: list all entities with get request and queries parameters using NGSI v2
     And verify that "<returned>" entities are returned
     And verify headers in response
       | parameter          | value      |
-      | fiware-total-count | <entities> |
+      | Fiware-Total-Count | <entities> |
     Examples:
       | entities | returned |
       | 1        | 1        |
@@ -130,7 +130,7 @@ Feature: list all entities with get request and queries parameters using NGSI v2
     And verify that "<returned>" entities are returned
     And verify headers in response
       | parameter          | value      |
-      | fiware-total-count | <entities> |
+      | Fiware-Total-Count | <entities> |
     Examples:
       | entities | returned |
       | 1        | 1        |
@@ -174,7 +174,7 @@ Feature: list all entities with get request and queries parameters using NGSI v2
     And verify that "<returned>" entities are returned
     And verify headers in response
       | parameter          | value      |
-      | fiware-total-count | <entities> |
+      | Fiware-Total-Count | <entities> |
     Examples:
       | entities | offset | limit | returned |
       | 1        | 1      | 1     | 0        |

--- a/test/acceptance/behave/components/ngsiv2/entities/list_entities/list_entities_traces_in_log.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/list_entities/list_entities_traces_in_log.feature
@@ -117,7 +117,7 @@ Feature: verify fields in log traces with list entities request using NGSI v2.
     And verify that "1" entities are returned
     And verify headers in response
       | parameter          | value |
-      | fiware-total-count | 1     |
+      | Fiware-Total-Count | 1     |
     And check in log, label "INFO" and message "Starting transaction from"
       | trace  | value              |
       | time   | ignored            |

--- a/test/acceptance/behave/components/ngsiv2/entities/retrieve_entity_attributes/retrieve_entity_attributes.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/retrieve_entity_attributes/retrieve_entity_attributes.feature
@@ -80,7 +80,7 @@ Feature: get attributes in an entity by ID using NGSI v2. "GET" - /v2/entities/<
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes in an entity by ID are returned
 
   # ------------------------ Content-Type header ----------------------------------------------

--- a/test/acceptance/behave/components/ngsiv2/entities/retrieve_entity_attributes/retrieve_entity_attributes_queries_parameters.feature
+++ b/test/acceptance/behave/components/ngsiv2/entities/retrieve_entity_attributes/retrieve_entity_attributes_queries_parameters.feature
@@ -81,7 +81,7 @@ Feature: get an entity by ID using NGSI v2. "GET" - /v2/entities/<entity_id>/att
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes in an entity by ID are returned
 
   # --- attrs query parameter ---

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_description.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_description.feature
@@ -65,8 +65,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @description
@@ -91,8 +91,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | desc                  |

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_expires.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_expires.feature
@@ -66,8 +66,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @expires_httpCustom_url
@@ -92,8 +92,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @expires_empty
@@ -118,8 +118,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @expires_permanent @ISSUE_1949
@@ -143,8 +143,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @expires_invalid_format

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_headers.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_headers.feature
@@ -72,8 +72,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @maximum_size
@@ -125,10 +125,10 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
       | error       | ContentLengthRequired                            |
       | description | Zero/No Content-Length in PUT/POST/PATCH request |
 
-  # ---------- content-type header --------------------------------
+  # ---------- Content-Type header --------------------------------
 
   @content_type_without
-  Scenario:  try to create a new subscription using NGSI v2 without content-type header
+  Scenario:  try to create a new subscription using NGSI v2 without Content-Type header
     Given  a definition of headers
       | parameter          | value             |
       | Fiware-Service     | test_content_type |
@@ -150,7 +150,7 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
       | description | Content-Type header not used, default application/octet-stream is not supported |
 
   @content_type_error
-  Scenario Outline:  try to create a new subscription using NGSI v2 with wrong content-type header
+  Scenario Outline:  try to create a new subscription using NGSI v2 with wrong Content-Type header
     Given  a definition of headers
       | parameter          | value             |
       | Fiware-Service     | test_content_type |
@@ -203,8 +203,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @service
@@ -227,8 +227,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | service            |
@@ -318,8 +318,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | service_path                                                  |
@@ -352,8 +352,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @service_path_without @BUG_2024
@@ -375,8 +375,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @service_path_error

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_notification_attrs.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_notification_attrs.feature
@@ -64,8 +64,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @notification_attrs_array_empty
@@ -87,8 +87,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @notification_attrs
@@ -110,8 +110,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | attributes |
@@ -174,8 +174,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | number |
@@ -327,8 +327,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @notification_except_attrs
@@ -350,8 +350,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | attributes |
@@ -436,8 +436,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | number |

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_notification_http.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_notification_http.feature
@@ -132,8 +132,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | url                                       |
@@ -389,8 +389,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | url                                       |

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_status.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_status.feature
@@ -65,8 +65,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @status
@@ -91,8 +91,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | status   |

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_subject_condition.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_subject_condition.feature
@@ -66,8 +66,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   # ------------ subject - condition - attributes ---------------------
@@ -114,8 +114,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @condition_attrs
@@ -137,8 +137,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | attributes |
@@ -179,8 +179,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | number |
@@ -378,8 +378,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @condition_expression_empty @ISSUE_1946
@@ -427,8 +427,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | q                                                         |
@@ -484,8 +484,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
 
   @condition_expression_q_parse_error @BUG_1989 @BUG_2106
   Scenario Outline:  try to create a new subscription using NGSI v2 with "q" condition expression but with parse errors
@@ -699,8 +699,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | georel                | geometry | coords                                                      |
@@ -1009,8 +1009,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | georel                | geometry | coords                                                      |

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_subject_entities.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_subject_entities.feature
@@ -115,8 +115,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @type_without
@@ -138,8 +138,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @type_only @BUG_1939
@@ -184,8 +184,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | type       |
@@ -226,8 +226,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | type       |
@@ -473,8 +473,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | number |
@@ -550,8 +550,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | id         |
@@ -783,8 +783,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | number |
@@ -816,8 +816,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | id_pattern   |
@@ -867,8 +867,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | id_pattern |
@@ -929,8 +929,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @id_pattern_not_plain_ascii @BUG_1976 @skip

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_throttling.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_throttling.feature
@@ -61,8 +61,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
 
   @throttling
@@ -83,8 +83,8 @@ Feature: create new subscriptions (POST) using NGSI v2. "POST" - /v2/subscriptio
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     Examples:
       | throttling |

--- a/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_traces_in_log.feature
+++ b/test/acceptance/behave/components/ngsiv2/subscriptions/create_a_new_subscription/create_a_new_subscription_traces_in_log.feature
@@ -74,8 +74,8 @@ Feature: verify fields in log traces with update or append entity attributes req
     Then verify that receive a "Created" http code
     And verify headers in response
       | parameter      | value                |
-      | location       | /v2/subscriptions/.* |
-      | content-length | 0                    |
+      | Location       | /v2/subscriptions/.* |
+      | Content-Length | 0                    |
     And verify that the subscription is stored in mongo
     And check in log, label "INFO" and message "Starting transaction from"
       | trace  | value              |

--- a/test/acceptance/behave/components/ngsiv2/types/retrieve_an_entity_type/retrieve_an_entity_type.feature
+++ b/test/acceptance/behave/components/ngsiv2/types/retrieve_an_entity_type/retrieve_an_entity_type.feature
@@ -152,7 +152,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes types by entity type are returned in response based on the info in the recorder
 
 
@@ -404,7 +404,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
       | entities_id       | room1       |
       | attributes_number | 2           |
       | attributes_name   | temperature |
-      | attributes_value  | 34          |
+      | attributes_value  | high        |
     And create entity group with "5" entities in "normalized" mode
       | entity | prefix |
       | id     | true   |
@@ -435,7 +435,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes types by entity type are returned in response based on the info in the recorder
     Examples:
       | service            |
@@ -461,6 +461,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
       | attributes_number | 2           |
       | attributes_name   | temperature |
       | attributes_value  | 34          |
+      | attributes_type   | celsius     |
     And create entity group with "5" entities in "normalized" mode
       | entity | prefix |
       | id     | true   |
@@ -490,7 +491,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes types by entity type are returned in response based on the info in the recorder
 
   @service_error
@@ -546,7 +547,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
       | entities_id       | room1       |
       | attributes_number | 2           |
       | attributes_name   | temperature |
-      | attributes_value  | 34          |
+      | attributes_value  | high        |
     And create entity group with "5" entities in "normalized" mode
       | entity | prefix |
       | id     | true   |
@@ -577,7 +578,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes types by entity type are returned in response based on the info in the recorder
     Examples:
       | service_path                                                  |
@@ -606,6 +607,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
       | attributes_number | 2           |
       | attributes_name   | temperature |
       | attributes_value  | 34          |
+      | attributes_type   | celsius     |
     And create entity group with "5" entities in "normalized" mode
       | entity | prefix |
       | id     | true   |
@@ -635,7 +637,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes types by entity type are returned in response based on the info in the recorder
 
   @service_path_error
@@ -737,7 +739,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes types by entity type are returned in response based on the info in the recorder
     Examples:
       | types      |
@@ -821,7 +823,7 @@ Feature: get an entity type using NGSI v2 API. "GET" - /v2/types/<entity_type>
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes types are returned in response based on the info in the recorder
 
   @type_forbidden

--- a/test/acceptance/behave/components/ngsiv2/types/retrieve_an_entity_type/retrieve_an_entity_type_traces_in_log.feature
+++ b/test/acceptance/behave/components/ngsiv2/types/retrieve_an_entity_type/retrieve_an_entity_type_traces_in_log.feature
@@ -152,7 +152,7 @@ Feature: verify fields in log traces with retrieve an entity type request using 
     Then verify that receive an "OK" http code
     And verify headers in response
       | parameter         | value      |
-      | fiware-correlator | [a-f0-9-]* |
+      | Fiware-Correlator | [a-f0-9-]* |
     And verify that attributes types by entity type are returned in response based on the info in the recorder
     And check in log, label "INFO" and message "Starting transaction from"
       | trace  | value              |

--- a/test/acceptance/behave/requirements.txt
+++ b/test/acceptance/behave/requirements.txt
@@ -2,7 +2,7 @@ importlib==1.0.3
 argparse==1.3.0
 behave==1.2.5
 PyHamcrest==1.8.3
-requests==2.7.0
+requests==2.11.1
 xmltodict==0.9.2
 fabric==1.10.2
 pymongo==3.0.3


### PR DESCRIPTION
The `requests` python library in 2.7 version, the response headers were returned all in lowercase (error in library), but iin 2.11.1 version they are returned correctly (as they are expected). 
