### PR TITLE
ADD NGSIv2 stable spec RC-2016.10

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_10_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_10_31.apib
@@ -1,9 +1,9 @@
 FORMAT: 1A
 HOST: http://orion.lab.fiware.org
-TITLE: FIWARE-NGSI v2 Specification (WIP)
-DATE: to be fixed upon next RC production
-VERSION: latest
-PREVIOUS_VERSION: stable
+TITLE: FIWARE-NGSI v2 Specification RC-2016_10
+DATE: 31 Oct 2016
+VERSION: stable
+PREVIOUS_VERSEION: RC-2016_05
 APIARY_PROJECT: orioncontextbroker
 SPEC_URL: https://telefonicaid.github.io/fiware-orion/api/v2/
 GITHUB_SOURCE: http://github.com/telefonicaid/fiware-orion.git
@@ -32,16 +32,34 @@ Sergio García Gómez (Telefónica I+D), Martin Bauer (NEC).
   
 ## Status
 
-This is a work in progress and is changing on a daily basis.
-Please send your comments to fiware-ngsi@lists.fiware.org.
-You can trace the discussions checking the archives of the mailing list:
-https://lists.fiware.org/private/fiware-ngsi/ (list subscription required).
+This specification is the October 2016 release candidate of the NGSIv2 API specification (RC-2016.10).
+By "release candidate" we mean that only Minor Changes are expected to the API described by this document.
+Nonetheless new functionalities will be added in the near future, particularly JSON-LD and
+NGSI9 (context registration) support
 
-In addition, note that a list of currently open discussions is available at
+In particular, Minor Changes may be of two types:
 
-* https://github.com/telefonicaid/fiware-orion/issues/1022
-* https://github.com/telefonicaid/fiware-orion/issues/1034
-* https://github.com/telefonicaid/fiware-orion/issues/1035
+* Extensions to the functionality currently specified by this document. Note that in this case
+  there isn't any risk of breaking backward compatibility on existing software implementations.
+* Slight modifications in the functionality currently specified by this document, as a consequence
+  of ongoing discussions. Backward compatibility will be taken into account in this case, trying
+  to minimize the impact on existing software implementations. In particular, only completely
+  justified changes impacting backward compatibility will be allowed and "matter of taste"
+  changes will not be allowed.
+
+The work in progress draft of the specification can be found at
+[the following link](http://fiware.github.io/specifications/ngsiv2/latest).
+
+## Changelog
+
+Changes since RC-2016.05:
+
+* Default typing for entities, attributes and metadata aligned with schema.org
+* `typePattern` (similar to `idPattern`)
+* Simple Query Language: metadata filters (`mq`)
+* Simple Query Language: Sub-key filtering (both attribute and metadata values, i.e. `q` and `mq`)
+* Notification metadata filtering
+* System/builtin metadata in notifications: `previousValue` and `actionType`
 
 ## Copyright
 
@@ -65,6 +83,11 @@ NGSI version 2 uses camel case (camelCase) syntax for naming properties and rela
 by the API. When  referring to URIs, as part of HATEOAS patterns, and to mark them appropriately,
 the suffix `_url` is added.
 
+## Reference Implementations
+
+* NGISv2 servers
+  * [Orion Context Broker](http://catalogue.fiware.org/enablers/publishsubscribe-context-broker-orion-context-broker) - [Implementation Notes](https://fiware-orion.readthedocs.io/en/master/user/ngsiv2_implementation_notes/index.html)
+
 # Specification
 
 ## Introduction
@@ -77,7 +100,6 @@ The FIWARE NGSI (Next Generation Service Interface) API defines
   update operations
 * a **context availability interface** for exchanging information on how to obtain context
   information (whether to separate the two interfaces is currently under discussion).
-* a set of typical **roles** played by NGSI-compliant components
 
 ## Terminology
 
@@ -101,28 +123,6 @@ For example, a context entity with id *sensor-365* could have the
 type *temperatureSensor*.
 
 Each entity is uniquely identified by the combination of its id and type.
-
-#### Context Elements
-
-*(Note: the distinction between context entities and context elements 
-is still under discussion; therefore the notion of context elements
-currently only appears in this section.)*
-
-A context element is a data object (e.g. JSON object; see the section
-on JSON representation below) that contains information about a
-specific context entity. Consequently, a context element has a
-mandatory property `id` in order to identify the context entity it
-refers to. It furthermore can contain an optional property `type`
-to describe the type of the entity. Further properties can be used
-to represent more information about the entity (see the **context
-attributes** section below).
-
-It is important to understand that the relationship between entities and context elements is
-one-to-many.
-This means that:
-* each context element refers to exactly one entity
-* there can be several context elements referring to the same entity. 
-The context elements can for example contain different pieces of information about the entity.
 
 #### Context Attributes 
 
@@ -155,48 +155,6 @@ above. Similar to attributes, each piece of metadata has:
  * a **metadata value** containing the actual metadata
 
 Note that in NGSI it is not foreseen that metadata may contain nested metadata.
-
-#### Restrictions and Operation Scopes
-
-(placeholder to describe restrictions and operation scopes)
-
-#### Context Queries
-
-(placeholder for describing what a context query is, and some hints on how this
-is typically done in the REST interface)
-
-#### Context Subscriptions
-
-(placeholder for describing the concept of context subscriptions)
-
-#### Context Updates
-
-(placeholder for describing updates)
-
-### Exchanging Context Availability Information
-
-(placeholder on some introduction of what context availability information is)
-
-#### Context Registrations
-
-(placeholder for describing what a context registration is and what it is used for)
-
-#### Context Discovery
-
-(placehoder for describing what discovery does)
-
-#### Context Availability Subscription
-
-(placeholder for describing context availability subscriptions)
-
-#### Registering Context Availability Information
-
-(placeholder for describing the operation of registering context)
-
-### Roles of FIWARE NGSI components
-
-(placeholder to describe roles like context provider, context producer,
-context broker, context registry, context consumer)
 
 ## MIME Types
 
@@ -428,8 +386,6 @@ If present, the error payload is a JSON object including the following fields:
 
 + `error` (required, string): a textual description of the error.
 + `description` (optional, string): additional information about the error.
-+ `affectedItems` (optional, array[string]): a list of elements affected by the error.
-  Depending on the operation, it may refer to entities, registrations or subscriptions.
 
 All NGSIv2 server implementations must use the following HTTP response codes and `error` texts.
 However, the particular text used for `description` field is an implementation specific aspect.
@@ -480,9 +436,6 @@ need special indexes which can be under resource constraints imposed by backend 
 Thus, implementations may raise errors when spatial index limits are exceeded.
 The recommended HTTP status code for those situations is ``413``, *Request entity too large*, and
 the reported error on the response payload must be ``NoResourcesAvailable``.
-
-*Note: At the time of writing it is still under discussion whether supporting both syntaxes is
-really needed* 
 
 ### Simple Location Format
 
@@ -960,12 +913,10 @@ to keep your client decoupled from implementation details.
         + types_url: /v2/types (required, string) - URL which points to the types resource
         + subscriptions_url: /v2/subscriptions (required, string) - URL which points to the
           subscriptions resource
-        + registrations_url: /v2/registrations (required, string) - URL which points to the
-          registrations resource
 
 # Group Entities
 
-### List entities [GET /v2/entities{?limit,offset,options,type,id,idPattern,typePattern,q,mq,georel,geometry,coords,attrs,metadata,orderBy}]
+### List entities [GET /v2/entities{?limit,offset,options,type,id,idPattern,typePattern,q,mq,georel,geometry,coords,attrs,orderBy}]
 
 Retrieves a list of entities that match different criteria by id, type, pattern matching (either id or type)
 and/or those which match a query or geographical query (see [Simple Query Language](#simple_query_language) and 
@@ -1023,10 +974,6 @@ Response code:
       are to be included in the response.
       The attributes are retrieved in the order specified by this parameter. If this parameter is
       not included, the attributes are retrieved in arbitrary order.
-
-    + metadata: accuracy (optional, string) - A list of metadata names to include in the response.
-      If omitted, it means "all metadata". The string `*` can be used as member of this list to
-      mean "all the custom (user) metadata".
 
     + orderBy: temperature,!speed (optional, string) - Criteria for ordering results.
       See "Ordering Results" section for details.
@@ -1134,7 +1081,7 @@ Response:
 
 ## Entity by ID [/v2/entities/{entityId}{?type,attrs,options}]
 
-### Retrieve entity [GET /v2/entities/{entityId}{?type,attrs,metadata,options}]
+### Retrieve entity [GET /v2/entities/{entityId}{?type,attrs,options}]
 
 The response is an object representing the entity identified by the ID. The object follows
 the JSON entity representation format (described in "JSON Entity Representation" section).
@@ -1157,9 +1104,6 @@ Response:
       this parameter.
       If this parameter is not included, the attributes are retrieved in arbitrary order, and all
       the attributes of the entity are included in the response.
-    + metadata: accuracy (optional, string) - A list of metadata names to include in the response.
-      If omitted, it means "all metadata". The string `*` can be used as member of this list to
-      mean "all the custom (user) metadata".
     + options (optional, string) - Options dictionary
       + Members
           + keyValues - when used, the response payload uses the `keyValues` simplified entity
@@ -1195,7 +1139,7 @@ Response:
           }
         }
 
-### Retrieve entity attributes [GET /v2/entities/{entityId}/attrs{?type,attrs,metadata,options}]
+### Retrieve entity attributes [GET /v2/entities/{entityId}/attrs{?type,attrs,options}]
 
 This request is similar to retreiving the whole entity, however this one omits the `id` and `type`
 fields.
@@ -1220,9 +1164,6 @@ Response:
       by this parameter.
       If this parameter is not included, the attributes are retrieved in arbitrary order, and all
       the attributes of the entity are included in the response.
-    + metadata: accuracy (optional, string) - A list of metadata names to include in the response.
-      If omitted, it means "all metadata". The string `*` can be used as member of this list to mean
-      "all the custom (user) metadata".
     + options (optional, string) - Options dictionary
       + Members
           + keyValues - when used, the response payload uses the `keyValues` simplified entity
@@ -1395,7 +1336,7 @@ Response:
 
 ## Attribute by Entity ID [/v2/entities/{entityId}/attrs/{attrName}{?type}]
 
-### Get attribute data [GET /v2/entities/{entityId}/attrs/{attrName}{?type,metadata}]
+### Get attribute data [GET /v2/entities/{entityId}/attrs/{attrName}{?type}]
 
 Returns a JSON object with the attribute data of the attribute. The object follows the JSON
 representation for attributes (described in "JSON Attribute Representation" section).
@@ -1411,9 +1352,6 @@ Response:
     + type (optional, string) - Entity type, to avoid ambiguity in the case there are several
       entities with the same entity id.
     + attrName: temperature (required, string) - Name of the attribute to be retrieved.
-    + metadata: accuracy (optional, string) - A list of metadata names to include in the response.
-      If omitted, it means "all metadata". The string `*` can be used as member of this list to
-      mean "all the custom (user) metadata".
 
 + Response 200 (application/json)
 
@@ -1940,188 +1878,6 @@ Response:
 
 + Response 204
 
-# Group Registrations
-
-Context Registration allows to associate external services to context data. One of the main
-use cases of this functionality is the association of Context Providers.
-
-A context registration is represented by a JSON object with the following fields:
-
-+ `id`       : Unique identifier assigned to the registration. Automatically generated at creation
-  time.
-+ `subject`  : Object that describes the subject of the registration.
-+ `callback` : URL which denotes the end-point of the registered service. It is optional, as it can
-  be undefined under certain conditions, for instance, transient unavailability of the provider.
-+ `metadata` : An optional JSON object which allows to associate extra metadata properties to the
-  registration.
-  It must follow the same representation conventions as context attribute metadata
-  (See JSON Attribute Representation). 
-+ `duration` : Duration of the registration in ISO8601 format. Default duration is infinite.
-
-A `subject` contains the following subfields:
-
-+ `entities`: A list of objects, each one composed of the following subfields:
-    + `id` or `idPattern`: Id or pattern of the affected entities. Both cannot be used at the same
-      time, but at least one of them must be present.
-    + `type` or `typePattern`: Type or pattern of the affected entities. Both cannot be used at
-      the same time. If omitted, it means "any entity type".
-+ `attributes`: List of attributes to be provided (if not specified, all attributes).
-
-## Registration list [/v2/registrations]
-
-### Retrieve registrations [GET /v2/registrations]
-
-Lists all the registrations present in the system.
-
-Response:
-
-* Successful operation uses 200 OK
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Response 200
-
-        [
-          {
-            "id": "abcdefg",
-            "subject": {
-              "entities": [
-                {
-                  "id": "Bcn_Welt",
-                  "type": "Room"
-                }
-              ],
-              "attributes": [
-                "temperature"
-              ]
-            },
-            "callback": "http://weather.example.com/ngsi",
-            "metadata": {
-              "providingService": {
-                 "value": "weather.example.com",
-                 "type": "Text"
-               },
-              "providingAuthority": {
-                 "value": "AEMET - Spain",
-                 "type": "Text"
-               }
-            },
-            "duration": "PT1M"
-          }
-        ]
-
-### Create a new context provider registration [POST /v2/registrations]
-
-Creates a new registration. This is typically used for associating context providers
-to certain data.
-The registration is represented by a JSON object as described at the beginning of this section.
-
-Response:
-
-* Successful operation uses 201 Created
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Request (application/json)
-
-        {
-          "subject": {
-            "entities": [
-              {
-                "id": "room2",
-                "type": "Room"
-              }
-            ],
-            "attributes": [
-              "humidity"
-            ]
-          },
-          "callback":  "http://localhost:1234",
-          "metadata" : {
-            "provider": {
-              "value": "example.com"
-            }
-          },
-          "duration": "PT1M"
-        }
-
-+ Response 201
-
-    + Headers
-
-            Location: /v2/registrations/abcde98765
-
-## Registration By ID [/v2/registrations/{registrationId}]
-
-### Retrieve context provider registration [GET /v2/registrations/{registrationId}]
-
-The response is the registration represented by a JSON object as described at the beginning of this
-section.
-
-Response:
-
-* Successful operation uses 200 OK
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Parameters
-    + registrationId: abcdef (required, string) - registration Id.
-
-+ Response 200 (application/json)
-
-        {
-          "id": "abcde",
-          "subject": {
-            "entities": [
-              {
-                "id": "room2",
-                "type": "Room"
-              }
-            ],
-            "attributes": [
-              "humidity"
-            ]
-          },
-          "callback":  "http://localhost:1234",
-          "duration": "PT1M"
-        }
-
-### Update context provider registration [PATCH /v2/registrations/{registrationId}]
-
-Only the fields included in the request are updated in the registration.
-
-Response:
-
-* Successful operation uses 204 No Content
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Parameters
-    + registrationId: abcdef (required, string) - registration Id.
-
-+ Request (application/json)
-
-        {
-          "duration": "PT1M"
-        }
-
-+ Response 204
-
-### Delete context provider registration [DELETE /v2/registrations/{registrationId}]
-
-Cancels registration.
-
-Response:
-
-* Successful operation uses 204 No Content
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Parameters
-    + registrationId: abcdef (required, string) - registration Id.
-
-+ Response 204
-
 # Group Batch Operations
 
 ### Update [POST /v2/op/update]
@@ -2193,12 +1949,6 @@ The payload may contain the following elements (all of them optional):
     + `type` or `typePattern`: Type or type pattern of the entities to search for. Both cannot be used at
       the same time. If omitted, it means "any entity type".
 + `attributes`: a list of attribute names to search for. If omitted, it means "all attributes".
-+ `scopes`: a list of scopes to restrict the result of the query. Each scope is represented by a
-   JSON object with a `type` (a JSON string) and `value` (whose type depends on the `type`
-   property).
-   The different available scopes are described elsewhere.
-+ `metadata`: a list of metadata names to include in the response. If omitted, it means "all metadata".
-   The string `*` can be used as member of this list to mean "all the custom (user) metadata".
 
 Response code:
 
@@ -2239,16 +1989,6 @@ Response code:
           "attributes": [
             "temperature",
             "humidity"
-          ],
-          "scopes": [
-            {
-              "type": "FIWARE::...",
-              "value": "..."
-            }
-          ],
-          "metadata": [
-            "accuracy",
-            "timestamp"
           ]
         }
 
@@ -2285,200 +2025,3 @@ Response code:
             }
           }
         ]
-
-
-### Register [POST /v2/op/register]
-
-This operation allows to create, update and/or delete several registrations in a single batch
-operation. The payload is an object with two properties:
-
-+ `actionType`, to specify the kind of register action to do: either CREATE, UPDATE, or DELETE.
-+ `registrations`, an array of registrations, each one specified using the JSON registration 
-  representation format (described above). In the case of CREATE operation, the registration `id`
-  must not be included.
-
-Response:
-
-* Successful operation uses 200 OK. In addition, in the case of successful CREATE, a list of IDs is
-  returned, each one corresponding to the ID of the element in the request payload and in that same
-  order.
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Request (application/json)
-
-        {
-          "actionType": "CREATE",
-          "registrations": [
-            {
-              "subject": {
-                "entities": [
-                  {
-                    "type": "Room"
-                  }
-                ],
-                "attributes": [
-                  "humidity"
-                ]
-              },
-              "callback": "http://localhost:1234",
-              "duration": "PT1M"
-            },
-            {
-              "subject": {
-                "entities": [
-                  {
-                    "type": "Car"
-                  }
-                ],
-                "attributes": [
-                  "speed"
-                ]
-              },
-              "callback": "http://localhost:5678",
-              "duration": "PT1M"
-            }
-          ]
-        }
-
-+ Response 200
-
-        [
-          "abcd",
-          "efgh"
-        ]
-
-
-### Discover [POST /v2/op/discover/{?limit,offset,options}]
-
-The response payload is an Array that contains one object per matching registration.
-The registrations follow the JSON registration representation format (described in a section above).
-
-The payload may contain the following elements (all of them optional):
-
-+ `entities`: a list of entites to search for. Each entity is represented by a JSON object with the
-  following elements:
-    + `id` or `idPattern`: Id or pattern of the affected entities. Both cannot be used at the same
-      time, but at least one of them must be present.
-    + `type` or `typePattern`: Type or type pattern of the entities to search for. Both cannot be used at
-      the same time. If omitted, it means "any entity type".
-+ `attributes`: a list of attribute names to search for. If omitted, it means "all attributes".
-+ `scopes`: a list of scopes to restrict the results of the query. Each scope is represented by a
-  JSON object with a `type` (a JSON string) and a `value` (whose type depends on the `type`
-  property). The different available scopes are described elsewhere.
-
-Response code:
-
-* Successful operation uses 200 OK
-* Errors use a non-2xx and (optionally) an error payload. See subsection on "Error Responses" for
-  more details.
-
-+ Parameters
-    + limit: 10 (optional, number) - Limit the number of registrations to be retrieved.
-    + offset: 22 (optional, number) - Skip a number of registrations.
-    + options (optional, string) - Options dictionary.
-        + Members
-          + count - when used, the total number of registrations is returned in the response as the
-            HTTP header `Fiware-Total-Count`.
-
-
-+ Request (application/json)
-
-        {
-          "entities": [
-            {
-              "idPattern": ".*",
-              "type": "myFooType"
-            },
-            {
-              "id": "myBar",
-              "type": "myBarType"
-            }
-          ],
-          "attributes": [
-            "temperature",
-            "humidity"
-          ],
-          "scopes": [
-            {
-              "type": "FIWARE::Filter::Foo",
-              "value": "Bar"
-            }
-          ]
-        }
-
-+ Response 200 (application/json)
-
-        [
-          {
-            "id": "abcde",
-            "subject": {
-              "entities": [
-                {
-                  "id": "Foo",
-                  "type": "myFooType"
-                }
-              ],
-              "attributes": [
-                "humidity"
-              ]
-            },
-            "callback": "http://localhost:1234",
-            "duration": "PT1M"
-          },
-          {
-            "id": "efgh",
-            "subject": {
-              "entities": [
-                {
-                  "id": "myBar",
-                  "type": "myBarType"
-                }
-              ],
-              "attributes": [
-                "speed"
-              ]
-            },
-            "callback": "http://localhost:5678",
-            "duration": "PT1M"
-          }
-        ]
-
-# Group OMA-NGSI Operations
-
-(The need/usefulness of these operations is currently under discussion)
-
-For the sake of completeness here is an enumeration of the OMA-NGSI (9 & 10) operations. These
-operations will be supported under the 'v2' resource as well.
-
-### subscribeContext [POST /v2/subscribeContext]
-
-(Not needed, as it is covered by the RESTful POST /v2/subscriptions operation)
-
-### updateContextSubscription [POST /v2/updateContextSubscription]
-
-(Not needed, as it is covered by the RESTful PATCH /v2/subscriptions operation)
-
-### unsubscribeContext [POST /v2/unsubscribeContext]
-
-(Not needed, as it is covered by the RESTful DELETE /v2/subscriptions operation)
-
-### notifyContext [POST /v2/notifyContext]
-
-(The payload of the v2 notifyContext should be described)
-
-### subscribeContextAvailability [POST /v2/subscribeContextAvailability]
-
-(Not needed as POJ RPC, but we need to define a RESTful operation for this, analogous to the NGSI10 one)
-
-### updateContextAvailabilitySubscription [POST /v2/updateContextAvailabilitySubscription]
-
-(Not needed as POJ RPC, but we need to define a RESTful operation for this, analogous to the NGSI10 one)
-
-### unsubscribeContextAvailability [POST /v2/unsubscribeContextAvailability]
-
-(Not needed as POJ RPC, but we need to define a RESTful operation for this, analogous to the NGSI10 one)
-
-### notifyContextAvailability [POST /v2/notifyContextAvailability]
-
-(The payload of the v2 notifyContextAvailability should be described)

--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_10_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_10_31.apib
@@ -3,7 +3,7 @@ HOST: http://orion.lab.fiware.org
 TITLE: FIWARE-NGSI v2 Specification RC-2016_10
 DATE: 31 Oct 2016
 VERSION: stable
-PREVIOUS_VERSEION: RC-2016_05
+PREVIOUS_VERSION: RC-2016_05
 APIARY_PROJECT: orioncontextbroker
 SPEC_URL: https://telefonicaid.github.io/fiware-orion/api/v2/
 GITHUB_SOURCE: http://github.com/telefonicaid/fiware-orion.git


### PR DESCRIPTION
How to review this PR:

Looking to diff tab is not useful in this case, as the fiware-ngsiv2-rc-2016_10_31.apib  is enterely new. Thus, the best way to review this PR and provide feedback is to checkout task/prepare_ngsiv2_rc2016.10 branch them do the following comparison (meld or tkdiff are recommended):

- Compare fiware-ngsiv2-rc-2016_10_31.apib with fiware-ngsiv2-rc-2016_05_31.apib to check the new things that will be added to stable since last time.
- Compare fiware-ngsiv2-rc-2016_10_31.apib with fiware-ngsiv2-reference.apib to check the things in latests that are not going to be included in RC-2016.10 (thus deferred to a next RC).