### PR TITLE
Bug/1068 render metadata value when compound

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,6 +2,7 @@
 - Add: filtering metadata in notifications (#2507)
 - Fix: removed spurious decimals in metadata numbers in NGSIv1 rendering (a follow up of #2176)
 - Fix: crash when creating entity with metadata when subscription is in place with "mq" on a different metadata (#2496)
+- Fix: correct rendering of metadata compound values when a vector
 - Fix: crash with request with empty URI PATH (Issue #2527)
 - Fix: supporting DateTime filters for metadata (#2443, #2445)
 - Fix: wrong matching in metadata existence and not existence filters with compounds

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,7 +2,7 @@
 - Add: filtering metadata in notifications (#2507)
 - Fix: removed spurious decimals in metadata numbers in NGSIv1 rendering (a follow up of #2176)
 - Fix: crash when creating entity with metadata when subscription is in place with "mq" on a different metadata (#2496)
-- Fix: correct rendering of metadata compound values when a vector
+- Fix: correct rendering of metadata compound values when a vector (bugfix for issue #1068)
 - Fix: crash with request with empty URI PATH (Issue #2527)
 - Fix: supporting DateTime filters for metadata (#2443, #2445)
 - Fix: wrong matching in metadata existence and not existence filters with compounds

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -261,11 +261,15 @@ std::string Metadata::render(const std::string& indent, bool comma)
     {
       // Note in this case we don't add the "value" key, the toJson()
       // method does it for toplevel compound (a bit crazy... this deserves a FIXME mark)
+      LM_W(("KZ: Rendering compound metadata object"));
       compoundValueP->renderName = true;
+      compoundValueP->container = compoundValueP;  // To mark as TOPLEVEL
       part = compoundValueP->toJson(true, false);
     }
     else if (compoundValueP->isVector())
     {
+      LM_W(("KZ: Rendering compound metadata vector (name: [] already given)"));
+      compoundValueP->container = compoundValueP;  // To mark as TOPLEVEL
       part = JSON_STR("value") + ": [" + compoundValueP->toJson(true, false) + "]";
     }    
 

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -259,16 +259,17 @@ std::string Metadata::render(const std::string& indent, bool comma)
 
     if (compoundValueP->isObject())
     {
+      //
       // Note in this case we don't add the "value" key, the toJson()
       // method does it for toplevel compound (a bit crazy... this deserves a FIXME mark)
-      LM_W(("KZ: Rendering compound metadata object"));
+      // FIXME P4: modify/simplify the rendering of compound values. Too many if/else ...
+      //
       compoundValueP->renderName = true;
       compoundValueP->container = compoundValueP;  // To mark as TOPLEVEL
       part = compoundValueP->toJson(true, false);
     }
     else if (compoundValueP->isVector())
     {
-      LM_W(("KZ: Rendering compound metadata vector (name: [] already given)"));
       compoundValueP->container = compoundValueP;  // To mark as TOPLEVEL
       part = JSON_STR("value") + ": [" + compoundValueP->toJson(true, false) + "]";
     }    

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1113,7 +1113,6 @@ static int connectionTreat
     LM_T(LmtRequest, (""));
     // WARNING: This log message below is crucial for the correct function of the Behave tests - CANNOT BE REMOVED
     LM_T(LmtRequest, ("--------------------- Serving request %s %s -----------------", method, url));
-    LM_W(("KZ: --------------------- Serving request %s %s -----------------", method, url));
     *con_cls     = (void*) ciP; // Pointer to ConnectionInfo for subsequent calls
     ciP->port    = port;
     ciP->ip      = ip;

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1113,6 +1113,7 @@ static int connectionTreat
     LM_T(LmtRequest, (""));
     // WARNING: This log message below is crucial for the correct function of the Behave tests - CANNOT BE REMOVED
     LM_T(LmtRequest, ("--------------------- Serving request %s %s -----------------", method, url));
+    LM_W(("KZ: --------------------- Serving request %s %s -----------------", method, url));
     *con_cls     = (void*) ciP; // Pointer to ConnectionInfo for subsequent calls
     ciP->port    = port;
     ciP->ip      = ip;

--- a/test/functionalTest/cases/1068_metadata_value_as_compound/vector_compound_in_metadata_for_api_v1.test
+++ b/test/functionalTest/cases/1068_metadata_value_as_compound/vector_compound_in_metadata_for_api_v1.test
@@ -1,0 +1,164 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Check rendering of metadata compound vector in APIv1
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity with attribute with metadata M1 that has a compound vector as value
+# 02. See the entity using POST /v1/queryContext and make sure the metadata value-vector is correctly rendered
+# 03. See the entity using GET /v2/entities make sure the metadata value-vector is correctly rendered
+#
+
+echo "01. Create entity with attribute with metadata M1 that has a compound vector as value"
+echo "====================================================================================="
+payload='{
+  "id": "E1",
+  "A1": {
+    "value": 1,
+    "metadata": {
+      "M1": {
+        "value": [ 1,2,3 ]
+      }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. See the entity using POST /v1/queryContext and make sure the metadata value-vector is correctly rendered"
+echo "============================================================================================================"
+payload='{
+    "entities": [
+        {
+            "isPattern": "false",
+            "id": "E1"
+        }
+    ]
+}'
+orionCurl --url /v1/queryContext --payload "$payload"
+echo
+echo
+
+
+echo "03. See the entity using GET /v2/entities make sure the metadata value-vector is correctly rendered"
+echo "==================================================================================================="
+orionCurl --url /v2/entities
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity with attribute with metadata M1 that has a compound vector as value
+=====================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=Thing
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. See the entity using POST /v1/queryContext and make sure the metadata value-vector is correctly rendered
+============================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 551
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "metadatas": [
+                            {
+                                "name": "M1",
+                                "type": "StructuredValue",
+                                "value": [
+                                    1,
+                                    2,
+                                    3
+                                ]
+                            }
+                        ],
+                        "name": "A1",
+                        "type": "Number",
+                        "value": 1
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+03. See the entity using GET /v2/entities make sure the metadata value-vector is correctly rendered
+===================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 122
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A1": {
+            "metadata": {
+                "M1": {
+                    "type": "StructuredValue",
+                    "value": [
+                        1,
+                        2,
+                        3
+                    ]
+                }
+            },
+            "type": "Number",
+            "value": 1
+        },
+        "id": "E1",
+        "type": "Thing"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Part of old and closed issue #1068.
Fixed the rendering of compound metadatas when the value is a vector.

An intent to rewrite/simplify that part (before I found the fix) has been kept inside #if 0/#endif.
I don't want to throw away this simplification as I believe we should use it in the near future.

Also, not sure if this fix should have an entry in the CNR ...