### PR TITLE
FIX support attributes with double underscore as part of the name

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: over-logging of Runtime Error traces not representing actual error (#2597)
+- Fix: support attributes with double underscore as part of the name (#2453)

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -39,9 +39,9 @@ Fields:
 -   **attrs** is an keymap of the different attributes that have been
     created for that entity. The key is generated with the attribute
     name (changing "." for "=", as "." is not a valid character in
-    MongoDB document keys), appending '\_\_<id>' in the case of having
+    MongoDB document keys), appending `()<id>` in the case of having
     and ID. For example, the attribute with name "my.attr" with ID "id1"
-    will use the following key: "my=attr\_\_id2". Each one of the
+    will use the following key: `my=attr()id2`. Each one of the
     elements in the map has the following information:
     -   **type**: the attribute type
     -   **value**: the attribute value (for those attribute that has
@@ -149,7 +149,7 @@ Example document:
            },
            "mdNames": [ "customMD1", "customMD2" ]
        },
-       "A2_ID101": {
+       "A2()ID101": {
            "type": "TA2",
            "value": "176",
            "creDate" : 1389376244,

--- a/doc/manuals/admin/install.md
+++ b/doc/manuals/admin/install.md
@@ -91,6 +91,7 @@ You only need to pay attention to this if your upgrade path crosses 0.14.1, 0.19
 * [Upgrading to 0.19.0 and beyond from a pre-0.19.0 version](upgrading_crossing_0-19-0.md)
 * [Upgrading to 0.21.0 and beyond from a pre-0.21.0 version](upgrading_crossing_0-21-0.md)
 * [Upgrading to 1.3.0 and beyond from a pre-1.3.0 version](upgrading_crossing_1-3-0.md)
+* [Upgrading to 1.5.0 and beyond from a pre-1.5.0 version](upgrading_crossing_1-5-0.md)
 
 If your upgrade cover several segments (e.g. you are using 0.13.0 and
 want to upgrade to 0.19.0, so both "upgrading to 0.14.1 and beyond from

--- a/doc/manuals/admin/upgrading_crossing_1-5-0.md
+++ b/doc/manuals/admin/upgrading_crossing_1-5-0.md
@@ -1,0 +1,77 @@
+# Upgrading to 1.5.0 and beyond from a pre-1.5.0 version
+
+This procedure has to be done *only* if your DB contains attributes with [ID metadata](../user/metadata.md#metadata-id-for-attributes).
+
+-   Stop contextBroker
+-   Remove previous contextBroker version
+
+        yum remove contextBroker
+
+-   [Take a backup of your
+    DBs](database_admin.md#backup) (this is just a
+    safety measure in case any problem occurs, e.g some script gets
+    interrupted before finished and your database data ends in an
+    incoherent state)
+-   Download the following script:
+    -   [change_attr_id_separator.py](https://github.com/telefonicaid/fiware-orion/blob/1.5.0/scripts/managedb/change_attr_id_separator.py)
+-   Install pymongo (it is a script dependency) in case you don't have
+    it previously installed
+
+        pip-python install pymongo
+
+-   Apply the change_attr_id_separator.py script to your DBs, using the
+    following command (where 'db' is the database name). Note that if you are
+    using
+    [multitenant/multiservice](database_admin.md#multiservicemultitenant-database-separation)
+    you need to apply the procedure to each per-tenant/service database.
+    The script can take a while, so an interactive progress counter
+    is shown.
+
+        python change_attr_id_separator.py orion
+
+-   If you get any of the following messages, there is some problem that needs
+    to be solved before going to the next step. Check the
+    "Troubleshooting mdsvector2mdsobject" section below.
+
+        WARNING: some problem was found during the process.
+        ERROR: document ... change attempt failed
+
+-   Install new contextBroker version (Sometimes the commands fails due
+    to yum cache. In that case, run "yum clean all" and try again)
+
+        yum install contextBroker
+
+-   Start contextBroker
+
+Note that the rpm command demands superuser privileges, so you have to
+run it as root or using the sudo command.
+
+## Troubleshooting
+
+Three different kinds of problems may happen:
+
+-   You get the following error message:
+
+        OperationFailed: Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit.
+
+    Try to create a suitable index with the following command in the mongo shell, then run the script again.
+
+        db.entities.createIndex({"_id.id": 1, "_id.type": -1, "_id.servicePath": 1})
+
+    Once migration has ended, you can remove the index with the following command:
+
+        db.entities.dropIndex({"_id.id": 1, "_id.type": -1, "_id.servicePath": 1})
+
+-   Due to some unexpected problem during DB updating. The symptom of
+    this problem is getting errors like this one:
+
+        - <n>: ERROR: document <...> change attempt failed!
+
+    There is no a general solution for this problem, it has to be
+    analyzed case by case. If this happens to you, please have a look at
+    the [existing questions in StackOverflow about
+    fiware-orion](http://stackoverflow.com/questions/tagged/fiware-orion)
+    in order to check whether your problem is solved there. Otherwise create
+    your own question (don't forget to include the "fiware-orion" tag
+    and the exact error message in your case).
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ pages:
       - 'Upgrading from previous to 0.19.0': 'admin/upgrading_crossing_0-19-0.md'
       - 'Upgrading from previous to 0.21.0': 'admin/upgrading_crossing_0-21-0.md'
       - 'Upgrading from previous to 1.3.0': 'admin/upgrading_crossing_1-3-0.md'
+      - 'Upgrading from previous to 1.5.0': 'admin/upgrading_crossing_1-5-0.md'
       - 'Sanity check procedures': 'admin/sanity_check.md'
       - 'Diagnosis procedures': 'admin/diagnosis.md'
   - 'Deprecated functionality': 'deprecated.md'

--- a/scripts/managedb/change_attr_id_separator.py
+++ b/scripts/managedb/change_attr_id_separator.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+# -*- coding: latin-1 -*-
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+
+__author__ = 'fermin'
+
+from pymongo import MongoClient
+import json
+import sys
+from time import sleep
+
+ATTRS = 'attrs'
+
+def flatten(_id):
+    """
+    The way in which Python manage dictionaries doesn't make easy to be sure
+    of field ordering, which is important for MongoDB in the case of using an
+    embedded document for _id. This function helps.
+
+    :param _id: JSON document containing id, type and servicePath
+    :return: a "flatten" version of the _id
+    """
+
+    r = {'_id.id': _id['id']}
+
+    if 'type' in _id:
+       r['_id.type'] = _id['type']
+    else:
+       r['_id.type'] = {'$exists': False}
+
+    if 'servicePath' in _id:
+       r['_id.servicePath'] = _id['servicePath']
+    else:
+       r['_id.servicePath'] = {'$exists': False}
+
+    return r
+
+def update_ok(doc, check_attrs):
+    """
+    Check that entity document was updated correctly at DB.
+
+    :param doc: the doc to check
+    :param check_attrs: list of attributes which existente is checked
+    """
+
+    if not ATTRS in doc:
+        #print "debug1: no attrs"
+        return False
+
+    for attr in check_attrs:
+
+        if attr not in doc[ATTRS]:
+            #print "debug2: %s" % attr
+            return False
+
+    return True
+
+
+##########################
+# Main program starts here
+
+if len(sys.argv) != 2:
+    print "invalid number of arguments, please check https://fiware-orion.readthedocs.io/en/master/admin/upgrading_crossing_1-5-0/index.html"
+    sys.exit()
+
+DB = sys.argv[1]
+COL = 'entities'
+
+# Warn user
+print "WARNING!!!! This script modifies your '%s' database. It is STRONGLY RECOMMENDED that you" % DB
+print "do a backup of your database before using it as described in https://fiware-orion.readthedocs.io/en/master/admin/database_admin/index.html#backup. Use this script at your own risk."
+print "If you are sure you want to continue type 'yes' and press Enter"
+
+confirm = raw_input()
+
+if (confirm != 'yes'):
+    sys.exit()
+
+client = MongoClient('localhost', 27017)
+db = client[DB]
+
+need_fix = False
+
+skipped     = 0
+changed     = 0
+error       = 0
+processed   = 0
+
+total = db[COL].count()
+
+print "- processing entities collection (%d entities) changing metadata separator for attributes, this may take a while... " % total
+
+# The sort() is a way of ensuring that a modified document doesn't enters again at the end of the cursor (we have
+# observed that this may happen with large collections, e.g ~50,000 entities). In addition, we have to use
+# batch_size so the cursor doesn't expires at server (see http://stackoverflow.com/questions/10298354/mongodb-cursor-id-not-valid-error).
+# The used batch_size value is an heuristic
+for doc in db[COL].find().sort([('_id.id', 1), ('_id.type', -1), ('_id.servicePath', 1)]).batch_size(100):
+
+    processed += 1
+
+    sys.stdout.write('- processing entity: %d/%d   \r' % (processed, total) )
+    sys.stdout.flush()
+
+    # It may happen that entity doesn't have any attribute. We early detect that situation and skip in that case
+    if len(doc[ATTRS].keys()) == 0:
+        #print '- %d: entity without attributes %s. Skipping' % (processed, json.dumps(doc['_id']))
+        skipped += 1
+        continue   # entities loop
+
+    # Processing attribute by attribute
+    to_skip = True
+    new_attrs = dict(doc[ATTRS])
+    check_attrs = []
+
+    for attr in doc[ATTRS].keys():
+
+        if attr.find("__") > 0:
+            new_attr = attr.replace("__", "()")
+            print "- entity %s: found attr <%s>, changing to <%s>" % (doc['_id'], attr, new_attr)
+
+            new_attrs[new_attr] = new_attrs.pop(attr)
+            check_attrs.append(new_attr)
+
+            to_skip = False
+
+    # Need to skip to next entity?
+    if to_skip:
+        skipped += 1
+        continue    # entities loop 
+
+    # Update document with the new attribute field
+    db[COL].update(flatten(doc['_id']), {'$set': {ATTRS: new_attrs}})
+
+    # Check update was ok (this is not an exhaustive checking that is better than nothing :)
+    check_doc = db[COL].find_one(flatten(doc['_id']))
+
+    if update_ok(check_doc, check_attrs):
+        changed += 1
+    else:
+        print "- %d: ERROR: document <%s> change attempt failed!" % (processed, json.dumps(check_doc['_id']))
+        need_fix = True
+        error += 1
+
+print '- processing entity: %d/%d' % (processed, total)
+print '- documents processed:   %d' % processed
+print '  * changed:             %d' % changed
+print '  * skipped:             %d' % skipped
+print '  * error:               %d' % error
+
+if need_fix:
+    print "------------------------------------------------------"
+    print "WARNING: some problem was found during the process. Please check the documentation at https://fiware-orion.readthedocs.io/en/master/admin/upgrading_crossing_1-5-0/index.html"

--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -71,6 +71,14 @@
 
 /* ****************************************************************************
 *
+* metadata ID separator
+*/
+#define MD_ID_SEPARATOR "()"
+
+
+
+/* ****************************************************************************
+*
 * Default Types for entities, attributes and metadata
 */
 #define DEFAULT_ENTITY_TYPE       "Thing"

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -705,11 +705,11 @@ static bool updateAttribute
 {
   actualUpdate = false;
 
-  /* Attributes with metadata ID are stored as <attrName>__<ID> in the attributes embedded document */
+  /* Attributes with metadata ID are stored as <attrName>()<ID> in the attributes embedded document */
   std::string effectiveName = dbDotEncode(caP->name);
   if (caP->getId() != "")
   {
-    effectiveName += "__" + caP->getId();
+    effectiveName += MD_ID_SEPARATOR + caP->getId();
   }
 
   if (isReplace)
@@ -805,7 +805,7 @@ static bool appendAttribute
 
   if (caP->getId() != "")
   {
-    effectiveName += "__" + caP->getId();
+    effectiveName += MD_ID_SEPARATOR + caP->getId();
   }
 
   /* APPEND with existing attribute equals to UPDATE */
@@ -876,12 +876,12 @@ static bool appendAttribute
 */
 static bool legalIdUsage(BSONObj& attrs, ContextAttribute* caP)
 {
-  std::string prefix = caP->name + "__";
+  std::string prefix = caP->name + MD_ID_SEPARATOR;
 
   if (caP->getId() == "")
   {
     /* Attribute attempting to append doesn't have any ID. Thus, no attribute with same name can have ID in attrs,
-     * i.e. no attribute starting with "<attrName>" can at the same time start with "<attrName>__" */
+     * i.e. no attribute starting with "<attrName>" can at the same time start with "<attrName>()" */
     std::set<std::string> attrNames;
     attrs.getFieldNames(attrNames);
 
@@ -899,7 +899,7 @@ static bool legalIdUsage(BSONObj& attrs, ContextAttribute* caP)
   else
   {
     /* Attribute attempting to append has ID. Thus, no attribute with same name cannot have ID in attrs,
-     * i.e. no attribute starting with "<attrName>" can at the same time have a name not starting with "<attrName>__"
+     * i.e. no attribute starting with "<attrName>" can at the same time have a name not starting with "<attrName>()"
      */
     std::set<std::string> attrNames;
 
@@ -963,7 +963,7 @@ static bool legalIdUsage(const ContextAttributeVector& caV)
 *
 * Returns true if an attribute was deleted, false otherwise
 *
-* Attributes with metadata ID are stored as <attrName>__<ID> in the attributes embedded document
+* Attributes with metadata ID are stored as <attrName>()<ID> in the attributes embedded document
 */
 static bool deleteAttribute
 (
@@ -977,7 +977,7 @@ static bool deleteAttribute
 
   if (caP->getId() != "")
   {
-    effectiveName += "__" + caP->getId();
+    effectiveName += MD_ID_SEPARATOR + caP->getId();
   }
 
   if (!attrs.hasField(effectiveName.c_str()))
@@ -2755,7 +2755,7 @@ static bool createEntity
     std::string effectiveName = dbDotEncode(attrsV[ix]->name);
     if (attrId.length() != 0)
     {
-      effectiveName += "__" + attrId;
+      effectiveName += MD_ID_SEPARATOR + attrId;
     }
 
     LM_T(LmtMongo, ("new attribute: {name: %s, type: %s, value: %s}",

--- a/src/lib/mongoBackend/dbFieldEncoding.h
+++ b/src/lib/mongoBackend/dbFieldEncoding.h
@@ -28,17 +28,19 @@
 
 #include <string>
 
+#include "common/globals.h"
+
 /* ****************************************************************************
 *
 * basePart, idPart -
 *
 * Helper functions for entitysQuery to split the attribute name string into part,
-* e.g. "A1__ID1" into "A1" and "ID1"
+* e.g. "A1()ID1" into "A1" and "ID1"
 */
 inline std::string basePart(std::string name)
 {
-  /* Search for "__" */
-  std::size_t pos = name.find("__");
+  /* Search for "()" */
+  std::size_t pos = name.find(MD_ID_SEPARATOR);
   if (pos == std::string::npos)
   {
     /* If not found, return just 'name' */
@@ -52,8 +54,8 @@ inline std::string basePart(std::string name)
 
 inline std::string idPart(std::string name)
 {
-  /* Search for "__" */
-  std::size_t pos = name.find("__");
+  /* Search for "()" */
+  std::size_t pos = name.find(MD_ID_SEPARATOR);
   if (pos == std::string::npos)
   {
     /* If not found, return just "" */

--- a/test/functionalTest/cases/2453_attrs_with_double_underscore/attrs_with_double_underscore.test
+++ b/test/functionalTest/cases/2453_attrs_with_double_underscore/attrs_with_double_underscore.test
@@ -1,0 +1,158 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute with double underscore
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create an entity with double undercore
+# 02. Retreive entity
+#
+
+echo '01. Create an entity with double undercore'
+echo '=========================================='
+payload='{
+    "id": "KMZ1211",
+    "type": "Bus",
+    "__owner": {
+        "value": 1,
+        "type": "Integer",
+        "metadata": {
+            "client_id": {
+                "type": "Integer",
+                "value": "1cb7246a5fcd11e69cd1ecf4bbf955f4"
+            }
+        }
+    },
+    "__UID": {
+        "value": 17,
+        "type": "Integer",
+        "metadata": {
+            "class_uid": {
+                "type": "Integer",
+                "value": 1
+            }
+        }
+    },
+    "__label": {
+        "value": "test",
+        "type": "String"
+    },
+    "pre__label": {
+        "value": "test",
+        "type": "String"
+    },
+    "label__post": {
+        "value": "test",
+        "type": "String"
+    },
+    "label__": {
+        "value": "test",
+        "type": "String"
+    }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Retreive entity"
+echo "==================="
+orionCurl --url /v2/entities/KMZ1211
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity with double undercore
+==========================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/KMZ1211?type=Bus
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Retreive entity
+===================
+HTTP/1.1 200 OK
+Content-Length: 482
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "__UID": {
+        "metadata": {
+            "class_uid": {
+                "type": "Integer",
+                "value": 1
+            }
+        },
+        "type": "Integer",
+        "value": 17
+    },
+    "__label": {
+        "metadata": {},
+        "type": "String",
+        "value": "test"
+    },
+    "__owner": {
+        "metadata": {
+            "client_id": {
+                "type": "Integer",
+                "value": "1cb7246a5fcd11e69cd1ecf4bbf955f4"
+            }
+        },
+        "type": "Integer",
+        "value": 1
+    },
+    "id": "KMZ1211",
+    "label__": {
+        "metadata": {},
+        "type": "String",
+        "value": "test"
+    },
+    "label__post": {
+        "metadata": {},
+        "type": "String",
+        "value": "test"
+    },
+    "pre__label": {
+        "metadata": {},
+        "type": "String",
+        "value": "test"
+    },
+    "type": "Bus"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fixes #2453 

The regresion for metadata id (pe. compound_convop_attribute_json.test or compound_convop_attribute_by_valueid_json.test) ensures that the old functionality still works in a backward compatible mode.