### PR TITLE
render() and check() refactor to keep their argument to the minumum needed

### DIFF
--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -29,7 +29,8 @@
 #include "common/errorMessages.h"
 #include "common/RenderFormat.h"
 #include "common/string.h"
-#include "rest/uriParamNames.h"
+#include "rest/ConnectionInfo.h"  // FIXME PR
+#include "rest/uriParamNames.h"   // FIXME PR
 #include "apiTypesV2/Attribute.h"
 #include "ngsi10/QueryContextResponse.h"
 

--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -29,8 +29,6 @@
 #include "common/errorMessages.h"
 #include "common/RenderFormat.h"
 #include "common/string.h"
-#include "rest/ConnectionInfo.h"  // FIXME PR
-#include "rest/uriParamNames.h"   // FIXME PR
 #include "apiTypesV2/Attribute.h"
 #include "ngsi10/QueryContextResponse.h"
 
@@ -42,15 +40,14 @@
 */
 std::string Attribute::render
 (
-  // FIXME PR
   const std::string&  apiVersion,          // in parameter (pass-through)
   bool                acceptedTextPlain,   // in parameter (pass-through)
   bool                acceptedJson,        // in parameter (pass-through)
   MimeType            outFormatSelection,  // in parameter (pass-through)
   MimeType*           outMimeTypeP,        // out parameter (pass-through)
   HttpStatusCode*     scP,                 // out parameter (pass-through)
-  bool                keyValues,           // in parameter ciP->uriParamOptions[OPT_KEY_VALUES]
-  const std::string&  metadataList,        // in parameter ciP->uriParam[URI_PARAM_METADATA]
+  bool                keyValues,           // in parameter
+  const std::string&  metadataList,        // in parameter
   RequestType         requestType,         // in parameter
   bool                comma                // in parameter
 )

--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -40,9 +40,21 @@
 *
 * Attribute::render -
 */
-std::string Attribute::render(ConnectionInfo* ciP, RequestType requestType, bool comma)
+std::string Attribute::render
+(
+  // FIXME PR
+  const std::string&  apiVersion,          // in parameter (pass-through)
+  bool                acceptedTextPlain,   // in parameter (pass-through)
+  bool                acceptedJson,        // in parameter (pass-through)
+  MimeType            outFormatSelection,  // in parameter (pass-through)
+  MimeType*           outMimeTypeP,        // out parameter (pass-through)
+  HttpStatusCode*     scP,                 // out parameter (pass-through)
+  bool                keyValues,           // in parameter ciP->uriParamOptions[OPT_KEY_VALUES]
+  const std::string&  metadataList,        // in parameter ciP->uriParam[URI_PARAM_METADATA]
+  RequestType         requestType,         // in parameter
+  bool                comma                // in parameter
+)
 {
-  bool          keyValues  = ciP->uriParamOptions[OPT_KEY_VALUES];
   RenderFormat  renderFormat = (keyValues == true)? NGSI_V2_KEYVALUES : NGSI_V2_NORMALIZED;
 
   if (pcontextAttribute)
@@ -51,15 +63,15 @@ std::string Attribute::render(ConnectionInfo* ciP, RequestType requestType, bool
 
     if (requestType == EntityAttributeValueRequest)
     {
-      out = pcontextAttribute->toJsonAsValue(ciP);
+      out = pcontextAttribute->toJsonAsValue(apiVersion, acceptedTextPlain, acceptedJson, outFormatSelection, outMimeTypeP, scP);
     }
     else
     {
       std::vector<std::string> metadataFilter;
 
-      if (ciP->uriParam[URI_PARAM_METADATA] != "")
+      if (metadataList != "")
       {
-        stringSplit(ciP->uriParam[URI_PARAM_METADATA], ',', metadataFilter);
+        stringSplit(metadataList, ',', metadataFilter);
       }
 
       out = "{";

--- a/src/lib/apiTypesV2/Attribute.h
+++ b/src/lib/apiTypesV2/Attribute.h
@@ -46,7 +46,16 @@ public:
   OrionError         oe;                    // Optional - mandatory if not 200-OK
 
   Attribute(): pcontextAttribute(0) {}
-  std::string  render(ConnectionInfo* ciP, RequestType requestType, bool comma = false);
+  std::string  render(const std::string&  apiVersion,
+                      bool                acceptedTextPlain,
+                      bool                acceptedJson,
+                      MimeType            outFormatSelection,
+                      MimeType*           outMimeTypeP,
+                      HttpStatusCode*     scP,
+                      bool                keyValues,
+                      const std::string&  metadataList,
+                      RequestType         requestType,
+                      bool                comma = false);
   void         fill(QueryContextResponse* qcrsP, std::string attrName);
 };
 

--- a/src/lib/apiTypesV2/BatchQuery.h
+++ b/src/lib/apiTypesV2/BatchQuery.h
@@ -32,7 +32,6 @@
 #include "ngsi/Request.h"
 #include "ngsi/ScopeVector.h"
 #include "apiTypesV2/Entities.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/apiTypesV2/BatchUpdate.h
+++ b/src/lib/apiTypesV2/BatchUpdate.h
@@ -31,7 +31,6 @@
 #include "ngsi/UpdateActionType.h"
 #include "ngsi/Request.h"
 #include "apiTypesV2/Entities.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/apiTypesV2/Entities.cpp
+++ b/src/lib/apiTypesV2/Entities.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "logMsg/traceLevels.h"
+#include "logMsg/logMsg.h"
 #include "ngsi10/QueryContextResponse.h"
 #include "apiTypesV2/Entities.h"
 

--- a/src/lib/apiTypesV2/Entities.cpp
+++ b/src/lib/apiTypesV2/Entities.cpp
@@ -58,9 +58,9 @@ Entities::~Entities()
 * Entities::render - 
 *
 */
-std::string Entities::render(ConnectionInfo* ciP, RequestType requestType)
+std::string Entities::render(ConnectionInfo* ciP)
 {
-  return vec.render(ciP, requestType, false);
+  return vec.render(ciP);
 } 
 
 

--- a/src/lib/apiTypesV2/Entities.cpp
+++ b/src/lib/apiTypesV2/Entities.cpp
@@ -73,9 +73,9 @@ std::string Entities::render(ConnectionInfo* ciP, RequestType requestType)
 *   The 'check' method is normally only used to check that incoming payload is correct.
 *   For now (at least), the Entities type is only used as outgoing payload ...
 */
-std::string Entities::check(ConnectionInfo* ciP, RequestType requestType)
+std::string Entities::check(const std::string& apiVersion, RequestType requestType)
 {
-  return vec.check(ciP, requestType);
+  return vec.check(apiVersion, requestType);
 }
 
 

--- a/src/lib/apiTypesV2/Entities.cpp
+++ b/src/lib/apiTypesV2/Entities.cpp
@@ -59,9 +59,13 @@ Entities::~Entities()
 * Entities::render - 
 *
 */
-std::string Entities::render(ConnectionInfo* ciP)
+std::string Entities::render
+(
+  std::map<std::string, bool>&         uriParamOptions,
+  std::map<std::string, std::string>&  uriParam
+)
 {
-  return vec.render(ciP);
+  return vec.render(uriParamOptions, uriParam);
 } 
 
 

--- a/src/lib/apiTypesV2/Entities.h
+++ b/src/lib/apiTypesV2/Entities.h
@@ -47,7 +47,7 @@ public:
   Entities();
   ~Entities();
 
-  std::string  render(ConnectionInfo* ciP, RequestType requestType);
+  std::string  render(ConnectionInfo* ciP);
   std::string  check(const std::string& apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);

--- a/src/lib/apiTypesV2/Entities.h
+++ b/src/lib/apiTypesV2/Entities.h
@@ -47,7 +47,8 @@ public:
   Entities();
   ~Entities();
 
-  std::string  render(ConnectionInfo* ciP);
+  std::string  render(std::map<std::string, bool>&         uriParamOptions,
+                      std::map<std::string, std::string>&  uriParam);
   std::string  check(const std::string& apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);

--- a/src/lib/apiTypesV2/Entities.h
+++ b/src/lib/apiTypesV2/Entities.h
@@ -48,7 +48,7 @@ public:
   ~Entities();
 
   std::string  render(ConnectionInfo* ciP, RequestType requestType);
-  std::string  check(ConnectionInfo*  ciP, RequestType requestType);
+  std::string  check(const std::string& apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);
   void         fill(QueryContextResponse* qcrsP);

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -36,6 +36,8 @@
 #include "apiTypesV2/Entity.h"
 #include "ngsi10/QueryContextResponse.h"
 
+#include "rest/ConnectionInfo.h"  // FIXME PR
+
 
 
 /* ****************************************************************************

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -169,12 +169,12 @@ std::string Entity::render(ConnectionInfo* ciP, RequestType requestType, bool co
 *
 * Entity::check - 
 */
-std::string Entity::check(ConnectionInfo* ciP, RequestType requestType)
+std::string Entity::check(const std::string& apiVersion, RequestType requestType)
 {
   ssize_t len;
   char errorMsg[128];
 
-  if (((ciP->apiVersion == "v2") && (len = strlen(id.c_str())) < MIN_ID_LEN) && (requestType != EntityRequest))
+  if (((apiVersion == "v2") && (len = strlen(id.c_str())) < MIN_ID_LEN) && (requestType != EntityRequest))
   {
     snprintf(errorMsg, sizeof errorMsg, "entity id length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
@@ -193,7 +193,7 @@ std::string Entity::check(ConnectionInfo* ciP, RequestType requestType)
     return std::string(errorMsg);
   }
 
-  if (forbiddenIdChars(ciP->apiVersion, id.c_str()))
+  if (forbiddenIdChars(apiVersion, id.c_str()))
   {
     alarmMgr.badInput(clientIp, "found a forbidden character in the id of an entity");
     return "Invalid characters in entity id";
@@ -206,14 +206,14 @@ std::string Entity::check(ConnectionInfo* ciP, RequestType requestType)
     return std::string(errorMsg);
   }
 
-  if ((ciP->apiVersion == "v2") && ((len = strlen(type.c_str())) < MIN_ID_LEN) && (requestType != BatchQueryRequest))
+  if ((apiVersion == "v2") && ((len = strlen(type.c_str())) < MIN_ID_LEN) && (requestType != BatchQueryRequest))
   {
     snprintf(errorMsg, sizeof errorMsg, "entity type length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
     return std::string(errorMsg);
   }
 
-  if (forbiddenIdChars(ciP->apiVersion, type.c_str()))
+  if (forbiddenIdChars(apiVersion, type.c_str()))
   {
     alarmMgr.badInput(clientIp, "found a forbidden character in the type of an entity");
     return "Invalid characters in entity type";
@@ -225,7 +225,7 @@ std::string Entity::check(ConnectionInfo* ciP, RequestType requestType)
     return "Invalid characters in entity isPattern";
   }
 
-  return attributeVector.check(ciP, requestType, "", "", 0);
+  return attributeVector.check(apiVersion, requestType);
 }
 
 

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "logMsg/traceLevels.h"
+#include "logMsg/logMsg.h"
 #include "common/tag.h"
 #include "common/string.h"
 #include "common/globals.h"
@@ -35,8 +36,6 @@
 #include "parse/forbiddenChars.h"
 #include "apiTypesV2/Entity.h"
 #include "ngsi10/QueryContextResponse.h"
-
-#include "rest/ConnectionInfo.h"  // FIXME PR
 
 
 
@@ -71,13 +70,18 @@ Entity::~Entity()
 *   o 'keyValues'  (less verbose, only name and values shown for attributes - no type, no metadatas)
 *   o 'values'     (only the values of the attributes are printed, in a vector)
 */
-std::string Entity::render(ConnectionInfo* ciP, bool comma)
+std::string Entity::render
+(
+  std::map<std::string, bool>&         uriParamOptions,
+  std::map<std::string, std::string>&  uriParam,
+  bool                                 comma
+)
 {
   RenderFormat  renderFormat = NGSI_V2_NORMALIZED;
 
-  if      (ciP->uriParamOptions[OPT_KEY_VALUES]    == true)  { renderFormat = NGSI_V2_KEYVALUES;     }
-  else if (ciP->uriParamOptions[OPT_VALUES]        == true)  { renderFormat = NGSI_V2_VALUES;        }
-  else if (ciP->uriParamOptions[OPT_UNIQUE_VALUES] == true)  { renderFormat = NGSI_V2_UNIQUE_VALUES; }
+  if      (uriParamOptions[OPT_KEY_VALUES]    == true)  { renderFormat = NGSI_V2_KEYVALUES;     }
+  else if (uriParamOptions[OPT_VALUES]        == true)  { renderFormat = NGSI_V2_VALUES;        }
+  else if (uriParamOptions[OPT_UNIQUE_VALUES] == true)  { renderFormat = NGSI_V2_UNIQUE_VALUES; }
 
   if ((oe.details == "") && ((oe.reasonPhrase == "OK") || (oe.reasonPhrase == "")))
   {
@@ -85,23 +89,23 @@ std::string Entity::render(ConnectionInfo* ciP, bool comma)
     std::vector<std::string> metadataFilter;
     std::vector<std::string> attrsFilter;
 
-    if (ciP->uriParam[URI_PARAM_METADATA] != "")
+    if (uriParam[URI_PARAM_METADATA] != "")
     {
-      stringSplit(ciP->uriParam[URI_PARAM_METADATA], ',', metadataFilter);
+      stringSplit(uriParam[URI_PARAM_METADATA], ',', metadataFilter);
     }
 
-    if (ciP->uriParam[URI_PARAM_ATTRIBUTES] != "")
+    if (uriParam[URI_PARAM_ATTRIBUTES] != "")
     {
-      stringSplit(ciP->uriParam[URI_PARAM_ATTRIBUTES], ',', attrsFilter);
+      stringSplit(uriParam[URI_PARAM_ATTRIBUTES], ',', attrsFilter);
     }
 
     // Add special attributes representing entity dates
-    if ((creDate != 0) && (ciP->uriParamOptions[DATE_CREATED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_CREATED) != attrsFilter.end())))
+    if ((creDate != 0) && (uriParamOptions[DATE_CREATED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_CREATED) != attrsFilter.end())))
     {
       ContextAttribute* caP = new ContextAttribute(DATE_CREATED, DATE_TYPE, creDate);
       attributeVector.push_back(caP);
     }
-    if ((modDate != 0) && (ciP->uriParamOptions[DATE_MODIFIED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_MODIFIED) != attrsFilter.end())))
+    if ((modDate != 0) && (uriParamOptions[DATE_MODIFIED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_MODIFIED) != attrsFilter.end())))
     {
       ContextAttribute* caP = new ContextAttribute(DATE_MODIFIED, DATE_TYPE, modDate);
       attributeVector.push_back(caP);

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -69,7 +69,7 @@ Entity::~Entity()
 *   o 'keyValues'  (less verbose, only name and values shown for attributes - no type, no metadatas)
 *   o 'values'     (only the values of the attributes are printed, in a vector)
 */
-std::string Entity::render(ConnectionInfo* ciP, RequestType requestType, bool comma)
+std::string Entity::render(ConnectionInfo* ciP, bool comma)
 {
   RenderFormat  renderFormat = NGSI_V2_NORMALIZED;
 

--- a/src/lib/apiTypesV2/Entity.h
+++ b/src/lib/apiTypesV2/Entity.h
@@ -57,7 +57,7 @@ public:
   Entity();
   ~Entity();
 
-  std::string  render(ConnectionInfo* ciP, RequestType requestType, bool comma = false);
+  std::string  render(ConnectionInfo* ciP, bool comma = false);
   std::string  check(const std::string& apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);

--- a/src/lib/apiTypesV2/Entity.h
+++ b/src/lib/apiTypesV2/Entity.h
@@ -57,7 +57,9 @@ public:
   Entity();
   ~Entity();
 
-  std::string  render(ConnectionInfo* ciP, bool comma = false);
+  std::string  render(std::map<std::string, bool>&         uriParamOptions,
+                      std::map<std::string, std::string>&  uriParam,
+                      bool                                 comma = false);
   std::string  check(const std::string& apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);

--- a/src/lib/apiTypesV2/Entity.h
+++ b/src/lib/apiTypesV2/Entity.h
@@ -58,7 +58,7 @@ public:
   ~Entity();
 
   std::string  render(ConnectionInfo* ciP, RequestType requestType, bool comma = false);
-  std::string  check(ConnectionInfo*  ciP, RequestType requestType);
+  std::string  check(const std::string& apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);
   void         fill(const std::string&       id,

--- a/src/lib/apiTypesV2/EntityVector.cpp
+++ b/src/lib/apiTypesV2/EntityVector.cpp
@@ -69,17 +69,13 @@ std::string EntityVector::render(ConnectionInfo* ciP, RequestType requestType, b
 *
 * EntityVector::check -
 */
-std::string EntityVector::check
-(
-  ConnectionInfo*     ciP,
-  RequestType         requestType
-)
+std::string EntityVector::check(const std::string& apiVersion, RequestType requestType)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, requestType)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, requestType)) != "OK")
     {
       alarmMgr.badInput(clientIp, "invalid vector of Entity");
       return res;

--- a/src/lib/apiTypesV2/EntityVector.cpp
+++ b/src/lib/apiTypesV2/EntityVector.cpp
@@ -42,7 +42,7 @@
 *
 * EntityVector::render -
 */
-std::string EntityVector::render(ConnectionInfo* ciP, RequestType requestType, bool comma)
+std::string EntityVector::render(ConnectionInfo* ciP)
 {
   if (vec.size() == 0)
   {
@@ -55,7 +55,7 @@ std::string EntityVector::render(ConnectionInfo* ciP, RequestType requestType, b
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += vec[ix]->render(ciP, requestType, ix != vec.size() - 1);
+    out += vec[ix]->render(ciP, ix != vec.size() - 1);
   }
 
   out += "]";

--- a/src/lib/apiTypesV2/EntityVector.cpp
+++ b/src/lib/apiTypesV2/EntityVector.cpp
@@ -42,7 +42,11 @@
 *
 * EntityVector::render -
 */
-std::string EntityVector::render(ConnectionInfo* ciP)
+std::string EntityVector::render
+(
+  std::map<std::string, bool>&         uriParamOptions,
+  std::map<std::string, std::string>&  uriParam
+)
 {
   if (vec.size() == 0)
   {
@@ -55,7 +59,7 @@ std::string EntityVector::render(ConnectionInfo* ciP)
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += vec[ix]->render(ciP, ix != vec.size() - 1);
+    out += vec[ix]->render(uriParamOptions, uriParam, ix != vec.size() - 1);
   }
 
   out += "]";

--- a/src/lib/apiTypesV2/EntityVector.h
+++ b/src/lib/apiTypesV2/EntityVector.h
@@ -40,7 +40,7 @@ typedef struct EntityVector
 {
   std::vector<Entity*>  vec;
 
-  std::string   render(ConnectionInfo* ciP, RequestType requestType, bool comma = false);
+  std::string   render(ConnectionInfo* ciP);
   std::string   check(const std::string& apiVersion, RequestType requestType);
   void          present(const std::string& indent);
   void          push_back(Entity* item);

--- a/src/lib/apiTypesV2/EntityVector.h
+++ b/src/lib/apiTypesV2/EntityVector.h
@@ -41,7 +41,7 @@ typedef struct EntityVector
   std::vector<Entity*>  vec;
 
   std::string   render(ConnectionInfo* ciP, RequestType requestType, bool comma = false);
-  std::string   check(ConnectionInfo*  ciP, RequestType requestType);
+  std::string   check(const std::string& apiVersion, RequestType requestType);
   void          present(const std::string& indent);
   void          push_back(Entity* item);
   unsigned int  size(void);

--- a/src/lib/apiTypesV2/EntityVector.h
+++ b/src/lib/apiTypesV2/EntityVector.h
@@ -40,7 +40,8 @@ typedef struct EntityVector
 {
   std::vector<Entity*>  vec;
 
-  std::string   render(ConnectionInfo* ciP);
+  std::string   render(std::map<std::string, bool>&         uriParamOptions,
+                       std::map<std::string, std::string>&  uriParam);
   std::string   check(const std::string& apiVersion, RequestType requestType);
   void          present(const std::string& indent);
   void          push_back(Entity* item);

--- a/src/lib/common/macroSubstitute.cpp
+++ b/src/lib/common/macroSubstitute.cpp
@@ -24,9 +24,12 @@
 */
 #include <string>
 
+#include "logMsg/logMsg.h"
+
 #include "common/string.h"
-#include "ngsi/ContextElement.h"
 #include "common/macroSubstitute.h"
+
+#include "ngsi/ContextElement.h"
 
 
 

--- a/src/lib/convenience/AppendContextElementRequest.cpp
+++ b/src/lib/convenience/AppendContextElementRequest.cpp
@@ -49,7 +49,7 @@ AppendContextElementRequest::AppendContextElementRequest()
 *
 * render - 
 */
-std::string AppendContextElementRequest::render(ConnectionInfo* ciP, RequestType requestType, std::string indent)
+std::string AppendContextElementRequest::render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
 {
   std::string tag = "appendContextElementRequest";
   std::string out = "";
@@ -62,7 +62,7 @@ std::string AppendContextElementRequest::render(ConnectionInfo* ciP, RequestType
   }
 
   out += attributeDomainName.render(indent + "  ", true);
-  out += contextAttributeVector.render(ciP, requestType, indent + "  ");
+  out += contextAttributeVector.render(apiVersion, asJsonObject, requestType, indent + "  ");
   out += domainMetadataVector.render(indent + "  ");
   out += endTag(indent);
 
@@ -86,11 +86,12 @@ std::string AppendContextElementRequest::render(ConnectionInfo* ciP, RequestType
 */
 std::string AppendContextElementRequest::check
 (
-  ConnectionInfo*  ciP,
-  RequestType      requestType,
-  std::string      indent,
-  std::string      predetectedError,     // Predetected Error, normally during parsing
-  int              counter
+  const std::string& apiVersion,
+  bool               asJsonObject,
+  RequestType        requestType,
+  std::string        indent,
+  std::string        predetectedError,     // Predetected Error, normally during parsing
+  int                counter
 )
 {
   AppendContextElementResponse  response;
@@ -100,13 +101,11 @@ std::string AppendContextElementRequest::check
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  // FIXME PR
-  else if ((res = contextAttributeVector.check(ciP->apiVersion, AppendContextElement)) != "OK")
+  else if ((res = contextAttributeVector.check(apiVersion, AppendContextElement)) != "OK")
   {
     response.errorCode.fill(SccBadRequest, res);
   }
-  // FIXME PR
-  else if ((res = domainMetadataVector.check(ciP->apiVersion)) != "OK")
+  else if ((res = domainMetadataVector.check(apiVersion)) != "OK")
   {
     response.errorCode.fill(SccBadRequest, res);
   }
@@ -115,7 +114,7 @@ std::string AppendContextElementRequest::check
     return "OK";
   }
 
-  return response.render(ciP, requestType, indent);
+  return response.render(apiVersion, asJsonObject, requestType, indent);
 }
 
 

--- a/src/lib/convenience/AppendContextElementRequest.cpp
+++ b/src/lib/convenience/AppendContextElementRequest.cpp
@@ -100,11 +100,13 @@ std::string AppendContextElementRequest::check
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = contextAttributeVector.check(ciP, AppendContextElement, indent, predetectedError, counter)) != "OK")
+  // FIXME PR
+  else if ((res = contextAttributeVector.check(ciP->apiVersion, AppendContextElement)) != "OK")
   {
     response.errorCode.fill(SccBadRequest, res);
   }
-  else if ((res = domainMetadataVector.check(ciP, AppendContextElement, indent, predetectedError, counter)) != "OK")
+  // FIXME PR
+  else if ((res = domainMetadataVector.check(ciP->apiVersion)) != "OK")
   {
     response.errorCode.fill(SccBadRequest, res);
   }

--- a/src/lib/convenience/AppendContextElementRequest.h
+++ b/src/lib/convenience/AppendContextElementRequest.h
@@ -56,14 +56,15 @@ typedef struct AppendContextElementRequest
 
   AppendContextElementRequest();
 
-  std::string  render(ConnectionInfo* ciP, RequestType requestType, std::string indent);
+  std::string  render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
   void         present(std::string indent);
   void         release();
-  std::string  check(ConnectionInfo*  ciP,
-                     RequestType      requestType,
-                     std::string      indent,
-                     std::string      predetectedError,
-                     int              counter);
+  std::string  check(const std::string&  apiVersion,
+                     bool                asJsonObject,
+                     RequestType         requestType,
+                     std::string         indent,
+                     std::string         predetectedError,
+                     int                 counter);
 } AppendContextElementRequest;
 
 #endif  // SRC_LIB_CONVENIENCE_APPENDCONTEXTELEMENTREQUEST_H_

--- a/src/lib/convenience/AppendContextElementResponse.cpp
+++ b/src/lib/convenience/AppendContextElementResponse.cpp
@@ -52,7 +52,12 @@ AppendContextElementResponse::AppendContextElementResponse() : errorCode("errorC
 *
 * AppendContextElementResponse::render - 
 */
-std::string AppendContextElementResponse::render(ConnectionInfo* ciP, RequestType requestType, std::string indent)
+std::string AppendContextElementResponse::render
+(
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  RequestType         requestType,
+  const std::string& indent)
 {
   std::string tag = "appendContextElementResponse";
   std::string out = "";
@@ -70,7 +75,7 @@ std::string AppendContextElementResponse::render(ConnectionInfo* ciP, RequestTyp
       out += entity.render(indent + "  ", true);
     }
 
-    out += contextAttributeResponseVector.render(ciP, requestType, indent + "  ");
+    out += contextAttributeResponseVector.render(apiVersion, asJsonObject, requestType, indent + "  ");
   }
 
   out += endTag(indent);
@@ -86,11 +91,12 @@ std::string AppendContextElementResponse::render(ConnectionInfo* ciP, RequestTyp
 */
 std::string AppendContextElementResponse::check
 (
-  ConnectionInfo*  ciP,
-  RequestType      requestType,
-  std::string      indent,
-  std::string      predetectedError,
-  int              counter
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  RequestType         requestType,
+  std::string         indent,
+  std::string         predetectedError,
+  int                 counter
 )
 {
   std::string res;
@@ -99,7 +105,7 @@ std::string AppendContextElementResponse::check
   {
     errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = contextAttributeResponseVector.check(ciP, requestType, indent, "", counter)) != "OK")
+  else if ((res = contextAttributeResponseVector.check(apiVersion, asJsonObject, requestType, indent, "", counter)) != "OK")
   {
     errorCode.fill(SccBadRequest, res);
   }
@@ -108,7 +114,7 @@ std::string AppendContextElementResponse::check
     return "OK";
   }
 
-  return render(ciP, requestType, indent);
+  return render(apiVersion, asJsonObject, requestType, indent);
 }
 
 

--- a/src/lib/convenience/AppendContextElementResponse.h
+++ b/src/lib/convenience/AppendContextElementResponse.h
@@ -71,14 +71,18 @@ typedef struct AppendContextElementResponse
 
   AppendContextElementResponse();
 
-  std::string  render(ConnectionInfo* ciP, RequestType requestType, std::string indent);
+  std::string  render(const std::string&  apiVersion,
+                      bool                asJsonObject,
+                      RequestType         requestType,
+                      const std::string&  indent);
   void         present(void);
   void         release(void);
-  std::string  check(ConnectionInfo*  ciP,
-                     RequestType      requestType,
-                     std::string      indent,
-                     std::string      predetectedError,
-                     int              counter);
+  std::string  check(const std::string&  apiVersion,
+                     bool                asJsonObject,
+                     RequestType         requestType,
+                     std::string         indent,
+                     std::string         predetectedError,
+                     int                 counter);
   void         fill(UpdateContextResponse* ucrsP, const std::string& entityId = "", const std::string& entityType = "");
 } AppendContextElementResponse;
 

--- a/src/lib/convenience/ContextAttributeResponse.cpp
+++ b/src/lib/convenience/ContextAttributeResponse.cpp
@@ -76,7 +76,8 @@ std::string ContextAttributeResponse::check
   {
     statusCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = contextAttributeVector.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  // FIXME PR
+  else if ((res = contextAttributeVector.check(ciP->apiVersion, requestType)) != "OK")
   {
     std::string details = std::string("contextAttributeVector: '") + res + "'";
     alarmMgr.badInput(clientIp, details);

--- a/src/lib/convenience/ContextAttributeResponse.cpp
+++ b/src/lib/convenience/ContextAttributeResponse.cpp
@@ -42,13 +42,19 @@
 *
 * render - 
 */
-std::string ContextAttributeResponse::render(ConnectionInfo* ciP, RequestType request, std::string indent)
+std::string ContextAttributeResponse::render
+(
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  RequestType         request,
+  const std::string&  indent
+)
 {
   std::string tag = "contextAttributeResponse";
   std::string out = "";
 
   out += startTag1(indent, tag, false);
-  out += contextAttributeVector.render(ciP, request, indent + "  ", true);
+  out += contextAttributeVector.render(apiVersion, asJsonObject, request, indent + "  ", true);
   out += statusCode.render(indent + "  ");
   out += endTag(indent);
 
@@ -63,11 +69,12 @@ std::string ContextAttributeResponse::render(ConnectionInfo* ciP, RequestType re
 */
 std::string ContextAttributeResponse::check
 (
-  ConnectionInfo*  ciP,
-  RequestType      requestType,
-  std::string      indent,
-  std::string      predetectedError,
-  int              counter
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  RequestType         requestType,
+  std::string         indent,
+  std::string         predetectedError,
+  int                 counter
 )
 {
   std::string  res;
@@ -76,8 +83,7 @@ std::string ContextAttributeResponse::check
   {
     statusCode.fill(SccBadRequest, predetectedError);
   }
-  // FIXME PR
-  else if ((res = contextAttributeVector.check(ciP->apiVersion, requestType)) != "OK")
+  else if ((res = contextAttributeVector.check(apiVersion, requestType)) != "OK")
   {
     std::string details = std::string("contextAttributeVector: '") + res + "'";
     alarmMgr.badInput(clientIp, details);
@@ -97,7 +103,7 @@ std::string ContextAttributeResponse::check
     return "OK";
   }
 
-  return render(ciP, requestType, indent);
+  return render(apiVersion, asJsonObject, requestType, indent);
 }
 
 

--- a/src/lib/convenience/ContextAttributeResponse.h
+++ b/src/lib/convenience/ContextAttributeResponse.h
@@ -51,14 +51,18 @@ typedef struct ContextAttributeResponse
   ContextAttributeVector     contextAttributeVector;     // Mandatory
   StatusCode                 statusCode;                 // Mandatory
 
-  std::string render(ConnectionInfo* ciP, RequestType requestType, std::string indent);
+  std::string render(const std::string&  apiVersion,
+                     bool                asJsonObject,
+                     RequestType         request,
+                     const std::string&  indent);
   void        present(std::string indent);
   void        release(void);
-  std::string check(ConnectionInfo*  ciP,
-                    RequestType      requestType,
-                    std::string      indent,
-                    std::string      predetectedError,
-                    int              counter);
+  std::string check(const std::string&  apiVersion,
+                    bool                asJsonObject,
+                    RequestType         requestType,
+                    std::string         indent,
+                    std::string         predetectedError,
+                    int                 counter);
   void        fill(ContextAttributeVector* _cavP, const StatusCode& _statusCode);
   void        fill(QueryContextResponse*  qcrP,
                    const std::string&     entityId,

--- a/src/lib/convenience/ContextAttributeResponseVector.cpp
+++ b/src/lib/convenience/ContextAttributeResponseVector.cpp
@@ -38,7 +38,12 @@
 *
 * ContextAttributeResponseVector::render - 
 */
-std::string ContextAttributeResponseVector::render(ConnectionInfo* ciP, RequestType request, std::string indent)
+std::string ContextAttributeResponseVector::render
+(
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  RequestType         request,
+  const std::string&  indent)
 {
   std::string out = "";
   std::string key = "contextResponses";
@@ -54,7 +59,7 @@ std::string ContextAttributeResponseVector::render(ConnectionInfo* ciP, RequestT
   out += startTag2(indent, key, true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += vec[ix]->render(ciP, request, indent + "  ");
+    out += vec[ix]->render(apiVersion, asJsonObject, request, indent + "  ");
   }
   out += endTag(indent, false, true);
 
@@ -69,18 +74,19 @@ std::string ContextAttributeResponseVector::render(ConnectionInfo* ciP, RequestT
 */
 std::string ContextAttributeResponseVector::check
 (
-  ConnectionInfo*  ciP,
-  RequestType      request,
-  std::string      indent,
-  std::string      predetectedError,
-  int              counter
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  RequestType         request,
+  std::string         indent,
+  std::string         predetectedError,
+  int                 counter
 )
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, request, indent, predetectedError, counter)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, asJsonObject, request, indent, predetectedError, counter)) != "OK")
     {
       return res;
     }

--- a/src/lib/convenience/ContextAttributeResponseVector.h
+++ b/src/lib/convenience/ContextAttributeResponseVector.h
@@ -41,16 +41,20 @@ typedef struct ContextAttributeResponseVector
 {
   std::vector<ContextAttributeResponse*>  vec;
 
-  std::string                render(ConnectionInfo* ciP, RequestType requestType, std::string indent);
+  std::string                render(const std::string&  apiVersion,
+                                    bool                asJsonObject,
+                                    RequestType         request,
+                                    const std::string&  indent);
   void                       present(std::string indent);
   void                       push_back(ContextAttributeResponse* item);
   unsigned int               size(void);
   void                       release(void);
-  std::string                check(ConnectionInfo*  ciP,
-                                   RequestType      requestType,
-                                   std::string      indent,
-                                   std::string      predetectedError,
-                                   int              counter);
+  std::string                check(const std::string&  apiVersion,
+                                   bool                asJsonObject,
+                                   RequestType         requestType,
+                                   std::string         indent,
+                                   std::string         predetectedError,
+                                   int                 counter);
   void                       fill(ContextAttributeVector* cavP, const StatusCode& statusCode);
 
   ContextAttributeResponse*  operator[](unsigned int ix) const;

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -115,7 +115,7 @@ std::string RegisterProviderRequest::check
   std::string details = std::string("RegisterProviderRequest Error: '") + res + "'";
   alarmMgr.badInput(clientIp, details);
 
-  return response.render(DiscoverContextAvailability, indent);
+  return response.render(indent);
 }
 
 

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -86,11 +86,11 @@ std::string RegisterProviderRequest::render(std::string indent)
 */
 std::string RegisterProviderRequest::check
 (
-  ConnectionInfo* ciP,
-  RequestType     requestType,  
-  std::string     indent,
-  std::string     predetectedError,
-  int             counter
+  const std::string&  apiVersion,
+  RequestType         requestType,
+  std::string         indent,
+  std::string         predetectedError,
+  int                 counter
 )
 {
   DiscoverContextAvailabilityResponse  response;
@@ -100,8 +100,7 @@ std::string RegisterProviderRequest::check
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  // FIXME PR
-  else if (((res = metadataVector.check(ciP->apiVersion))  != "OK") ||
+  else if (((res = metadataVector.check(apiVersion))                        != "OK") ||
            ((res = duration.check(requestType, indent, "", 0))              != "OK") ||
            ((res = providingApplication.check(requestType, indent, "", 0))  != "OK") ||
            ((res = registrationId.check(requestType, indent, "", 0))        != "OK"))

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -100,7 +100,8 @@ std::string RegisterProviderRequest::check
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if (((res = metadataVector.check(ciP, requestType, indent, "", counter))  != "OK") ||
+  // FIXME PR
+  else if (((res = metadataVector.check(ciP->apiVersion))  != "OK") ||
            ((res = duration.check(requestType, indent, "", 0))              != "OK") ||
            ((res = providingApplication.check(requestType, indent, "", 0))  != "OK") ||
            ((res = registrationId.check(requestType, indent, "", 0))        != "OK"))

--- a/src/lib/convenience/RegisterProviderRequest.h
+++ b/src/lib/convenience/RegisterProviderRequest.h
@@ -49,7 +49,7 @@ typedef struct RegisterProviderRequest
   RegisterProviderRequest();
 
   std::string  render(std::string indent);
-  std::string  check(ConnectionInfo* ciP, RequestType requestType, std::string indent, std::string preError, int counter);
+  std::string  check(const std::string& apiVersion, RequestType requestType, std::string indent, std::string preError, int counter);
   void         present(std::string indent);
   void         release();
 } RegisterProviderRequest;

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -77,8 +77,9 @@ std::string UpdateContextAttributeRequest::render(ConnectionInfo* ciP, std::stri
       isCompoundVector = true;
     }
 
+    // FIXME PR
     out += startTag2(indent + "  ", "value", isCompoundVector, true);
-    out += compoundValueP->render(ciP, indent + "    ");
+    out += compoundValueP->render(ciP->apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }
 

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -54,7 +54,7 @@ UpdateContextAttributeRequest::UpdateContextAttributeRequest()
 *
 * render - 
 */
-std::string UpdateContextAttributeRequest::render(ConnectionInfo* ciP, std::string indent)
+std::string UpdateContextAttributeRequest::render(const std::string& apiVersion, std::string indent)
 {
   std::string tag = "updateContextAttributeRequest";
   std::string out = "";
@@ -77,9 +77,8 @@ std::string UpdateContextAttributeRequest::render(ConnectionInfo* ciP, std::stri
       isCompoundVector = true;
     }
 
-    // FIXME PR
     out += startTag2(indent + "  ", "value", isCompoundVector, true);
-    out += compoundValueP->render(ciP->apiVersion, indent + "    ");
+    out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }
 
@@ -97,11 +96,11 @@ std::string UpdateContextAttributeRequest::render(ConnectionInfo* ciP, std::stri
 */
 std::string UpdateContextAttributeRequest::check
 (
-  ConnectionInfo* ciP,
-  RequestType     requestType,
-  std::string     indent,
-  std::string     predetectedError,
-  int             counter
+  const std::string&  apiVersion,
+  RequestType         requestType,
+  std::string         indent,
+  std::string         predetectedError,
+  int                 counter
 )
 {
   StatusCode       response;
@@ -113,8 +112,7 @@ std::string UpdateContextAttributeRequest::check
   {
     response.fill(SccBadRequest, predetectedError);
   }
-  // FIXME
-  else if ((res = metadataVector.check(ciP->apiVersion)) != "OK")
+  else if ((res = metadataVector.check(apiVersion)) != "OK")
   {
     response.fill(SccBadRequest, res);
   }

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -112,7 +112,8 @@ std::string UpdateContextAttributeRequest::check
   {
     response.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = metadataVector.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  // FIXME
+  else if ((res = metadataVector.check(ciP->apiVersion)) != "OK")
   {
     response.fill(SccBadRequest, res);
   }

--- a/src/lib/convenience/UpdateContextAttributeRequest.h
+++ b/src/lib/convenience/UpdateContextAttributeRequest.h
@@ -49,8 +49,8 @@ typedef struct UpdateContextAttributeRequest
   orion::CompoundValueNode*  compoundValueP;
 
   UpdateContextAttributeRequest();
-  std::string  render(ConnectionInfo* ciP, std::string indent);
-  std::string  check(ConnectionInfo* ciP, RequestType requestType, std::string indent, std::string preError, int counter);
+  std::string  render(const std::string& apiVersion, std::string indent);
+  std::string  check(const std::string& apiVersion, RequestType requestType, std::string indent, std::string preError, int counter);
   void         present(std::string indent);
   void         release();
 } UpdateContextAttributeRequest;

--- a/src/lib/convenience/UpdateContextElementRequest.cpp
+++ b/src/lib/convenience/UpdateContextElementRequest.cpp
@@ -39,14 +39,14 @@
 *
 * render - 
 */
-std::string UpdateContextElementRequest::render(ConnectionInfo* ciP, RequestType requestType, std::string indent)
+std::string UpdateContextElementRequest::render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
 {
   std::string tag = "updateContextElementRequest";
   std::string out = "";
 
   out += startTag1(indent, tag, false);
   out += attributeDomainName.render(indent + "  ", true);
-  out += contextAttributeVector.render(ciP, requestType, indent + "  ");
+  out += contextAttributeVector.render(apiVersion, asJsonObject, requestType, indent + "  ");
   out += endTag(indent);
 
   return out;
@@ -70,11 +70,12 @@ std::string UpdateContextElementRequest::render(ConnectionInfo* ciP, RequestType
 */
 std::string UpdateContextElementRequest::check
 (
-  ConnectionInfo*  ciP,
-  RequestType      requestType,
-  std::string      indent,
-  std::string      predetectedError,     // Predetected Error, normally during parsing
-  int              counter
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  RequestType         requestType,
+  std::string         indent,
+  std::string         predetectedError,     // Predetected Error, normally during parsing
+  int                 counter
 )
 {
   UpdateContextElementResponse  response;
@@ -83,9 +84,8 @@ std::string UpdateContextElementRequest::check
   if (predetectedError != "")
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
-  }
-  // FIXME PR
-  else if ((res = contextAttributeVector.check(ciP->apiVersion, UpdateContextElement)) != "OK")
+  }  
+  else if ((res = contextAttributeVector.check(apiVersion, UpdateContextElement)) != "OK")
   {
     response.errorCode.fill(SccBadRequest, res);
   }
@@ -94,7 +94,7 @@ std::string UpdateContextElementRequest::check
     return "OK";
   }
 
-  return response.render(ciP, requestType, indent);
+  return response.render(apiVersion, asJsonObject, requestType, indent);
 }
 
 

--- a/src/lib/convenience/UpdateContextElementRequest.cpp
+++ b/src/lib/convenience/UpdateContextElementRequest.cpp
@@ -84,7 +84,8 @@ std::string UpdateContextElementRequest::check
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = contextAttributeVector.check(ciP, UpdateContextElement, indent, predetectedError, counter)) != "OK")
+  // FIXME PR
+  else if ((res = contextAttributeVector.check(ciP->apiVersion, UpdateContextElement)) != "OK")
   {
     response.errorCode.fill(SccBadRequest, res);
   }

--- a/src/lib/convenience/UpdateContextElementRequest.h
+++ b/src/lib/convenience/UpdateContextElementRequest.h
@@ -44,14 +44,15 @@ typedef struct UpdateContextElementRequest
   ContextAttributeVector     contextAttributeVector;     // Optional
   MetadataVector             domainMetadataVector;       // Optional
 
-  std::string  render(ConnectionInfo* ciP, RequestType requestType, std::string indent);
+  std::string  render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
   void         present(std::string indent);
   void         release(void);
-  std::string  check(ConnectionInfo*  ciP,
-                     RequestType      requestType,
-                     std::string      indent,
-                     std::string      predetectedError,
-                     int              counter);
+  std::string  check(const std::string&  apiVersion,
+                     bool                asJsonObject,
+                     RequestType         requestType,
+                     std::string         indent,
+                     std::string         predetectedError,
+                     int                 counter);
 } UpdateContextElementRequest;
 
 #endif  // SRC_LIB_CONVENIENCE_UPDATECONTEXTELEMENTREQUEST_H_

--- a/src/lib/convenience/UpdateContextElementResponse.cpp
+++ b/src/lib/convenience/UpdateContextElementResponse.cpp
@@ -52,7 +52,8 @@ UpdateContextElementResponse::UpdateContextElementResponse()
 */
 std::string UpdateContextElementResponse::render
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent
 )
@@ -68,7 +69,7 @@ std::string UpdateContextElementResponse::render
   }
   else
   {
-    out += contextAttributeResponseVector.render(ciP, requestType, indent + "  ");
+    out += contextAttributeResponseVector.render(apiVersion, asJsonObject, requestType, indent + "  ");
   }
 
   out += endTag(indent);
@@ -84,7 +85,8 @@ std::string UpdateContextElementResponse::render
 */
 std::string UpdateContextElementResponse::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,  // Predetected Error, normally during parsing
@@ -97,7 +99,7 @@ std::string UpdateContextElementResponse::check
   {
     errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = contextAttributeResponseVector.check(ciP, requestType, indent, "", counter)) != "OK")
+  else if ((res = contextAttributeResponseVector.check(apiVersion, asJsonObject, requestType, indent, "", counter)) != "OK")
   {
     errorCode.fill(SccBadRequest, res);
   }
@@ -106,7 +108,7 @@ std::string UpdateContextElementResponse::check
     return "OK";
   }
 
-  return render(ciP, requestType, indent);
+  return render(apiVersion, asJsonObject, requestType, indent);
 }
 
 

--- a/src/lib/convenience/UpdateContextElementResponse.h
+++ b/src/lib/convenience/UpdateContextElementResponse.h
@@ -58,10 +58,14 @@ typedef struct UpdateContextElementResponse
 
   UpdateContextElementResponse();
 
-  std::string  render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent);
+  std::string  render(const std::string&  apiVersion,
+                      bool                asJsonObject,
+                      RequestType         requestType,
+                      const std::string&   indent);
   void         present(const std::string& indent);
   void         release();
-  std::string  check(ConnectionInfo*     ciP,
+  std::string  check(const std::string&  apiVersion,
+                     bool                asJsonObject,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/jsonParse/jsonAppendContextElementRequest.cpp
+++ b/src/lib/jsonParse/jsonAppendContextElementRequest.cpp
@@ -36,7 +36,7 @@
 #include "parse/nullTreat.h"
 #include "ngsi/Request.h"
 #include "rest/ConnectionInfo.h"
-
+#include "rest/uriParamNames.h"
 
 
 /* ****************************************************************************
@@ -329,7 +329,9 @@ void jsonAcerRelease(ParseData* reqData)
 */
 std::string jsonAcerCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->acer.res.check(ciP, AppendContextElement, "", reqData->errorString, 0);
+  return reqData->acer.res.check(ciP->apiVersion,
+                                 ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                 AppendContextElement, "", reqData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonDiscoverContextAvailabilityRequest.cpp
+++ b/src/lib/jsonParse/jsonDiscoverContextAvailabilityRequest.cpp
@@ -251,11 +251,7 @@ void jsonDcarRelease(ParseData* reqDataP)
 */
 std::string jsonDcarCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->dcar.res.check(ciP,
-                                  DiscoverContextAvailability,
-                                  "",
-                                  reqDataP->errorString,
-                                  reqDataP->dcar.res.restrictions);
+  return reqDataP->dcar.res.check("", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonNotifyContextAvailabilityRequest.cpp
+++ b/src/lib/jsonParse/jsonNotifyContextAvailabilityRequest.cpp
@@ -382,7 +382,7 @@ void jsonNcarRelease(ParseData* parseDataP)
 */
 std::string jsonNcarCheck(ParseData* parseDataP, ConnectionInfo* ciP)
 {
-  return parseDataP->ncar.res.check(ciP, NotifyContext, "", parseDataP->errorString, 0);
+  return parseDataP->ncar.res.check(ciP->apiVersion, "", parseDataP->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonNotifyContextRequest.cpp
+++ b/src/lib/jsonParse/jsonNotifyContextRequest.cpp
@@ -421,7 +421,7 @@ void jsonNcrRelease(ParseData* parseDataP)
 */
 std::string jsonNcrCheck(ParseData* parseDataP, ConnectionInfo* ciP)
 {
-  return parseDataP->ncr.res.check(ciP, NotifyContext, "", parseDataP->errorString, 0);
+  return parseDataP->ncr.res.check(ciP->apiVersion, "", parseDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonQueryContextRequest.cpp
+++ b/src/lib/jsonParse/jsonQueryContextRequest.cpp
@@ -40,6 +40,7 @@
 #include "jsonParse/jsonQueryContextRequest.h"
 #include "parse/nullTreat.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 
 using namespace orion;
 
@@ -767,7 +768,8 @@ void jsonQcrRelease(ParseData* reqDataP)
 */
 std::string jsonQcrCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->qcr.res.check(ciP, "", reqDataP->errorString);
+  return reqDataP->qcr.res.check(ciP->apiVersion,
+                                 ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, "", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonQueryContextRequest.cpp
+++ b/src/lib/jsonParse/jsonQueryContextRequest.cpp
@@ -767,11 +767,7 @@ void jsonQcrRelease(ParseData* reqDataP)
 */
 std::string jsonQcrCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->qcr.res.check(ciP,
-                                 DiscoverContextAvailability,
-                                 "",
-                                 reqDataP->errorString,
-                                 reqDataP->qcr.res.restrictions);
+  return reqDataP->qcr.res.check(ciP, "", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonQueryContextResponse.cpp
+++ b/src/lib/jsonParse/jsonQueryContextResponse.cpp
@@ -444,11 +444,7 @@ void jsonQcrsRelease(ParseData* reqDataP)
 */
 std::string jsonQcrsCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->qcrs.res.check(ciP,
-                                 RtQueryContextResponse,
-                                 "",
-                                 reqDataP->errorString,
-                                 0);
+  return reqDataP->qcrs.res.check(ciP, "", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonQueryContextResponse.cpp
+++ b/src/lib/jsonParse/jsonQueryContextResponse.cpp
@@ -39,6 +39,7 @@
 #include "parse/nullTreat.h"
 
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 
 using namespace orion;
 
@@ -444,7 +445,7 @@ void jsonQcrsRelease(ParseData* reqDataP)
 */
 std::string jsonQcrsCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->qcrs.res.check(ciP, "", reqDataP->errorString);
+  return reqDataP->qcrs.res.check(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, "", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonRegisterContextRequest.cpp
+++ b/src/lib/jsonParse/jsonRegisterContextRequest.cpp
@@ -436,7 +436,7 @@ void jsonRcrRelease(ParseData* reqDataP)
 */
 std::string jsonRcrCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->rcr.res.check(ciP, RegisterContext, "", reqData->errorString, 0);
+  return reqData->rcr.res.check(ciP->apiVersion, "", reqData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonRegisterProviderRequest.cpp
+++ b/src/lib/jsonParse/jsonRegisterProviderRequest.cpp
@@ -36,6 +36,7 @@
 #include "parse/nullTreat.h"
 #include "ngsi/Request.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 
 
 
@@ -184,7 +185,7 @@ void jsonRprRelease(ParseData* reqData)
 */
 std::string jsonRprCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->rpr.res.check(ciP, ContextEntitiesByEntityId, "", reqData->errorString, 0);
+  return reqData->rpr.res.check(ciP->apiVersion, ContextEntitiesByEntityId, "", reqData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonSubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/jsonParse/jsonSubscribeContextAvailabilityRequest.cpp
@@ -298,7 +298,7 @@ void jsonScarRelease(ParseData* reqDataP)
 std::string jsonScarCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
   std::string s;
-  s = reqData->scar.res.check(ciP, SubscribeContextAvailability, "", reqData->errorString, 0);
+  s = reqData->scar.res.check("", reqData->errorString, 0);
   return s;
 }
 

--- a/src/lib/jsonParse/jsonSubscribeContextRequest.cpp
+++ b/src/lib/jsonParse/jsonSubscribeContextRequest.cpp
@@ -562,7 +562,7 @@ void jsonScrRelease(ParseData* parseDataP)
 std::string jsonScrCheck(ParseData* parseDataP, ConnectionInfo* ciP)
 {
   std::string s;
-  s = parseDataP->scr.res.check(ciP, SubscribeContext, "", parseDataP->errorString, 0);
+  s = parseDataP->scr.res.check("", parseDataP->errorString, 0);
   return s;
 }
 

--- a/src/lib/jsonParse/jsonUnsubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/jsonParse/jsonUnsubscribeContextAvailabilityRequest.cpp
@@ -88,7 +88,7 @@ void jsonUcarRelease(ParseData* parseDataP)
 */
 std::string jsonUcarCheck(ParseData* parseData, ConnectionInfo* ciP)
 {
-  return parseData->ucar.res.check(UnsubscribeContext, "", parseData->errorString, 0);
+  return parseData->ucar.res.check("", parseData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonUnsubscribeContextRequest.cpp
+++ b/src/lib/jsonParse/jsonUnsubscribeContextRequest.cpp
@@ -88,7 +88,7 @@ void jsonUncrRelease(ParseData* parseDataP)
 */
 std::string jsonUncrCheck(ParseData* parseData, ConnectionInfo* ciP)
 {
-  return parseData->uncr.res.check(UnsubscribeContext, "", parseData->errorString, 0);
+  return parseData->uncr.res.check("", parseData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextAttributeRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextAttributeRequest.cpp
@@ -35,6 +35,7 @@
 #include "jsonParse/jsonUpdateContextAttributeRequest.h"
 #include "parse/nullTreat.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 
 
 
@@ -165,7 +166,7 @@ void jsonUpcarRelease(ParseData* reqData)
 */
 std::string jsonUpcarCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->upcar.res.check(ciP, UpdateContextAttribute, "", reqData->errorString, 0);
+  return reqData->upcar.res.check(ciP->apiVersion, UpdateContextAttribute, "", reqData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextAvailabilitySubscriptionRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextAvailabilitySubscriptionRequest.cpp
@@ -295,7 +295,7 @@ void jsonUcasRelease(ParseData* reqDataP)
 std::string jsonUcasCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
   std::string s;
-  s = reqData->ucas.res.check(ciP, SubscribeContextAvailability, "", reqData->errorString, 0);
+  s = reqData->ucas.res.check("", reqData->errorString, 0);
   return s;
 }
 

--- a/src/lib/jsonParse/jsonUpdateContextElementRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextElementRequest.cpp
@@ -214,7 +214,10 @@ void jsonUcerRelease(ParseData* reqData)
 */
 std::string jsonUcerCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->ucer.res.check(ciP, UpdateContextElement, "", reqData->errorString, 0);
+  // FIXME PR
+  return reqData->ucer.res.check(ciP->apiVersion,
+                                 ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                 UpdateContextElement, "", reqData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextElementRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextElementRequest.cpp
@@ -35,6 +35,8 @@
 #include "parse/nullTreat.h"
 #include "ngsi/Request.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
+
 
 
 
@@ -214,7 +216,6 @@ void jsonUcerRelease(ParseData* reqData)
 */
 std::string jsonUcerCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  // FIXME PR
   return reqData->ucer.res.check(ciP->apiVersion,
                                  ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
                                  UpdateContextElement, "", reqData->errorString, 0);

--- a/src/lib/jsonParse/jsonUpdateContextRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextRequest.cpp
@@ -36,6 +36,7 @@
 #include "ngsi9/RegisterContextRequest.h"
 #include "parse/nullTreat.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 
 
 
@@ -384,7 +385,7 @@ void jsonUpcrRelease(ParseData* reqDataP)
 */
 std::string jsonUpcrCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->upcr.res.check(ciP, UpdateContext, "", reqData->errorString, 0);
+  return reqData->upcr.res.check(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, UpdateContext, "", reqData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextRequest.cpp
@@ -385,7 +385,9 @@ void jsonUpcrRelease(ParseData* reqDataP)
 */
 std::string jsonUpcrCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->upcr.res.check(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, UpdateContext, "", reqData->errorString, 0);
+  return reqData->upcr.res.check(ciP->apiVersion,
+                                 ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                 "", reqData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextResponse.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextResponse.cpp
@@ -39,6 +39,7 @@
 #include "parse/nullTreat.h"
 
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 
 using namespace orion;
 
@@ -443,7 +444,7 @@ void jsonUpcrsRelease(ParseData* reqDataP)
 */
 std::string jsonUpcrsCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->upcrs.res.check(ciP, "", reqDataP->errorString);
+  return reqDataP->upcrs.res.check(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, "", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextResponse.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextResponse.cpp
@@ -443,11 +443,7 @@ void jsonUpcrsRelease(ParseData* reqDataP)
 */
 std::string jsonUpcrsCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->upcrs.res.check(ciP,
-                                 RtUpdateContextResponse,
-                                 "",
-                                 reqDataP->errorString,
-                                 0);
+  return reqDataP->upcrs.res.check(ciP, "", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextSubscriptionRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextSubscriptionRequest.cpp
@@ -470,7 +470,7 @@ void jsonUcsrRelease(ParseData* parseDataP)
 std::string jsonUcsrCheck(ParseData* parseDataP, ConnectionInfo* ciP)
 {
   std::string s;
-  s = parseDataP->ucsr.res.check(UpdateContextSubscription, "", parseDataP->errorString, 0);
+  s = parseDataP->ucsr.res.check("", parseDataP->errorString, 0);
   return s;
 }
 

--- a/src/lib/jsonParseV2/jsonRequestTreat.cpp
+++ b/src/lib/jsonParseV2/jsonRequestTreat.cpp
@@ -77,7 +77,7 @@ std::string jsonRequestTreat
     if ((answer = parseDataP->ent.res.check(ciP->apiVersion, EntitiesRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
-      return oe.setStatusCodeAndSmartRender(ciP);
+      return oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
     }
     break;
 
@@ -92,7 +92,7 @@ std::string jsonRequestTreat
     if ((answer = parseDataP->ent.res.check(ciP->apiVersion, EntityRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
-      return oe.setStatusCodeAndSmartRender(ciP);
+      return oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
     }
     break;
 
@@ -108,7 +108,7 @@ std::string jsonRequestTreat
     if ((answer = parseDataP->attr.attribute.check(ciP->apiVersion, EntityAttributeRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
-      return oe.setStatusCodeAndSmartRender(ciP);
+      return oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
     }
     break;
 

--- a/src/lib/jsonParseV2/jsonRequestTreat.cpp
+++ b/src/lib/jsonParseV2/jsonRequestTreat.cpp
@@ -74,7 +74,6 @@ std::string jsonRequestTreat
       return answer;
     }
 
-    // FIXME PR
     if ((answer = parseDataP->ent.res.check(ciP->apiVersion, EntitiesRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
@@ -90,7 +89,6 @@ std::string jsonRequestTreat
       return answer;
     }
 
-    // FIXME PR
     if ((answer = parseDataP->ent.res.check(ciP->apiVersion, EntityRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
@@ -107,7 +105,6 @@ std::string jsonRequestTreat
       return answer;
     }
 
-    // FIXME PR
     if ((answer = parseDataP->attr.attribute.check(ciP->apiVersion, EntityAttributeRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);

--- a/src/lib/jsonParseV2/jsonRequestTreat.cpp
+++ b/src/lib/jsonParseV2/jsonRequestTreat.cpp
@@ -74,7 +74,8 @@ std::string jsonRequestTreat
       return answer;
     }
 
-    if ((answer = parseDataP->ent.res.check(ciP, EntitiesRequest)) != "OK")
+    // FIXME PR
+    if ((answer = parseDataP->ent.res.check(ciP->apiVersion, EntitiesRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
       return oe.setStatusCodeAndSmartRender(ciP);
@@ -89,7 +90,8 @@ std::string jsonRequestTreat
       return answer;
     }
 
-    if ((answer = parseDataP->ent.res.check(ciP, EntityRequest)) != "OK")
+    // FIXME PR
+    if ((answer = parseDataP->ent.res.check(ciP->apiVersion, EntityRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
       return oe.setStatusCodeAndSmartRender(ciP);
@@ -105,7 +107,8 @@ std::string jsonRequestTreat
       return answer;
     }
 
-    if ((answer = parseDataP->attr.attribute.check(ciP, EntityAttributeRequest, "", "", 0)) != "OK")
+    // FIXME PR
+    if ((answer = parseDataP->attr.attribute.check(ciP->apiVersion, EntityAttributeRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
       return oe.setStatusCodeAndSmartRender(ciP);

--- a/src/lib/jsonParseV2/parseBatchQuery.cpp
+++ b/src/lib/jsonParseV2/parseBatchQuery.cpp
@@ -104,7 +104,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
       std::string r = parseAttributeList(ciP, iter, &bqrP->attributeV);
 
       if (r != "OK")
-      {        
+      {
         alarmMgr.badInput(clientIp, r);
         oe.fill(SccBadRequest, r, "BadRequest");
         ciP->httpStatusCode = SccBadRequest;
@@ -116,7 +116,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
       std::string r = parseScopeVector(ciP, iter, &bqrP->scopeV);
 
       if (r != "OK")
-      {        
+      {
         alarmMgr.badInput(clientIp, r);
         oe.fill(SccBadRequest, r, "BadRequest");
         ciP->httpStatusCode = SccBadRequest;

--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -278,7 +278,6 @@ std::string parseContextAttribute(ConnectionInfo* ciP, const Value::ConstMemberI
     caP->type = (compoundVector)? defaultType(orion::ValueTypeVector) : defaultType(caP->valueType);
   }
 
-  // FIXME PR
   std::string r = caP->check(ciP->apiVersion, ciP->requestType);
   if (r != "OK")
   {

--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -278,9 +278,8 @@ std::string parseContextAttribute(ConnectionInfo* ciP, const Value::ConstMemberI
     caP->type = (compoundVector)? defaultType(orion::ValueTypeVector) : defaultType(caP->valueType);
   }
 
-  // FIXME P2: weird... one argument is a sub-argument of the other. ciP should be expanded to the minimum set
-  // of needed arguments
-  std::string r = caP->check(ciP, ciP->requestType, "", "", 0);
+  // FIXME PR
+  std::string r = caP->check(ciP->apiVersion, ciP->requestType);
   if (r != "OK")
   {
     alarmMgr.badInput(clientIp, r);

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -68,7 +68,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     alarmMgr.badInput(clientIp, "JSON parse error");
     eP->oe.fill(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
     ciP->httpStatusCode = SccBadRequest;
-    return eP->render(ciP, EntitiesRequest);
+    return eP->render(ciP->uriParamOptions, ciP->uriParam);
   }
 
 
@@ -77,7 +77,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     alarmMgr.badInput(clientIp, "JSON Parse Error");
     eP->oe.fill(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
     ciP->httpStatusCode = SccBadRequest;
-    return eP->render(ciP, EntitiesRequest);
+    return eP->render(ciP->uriParamOptions, ciP->uriParam);
   }
 
 
@@ -89,7 +89,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       eP->oe.fill(SccBadRequest, "no entity id specified", "BadRequest");
       ciP->httpStatusCode = SccBadRequest;;
 
-      return eP->render(ciP, EntitiesRequest);
+      return eP->render(ciP->uriParamOptions, ciP->uriParam);
     }
   }
 
@@ -102,7 +102,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       eP->oe.fill(SccBadRequest, "entity id specified in payload", "BadRequest");
       ciP->httpStatusCode = SccBadRequest;;
 
-      return eP->render(ciP, EntitiesRequest);
+      return eP->render(ciP->uriParamOptions, ciP->uriParam);
     }
 
     if (document.HasMember("type"))
@@ -111,7 +111,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       eP->oe.fill(SccBadRequest, "entity type specified in payload", "BadRequest");
       ciP->httpStatusCode = SccBadRequest;;
 
-      return eP->render(ciP, EntitiesRequest);
+      return eP->render(ciP->uriParamOptions, ciP->uriParam);
     }
   }
   else if (document.ObjectEmpty()) 
@@ -125,7 +125,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     eP->oe.fill(SccBadRequest, "empty payload", "BadRequest");
     ciP->httpStatusCode = SccBadRequest;
 
-    return eP->render(ciP, EntitiesRequest);
+    return eP->render(ciP->uriParamOptions, ciP->uriParam);
   }
 
   int membersFound = 0;
@@ -146,7 +146,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
           eP->oe.fill(SccBadRequest, "invalid JSON type for entity id", "BadRequest");
           ciP->httpStatusCode = SccBadRequest;;
 
-          return eP->render(ciP, EntitiesRequest);
+          return eP->render(ciP->uriParamOptions, ciP->uriParam);
         }
 
         eP->id = iter->value.GetString();
@@ -157,7 +157,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         eP->oe.fill(SccBadRequest, "invalid input, 'id' as attribute", "BadRequest");
         ciP->httpStatusCode = SccBadRequest;;
 
-        return eP->render(ciP, EntitiesRequest);
+        return eP->render(ciP->uriParamOptions, ciP->uriParam);
       }
     }
     else if (name == "type")
@@ -168,7 +168,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         eP->oe.fill(SccBadRequest, "invalid JSON type for entity type", "BadRequest");
         ciP->httpStatusCode = SccBadRequest;;
 
-        return eP->render(ciP, EntitiesRequest);
+        return eP->render(ciP->uriParamOptions, ciP->uriParam);
       }
 
       eP->type      = iter->value.GetString();
@@ -187,7 +187,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         eP->oe.fill(SccBadRequest, r, "BadRequest");
         ciP->httpStatusCode = SccBadRequest;
 
-        return eP->render(ciP, EntitiesRequest);
+        return eP->render(ciP->uriParamOptions, ciP->uriParam);
       }
     }
   }
@@ -196,7 +196,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
   {
     eP->oe.fill(SccBadRequest, "empty payload", "BadRequest");
     ciP->httpStatusCode = SccBadRequest;
-    return eP->render(ciP, EntitiesRequest);
+    return eP->render(ciP->uriParamOptions, ciP->uriParam);
   }
 
   if (eidInURL == false)
@@ -207,7 +207,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       eP->oe.fill(SccBadRequest, "empty entity id", "BadRequest");
       ciP->httpStatusCode = SccBadRequest;
 
-      return eP->render(ciP, EntitiesRequest);
+      return eP->render(ciP->uriParamOptions, ciP->uriParam);
     }
   }
 

--- a/src/lib/jsonParseV2/parseEntityObject.cpp
+++ b/src/lib/jsonParseV2/parseEntityObject.cpp
@@ -140,7 +140,6 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
     }
   }
 
-  // FIXME P2: weird... one argument is a sub-argument of the other. ciP should be expanded to the minimum set
-  // of needed arguments
-  return eP->check(ciP, ciP->requestType);
+  // FIXME PR
+  return eP->check(ciP->apiVersion, ciP->requestType);
 }

--- a/src/lib/jsonParseV2/parseEntityObject.cpp
+++ b/src/lib/jsonParseV2/parseEntityObject.cpp
@@ -140,6 +140,5 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
     }
   }
 
-  // FIXME PR
   return eP->check(ciP->apiVersion, ciP->requestType);
 }

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -669,7 +669,7 @@ static bool contextAttributeCustomMetadataToBson(BSONObj* md, BSONArray* mdNames
   *mdNames = mdNamesToAdd.arr();
 
   if (md->nFields() > 0)
-  {    
+  {
     return true;
   }
 
@@ -2913,7 +2913,7 @@ static bool createEntity
 
   /* Add location information in the case it was found */
   if (locAttr.length() > 0)
-  {    
+  {
     insertedDoc.append(ENT_LOCATION, BSON(ENT_LOCATION_ATTRNAME << locAttr <<
                                           ENT_LOCATION_COORDS   << geoJson.obj()));
   }

--- a/src/lib/mongoBackend/location.cpp
+++ b/src/lib/mongoBackend/location.cpp
@@ -28,7 +28,10 @@
 
 #include <string>
 #include <vector>
+
 #include "common/string.h"
+#include "common/globals.h"
+#include "logMsg/logMsg.h"
 #include "ngsi/ContextAttribute.h"
 #include "parse/CompoundValueNode.h"
 

--- a/src/lib/mongoBackend/mongoNotifyContextAvailability.cpp
+++ b/src/lib/mongoBackend/mongoNotifyContextAvailability.cpp
@@ -45,7 +45,7 @@ HttpStatusCode mongoNotifyContextAvailability
   const std::string&                   tenant,
   const std::string&                   servicePath
 )
-{    
+{
     bool              reqSemTaken;
 
     reqSemTake(__FUNCTION__, "mongo ngsi9 notification", SemWriteOp, &reqSemTaken);

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -466,7 +466,7 @@ HttpStatusCode mongoEntityTypes
     }
     // entityType corresponding to nullId case is skipped, as it is (eventually) added outside the for loop
     if (!nullId)
-    {      
+    {
       responseP->entityTypeVector.push_back(entityType);
     }
   }
@@ -496,7 +496,7 @@ HttpStatusCode mongoEntityTypes
   else
   {
     if (totalTypesP != NULL)
-    {      
+    {
       snprintf(detailsMsg, sizeof(detailsMsg), "Number of types: %zu. Offset is %u", resultsArray.size(), offset);
       responseP->statusCode.fill(SccContextElementNotFound, detailsMsg);
     }

--- a/src/lib/mongoBackend/mongoSubscribeContext.cpp
+++ b/src/lib/mongoBackend/mongoSubscribeContext.cpp
@@ -57,7 +57,7 @@ HttpStatusCode mongoSubscribeContext
     std::string subId = mongoCreateSubscription(sub, &oe, tenant, servicePathV, xauthToken, fiwareCorrelator);
 
     if (subId != "")
-    {      
+    {
       if (requestP->duration.isEmpty())
       {
         responseP->subscribeResponse.duration.set(DEFAULT_DURATION);

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -395,7 +395,7 @@ static void setCondsAndInitialNotify
     }
   }
   else
-  {    
+  {
     BSONArray conds = getArrayFieldF(subOrig, CSUB_CONDITIONS);
     b->append(CSUB_CONDITIONS, conds);
     LM_T(LmtMongo, ("Subscription conditions: %s", conds.toString().c_str()));

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -955,19 +955,12 @@ std::string ContextAttribute::toJsonAsValue(ConnectionInfo* ciP)
 *
 * ContextAttribute::check - 
 */
-std::string ContextAttribute::check
-(
-  ConnectionInfo*     ciP,
-  RequestType         requestType,
-  const std::string&  indent,
-  const std::string&  predetectedError,
-  int                 counter
-)
+std::string ContextAttribute::check(const std::string& apiVersion, RequestType requestType)
 {
   size_t len;
   char errorMsg[128];
 
-  if (((ciP->apiVersion == "v2") && (len = strlen(name.c_str())) < MIN_ID_LEN) && (requestType != EntityAttributeValueRequest))
+  if (((apiVersion == "v2") && (len = strlen(name.c_str())) < MIN_ID_LEN) && (requestType != EntityAttributeValueRequest))
   {
     snprintf(errorMsg, sizeof errorMsg, "attribute name length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
@@ -986,7 +979,7 @@ std::string ContextAttribute::check
     return std::string(errorMsg);
   }
 
-  if (forbiddenIdChars(ciP->apiVersion, name.c_str()))
+  if (forbiddenIdChars(apiVersion, name.c_str()))
   {
     alarmMgr.badInput(clientIp, "found a forbidden character in the name of an attribute");
     return "Invalid characters in attribute name";
@@ -1000,14 +993,14 @@ std::string ContextAttribute::check
   }
 
 
-  if (ciP->apiVersion == "v2" && (requestType != EntityAttributeValueRequest) && (len = strlen(type.c_str())) < MIN_ID_LEN)
+  if (apiVersion == "v2" && (requestType != EntityAttributeValueRequest) && (len = strlen(type.c_str())) < MIN_ID_LEN)
   {
     snprintf(errorMsg, sizeof errorMsg, "attribute type length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
     return std::string(errorMsg);
   }
 
-  if ((requestType != EntityAttributeValueRequest) && forbiddenIdChars(ciP->apiVersion, type.c_str()))
+  if ((requestType != EntityAttributeValueRequest) && forbiddenIdChars(apiVersion, type.c_str()))
   {
     alarmMgr.badInput(clientIp, "found a forbidden character in the type of an attribute");
     return "Invalid characters in attribute type";
@@ -1027,7 +1020,7 @@ std::string ContextAttribute::check
     }
   }
 
-  return metadataVector.check(ciP, requestType, indent + "  ", predetectedError, counter);
+  return metadataVector.check(apiVersion);
 }
 
 

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -603,7 +603,8 @@ std::string ContextAttribute::renderAsNameString(const std::string& indent, bool
 */
 std::string ContextAttribute::render
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
   RequestType         request,
   const std::string&  indent,
   bool                comma,
@@ -618,10 +619,9 @@ std::string ContextAttribute::render
 
   metadataVector.keyNameSet("metadata");
 
-  if ((ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object") && (ciP->outMimeType == JSON))
+  if (asJsonObject)
   {
-    // FIXME PR
-    return renderAsJsonObject(ciP->apiVersion, request, indent, comma, omitValue);
+    return renderAsJsonObject(apiVersion, request, indent, comma, omitValue);
   }
 
   out += startTag2(indent, key, false, false);
@@ -686,9 +686,8 @@ std::string ContextAttribute::render
       isCompoundVector = true;
     }
 
-    // FIXME PR
     out += startTag2(indent + "  ", "value", isCompoundVector, true);
-    out += compoundValueP->render(ciP->apiVersion, indent + "    ");
+    out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }
 

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -896,7 +896,7 @@ std::string ContextAttribute::toJsonAsValue
           out = isodate2str(numberValue);
         }
         else // regular number
-        {          
+        {
           out = toString(numberValue);
         }
         break;

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -560,8 +560,9 @@ std::string ContextAttribute::renderAsJsonObject
       isCompoundVector = true;
     }
 
+    // FIXME PR
     out += startTag2(indent + "  ", "value", isCompoundVector, true);
-    out += compoundValueP->render(ciP, indent + "    ");
+    out += compoundValueP->render(ciP->apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }
 
@@ -690,8 +691,9 @@ std::string ContextAttribute::render
       isCompoundVector = true;
     }
 
+    // FIXME PR
     out += startTag2(indent + "  ", "value", isCompoundVector, true);
-    out += compoundValueP->render(ciP, indent + "    ");
+    out += compoundValueP->render(ciP->apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }
 

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -487,7 +487,7 @@ std::string ContextAttribute::getLocation(const std::string& apiVersion) const
 */
 std::string ContextAttribute::renderAsJsonObject
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         request,
   const std::string&  indent,
   bool                comma,
@@ -562,7 +562,7 @@ std::string ContextAttribute::renderAsJsonObject
 
     // FIXME PR
     out += startTag2(indent + "  ", "value", isCompoundVector, true);
-    out += compoundValueP->render(ciP->apiVersion, indent + "    ");
+    out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }
 
@@ -580,15 +580,9 @@ std::string ContextAttribute::renderAsJsonObject
 *
 * renderAsNameString -
 */
-std::string ContextAttribute::renderAsNameString
-(
-  ConnectionInfo*     ciP,
-  RequestType         request,
-  const std::string&  indent,
-  bool                comma
-)
+std::string ContextAttribute::renderAsNameString(const std::string& indent, bool comma)
 {
-  std::string  out                    = "";
+  std::string  out = "";
 
   if (comma)
   {
@@ -626,7 +620,8 @@ std::string ContextAttribute::render
 
   if ((ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object") && (ciP->outMimeType == JSON))
   {
-    return renderAsJsonObject(ciP, request, indent, comma, omitValue);
+    // FIXME PR
+    return renderAsJsonObject(ciP->apiVersion, request, indent, comma, omitValue);
   }
 
   out += startTag2(indent, key, false, false);

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -560,7 +560,6 @@ std::string ContextAttribute::renderAsJsonObject
       isCompoundVector = true;
     }
 
-    // FIXME PR
     out += startTag2(indent + "  ", "value", isCompoundVector, true);
     out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -859,13 +859,12 @@ std::string ContextAttribute::toJson
 */
 std::string ContextAttribute::toJsonAsValue
 (
-  // FIXME PR
   const std::string&  apiVersion,          // in parameter
-  bool                acceptedTextPlain,   // in parameter  ciP->httpHeaders.accepted("text/plain")
-  bool                acceptedJson,        // in parameter  ciP->httpHeaders.accepted("application/json")
-  MimeType            outFormatSelection,  // in parameter  ciP->httpHeaders.outformatSelect()
-  MimeType*           outMimeTypeP,        // out parameter ciP->outMimeType
-  HttpStatusCode*     scP                  // out parameter ciP->httpStatusCode
+  bool                acceptedTextPlain,   // in parameter
+  bool                acceptedJson,        // in parameter
+  MimeType            outFormatSelection,  // in parameter
+  MimeType*           outMimeTypeP,        // out parameter
+  HttpStatusCode*     scP                  // out parameter
 )
 {
   std::string  out;

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -37,8 +37,7 @@
 #include "orionTypes/OrionValueType.h"
 #include "parse/forbiddenChars.h"
 #include "ngsi/ContextAttribute.h"
-#include "rest/ConnectionInfo.h"
-#include "rest/uriParamNames.h"
+#include "rest/ConnectionInfo.h"     // FIXME PR
 #include "rest/OrionError.h"
 #include "parse/CompoundValueNode.h"
 

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -34,6 +34,7 @@
 #include "ngsi/Request.h"
 #include "ngsi/ProvidingApplication.h"
 #include "parse/CompoundValueNode.h"
+#include "rest/HttpStatusCode.h"
 
 
 
@@ -102,7 +103,12 @@ public:
                       RenderFormat                     renderFormat,
                       const std::vector<std::string>&  metadataFilter,
                       RequestType                      requestType = NoRequest);
-  std::string  toJsonAsValue(ConnectionInfo* ciP);
+  std::string  toJsonAsValue(const std::string&  apiVersion,
+                             bool                acceptedTextPlain,
+                             bool                acceptedJson,
+                             MimeType            outFormatSelection,
+                             MimeType*           outMimeTypeP,
+                             HttpStatusCode*     scP);
   void         present(const std::string& indent, int ix);
   void         release(void);
   std::string  getName(void);

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -109,11 +109,7 @@ public:
   /* Helper method to be use in some places wher '%s' is needed */
   std::string  getValue(void) const;
 
-  std::string  check(ConnectionInfo*     ciP,
-                     RequestType         requestType,
-                     const std::string&  indent,
-                     const std::string&  predetectedError,
-                     int                 counter);
+  std::string  check(const std::string& apiVersion, RequestType requestType);
   ContextAttribute* clone();
   bool              compoundItemExists(const std::string& compoundPath, orion::CompoundValueNode** compoundItemPP = NULL);
 

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -91,7 +91,12 @@ public:
   std::string  getId() const;
   std::string  getLocation(const std::string& apiValue ="v1") const;
 
-  std::string  render(ConnectionInfo* ciP, RequestType request, const std::string& indent, bool comma = false, bool omitValue = false);
+  std::string  render(const std::string&  apiVersion,
+                      bool                asJsonObject,
+                      RequestType         request,
+                      const std::string&  indent,
+                      bool                comma = false,
+                      bool                omitValue = false);
   std::string  renderAsJsonObject(const std::string& apiVersion, RequestType request, const std::string& indent, bool comma, bool omitValue = false);
   std::string  renderAsNameString(const std::string& indent, bool comma = false);
   std::string  toJson(bool                             isLastElement,

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -92,8 +92,8 @@ public:
   std::string  getLocation(const std::string& apiValue ="v1") const;
 
   std::string  render(ConnectionInfo* ciP, RequestType request, const std::string& indent, bool comma = false, bool omitValue = false);
-  std::string  renderAsJsonObject(ConnectionInfo* ciP, RequestType request, const std::string& indent, bool comma, bool omitValue = false);
-  std::string  renderAsNameString(ConnectionInfo* ciP, RequestType request, const std::string& indent, bool comma = false);
+  std::string  renderAsJsonObject(const std::string& apiVersion, RequestType request, const std::string& indent, bool comma, bool omitValue = false);
+  std::string  renderAsNameString(const std::string& indent, bool comma = false);
   std::string  toJson(bool                             isLastElement,
                       RenderFormat                     renderFormat,
                       const std::vector<std::string>&  metadataFilter,

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -34,7 +34,6 @@
 #include "ngsi/Request.h"
 #include "ngsi/ProvidingApplication.h"
 #include "parse/CompoundValueNode.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -36,8 +36,6 @@
 #include "common/RenderFormat.h"
 #include "ngsi/ContextAttributeVector.h"
 #include "ngsi/Request.h"
-#include "rest/ConnectionInfo.h"
-#include "rest/uriParamNames.h"
 
 
 

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -345,10 +345,11 @@ std::string ContextAttributeVector::render
     {
       if (attrsAsName)
       {
-        out += vec[ix]->renderAsNameString(ciP, request, indent + "  ", ix != vec.size() - 1);
+        // FIXME PR
+        out += vec[ix]->renderAsNameString(ciP->apiVersion, request);
       }
       else
-      {
+      {        
         out += vec[ix]->render(ciP, request, indent + "  ", ix != vec.size() - 1, omitValue);
       }
     }
@@ -361,7 +362,8 @@ std::string ContextAttributeVector::render
     {
       if (attrsAsName)
       {
-        out += vec[ix]->renderAsNameString(ciP, request, indent + "  ", ix != vec.size() - 1);
+        // FIXME PR
+        out += vec[ix]->renderAsNameString(ciP->apiVersion, request);
       }
       else
       {

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -380,20 +380,13 @@ std::string ContextAttributeVector::render
 *
 * ContextAttributeVector::check - 
 */
-std::string ContextAttributeVector::check
-(
-  ConnectionInfo*     ciP,
-  RequestType         requestType,
-  const std::string&  indent,
-  const std::string&  predetectedError,
-  int                 counter
-)
+std::string ContextAttributeVector::check(const std::string& apiVersion, RequestType requestType)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, requestType, indent, predetectedError, 0)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, requestType)) != "OK")
       return res;
   }
 

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -292,7 +292,8 @@ std::string ContextAttributeVector::toJson
 */
 std::string ContextAttributeVector::render
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
   RequestType         request,
   const std::string&  indent,
   bool                comma,
@@ -316,7 +317,7 @@ std::string ContextAttributeVector::render
   // only one of them should be included in the vector. Any one of them.
   // So, step 1 is to purge the context attribute vector from 'copies'.
   //
-  if ((ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object") && (ciP->outMimeType == JSON))
+  if (asJsonObject)
   {
     std::vector<std::string> added;
 
@@ -345,12 +346,11 @@ std::string ContextAttributeVector::render
     {
       if (attrsAsName)
       {
-        // FIXME PR
-        out += vec[ix]->renderAsNameString(ciP->apiVersion, request);
+        out += vec[ix]->renderAsNameString(apiVersion, request);
       }
       else
-      {        
-        out += vec[ix]->render(ciP, request, indent + "  ", ix != vec.size() - 1, omitValue);
+      {
+        out += vec[ix]->render(apiVersion, asJsonObject, request, indent + "  ", ix != vec.size() - 1, omitValue);
       }
     }
     out += endTag(indent, comma, attrsAsName);
@@ -362,12 +362,11 @@ std::string ContextAttributeVector::render
     {
       if (attrsAsName)
       {
-        // FIXME PR
-        out += vec[ix]->renderAsNameString(ciP->apiVersion, request);
+        out += vec[ix]->renderAsNameString(apiVersion, request);
       }
       else
       {
-        out += vec[ix]->render(ciP, request, indent + "  ", ix != vec.size() - 1, omitValue);
+        out += vec[ix]->render(apiVersion, asJsonObject, request, indent + "  ", ix != vec.size() - 1, omitValue);
       }
     }
     out += endTag(indent, comma, true);

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -346,7 +346,7 @@ std::string ContextAttributeVector::render
     {
       if (attrsAsName)
       {
-        out += vec[ix]->renderAsNameString(apiVersion, request);
+        out += vec[ix]->renderAsNameString(indent + "  ", ix != vec.size() - 1);
       }
       else
       {
@@ -362,7 +362,7 @@ std::string ContextAttributeVector::render
     {
       if (attrsAsName)
       {
-        out += vec[ix]->renderAsNameString(apiVersion, request);
+        out += vec[ix]->renderAsNameString(indent + "  ", ix != vec.size() - 1);
       }
       else
       {

--- a/src/lib/ngsi/ContextAttributeVector.h
+++ b/src/lib/ngsi/ContextAttributeVector.h
@@ -56,11 +56,7 @@ typedef struct ContextAttributeVector
   ContextAttribute*  operator[](unsigned int ix) const;
 
 
-  std::string        check(ConnectionInfo* ciP,
-                           RequestType          requestType,
-                           const std::string&   indent,
-                           const std::string&   predetectedError,
-                           int                  counter);
+  std::string        check(const std::string& apiVersion, RequestType requestType);
 
   std::string        render(ConnectionInfo*     ciP,
                             RequestType         requestType,

--- a/src/lib/ngsi/ContextAttributeVector.h
+++ b/src/lib/ngsi/ContextAttributeVector.h
@@ -58,7 +58,8 @@ typedef struct ContextAttributeVector
 
   std::string        check(const std::string& apiVersion, RequestType requestType);
 
-  std::string        render(ConnectionInfo*     ciP,
+  std::string        render(const std::string&  apiVersion,
+                            bool                asJsonObject,
                             RequestType         requestType,
                             const std::string&  indent,
                             bool                comma       = false,

--- a/src/lib/ngsi/ContextAttributeVector.h
+++ b/src/lib/ngsi/ContextAttributeVector.h
@@ -30,7 +30,6 @@
 
 #include "common/RenderFormat.h"
 #include "ngsi/ContextAttribute.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -188,12 +188,14 @@ std::string ContextElement::check
     return res;
   }
 
-  if ((res = contextAttributeVector.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  // FIXME PR ciP->apiVersion
+  if ((res = contextAttributeVector.check(ciP->apiVersion, requestType)) != "OK")
   {
     return res;
   }
 
-  if ((res = domainMetadataVector.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  // FIXME PR ciP->apiVersion
+  if ((res = domainMetadataVector.check(ciP->apiVersion)) != "OK")
   {
     return res;
   }

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -76,7 +76,7 @@ ContextElement::ContextElement(const std::string& id, const std::string& type, c
 *
 * ContextElement::render - 
 */
-std::string ContextElement::render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues)
+std::string ContextElement::render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues)
 {
   std::string  out                              = "";
   std::string  key                              = "contextElement";
@@ -100,10 +100,7 @@ std::string ContextElement::render(ConnectionInfo* ciP, RequestType requestType,
 
   out += entityId.render(indent + "  ", commaAfterEntityId, false);
   out += attributeDomainName.render(indent + "  ", commaAfterAttributeDomainName);
-  // FIXME PR
-  out += contextAttributeVector.render(ciP->apiVersion,
-                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                       requestType, indent + "  ", commaAfterContextAttributeVector, omitAttributeValues);
+  out += contextAttributeVector.render(apiVersion, asJsonObject, requestType, indent + "  ", commaAfterContextAttributeVector, omitAttributeValues);
   out += domainMetadataVector.render(indent + "  ", commaAfterDomainMetadataVector);
 
   out += endTag(indent, comma, false);
@@ -173,7 +170,7 @@ ContextAttribute* ContextElement::getAttribute(const std::string& attrName)
 */
 std::string ContextElement::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,
@@ -182,7 +179,7 @@ std::string ContextElement::check
 {
   std::string res;
 
-  if ((res = entityId.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  if ((res = entityId.check(requestType, indent)) != "OK")
   {
     return res;
   }
@@ -192,14 +189,12 @@ std::string ContextElement::check
     return res;
   }
 
-  // FIXME PR ciP->apiVersion
-  if ((res = contextAttributeVector.check(ciP->apiVersion, requestType)) != "OK")
+  if ((res = contextAttributeVector.check(apiVersion, requestType)) != "OK")
   {
     return res;
   }
 
-  // FIXME PR ciP->apiVersion
-  if ((res = domainMetadataVector.check(ciP->apiVersion)) != "OK")
+  if ((res = domainMetadataVector.check(apiVersion)) != "OK")
   {
     return res;
   }

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -31,6 +31,7 @@
 #include "common/MimeType.h"
 #include "common/globals.h"
 #include "common/tag.h"
+#include "rest/uriParamNames.h"
 #include "ngsi/ContextElement.h"
 #include "ngsi/EntityId.h"
 #include "ngsi/Request.h"
@@ -99,7 +100,10 @@ std::string ContextElement::render(ConnectionInfo* ciP, RequestType requestType,
 
   out += entityId.render(indent + "  ", commaAfterEntityId, false);
   out += attributeDomainName.render(indent + "  ", commaAfterAttributeDomainName);
-  out += contextAttributeVector.render(ciP, requestType, indent + "  ", commaAfterContextAttributeVector, omitAttributeValues);
+  // FIXME PR
+  out += contextAttributeVector.render(ciP->apiVersion,
+                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                       requestType, indent + "  ", commaAfterContextAttributeVector, omitAttributeValues);
   out += domainMetadataVector.render(indent + "  ", commaAfterDomainMetadataVector);
 
   out += endTag(indent, comma, false);

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -31,7 +31,6 @@
 #include "common/MimeType.h"
 #include "common/globals.h"
 #include "common/tag.h"
-#include "rest/uriParamNames.h"
 #include "ngsi/ContextElement.h"
 #include "ngsi/EntityId.h"
 #include "ngsi/Request.h"

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -35,7 +35,6 @@
 #include "ngsi/ContextElement.h"
 #include "ngsi/EntityId.h"
 #include "ngsi/Request.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi/ContextElement.h
+++ b/src/lib/ngsi/ContextElement.h
@@ -33,7 +33,6 @@
 #include "ngsi/AttributeDomainName.h"
 #include "ngsi/ContextAttributeVector.h"
 #include "ngsi/MetadataVector.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi/ContextElement.h
+++ b/src/lib/ngsi/ContextElement.h
@@ -54,7 +54,7 @@ typedef struct ContextElement
   ContextElement(const std::string& id, const std::string& type, const std::string& isPattern);
   ContextElement(EntityId* eP);
 
-  std::string  render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues = false);
+  std::string  render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues = false);
   std::string  toJson(RenderFormat                     renderFormat,
                       const std::vector<std::string>&  attrsFilter,
                       const std::vector<std::string>&  metadataFilter,
@@ -66,7 +66,7 @@ typedef struct ContextElement
 
   ContextAttribute* getAttribute(const std::string& attrName);
 
-  std::string  check(ConnectionInfo* ciP,
+  std::string  check(const std::string&  apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -33,7 +33,6 @@
 #include "ngsi/ContextElementResponse.h"
 #include "ngsi/AttributeList.h"
 #include "ngsi10/QueryContextResponse.h"
-#include "rest/ConnectionInfo.h"
 
 #include "mongoBackend/dbConstants.h"
 #include "mongoBackend/safeMongo.h"

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -325,7 +325,8 @@ ContextElementResponse::ContextElementResponse(ContextElement* ceP, bool useDefa
 */
 std::string ContextElementResponse::render
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
   bool                comma,
@@ -336,7 +337,7 @@ std::string ContextElementResponse::render
   std::string out = "";
 
   out += startTag2(indent, key, false, false);
-  out += contextElement.render(ciP, requestType, indent + "  ", true, omitAttributeValues);
+  out += contextElement.render(apiVersion, asJsonObject, requestType, indent + "  ", true, omitAttributeValues);
   out += statusCode.render(indent + "  ", false);
   out += endTag(indent, comma, false);
 
@@ -384,7 +385,7 @@ void ContextElementResponse::release(void)
 */
 std::string ContextElementResponse::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,
@@ -393,7 +394,7 @@ std::string ContextElementResponse::check
 {
   std::string res;
 
-  if ((res = contextElement.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  if ((res = contextElement.check(apiVersion, requestType, indent, predetectedError, counter)) != "OK")
   {
     return res;
   }

--- a/src/lib/ngsi/ContextElementResponse.h
+++ b/src/lib/ngsi/ContextElementResponse.h
@@ -31,7 +31,6 @@
 #include "ngsi/ContextElement.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi/AttributeList.h"
-#include "rest/ConnectionInfo.h"
 
 #include "mongo/client/dbclient.h"
 

--- a/src/lib/ngsi/ContextElementResponse.h
+++ b/src/lib/ngsi/ContextElementResponse.h
@@ -65,7 +65,8 @@ typedef struct ContextElementResponse
                          const std::string&     apiVersion   = "v1");
   ContextElementResponse(ContextElement* ceP, bool useDefaultType = false);
 
-  std::string  render(ConnectionInfo*     ciP,
+  std::string  render(const std::string&  apiVersion,
+                      bool                asJsonObject,
                       RequestType         requestType,
                       const std::string&  indent,
                       bool                comma               = false,
@@ -77,7 +78,7 @@ typedef struct ContextElementResponse
   void         present(const std::string& indent, int ix);
   void         release(void);
 
-  std::string  check(ConnectionInfo*     ciP,
+  std::string  check(const std::string&  apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -33,7 +33,6 @@
 #include "common/tag.h"
 #include "common/RenderFormat.h"
 #include "ngsi/ContextElementResponseVector.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -43,7 +43,8 @@
 */
 std::string ContextElementResponseVector::render
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
   bool                comma,
@@ -62,7 +63,7 @@ std::string ContextElementResponseVector::render
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += vec[ix]->render(ciP, requestType, indent + "  ", ix < (vec.size() - 1), omitAttributeValues);
+    out += vec[ix]->render(apiVersion, asJsonObject, requestType, indent + "  ", ix < (vec.size() - 1), omitAttributeValues);
   }
 
   out += endTag(indent, comma, true);
@@ -109,7 +110,7 @@ std::string ContextElementResponseVector::toJson
 */
 std::string ContextElementResponseVector::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,
@@ -120,7 +121,7 @@ std::string ContextElementResponseVector::check
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, requestType, indent, predetectedError, counter)) != "OK")
     {
       return res;
     }

--- a/src/lib/ngsi/ContextElementResponseVector.h
+++ b/src/lib/ngsi/ContextElementResponseVector.h
@@ -30,7 +30,6 @@
 
 #include "ngsi/ContextElementResponse.h"
 #include "common/RenderFormat.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi/ContextElementResponseVector.h
+++ b/src/lib/ngsi/ContextElementResponseVector.h
@@ -42,7 +42,8 @@ typedef struct ContextElementResponseVector
 {
   std::vector<ContextElementResponse*>  vec;
 
-  std::string              render(ConnectionInfo*     ciP,
+  std::string              render(const std::string&  apiVersion,
+                                  bool                asJsonObject,
                                   RequestType         requestType,
                                   const std::string&  indent,
                                   bool                comma               = false,
@@ -61,7 +62,7 @@ typedef struct ContextElementResponseVector
   ContextElementResponse*  operator[] (unsigned int ix) const;
   
 
-  std::string              check(ConnectionInfo*     ciP,
+  std::string              check(const std::string&  apiVersion,
                                  RequestType         requestType,
                                  const std::string&  indent,
                                  const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementVector.cpp
+++ b/src/lib/ngsi/ContextElementVector.cpp
@@ -52,7 +52,8 @@ void ContextElementVector::push_back(ContextElement* item)
 */
 std::string ContextElementVector::render
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
   bool                comma
@@ -70,7 +71,7 @@ std::string ContextElementVector::render
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += vec[ix]->render(ciP, requestType, indent + "  ", ix != vec.size() - 1);
+    out += vec[ix]->render(apiVersion, asJsonObject, requestType, indent + "  ", ix != vec.size() - 1);
   }
 
   out += endTag(indent, comma, true);
@@ -144,7 +145,7 @@ unsigned int ContextElementVector::size(void)
 */
 std::string ContextElementVector::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,
@@ -163,7 +164,7 @@ std::string ContextElementVector::check
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, requestType, indent, predetectedError, counter)) != "OK")
     {
       return res;
     }

--- a/src/lib/ngsi/ContextElementVector.cpp
+++ b/src/lib/ngsi/ContextElementVector.cpp
@@ -31,7 +31,6 @@
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/ContextElementVector.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi/ContextElementVector.h
+++ b/src/lib/ngsi/ContextElementVector.h
@@ -43,13 +43,13 @@ typedef struct ContextElementVector
 
   void             push_back(ContextElement* item);
   unsigned int     size(void);
-  std::string      render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, bool comma);
+  std::string      render(const std::string&  apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma);
   void             present(const std::string& indent);
   void             release(void);
   ContextElement*  lookup(EntityId* eP);
   ContextElement*  operator[](unsigned int ix) const;
 
-  std::string      check(ConnectionInfo*     ciP,
+  std::string      check(const std::string&  apiVersion,
                          RequestType         requestType,
                          const std::string&  indent,
                          const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementVector.h
+++ b/src/lib/ngsi/ContextElementVector.h
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include "ngsi/ContextElement.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi/ContextRegistration.cpp
+++ b/src/lib/ngsi/ContextRegistration.cpp
@@ -99,7 +99,8 @@ std::string ContextRegistration::check
     return res;
   }
 
-  if ((res = registrationMetadataVector.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  // FIXME PR
+  if ((res = registrationMetadataVector.check(ciP->apiVersion)) != "OK")
   {
     return res;
   }

--- a/src/lib/ngsi/ContextRegistration.cpp
+++ b/src/lib/ngsi/ContextRegistration.cpp
@@ -80,7 +80,7 @@ std::string ContextRegistration::render(const std::string& indent, bool comma, b
 */
 std::string ContextRegistration::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,
@@ -89,18 +89,17 @@ std::string ContextRegistration::check
 {
   std::string res;
 
-  if ((res = entityIdVector.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  if ((res = entityIdVector.check(requestType, indent)) != "OK")
   {
     return res;
   }
 
-  if ((res = contextRegistrationAttributeVector.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  if ((res = contextRegistrationAttributeVector.check(apiVersion, requestType, indent, predetectedError, counter)) != "OK")
   {
     return res;
   }
 
-  // FIXME PR
-  if ((res = registrationMetadataVector.check(ciP->apiVersion)) != "OK")
+  if ((res = registrationMetadataVector.check(apiVersion)) != "OK")
   {
     return res;
   }

--- a/src/lib/ngsi/ContextRegistration.h
+++ b/src/lib/ngsi/ContextRegistration.h
@@ -53,7 +53,7 @@ typedef struct ContextRegistration
   void         present(const std::string& indent, int ix);
   void         release();
 
-  std::string  check(ConnectionInfo*     ciP,
+  std::string  check(const std::string&  apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -100,11 +100,8 @@ std::string ContextRegistrationAttribute::render(const std::string& indent, bool
 */
 std::string ContextRegistrationAttribute::check
 (
-  ConnectionInfo*     ciP,
-  RequestType         requestType,
-  const std::string&  indent,
-  const std::string&  predetectedError,
-  int                 counter
+  const std::string&  apiVersion,
+  const std::string&  indent
 )
 {
 
@@ -124,8 +121,7 @@ std::string ContextRegistrationAttribute::check
   }
 
   std::string res;
-  // FIXME PR
-  if ((res = metadataVector.check(ciP->apiVersion)) != "OK")
+  if ((res = metadataVector.check(apiVersion)) != "OK")
   {
     return res;
   }

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -28,6 +28,7 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "rest/ConnectionInfo.h"
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/ContextRegistrationAttribute.h"
@@ -123,7 +124,8 @@ std::string ContextRegistrationAttribute::check
   }
 
   std::string res;
-  if ((res = metadataVector.check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+  // FIXME PR
+  if ((res = metadataVector.check(ciP->apiVersion)) != "OK")
   {
     return res;
   }

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -28,7 +28,6 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
-#include "rest/ConnectionInfo.h"
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/ContextRegistrationAttribute.h"

--- a/src/lib/ngsi/ContextRegistrationAttribute.h
+++ b/src/lib/ngsi/ContextRegistrationAttribute.h
@@ -50,11 +50,8 @@ typedef struct ContextRegistrationAttribute
   void            present(int ix, const std::string& indent);
   void            release(void);
 
-  std::string     check(ConnectionInfo*     ciP,
-                        RequestType         requestType,
-                        const std::string&  indent,
-                        const std::string&  predetectedError,
-                        int                 counter);
+  std::string     check(const std::string&  apiVersion,
+                        const std::string&  indent);
 } ContextRegistrationAttribute;
 
 #endif  // SRC_LIB_NGSI_CONTEXTREGISTRATIONATTRIBUTE_H_

--- a/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
@@ -68,7 +68,7 @@ std::string ContextRegistrationAttributeVector::render(const std::string& indent
 */
 std::string ContextRegistrationAttributeVector::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,
@@ -79,7 +79,7 @@ std::string ContextRegistrationAttributeVector::check
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, indent)) != "OK")
     {
       return res;
     }

--- a/src/lib/ngsi/ContextRegistrationAttributeVector.h
+++ b/src/lib/ngsi/ContextRegistrationAttributeVector.h
@@ -46,7 +46,7 @@ typedef struct ContextRegistrationAttributeVector
   unsigned int                     size(void);
   void                             release();
 
-  std::string                      check(ConnectionInfo*     ciP,
+  std::string                      check(const std::string&  apiVersion,
                                          RequestType         requestType,
                                          const std::string&  indent,
                                          const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationResponse.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponse.cpp
@@ -74,14 +74,14 @@ std::string ContextRegistrationResponse::render(const std::string& indent, bool 
 */
 std::string ContextRegistrationResponse::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,
   int                 counter
 )
 {
-  return contextRegistration.check(ciP, requestType, indent, predetectedError, counter);
+  return contextRegistration.check(apiVersion, requestType, indent, predetectedError, counter);
 }
 
 

--- a/src/lib/ngsi/ContextRegistrationResponse.h
+++ b/src/lib/ngsi/ContextRegistrationResponse.h
@@ -48,7 +48,7 @@ typedef struct ContextRegistrationResponse
   void         present(const std::string& indent);
   void         release(void);
 
-  std::string  check(ConnectionInfo*     ciP,
+  std::string  check(const std::string&  apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationResponseVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponseVector.cpp
@@ -138,7 +138,7 @@ unsigned int ContextRegistrationResponseVector::size(void)
 */
 std::string ContextRegistrationResponseVector::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,
@@ -149,7 +149,7 @@ std::string ContextRegistrationResponseVector::check
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, requestType, indent, predetectedError, counter)) != "OK")
     {
       return res;
     }

--- a/src/lib/ngsi/ContextRegistrationResponseVector.h
+++ b/src/lib/ngsi/ContextRegistrationResponseVector.h
@@ -49,7 +49,7 @@ typedef struct ContextRegistrationResponseVector
   ContextRegistrationResponse*  operator[](unsigned int ix) const;
 
 
-  std::string                   check(ConnectionInfo*     ciP,
+  std::string                   check(const std::string&  apiVersion,
                                       RequestType         requestType,
                                       const std::string&  indent,
                                       const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationVector.cpp
@@ -139,7 +139,7 @@ unsigned int ContextRegistrationVector::size(void)
 */
 std::string ContextRegistrationVector::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
   RequestType         requestType, 
   const std::string&  indent,
   const std::string&  predetectedError,
@@ -150,7 +150,7 @@ std::string ContextRegistrationVector::check
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, requestType, indent, predetectedError, counter)) != "OK")
     {
       return res;
     }

--- a/src/lib/ngsi/ContextRegistrationVector.h
+++ b/src/lib/ngsi/ContextRegistrationVector.h
@@ -46,7 +46,7 @@ typedef struct ContextRegistrationVector
   void                  present(const std::string& indent);
   void                  release(void);
 
-  std::string           check(ConnectionInfo*     ciP,
+  std::string           check(const std::string&  apiVersion,
                               RequestType         requestType,
                               const std::string&  indent,
                               const std::string&  predetectedError,

--- a/src/lib/ngsi/EntityId.cpp
+++ b/src/lib/ngsi/EntityId.cpp
@@ -153,11 +153,8 @@ std::string EntityId::toJson(void) const
 */
 std::string EntityId::check
 (
-  ConnectionInfo* ciP,
   RequestType         requestType,
-  const std::string&  indent,
-  const std::string&  predetectedError,
-  int                 counter
+  const std::string&  indent
 )
 {
   if (id == "")

--- a/src/lib/ngsi/EntityId.h
+++ b/src/lib/ngsi/EntityId.h
@@ -68,11 +68,8 @@ class EntityId
                       bool                comma      = false,
                       bool                isInVector = false);
 
-  std::string  check(ConnectionInfo*      ciP,
-                     RequestType          requestType,
-                     const std::string&   indent,
-                     const std::string&   predetectedError,
-                     int                  counter);
+  std::string  check(RequestType          requestType,
+                     const std::string&   indent);
 
   std::string  toJson(void) const;
 };

--- a/src/lib/ngsi/EntityIdVector.cpp
+++ b/src/lib/ngsi/EntityIdVector.cpp
@@ -72,11 +72,8 @@ std::string EntityIdVector::render(const std::string& indent, bool comma)
 */
 std::string EntityIdVector::check
 (
-  ConnectionInfo*     ciP,
-  RequestType         requestType,  
-  const std::string&  indent,
-  const std::string&  predetectedError,
-  int                 counter
+  RequestType         requestType,
+  const std::string&  indent
 )
 {
   // Only OK to be empty if part of a ContextRegistration
@@ -97,7 +94,7 @@ std::string EntityIdVector::check
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+    if ((res = vec[ix]->check(requestType, indent)) != "OK")
     {
       alarmMgr.badInput(clientIp, "invalid vector of EntityIds");
       return res;

--- a/src/lib/ngsi/EntityIdVector.h
+++ b/src/lib/ngsi/EntityIdVector.h
@@ -60,11 +60,7 @@ typedef struct EntityIdVector
 
   EntityId* operator[](unsigned int ix) const;
 
-  std::string  check(ConnectionInfo*     ciP,
-                     RequestType         requestType,
-                     const std::string&  indent,
-                     const std::string&  predetectedError,
-                     int                 counter);
+  std::string  check(RequestType requestType, const std::string&  indent);
 } EntityIdVector;
 
 #endif  // SRC_LIB_NGSI_ENTITYIDVECTOR_H_

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -42,8 +42,6 @@
 #include "mongoBackend/safeMongo.h"
 #include "mongoBackend/compoundResponses.h"
 
-#include "rest/ConnectionInfo.h"
-
 using namespace mongo;
 
 

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -292,19 +292,12 @@ std::string Metadata::render(const std::string& indent, bool comma)
 *
 * Metadata::check -
 */
-std::string Metadata::check
-(
-  ConnectionInfo*     ciP,
-  RequestType         requestType,
-  const std::string&  indent,
-  const std::string&  predetectedError,
-  int                 counter
-)
+std::string Metadata::check(const std::string& apiVersion)
 {
   size_t len;
   char   errorMsg[128];
 
-  if (ciP->apiVersion == "v2" && (len = strlen(name.c_str())) < MIN_ID_LEN)
+  if (apiVersion == "v2" && (len = strlen(name.c_str())) < MIN_ID_LEN)
   {
     snprintf(errorMsg, sizeof errorMsg, "metadata name length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
@@ -324,7 +317,7 @@ std::string Metadata::check
     return std::string(errorMsg);
   }
 
-  if (forbiddenIdChars(ciP->apiVersion , name.c_str()))
+  if (forbiddenIdChars(apiVersion , name.c_str()))
   {
     alarmMgr.badInput(clientIp, "found a forbidden character in the name of a Metadata");
     return "Invalid characters in metadata name";
@@ -338,14 +331,14 @@ std::string Metadata::check
   }
 
 
-  if (ciP->apiVersion == "v2" && (len = strlen(type.c_str())) < MIN_ID_LEN)
+  if (apiVersion == "v2" && (len = strlen(type.c_str())) < MIN_ID_LEN)
   {
     snprintf(errorMsg, sizeof errorMsg, "metadata type length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
     return std::string(errorMsg);
   }
 
-  if (forbiddenIdChars(ciP->apiVersion, type.c_str()))
+  if (forbiddenIdChars(apiVersion, type.c_str()))
   {
     alarmMgr.badInput(clientIp, "found a forbidden character in the type of a Metadata");
     return "Invalid characters in metadata type";

--- a/src/lib/ngsi/Metadata.h
+++ b/src/lib/ngsi/Metadata.h
@@ -95,11 +95,7 @@ typedef struct Metadata
   std::string  toStringValue(void) const;
   bool         compoundItemExists(const std::string& compoundPath, orion::CompoundValueNode** compoundItemPP = NULL);
 
-  std::string  check(ConnectionInfo*     ciP,
-                     RequestType         requestType,
-                     const std::string&  indent,
-                     const std::string&  predetectedError,
-                     int                 counter);
+  std::string  check(const std::string& apiVersion);
 } Metadata;
 
 #endif  // SRC_LIB_NGSI_METADATA_H_

--- a/src/lib/ngsi/MetadataVector.cpp
+++ b/src/lib/ngsi/MetadataVector.cpp
@@ -176,20 +176,13 @@ std::string MetadataVector::toJson(bool isLastElement, const std::vector<std::st
 *
 * MetadataVector::check -
 */
-std::string MetadataVector::check
-(
-  ConnectionInfo*     ciP,
-  RequestType         requestType,
-  const std::string&  indent,
-  const std::string&  predetectedError,
-  int                 counter
-)
+std::string MetadataVector::check(const std::string& apiVersion)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, requestType, indent, predetectedError, counter)) != "OK")
+    if ((res = vec[ix]->check(apiVersion)) != "OK")
     {
       return res;
     }

--- a/src/lib/ngsi/MetadataVector.h
+++ b/src/lib/ngsi/MetadataVector.h
@@ -49,11 +49,7 @@ public:
   std::string     render(const std::string& indent, bool comma = false);
   std::string     toJson(bool                             isLastElement,
                          const std::vector<std::string>&  metadataFilter);
-  std::string     check(ConnectionInfo* ciP,
-                      RequestType requestType,
-                      const std::string& indent,
-                      const std::string& predetectedError,
-                      int counter);
+  std::string     check(const std::string& apiVersion);
 
   void            present(const std::string& metadataType, const std::string& indent);
   void            push_back(Metadata* item);

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -210,7 +210,7 @@ int Scope::fill
     }
 
     if (!str2double(coordV[0].c_str(), &latitude))
-    {      
+    {
       *errorStringP = "invalid coordinates";
       pointVectorRelease(pointV);
       pointV.clear();

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -40,7 +40,7 @@
 *
 * NotifyContextRequest::render -
 */
-std::string NotifyContextRequest::render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent)
+std::string NotifyContextRequest::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out                                  = "";
   std::string  tag                                  = "notifyContextRequest";
@@ -55,10 +55,7 @@ std::string NotifyContextRequest::render(ConnectionInfo* ciP, RequestType reques
   out += startTag1(indent, tag, false);
   out += subscriptionId.render(NotifyContext, indent + "  ", true);
   out += originator.render(indent  + "  ", contextElementResponseVectorRendered);
-  // FIXME PR
-  out += contextElementResponseVector.render(ciP->apiVersion,
-                                             ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                             NotifyContext, indent  + "  ", false);
+  out += contextElementResponseVector.render(apiVersion, asJsonObject, NotifyContext, indent  + "  ", false);
   out += endTag(indent);
 
   return out;
@@ -107,7 +104,7 @@ std::string NotifyContextRequest::toJson
 *
 * NotifyContextRequest::check
 */
-std::string NotifyContextRequest::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string NotifyContextRequest::check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError)
 {
   std::string            res;
   NotifyContextResponse  response;
@@ -118,8 +115,7 @@ std::string NotifyContextRequest::check(ConnectionInfo* ciP, RequestType request
   }
   else if (((res = subscriptionId.check(QueryContext, indent, predetectedError, 0))                    != "OK") ||
            ((res = originator.check(QueryContext, indent, predetectedError, 0))                        != "OK") ||
-           // FIXME PR
-           ((res = contextElementResponseVector.check(ciP->apiVersion, QueryContext, indent, predetectedError, 0)) != "OK"))
+           ((res = contextElementResponseVector.check(apiVersion, QueryContext, indent, predetectedError, 0)) != "OK"))
   {
     response.responseCode.fill(SccBadRequest, res);
   }

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -31,7 +31,6 @@
 #include "ngsi10/NotifyContextResponse.h"
 #include "rest/OrionError.h"
 #include "alarmMgr/alarmMgr.h"
-#include "rest/uriParamNames.h"
 
 
 

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -32,6 +32,7 @@
 #include "rest/ConnectionInfo.h"
 #include "rest/OrionError.h"
 #include "alarmMgr/alarmMgr.h"
+#include "rest/uriParamNames.h"
 
 
 
@@ -54,7 +55,10 @@ std::string NotifyContextRequest::render(ConnectionInfo* ciP, RequestType reques
   out += startTag1(indent, tag, false);
   out += subscriptionId.render(NotifyContext, indent + "  ", true);
   out += originator.render(indent  + "  ", contextElementResponseVectorRendered);
-  out += contextElementResponseVector.render(ciP, NotifyContext, indent  + "  ", false);
+  // FIXME PR
+  out += contextElementResponseVector.render(ciP->apiVersion,
+                                             ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                             NotifyContext, indent  + "  ", false);
   out += endTag(indent);
 
   return out;
@@ -114,7 +118,8 @@ std::string NotifyContextRequest::check(ConnectionInfo* ciP, RequestType request
   }
   else if (((res = subscriptionId.check(QueryContext, indent, predetectedError, 0))                    != "OK") ||
            ((res = originator.check(QueryContext, indent, predetectedError, 0))                        != "OK") ||
-           ((res = contextElementResponseVector.check(ciP, QueryContext, indent, predetectedError, 0)) != "OK"))
+           // FIXME PR
+           ((res = contextElementResponseVector.check(ciP->apiVersion, QueryContext, indent, predetectedError, 0)) != "OK"))
   {
     response.responseCode.fill(SccBadRequest, res);
   }

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -29,7 +29,6 @@
 #include "common/RenderFormat.h"
 #include "ngsi10/NotifyContextRequest.h"
 #include "ngsi10/NotifyContextResponse.h"
-#include "rest/ConnectionInfo.h"
 #include "rest/OrionError.h"
 #include "alarmMgr/alarmMgr.h"
 #include "rest/uriParamNames.h"
@@ -124,7 +123,7 @@ std::string NotifyContextRequest::check(const std::string& apiVersion, const std
     return "OK";
   }
 
-  return response.render(NotifyContext, indent);
+  return response.render(indent);
 }
 
 

--- a/src/lib/ngsi10/NotifyContextRequest.h
+++ b/src/lib/ngsi10/NotifyContextRequest.h
@@ -46,12 +46,12 @@ typedef struct NotifyContextRequest
   Originator                    originator;                    // Mandatory
   ContextElementResponseVector  contextElementResponseVector;  // Optional
 
-  std::string   render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent);
+  std::string   render(const std::string& apiVersion, bool asJsonObject, const std::string& indent);
   std::string   toJson(RenderFormat                     renderFormat,
                        const std::vector<std::string>&  attrsFilter,
                        const std::vector<std::string>&  metadataFilter,
                        bool                             blacklist = false);
-  std::string   check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string   check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   NotifyContextRequest* clone(void);

--- a/src/lib/ngsi10/NotifyContextRequest.h
+++ b/src/lib/ngsi10/NotifyContextRequest.h
@@ -32,7 +32,6 @@
 #include "ngsi/SubscriptionId.h"
 #include "ngsi/Originator.h"
 #include "ngsi/ContextElementResponseVector.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi10/NotifyContextResponse.cpp
+++ b/src/lib/ngsi10/NotifyContextResponse.cpp
@@ -62,7 +62,7 @@ NotifyContextResponse::NotifyContextResponse(StatusCode& sc)
 *
 * NotifyContextResponse::render -
 */
-std::string NotifyContextResponse::render(RequestType requestType, const std::string& indent)
+std::string NotifyContextResponse::render(const std::string& indent)
 {
   std::string out = "";
   std::string tag = "notifyContextResponse";

--- a/src/lib/ngsi10/NotifyContextResponse.h
+++ b/src/lib/ngsi10/NotifyContextResponse.h
@@ -44,7 +44,7 @@ typedef struct NotifyContextResponse
   NotifyContextResponse();
   NotifyContextResponse(StatusCode& sc);
 
-  std::string   render(RequestType requestType, const std::string& indent);
+  std::string   render(const std::string& indent);
   void          present(const std::string& indent);
   void          release(void);
 } NotifyContextResponse;

--- a/src/lib/ngsi10/QueryContextRequest.cpp
+++ b/src/lib/ngsi10/QueryContextRequest.cpp
@@ -95,7 +95,7 @@ QueryContextRequest::QueryContextRequest(const std::string& _contextProvider, En
 *
 * QueryContextRequest::render - 
 */
-std::string QueryContextRequest::render(RequestType requestType, const std::string& indent)
+std::string QueryContextRequest::render(const std::string& indent)
 {
   std::string   out                      = "";
   std::string   tag                      = "queryContextRequest";
@@ -119,7 +119,7 @@ std::string QueryContextRequest::render(RequestType requestType, const std::stri
 *
 * QueryContextRequest::check - 
 */
-std::string QueryContextRequest::check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError)
+std::string QueryContextRequest::check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
 {
   std::string           res;
   QueryContextResponse  response;
@@ -128,7 +128,6 @@ std::string QueryContextRequest::check(ConnectionInfo* ciP, const std::string& i
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  // FIXME PR
   else if (((res = entityIdVector.check(QueryContext, indent))                                 != "OK") ||
            ((res = attributeList.check(QueryContext,  indent, predetectedError, 0))            != "OK") ||
            ((res = restriction.check(QueryContext,    indent, predetectedError, restrictions)) != "OK"))
@@ -141,7 +140,7 @@ std::string QueryContextRequest::check(ConnectionInfo* ciP, const std::string& i
     return "OK";
   }
 
-  return response.render(ciP, QueryContext, indent);
+  return response.render(apiVersion, asJsonObject, indent);
 }
 
 

--- a/src/lib/ngsi10/QueryContextRequest.cpp
+++ b/src/lib/ngsi10/QueryContextRequest.cpp
@@ -34,7 +34,6 @@
 #include "ngsi/Restriction.h"
 #include "ngsi10/QueryContextResponse.h"
 #include "ngsi10/QueryContextRequest.h"
-#include "rest/ConnectionInfo.h"
 #include "rest/EntityTypeInfo.h"
 #include "apiTypesV2/BatchQuery.h"
 

--- a/src/lib/ngsi10/QueryContextRequest.cpp
+++ b/src/lib/ngsi10/QueryContextRequest.cpp
@@ -119,7 +119,7 @@ std::string QueryContextRequest::render(RequestType requestType, const std::stri
 *
 * QueryContextRequest::check - 
 */
-std::string QueryContextRequest::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string QueryContextRequest::check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError)
 {
   std::string           res;
   QueryContextResponse  response;
@@ -128,7 +128,8 @@ std::string QueryContextRequest::check(ConnectionInfo* ciP, RequestType requestT
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if (((res = entityIdVector.check(ciP, QueryContext, indent, predetectedError, 0))            != "OK") ||
+  // FIXME PR
+  else if (((res = entityIdVector.check(QueryContext, indent))                                 != "OK") ||
            ((res = attributeList.check(QueryContext,  indent, predetectedError, 0))            != "OK") ||
            ((res = restriction.check(QueryContext,    indent, predetectedError, restrictions)) != "OK"))
   {

--- a/src/lib/ngsi10/QueryContextRequest.h
+++ b/src/lib/ngsi10/QueryContextRequest.h
@@ -63,7 +63,7 @@ typedef struct QueryContextRequest
   QueryContextRequest(const std::string& _contextProvider, EntityId* eP, const AttributeList& attributeList);
 
   std::string   render(RequestType requestType, const std::string& indent);
-  std::string   check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   void          fill(const std::string& entityId, const std::string& entityType, const std::string& attributeName);

--- a/src/lib/ngsi10/QueryContextRequest.h
+++ b/src/lib/ngsi10/QueryContextRequest.h
@@ -62,8 +62,8 @@ typedef struct QueryContextRequest
   QueryContextRequest(const std::string& _contextProvider, EntityId* eP, const std::string& attributeName);
   QueryContextRequest(const std::string& _contextProvider, EntityId* eP, const AttributeList& attributeList);
 
-  std::string   render(RequestType requestType, const std::string& indent);
-  std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
+  std::string   render(const std::string& indent);
+  std::string   check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   void          fill(const std::string& entityId, const std::string& entityType, const std::string& attributeName);

--- a/src/lib/ngsi10/QueryContextRequest.h
+++ b/src/lib/ngsi10/QueryContextRequest.h
@@ -31,7 +31,6 @@
 #include "ngsi/AttributeList.h"
 #include "ngsi/EntityIdVector.h"
 #include "ngsi/Restriction.h"
-#include "rest/ConnectionInfo.h"
 #include "rest/EntityTypeInfo.h"
 
 

--- a/src/lib/ngsi10/QueryContextResponse.cpp
+++ b/src/lib/ngsi10/QueryContextResponse.cpp
@@ -33,7 +33,6 @@
 #include "rest/HttpStatusCode.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi10/QueryContextResponse.h"
-#include "rest/uriParamNames.h"
 
 
 

--- a/src/lib/ngsi10/QueryContextResponse.cpp
+++ b/src/lib/ngsi10/QueryContextResponse.cpp
@@ -96,7 +96,7 @@ QueryContextResponse::~QueryContextResponse()
 *
 * QueryContextResponse::render - 
 */
-std::string QueryContextResponse::render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent)
+std::string QueryContextResponse::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out               = "";
   std::string  tag               = "queryContextResponse";
@@ -131,8 +131,7 @@ std::string QueryContextResponse::render(ConnectionInfo* ciP, RequestType reques
 
   if (contextElementResponseVector.size() > 0)
   {
-    // FIXME PR
-    out += contextElementResponseVector.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, QueryContext, indent + "  ", errorCodeRendered);
+    out += contextElementResponseVector.render(apiVersion, asJsonObject, QueryContext, indent + "  ", errorCodeRendered);
   }
 
   if (errorCodeRendered == true)
@@ -165,7 +164,7 @@ std::string QueryContextResponse::render(ConnectionInfo* ciP, RequestType reques
 *
 * QueryContextResponse::check -
 */
-std::string QueryContextResponse::check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError)
+std::string QueryContextResponse::check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
 {
   std::string  res;
 
@@ -173,8 +172,7 @@ std::string QueryContextResponse::check(ConnectionInfo* ciP, const std::string& 
   {
     errorCode.fill(SccBadRequest, predetectedError);
   }
-  // FIXME PR
-  else if ((res = contextElementResponseVector.check(ciP->apiVersion, QueryContext, indent, predetectedError, 0)) != "OK")
+  else if ((res = contextElementResponseVector.check(apiVersion, QueryContext, indent, predetectedError, 0)) != "OK")
   {
     alarmMgr.badInput(clientIp, res);
     errorCode.fill(SccBadRequest, res);
@@ -184,7 +182,7 @@ std::string QueryContextResponse::check(ConnectionInfo* ciP, const std::string& 
     return "OK";
   }
 
-  return render(ciP, QueryContext, indent);
+  return render(apiVersion, asJsonObject, indent);
 }
 
 

--- a/src/lib/ngsi10/QueryContextResponse.cpp
+++ b/src/lib/ngsi10/QueryContextResponse.cpp
@@ -33,7 +33,6 @@
 #include "rest/HttpStatusCode.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi10/QueryContextResponse.h"
-#include "rest/ConnectionInfo.h"
 #include "rest/uriParamNames.h"
 
 

--- a/src/lib/ngsi10/QueryContextResponse.cpp
+++ b/src/lib/ngsi10/QueryContextResponse.cpp
@@ -34,6 +34,7 @@
 #include "ngsi/StatusCode.h"
 #include "ngsi10/QueryContextResponse.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 
 
 
@@ -130,7 +131,8 @@ std::string QueryContextResponse::render(ConnectionInfo* ciP, RequestType reques
 
   if (contextElementResponseVector.size() > 0)
   {
-    out += contextElementResponseVector.render(ciP, QueryContext, indent + "  ", errorCodeRendered);
+    // FIXME PR
+    out += contextElementResponseVector.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, QueryContext, indent + "  ", errorCodeRendered);
   }
 
   if (errorCodeRendered == true)
@@ -163,7 +165,7 @@ std::string QueryContextResponse::render(ConnectionInfo* ciP, RequestType reques
 *
 * QueryContextResponse::check -
 */
-std::string QueryContextResponse::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string QueryContextResponse::check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError)
 {
   std::string  res;
 
@@ -171,7 +173,8 @@ std::string QueryContextResponse::check(ConnectionInfo* ciP, RequestType request
   {
     errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = contextElementResponseVector.check(ciP, QueryContext, indent, predetectedError, 0)) != "OK")
+  // FIXME PR
+  else if ((res = contextElementResponseVector.check(ciP->apiVersion, QueryContext, indent, predetectedError, 0)) != "OK")
   {
     alarmMgr.badInput(clientIp, res);
     errorCode.fill(SccBadRequest, res);

--- a/src/lib/ngsi10/QueryContextResponse.h
+++ b/src/lib/ngsi10/QueryContextResponse.h
@@ -53,8 +53,8 @@ typedef struct QueryContextResponse
   QueryContextResponse(StatusCode& _errorCode);
   ~QueryContextResponse();
 
-  std::string            render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent);
-  std::string            check(ConnectionInfo* ciP, const std::string&  indent, const std::string&  predetectedError);
+  std::string            render(const std::string& apiVersion, bool asJsonObject, const std::string& indent);
+  std::string            check(const std::string& apiVersion, bool asJsonObject, const std::string&  indent, const std::string&  predetectedError);
   void                   present(const std::string& indent, const std::string& caller);
   void                   release(void);  
   void                   fill(QueryContextResponse* qcrsP);

--- a/src/lib/ngsi10/QueryContextResponse.h
+++ b/src/lib/ngsi10/QueryContextResponse.h
@@ -54,11 +54,7 @@ typedef struct QueryContextResponse
   ~QueryContextResponse();
 
   std::string            render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent);
-  std::string            check(ConnectionInfo*     ciP,
-                               RequestType         requestType,
-                               const std::string&  indent,
-                               const std::string&  predetectedError,
-                               int                 counter);
+  std::string            check(ConnectionInfo* ciP, const std::string&  indent, const std::string&  predetectedError);
   void                   present(const std::string& indent, const std::string& caller);
   void                   release(void);  
   void                   fill(QueryContextResponse* qcrsP);

--- a/src/lib/ngsi10/QueryContextResponse.h
+++ b/src/lib/ngsi10/QueryContextResponse.h
@@ -31,7 +31,6 @@
 
 #include "ngsi/ContextElementResponseVector.h"
 #include "ngsi/StatusCode.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/ngsi10/SubscribeContextRequest.cpp
+++ b/src/lib/ngsi10/SubscribeContextRequest.cpp
@@ -61,7 +61,7 @@ std::string SubscribeContextRequest::check(const std::string& indent, const std:
   {
     alarmMgr.badInput(clientIp, res);
     response.subscribeError.errorCode.fill(SccBadRequest, std::string("invalid payload: ") + res);
-    return response.render(SubscribeContext, indent);
+    return response.render(indent);
   }
 
   return "OK";

--- a/src/lib/ngsi10/SubscribeContextRequest.cpp
+++ b/src/lib/ngsi10/SubscribeContextRequest.cpp
@@ -43,7 +43,7 @@ using namespace ngsiv2;
 *
 * SubscribeContextRequest::check - 
 */
-std::string SubscribeContextRequest::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string SubscribeContextRequest::check(const std::string& indent, const std::string& predetectedError, int counter)
 {
   SubscribeContextResponse response;
   std::string              res;
@@ -51,7 +51,7 @@ std::string SubscribeContextRequest::check(ConnectionInfo* ciP, RequestType requ
   /* First, check optional fields only in the case they are present */
   /* Second, check the other (mandatory) fields */
 
-  if (((res = entityIdVector.check(ciP, SubscribeContext, indent, predetectedError, counter))        != "OK") ||
+  if (((res = entityIdVector.check(SubscribeContext, indent))                                   != "OK") ||
       ((res = attributeList.check(SubscribeContext, indent, predetectedError, counter))         != "OK") ||
       ((res = reference.check(SubscribeContext, indent, predetectedError, counter))             != "OK") ||
       ((res = duration.check(SubscribeContext, indent, predetectedError, counter))              != "OK") ||

--- a/src/lib/ngsi10/SubscribeContextRequest.cpp
+++ b/src/lib/ngsi10/SubscribeContextRequest.cpp
@@ -164,7 +164,7 @@ void SubscribeContextRequest::toNgsiv2Subscription(Subscription* sub)
 
   // Convert duration
   if (duration.isEmpty())
-  {    
+  {
     sub->expires = DEFAULT_DURATION_IN_SECONDS + getCurrentTime();
   }
   else

--- a/src/lib/ngsi10/SubscribeContextRequest.h
+++ b/src/lib/ngsi10/SubscribeContextRequest.h
@@ -60,7 +60,7 @@ typedef struct SubscribeContextRequest
 
   SubscribeContextRequest(): restrictions(0) {}
 
-  std::string  check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string  check(const std::string& indent, const std::string& predetectedError, int counter);
   void         present(const std::string& indent);
   void         release(void);
   void         toNgsiv2Subscription(ngsiv2::Subscription* sub);

--- a/src/lib/ngsi10/SubscribeContextResponse.cpp
+++ b/src/lib/ngsi10/SubscribeContextResponse.cpp
@@ -62,7 +62,7 @@ SubscribeContextResponse::SubscribeContextResponse(StatusCode& errorCode)
 *
 * SubscribeContextResponse::render - 
 */
-std::string SubscribeContextResponse::render(RequestType requestType, const std::string& indent)
+std::string SubscribeContextResponse::render(const std::string& indent)
 {
   std::string out     = "";
   std::string tag     = "subscribeContextResponse";

--- a/src/lib/ngsi10/SubscribeContextResponse.h
+++ b/src/lib/ngsi10/SubscribeContextResponse.h
@@ -46,7 +46,7 @@ typedef struct SubscribeContextResponse
   SubscribeContextResponse(StatusCode& errorCode);
   ~SubscribeContextResponse();
 
-  std::string render(RequestType requestType, const std::string& indent);
+  std::string render(const std::string& indent);
 } SubscribeContextResponse;
 
 #endif

--- a/src/lib/ngsi10/UnsubscribeContextRequest.cpp
+++ b/src/lib/ngsi10/UnsubscribeContextRequest.cpp
@@ -35,7 +35,7 @@
 *
 * UnsubscribeContextRequest::render - 
 */
-std::string UnsubscribeContextRequest::render(RequestType requestType, const std::string& indent)
+std::string UnsubscribeContextRequest::render(const std::string& indent)
 {
   std::string out = "";
   std::string tag = "unsubscribeContextRequest";
@@ -53,7 +53,7 @@ std::string UnsubscribeContextRequest::render(RequestType requestType, const std
 *
 * UnsubscribeContextRequest::check - 
 */
-std::string UnsubscribeContextRequest::check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string UnsubscribeContextRequest::check(const std::string& indent, const std::string& predetectedError, int counter)
 {
   UnsubscribeContextResponse  response;
   std::string                 res;
@@ -61,7 +61,7 @@ std::string UnsubscribeContextRequest::check(RequestType requestType, const std:
   if ((res = subscriptionId.check(SubscribeContext, indent, predetectedError, counter)) != "OK")
   {
      response.statusCode.fill(SccBadRequest, std::string("Invalid Subscription Id: /") + subscriptionId.get() + "/: " + res);
-     return response.render(UnsubscribeContext, indent);
+     return response.render(indent);
   }
 
   return "OK";

--- a/src/lib/ngsi10/UnsubscribeContextRequest.h
+++ b/src/lib/ngsi10/UnsubscribeContextRequest.h
@@ -39,8 +39,8 @@ typedef struct UnsubscribeContextRequest
 {
   SubscriptionId  subscriptionId;    // Mandatory
 
-  std::string     render(RequestType requestType, const std::string& indent);
-  std::string     check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string     render(const std::string& indent);
+  std::string     check(const std::string& indent, const std::string& predetectedError, int counter);
   void            present(const std::string& indent);
   void            release(void);
 } UnsubscribeContextRequest;

--- a/src/lib/ngsi10/UnsubscribeContextResponse.cpp
+++ b/src/lib/ngsi10/UnsubscribeContextResponse.cpp
@@ -66,7 +66,7 @@ UnsubscribeContextResponse::~UnsubscribeContextResponse()
 *
 * UnsubscribeContextResponse::render - 
 */
-std::string UnsubscribeContextResponse::render(RequestType requestType, const std::string& indent)
+std::string UnsubscribeContextResponse::render(const std::string& indent)
 {
   std::string out = "";
   std::string tag = "unsubscribeContextResponse";

--- a/src/lib/ngsi10/UnsubscribeContextResponse.h
+++ b/src/lib/ngsi10/UnsubscribeContextResponse.h
@@ -49,7 +49,7 @@ typedef struct UnsubscribeContextResponse
   UnsubscribeContextResponse(StatusCode& statusCode);
   ~UnsubscribeContextResponse();
 
-  std::string     render(RequestType requestType, const std::string& indent);
+  std::string     render(const std::string& indent);
   void            release(void);
 } UnsubscribeContextResponse;
 

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -68,7 +68,7 @@ UpdateContextRequest::UpdateContextRequest(const std::string& _contextProvider, 
 *
 * UpdateContextRequest::render - 
 */
-std::string UpdateContextRequest::render(ConnectionInfo* ciP, const std::string& indent)
+std::string UpdateContextRequest::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out = "";
   std::string  tag = "updateContextRequest";
@@ -77,8 +77,7 @@ std::string UpdateContextRequest::render(ConnectionInfo* ciP, const std::string&
   // Both fields are MANDATORY, so, comma after "contextElementVector"
   //  
   out += startTag1(indent, tag, false);
-  // FIXME PR
-  out += contextElementVector.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, UpdateContext, indent + "  ", true);
+  out += contextElementVector.render(apiVersion, asJsonObject, UpdateContext, indent + "  ", true);
   out += updateActionType.render(indent + "  ", false);
   out += endTag(indent, false);
 
@@ -91,7 +90,7 @@ std::string UpdateContextRequest::render(ConnectionInfo* ciP, const std::string&
 *
 * UpdateContextRequest::check - 
 */
-std::string UpdateContextRequest::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string UpdateContextRequest::check(const std::string& apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string            res;
   UpdateContextResponse  response;
@@ -99,15 +98,14 @@ std::string UpdateContextRequest::check(ConnectionInfo* ciP, RequestType request
   if (predetectedError != "")
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
-    return response.render(ciP, indent);
+    return response.render(apiVersion, asJsonObject, indent);
   }
 
-  // FIXME PR
-  if (((res = contextElementVector.check(ciP->apiVersion, requestType, indent, predetectedError, counter)) != "OK") ||
+  if (((res = contextElementVector.check(apiVersion, requestType, indent, predetectedError, counter)) != "OK") ||
       ((res = updateActionType.check()) != "OK"))
   {
     response.errorCode.fill(SccBadRequest, res);
-    return response.render(ciP, indent);
+    return response.render(apiVersion, asJsonObject, indent);
   }
 
   return "OK";

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -38,8 +38,8 @@
 #include "ngsi10/UpdateContextRequest.h"
 #include "ngsi10/UpdateContextResponse.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 #include "convenience/UpdateContextAttributeRequest.h"
-
 
 
 /* ****************************************************************************
@@ -68,16 +68,17 @@ UpdateContextRequest::UpdateContextRequest(const std::string& _contextProvider, 
 *
 * UpdateContextRequest::render - 
 */
-std::string UpdateContextRequest::render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent)
+std::string UpdateContextRequest::render(ConnectionInfo* ciP, const std::string& indent)
 {
   std::string  out = "";
   std::string  tag = "updateContextRequest";
 
   // JSON commas:
   // Both fields are MANDATORY, so, comma after "contextElementVector"
-  //
+  //  
   out += startTag1(indent, tag, false);
-  out += contextElementVector.render(ciP, UpdateContext, indent + "  ", true);
+  // FIXME PR
+  out += contextElementVector.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, UpdateContext, indent + "  ", true);
   out += updateActionType.render(indent + "  ", false);
   out += endTag(indent, false);
 
@@ -98,14 +99,15 @@ std::string UpdateContextRequest::check(ConnectionInfo* ciP, RequestType request
   if (predetectedError != "")
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
-    return response.render(ciP, UpdateContext, indent);
+    return response.render(ciP, indent);
   }
 
-  if (((res = contextElementVector.check(ciP, requestType, indent, predetectedError, counter)) != "OK") ||
+  // FIXME PR
+  if (((res = contextElementVector.check(ciP->apiVersion, requestType, indent, predetectedError, counter)) != "OK") ||
       ((res = updateActionType.check()) != "OK"))
   {
     response.errorCode.fill(SccBadRequest, res);
-    return response.render(ciP, UpdateContext, indent);
+    return response.render(ciP, indent);
   }
 
   return "OK";

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -37,7 +37,6 @@
 #include "ngsi/ContextAttribute.h"
 #include "ngsi10/UpdateContextRequest.h"
 #include "ngsi10/UpdateContextResponse.h"
-#include "rest/uriParamNames.h"
 #include "convenience/UpdateContextAttributeRequest.h"
 
 
@@ -89,7 +88,7 @@ std::string UpdateContextRequest::render(const std::string& apiVersion, bool asJ
 *
 * UpdateContextRequest::check - 
 */
-std::string UpdateContextRequest::check(const std::string& apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string UpdateContextRequest::check(const std::string& apiVersion, bool asJsonObject,  const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string            res;
   UpdateContextResponse  response;
@@ -100,8 +99,6 @@ std::string UpdateContextRequest::check(const std::string& apiVersion, bool asJs
     return response.render(apiVersion, asJsonObject, indent);
   }
 
-  // FIXME PR requestType
-  //if (((res = contextElementVector.check(apiVersion, requestType, indent, predetectedError, counter)) != "OK") ||
   if (((res = contextElementVector.check(apiVersion, UpdateContext, indent, predetectedError, counter)) != "OK") ||
       ((res = updateActionType.check()) != "OK"))
   {

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -101,7 +101,8 @@ std::string UpdateContextRequest::check(const std::string& apiVersion, bool asJs
   }
 
   // FIXME PR requestType
-  if (((res = contextElementVector.check(apiVersion, requestType, indent, predetectedError, counter)) != "OK") ||
+  //if (((res = contextElementVector.check(apiVersion, requestType, indent, predetectedError, counter)) != "OK") ||
+  if (((res = contextElementVector.check(apiVersion, UpdateContextRequest, indent, predetectedError, counter)) != "OK") ||
       ((res = updateActionType.check()) != "OK"))
   {
     response.errorCode.fill(SccBadRequest, res);

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -102,7 +102,7 @@ std::string UpdateContextRequest::check(const std::string& apiVersion, bool asJs
 
   // FIXME PR requestType
   //if (((res = contextElementVector.check(apiVersion, requestType, indent, predetectedError, counter)) != "OK") ||
-  if (((res = contextElementVector.check(apiVersion, UpdateContextRequest, indent, predetectedError, counter)) != "OK") ||
+  if (((res = contextElementVector.check(apiVersion, UpdateContext, indent, predetectedError, counter)) != "OK") ||
       ((res = updateActionType.check()) != "OK"))
   {
     response.errorCode.fill(SccBadRequest, res);

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -37,7 +37,6 @@
 #include "ngsi/ContextAttribute.h"
 #include "ngsi10/UpdateContextRequest.h"
 #include "ngsi10/UpdateContextResponse.h"
-#include "rest/ConnectionInfo.h"
 #include "rest/uriParamNames.h"
 #include "convenience/UpdateContextAttributeRequest.h"
 
@@ -101,6 +100,7 @@ std::string UpdateContextRequest::check(const std::string& apiVersion, bool asJs
     return response.render(apiVersion, asJsonObject, indent);
   }
 
+  // FIXME PR requestType
   if (((res = contextElementVector.check(apiVersion, requestType, indent, predetectedError, counter)) != "OK") ||
       ((res = updateActionType.check()) != "OK"))
   {

--- a/src/lib/ngsi10/UpdateContextRequest.h
+++ b/src/lib/ngsi10/UpdateContextRequest.h
@@ -60,7 +60,7 @@ typedef struct UpdateContextRequest
   UpdateContextRequest();
   UpdateContextRequest(const std::string& _contextProvider, EntityId* eP);
 
-  std::string        render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent);
+  std::string        render(ConnectionInfo* ciP, const std::string& indent);
   std::string        check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
   void               release(void);
   ContextAttribute*  attributeLookup(EntityId* eP, const std::string& attributeName);

--- a/src/lib/ngsi10/UpdateContextRequest.h
+++ b/src/lib/ngsi10/UpdateContextRequest.h
@@ -30,7 +30,6 @@
 
 #include "ngsi/ContextElementVector.h"
 #include "ngsi/UpdateActionType.h"
-#include "rest/ConnectionInfo.h"
 #include "apiTypesV2/Entity.h"
 #include "apiTypesV2/Entities.h"
 

--- a/src/lib/ngsi10/UpdateContextRequest.h
+++ b/src/lib/ngsi10/UpdateContextRequest.h
@@ -60,7 +60,7 @@ typedef struct UpdateContextRequest
   UpdateContextRequest(const std::string& _contextProvider, EntityId* eP);
 
   std::string        render(const std::string& apiVersion, bool asJsonObject, const std::string& indent);
-  std::string        check(const std::string& apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string        check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError, int counter);
   void               release(void);
   ContextAttribute*  attributeLookup(EntityId* eP, const std::string& attributeName);
 

--- a/src/lib/ngsi10/UpdateContextRequest.h
+++ b/src/lib/ngsi10/UpdateContextRequest.h
@@ -60,8 +60,8 @@ typedef struct UpdateContextRequest
   UpdateContextRequest();
   UpdateContextRequest(const std::string& _contextProvider, EntityId* eP);
 
-  std::string        render(ConnectionInfo* ciP, const std::string& indent);
-  std::string        check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string        render(const std::string& apiVersion, bool asJsonObject, const std::string& indent);
+  std::string        check(const std::string& apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
   void               release(void);
   ContextAttribute*  attributeLookup(EntityId* eP, const std::string& attributeName);
 

--- a/src/lib/ngsi10/UpdateContextResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextResponse.cpp
@@ -83,7 +83,7 @@ UpdateContextResponse::~UpdateContextResponse()
 *
 * UpdateContextResponse::render - 
 */
-std::string UpdateContextResponse::render(ConnectionInfo* ciP, const std::string& indent)
+std::string UpdateContextResponse::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string out = "";
   std::string tag = "updateContextResponse";
@@ -103,8 +103,7 @@ std::string UpdateContextResponse::render(ConnectionInfo* ciP, const std::string
     }
     else
     {
-      // FIXME PR
-      out += contextElementResponseVector.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, RtUpdateContextResponse, indent + "  ", false);
+      out += contextElementResponseVector.render(apiVersion, asJsonObject, RtUpdateContextResponse, indent + "  ", false);
     }
   }
   
@@ -121,7 +120,8 @@ std::string UpdateContextResponse::render(ConnectionInfo* ciP, const std::string
 */
 std::string UpdateContextResponse::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
   const std::string&  indent,
   const std::string&  predetectedError
 )
@@ -131,9 +131,8 @@ std::string UpdateContextResponse::check
   if (predetectedError != "")
   {
     errorCode.fill(SccBadRequest, predetectedError);
-  }
-  // FIXME PR
-  else if (contextElementResponseVector.check(ciP->apiVersion, UpdateContext, indent, predetectedError, 0) != "OK")
+  }  
+  else if (contextElementResponseVector.check(apiVersion, UpdateContext, indent, predetectedError, 0) != "OK")
   {
     alarmMgr.badInput(clientIp, res);
     errorCode.fill(SccBadRequest, res);
@@ -143,7 +142,7 @@ std::string UpdateContextResponse::check
     return "OK";
   }
 
-  return render(ciP, indent);
+  return render(apiVersion, asJsonObject, indent);
 }
 
 

--- a/src/lib/ngsi10/UpdateContextResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextResponse.cpp
@@ -36,7 +36,6 @@
 #include "ngsi/ContextElementResponse.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi10/UpdateContextResponse.h"
-#include "rest/ConnectionInfo.h"
 #include "rest/uriParamNames.h"
 
 

--- a/src/lib/ngsi10/UpdateContextResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextResponse.cpp
@@ -37,6 +37,7 @@
 #include "ngsi/StatusCode.h"
 #include "ngsi10/UpdateContextResponse.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 
 
 
@@ -82,7 +83,7 @@ UpdateContextResponse::~UpdateContextResponse()
 *
 * UpdateContextResponse::render - 
 */
-std::string UpdateContextResponse::render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent)
+std::string UpdateContextResponse::render(ConnectionInfo* ciP, const std::string& indent)
 {
   std::string out = "";
   std::string tag = "updateContextResponse";
@@ -101,7 +102,10 @@ std::string UpdateContextResponse::render(ConnectionInfo* ciP, RequestType reque
       out += errorCode.render(indent + "  ");
     }
     else
-      out += contextElementResponseVector.render(ciP, RtUpdateContextResponse, indent + "  ", false);
+    {
+      // FIXME PR
+      out += contextElementResponseVector.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, RtUpdateContextResponse, indent + "  ", false);
+    }
   }
   
   out += endTag(indent);
@@ -118,10 +122,8 @@ std::string UpdateContextResponse::render(ConnectionInfo* ciP, RequestType reque
 std::string UpdateContextResponse::check
 (
   ConnectionInfo*     ciP,
-  RequestType         requestType,
   const std::string&  indent,
-  const std::string&  predetectedError,
-  int                 counter
+  const std::string&  predetectedError
 )
 {
   std::string  res;
@@ -130,7 +132,8 @@ std::string UpdateContextResponse::check
   {
     errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if (contextElementResponseVector.check(ciP, UpdateContext, indent, predetectedError, 0) != "OK")
+  // FIXME PR
+  else if (contextElementResponseVector.check(ciP->apiVersion, UpdateContext, indent, predetectedError, 0) != "OK")
   {
     alarmMgr.badInput(clientIp, res);
     errorCode.fill(SccBadRequest, res);
@@ -140,7 +143,7 @@ std::string UpdateContextResponse::check
     return "OK";
   }
 
-  return render(ciP, UpdateContext, indent);
+  return render(ciP, indent);
 }
 
 

--- a/src/lib/ngsi10/UpdateContextResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextResponse.cpp
@@ -36,7 +36,6 @@
 #include "ngsi/ContextElementResponse.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi10/UpdateContextResponse.h"
-#include "rest/uriParamNames.h"
 
 
 
@@ -71,7 +70,6 @@ UpdateContextResponse::UpdateContextResponse(StatusCode& _errorCode)
 UpdateContextResponse::~UpdateContextResponse()
 {
   errorCode.release();
-//  errorCode.keyNameSet("errorCode");
   contextElementResponseVector.release();
   LM_T(LmtDestructor, ("destroyed"));
 }

--- a/src/lib/ngsi10/UpdateContextResponse.h
+++ b/src/lib/ngsi10/UpdateContextResponse.h
@@ -51,8 +51,8 @@ typedef struct UpdateContextResponse
   UpdateContextResponse(StatusCode& _errorCode);
   ~UpdateContextResponse();
 
-  std::string   render(ConnectionInfo* ciP, RequestType requestType, const std::string& indent);  
-  std::string   check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string   render(ConnectionInfo* ciP, const std::string& indent);
+  std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   void          fill(UpdateContextResponse* upcrsP);

--- a/src/lib/ngsi10/UpdateContextResponse.h
+++ b/src/lib/ngsi10/UpdateContextResponse.h
@@ -30,7 +30,6 @@
 
 #include "ngsi/ContextElementResponseVector.h"
 #include "ngsi/StatusCode.h"
-#include "rest/ConnectionInfo.h"
 
 #include "rest/OrionError.h"
 

--- a/src/lib/ngsi10/UpdateContextResponse.h
+++ b/src/lib/ngsi10/UpdateContextResponse.h
@@ -51,8 +51,8 @@ typedef struct UpdateContextResponse
   UpdateContextResponse(StatusCode& _errorCode);
   ~UpdateContextResponse();
 
-  std::string   render(ConnectionInfo* ciP, const std::string& indent);
-  std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
+  std::string   render(const std::string& apiVersion, bool asJsonObject, const std::string& indent);
+  std::string   check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   void          fill(UpdateContextResponse* upcrsP);

--- a/src/lib/ngsi10/UpdateContextSubscriptionRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextSubscriptionRequest.cpp
@@ -54,7 +54,7 @@ UpdateContextSubscriptionRequest::UpdateContextSubscriptionRequest()
 *
 * UpdateContextSubscriptionRequest::check - 
 */
-std::string UpdateContextSubscriptionRequest::check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string UpdateContextSubscriptionRequest::check(const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string                       res;
   UpdateContextSubscriptionResponse response;
@@ -76,7 +76,7 @@ std::string UpdateContextSubscriptionRequest::check(RequestType requestType, con
   else
     return "OK";
 
-  return response.render(UpdateContextSubscription, indent);
+  return response.render(indent);
 }
 
 

--- a/src/lib/ngsi10/UpdateContextSubscriptionRequest.h
+++ b/src/lib/ngsi10/UpdateContextSubscriptionRequest.h
@@ -48,7 +48,7 @@ struct UpdateContextSubscriptionRequest : public SubscribeContextRequest
   SubscriptionId                 subscriptionId;         // Mandatory 
 
   UpdateContextSubscriptionRequest();  
-  std::string check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string check(const std::string& indent, const std::string& predetectedError, int counter);
   void        present(const std::string& indent);
   void        release(void);
   void        toNgsiv2Subscription(ngsiv2::SubscriptionUpdate* subUp);

--- a/src/lib/ngsi10/UpdateContextSubscriptionResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextSubscriptionResponse.cpp
@@ -63,7 +63,7 @@ UpdateContextSubscriptionResponse::~UpdateContextSubscriptionResponse() {
 *
 * UpdateContextSubscriptionResponse::render - 
 */
-std::string UpdateContextSubscriptionResponse::render(RequestType requestType, const std::string& indent)
+std::string UpdateContextSubscriptionResponse::render(const std::string& indent)
 {
   std::string out  = "";
   std::string tag  = "updateContextSubscriptionResponse";

--- a/src/lib/ngsi10/UpdateContextSubscriptionResponse.h
+++ b/src/lib/ngsi10/UpdateContextSubscriptionResponse.h
@@ -46,7 +46,7 @@ typedef struct UpdateContextSubscriptionResponse
   UpdateContextSubscriptionResponse(StatusCode& errorCode);
   ~UpdateContextSubscriptionResponse();
 
-  std::string render(RequestType requestType, const std::string& indent);
+  std::string render(const std::string& indent);
 } UpdateContextSubscriptionResponse;
 
 #endif

--- a/src/lib/ngsi9/DiscoverContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/DiscoverContextAvailabilityRequest.cpp
@@ -63,7 +63,7 @@ void DiscoverContextAvailabilityRequest::release(void)
 *
 * DiscoverContextAvailabilityRequest::check - 
 */
-std::string DiscoverContextAvailabilityRequest::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string DiscoverContextAvailabilityRequest::check(const std::string& indent, const std::string& predetectedError)
 {
   DiscoverContextAvailabilityResponse  response;
   std::string                          res;
@@ -76,7 +76,7 @@ std::string DiscoverContextAvailabilityRequest::check(ConnectionInfo* ciP, Reque
   {
     response.errorCode.fill(SccContextElementNotFound);
   }
-  else if (((res = entityIdVector.check(ciP, DiscoverContextAvailability, indent, predetectedError, restrictions))                      != "OK") ||
+  else if (((res = entityIdVector.check(DiscoverContextAvailability, indent))                                                      != "OK") ||
            ((res = attributeList.check(DiscoverContextAvailability, indent, predetectedError, restrictions))                       != "OK") ||
            ((restrictions != 0) && ((res = restriction.check(DiscoverContextAvailability, indent, predetectedError, restrictions)) != "OK")))
   {

--- a/src/lib/ngsi9/DiscoverContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/DiscoverContextAvailabilityRequest.cpp
@@ -85,7 +85,7 @@ std::string DiscoverContextAvailabilityRequest::check(const std::string& indent,
   else
     return "OK";
 
-  return response.render(DiscoverContextAvailability, indent);
+  return response.render(indent);
 }
 
 

--- a/src/lib/ngsi9/DiscoverContextAvailabilityRequest.h
+++ b/src/lib/ngsi9/DiscoverContextAvailabilityRequest.h
@@ -52,11 +52,8 @@ typedef struct DiscoverContextAvailabilityRequest
   void                 release(void);
   void                 present(const std::string& indent);
 
-  std::string          check(ConnectionInfo*     ciP,
-                             RequestType         requestType,
-                             const std::string&  indent,
-                             const std::string&  predetectedError,
-                             int                 counter);
+  std::string          check(const std::string&  indent,
+                             const std::string&  predetectedError);
 
   void                 fill(EntityId&                        eid,
                             const std::vector<std::string>&  attributeV,

--- a/src/lib/ngsi9/DiscoverContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/DiscoverContextAvailabilityResponse.cpp
@@ -70,7 +70,7 @@ DiscoverContextAvailabilityResponse::DiscoverContextAvailabilityResponse(StatusC
 *
 * DiscoverContextAvailabilityResponse::render - 
 */
-std::string DiscoverContextAvailabilityResponse::render(RequestType requestType, const std::string& indent)
+std::string DiscoverContextAvailabilityResponse::render(const std::string& indent)
 {
   std::string  out = "";
   std::string  tag = "discoverContextAvailabilityResponse";

--- a/src/lib/ngsi9/DiscoverContextAvailabilityResponse.h
+++ b/src/lib/ngsi9/DiscoverContextAvailabilityResponse.h
@@ -47,7 +47,7 @@ typedef struct DiscoverContextAvailabilityResponse
   ~DiscoverContextAvailabilityResponse();
   DiscoverContextAvailabilityResponse(StatusCode& _errorCode);
 
-  std::string  render(RequestType requestType, const std::string& indent);
+  std::string  render(const std::string& indent);
   void         release();
 } DiscoverContextAvailabilityResponse;
 

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
@@ -46,7 +46,7 @@ NotifyContextAvailabilityRequest::NotifyContextAvailabilityRequest()
 *
 * NotifyContextAvailabilityRequest::render -
 */
-std::string NotifyContextAvailabilityRequest::render(RequestType requestType, const std::string& indent)
+std::string NotifyContextAvailabilityRequest::render(const std::string& indent)
 {
   std::string out = "";
   std::string tag = "notifyContextAvailabilityRequest";
@@ -71,7 +71,7 @@ std::string NotifyContextAvailabilityRequest::render(RequestType requestType, co
 *
 * NotifyContextAvailabilityRequest::check - 
 */
-std::string NotifyContextAvailabilityRequest::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string NotifyContextAvailabilityRequest::check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string                        res;
   NotifyContextAvailabilityResponse  response;
@@ -80,14 +80,15 @@ std::string NotifyContextAvailabilityRequest::check(ConnectionInfo* ciP, Request
   {
     response.responseCode.fill(SccBadRequest, predetectedError);
   }
-  // FIXME PR
-  else if (((res = subscriptionId.check(QueryContext, indent, predetectedError, 0))                    != "OK") ||
-           ((res = contextRegistrationResponseVector.check(ciP->apiVersion, QueryContext, indent, predetectedError, 0)) != "OK"))
+  else if (((res = subscriptionId.check(QueryContext, indent, predetectedError, 0))                                != "OK") ||
+           ((res = contextRegistrationResponseVector.check(apiVersion, QueryContext, indent, predetectedError, 0)) != "OK"))
   {
     response.responseCode.fill(SccBadRequest, res);
   }
   else
+  {
     return "OK";
+  }
 
   return response.render(NotifyContextAvailability, indent);
 }

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
@@ -90,7 +90,7 @@ std::string NotifyContextAvailabilityRequest::check(const std::string& apiVersio
     return "OK";
   }
 
-  return response.render(NotifyContextAvailability, indent);
+  return response.render(indent);
 }
 
 

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
@@ -80,8 +80,9 @@ std::string NotifyContextAvailabilityRequest::check(ConnectionInfo* ciP, Request
   {
     response.responseCode.fill(SccBadRequest, predetectedError);
   }
+  // FIXME PR
   else if (((res = subscriptionId.check(QueryContext, indent, predetectedError, 0))                    != "OK") ||
-           ((res = contextRegistrationResponseVector.check(ciP, QueryContext, indent, predetectedError, 0)) != "OK"))
+           ((res = contextRegistrationResponseVector.check(ciP->apiVersion, QueryContext, indent, predetectedError, 0)) != "OK"))
   {
     response.responseCode.fill(SccBadRequest, res);
   }

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.h
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.h
@@ -43,8 +43,8 @@ typedef struct NotifyContextAvailabilityRequest
 
   NotifyContextAvailabilityRequest();
 
-  std::string   render(RequestType requestType, const std::string& indent);
-  std::string   check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string   render(const std::string& indent);
+  std::string   check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
   void          present(const std::string& indent);
   void          release(void);
 } NotifyContextAvailabilityRequest;

--- a/src/lib/ngsi9/NotifyContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityResponse.cpp
@@ -62,7 +62,7 @@ NotifyContextAvailabilityResponse::NotifyContextAvailabilityResponse(StatusCode&
 *
 * NotifyContextAvailabilityResponse::render -
 */
-std::string NotifyContextAvailabilityResponse::render(RequestType requestType, const std::string& indent)
+std::string NotifyContextAvailabilityResponse::render(const std::string& indent)
 {
   std::string out = "";
   std::string tag = "notifyContextAvailabilityResponse";

--- a/src/lib/ngsi9/NotifyContextAvailabilityResponse.h
+++ b/src/lib/ngsi9/NotifyContextAvailabilityResponse.h
@@ -43,7 +43,7 @@ typedef struct NotifyContextAvailabilityResponse
   NotifyContextAvailabilityResponse();
   NotifyContextAvailabilityResponse(StatusCode& sc);
 
-  std::string   render(RequestType requestType, const std::string& indent);
+  std::string   render(const std::string& indent);
   void          present(const std::string& indent);
   void          release(void);
 } NotifyContextAvailabilityResponse;

--- a/src/lib/ngsi9/RegisterContextRequest.cpp
+++ b/src/lib/ngsi9/RegisterContextRequest.cpp
@@ -68,7 +68,7 @@ std::string RegisterContextRequest::render(RequestType requestType, const std::s
 *
 * RegisterContextRequest::check - 
 */
-std::string RegisterContextRequest::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string RegisterContextRequest::check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
 {
   RegisterContextResponse  response(this);
   std::string              res;
@@ -82,9 +82,8 @@ std::string RegisterContextRequest::check(ConnectionInfo* ciP, RequestType reque
   {
     alarmMgr.badInput(clientIp, "empty contextRegistration list");
     response.errorCode.fill(SccBadRequest, "Empty Context Registration List");
-  }
-  // FIXME PR
-  else if (((res = contextRegistrationVector.check(ciP->apiVersion, RegisterContext, indent, predetectedError, counter)) != "OK") ||
+  } 
+  else if (((res = contextRegistrationVector.check(apiVersion, RegisterContext, indent, predetectedError, counter)) != "OK") ||
            ((res = duration.check(RegisterContext, indent, predetectedError, counter))                  != "OK") ||
            ((res = registrationId.check(RegisterContext, indent, predetectedError, counter))            != "OK"))
   {

--- a/src/lib/ngsi9/RegisterContextRequest.cpp
+++ b/src/lib/ngsi9/RegisterContextRequest.cpp
@@ -83,7 +83,8 @@ std::string RegisterContextRequest::check(ConnectionInfo* ciP, RequestType reque
     alarmMgr.badInput(clientIp, "empty contextRegistration list");
     response.errorCode.fill(SccBadRequest, "Empty Context Registration List");
   }
-  else if (((res = contextRegistrationVector.check(ciP, RegisterContext, indent, predetectedError, counter)) != "OK") ||
+  // FIXME PR
+  else if (((res = contextRegistrationVector.check(ciP->apiVersion, RegisterContext, indent, predetectedError, counter)) != "OK") ||
            ((res = duration.check(RegisterContext, indent, predetectedError, counter))                  != "OK") ||
            ((res = registrationId.check(RegisterContext, indent, predetectedError, counter))            != "OK"))
   {

--- a/src/lib/ngsi9/RegisterContextRequest.cpp
+++ b/src/lib/ngsi9/RegisterContextRequest.cpp
@@ -42,7 +42,7 @@
 *
 * RegisterContextRequest::render - 
 */
-std::string RegisterContextRequest::render(RequestType requestType, const std::string& indent)
+std::string RegisterContextRequest::render(const std::string& indent)
 {
   std::string  out                                 = "";
   bool         durationRendered                    = duration.get() != "";
@@ -95,7 +95,7 @@ std::string RegisterContextRequest::check(const std::string& apiVersion, const s
     return "OK";
   }
 
-  return response.render(RegisterContext, indent);
+  return response.render(indent);
 }
 
 

--- a/src/lib/ngsi9/RegisterContextRequest.h
+++ b/src/lib/ngsi9/RegisterContextRequest.h
@@ -47,7 +47,7 @@ typedef struct RegisterContextRequest
 
   std::string                servicePath;                // Not part of payload, just an internal field
 
-  std::string   render(RequestType requestType, const std::string& indent);
+  std::string   render(const std::string& indent);
   std::string   check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
   void          present(void);
   void          release(void);

--- a/src/lib/ngsi9/RegisterContextRequest.h
+++ b/src/lib/ngsi9/RegisterContextRequest.h
@@ -48,7 +48,7 @@ typedef struct RegisterContextRequest
   std::string                servicePath;                // Not part of payload, just an internal field
 
   std::string   render(RequestType requestType, const std::string& indent);
-  std::string   check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string   check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
   void          present(void);
   void          release(void);
   void          fill(RegisterProviderRequest& rpr, const std::string& entityId, const std::string& entityType, const std::string& attributeName);

--- a/src/lib/ngsi9/RegisterContextResponse.cpp
+++ b/src/lib/ngsi9/RegisterContextResponse.cpp
@@ -99,7 +99,7 @@ RegisterContextResponse::RegisterContextResponse(const std::string& _registratio
 *
 * RegisterContextResponse::render - 
 */
-std::string RegisterContextResponse::render(RequestType requestType, const std::string& indent)
+std::string RegisterContextResponse::render(const std::string& indent)
 {
   std::string  out = "";
   std::string  tag = "registerContextResponse";
@@ -130,7 +130,7 @@ std::string RegisterContextResponse::render(RequestType requestType, const std::
 *
 * RegisterContextResponse::check - 
 */
-std::string RegisterContextResponse::check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string RegisterContextResponse::check(const std::string& indent, const std::string& predetectedError, int counter)
 {
   RegisterContextResponse  response;
   std::string              res;
@@ -147,7 +147,7 @@ std::string RegisterContextResponse::check(RequestType requestType, const std::s
   else
     return "OK";
 
-  return response.render(RegisterContext, indent);
+  return response.render(indent);
 }
 
 

--- a/src/lib/ngsi9/RegisterContextResponse.h
+++ b/src/lib/ngsi9/RegisterContextResponse.h
@@ -50,8 +50,8 @@ typedef struct RegisterContextResponse
   RegisterContextResponse(const std::string& _registrationId, const std::string& _duration);
   RegisterContextResponse(const std::string& _registrationId, StatusCode& _errorCode);
 
-  std::string render(RequestType requestType, const std::string& indent);
-  std::string check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string render(const std::string& indent);
+  std::string check(const std::string& indent, const std::string& predetectedError, int counter);
   void        present(const std::string& indent);
   void        release(void);
 } RegisterContextResponse;

--- a/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
@@ -52,7 +52,7 @@ SubscribeContextAvailabilityRequest::SubscribeContextAvailabilityRequest()
 *
 * SubscribeContextAvailabilityRequest::render - 
 */
-std::string SubscribeContextAvailabilityRequest::render(RequestType requestType, const std::string& indent)
+std::string SubscribeContextAvailabilityRequest::render(const std::string& indent)
 {
   std::string out                      = "";
   std::string tag                      = "subscribeContextAvailabilityRequest";
@@ -99,7 +99,7 @@ std::string SubscribeContextAvailabilityRequest::check(const std::string& indent
   else
     return "OK";
 
-  return response.render(SubscribeContextAvailability, indent);
+  return response.render(indent);
 }
 
 

--- a/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
@@ -88,7 +88,6 @@ std::string SubscribeContextAvailabilityRequest::check(const std::string& indent
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  // FIXME PR
   else if (((res = entityIdVector.check(SubscribeContextAvailability, indent))                              != "OK") ||
            ((res = attributeList.check(SubscribeContextAvailability, indent, predetectedError, counter))    != "OK") ||
            ((res = reference.check(SubscribeContextAvailability, indent, predetectedError, counter))        != "OK") ||

--- a/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
@@ -79,7 +79,7 @@ std::string SubscribeContextAvailabilityRequest::render(RequestType requestType,
 *
 * SubscribeContextAvailabilityRequest::check - 
 */
-std::string SubscribeContextAvailabilityRequest::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string SubscribeContextAvailabilityRequest::check(const std::string& indent, const std::string& predetectedError, int counter)
 {
   SubscribeContextAvailabilityResponse response;
   std::string                          res;
@@ -88,7 +88,8 @@ std::string SubscribeContextAvailabilityRequest::check(ConnectionInfo* ciP, Requ
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if (((res = entityIdVector.check(ciP, SubscribeContextAvailability, indent, predetectedError, counter))   != "OK") ||
+  // FIXME PR
+  else if (((res = entityIdVector.check(SubscribeContextAvailability, indent))                              != "OK") ||
            ((res = attributeList.check(SubscribeContextAvailability, indent, predetectedError, counter))    != "OK") ||
            ((res = reference.check(SubscribeContextAvailability, indent, predetectedError, counter))        != "OK") ||
            ((res = duration.check(SubscribeContextAvailability, indent, predetectedError, counter))         != "OK") ||

--- a/src/lib/ngsi9/SubscribeContextAvailabilityRequest.h
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityRequest.h
@@ -64,7 +64,7 @@ typedef struct SubscribeContextAvailabilityRequest
   int                    restrictions;
 
   SubscribeContextAvailabilityRequest();
-  std::string  render(RequestType requestType, const std::string& indent);
+  std::string  render(const std::string& indent);
   std::string  check(const std::string& indent, const std::string& predetectedError, int counter);
   void         release(void);
   void         present(const std::string& indent);

--- a/src/lib/ngsi9/SubscribeContextAvailabilityRequest.h
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityRequest.h
@@ -65,7 +65,7 @@ typedef struct SubscribeContextAvailabilityRequest
 
   SubscribeContextAvailabilityRequest();
   std::string  render(RequestType requestType, const std::string& indent);
-  std::string  check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string  check(const std::string& indent, const std::string& predetectedError, int counter);
   void         release(void);
   void         present(const std::string& indent);
 

--- a/src/lib/ngsi9/SubscribeContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityResponse.cpp
@@ -82,7 +82,7 @@ SubscribeContextAvailabilityResponse::SubscribeContextAvailabilityResponse(const
 *
 * SubscribeContextAvailabilityResponse::render - 
 */
-std::string SubscribeContextAvailabilityResponse::render(RequestType requestType, const std::string& indent)
+std::string SubscribeContextAvailabilityResponse::render(const std::string& indent)
 {
   std::string  tag                = "subscribeContextAvailabilityResponse";
   std::string  out                = "";

--- a/src/lib/ngsi9/SubscribeContextAvailabilityResponse.h
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityResponse.h
@@ -48,7 +48,7 @@ typedef struct SubscribeContextAvailabilityResponse
   SubscribeContextAvailabilityResponse(const std::string& _subscriptionId, const std::string& _duration);
   SubscribeContextAvailabilityResponse(const std::string& _subscriptionId, StatusCode& _errorCode);
 
-   std::string render(RequestType requestType, const std::string& indent);
+   std::string render(const std::string& indent);
 } SubscribeContextAvailabilityResponse;
 
 #endif

--- a/src/lib/ngsi9/UnsubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/UnsubscribeContextAvailabilityRequest.cpp
@@ -56,7 +56,7 @@ UnsubscribeContextAvailabilityRequest::UnsubscribeContextAvailabilityRequest(Sub
 *
 * UnsubscribeContextAvailabilityRequest::check - 
 */
-std::string UnsubscribeContextAvailabilityRequest::check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string UnsubscribeContextAvailabilityRequest::check(const std::string& indent, const std::string& predetectedError, int counter)
 {
    UnsubscribeContextAvailabilityResponse  response(subscriptionId);
    std::string                             res;
@@ -72,7 +72,7 @@ std::string UnsubscribeContextAvailabilityRequest::check(RequestType requestType
   else
     return "OK";
 
-  return response.render(UnsubscribeContextAvailability, indent);
+  return response.render(indent);
 }
 
 

--- a/src/lib/ngsi9/UnsubscribeContextAvailabilityRequest.h
+++ b/src/lib/ngsi9/UnsubscribeContextAvailabilityRequest.h
@@ -43,7 +43,7 @@ typedef struct UnsubscribeContextAvailabilityRequest
   UnsubscribeContextAvailabilityRequest();
   UnsubscribeContextAvailabilityRequest(SubscriptionId& _subscriptionId);
 
-  std::string     check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string     check(const std::string& indent, const std::string& predetectedError, int counter);
   void            release(void);
   void            fill(const std::string& _subscriptionId);
 } UnsubscribeContextAvailabilityRequest;

--- a/src/lib/ngsi9/UnsubscribeContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/UnsubscribeContextAvailabilityResponse.cpp
@@ -74,7 +74,7 @@ UnsubscribeContextAvailabilityResponse::~UnsubscribeContextAvailabilityResponse(
 *
 * UnsubscribeContextAvailabilityResponse::render - 
 */
-std::string UnsubscribeContextAvailabilityResponse::render(RequestType requestType, const std::string& indent)
+std::string UnsubscribeContextAvailabilityResponse::render(const std::string& indent)
 {
   std::string out = "";
   std::string tag = "unsubscribeContextAvailabilityResponse";

--- a/src/lib/ngsi9/UnsubscribeContextAvailabilityResponse.h
+++ b/src/lib/ngsi9/UnsubscribeContextAvailabilityResponse.h
@@ -46,7 +46,7 @@ typedef struct UnsubscribeContextAvailabilityResponse
   UnsubscribeContextAvailabilityResponse(SubscriptionId _subscriptionId);
   ~UnsubscribeContextAvailabilityResponse();
 
-  std::string render(RequestType requestType, const std::string& indent);
+  std::string render(const std::string& indent);
 } UnsubscribeContextAvailabilityResponse;
 
 #endif

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
@@ -49,12 +49,10 @@ UpdateContextAvailabilitySubscriptionRequest::UpdateContextAvailabilitySubscript
 *
 * UpdateContextAvailabilitySubscriptionRequest::render - 
 */
-std::string UpdateContextAvailabilitySubscriptionRequest::render(RequestType requestType, const std::string& indent)
+std::string UpdateContextAvailabilitySubscriptionRequest::render(const std::string& indent)
 {  
   std::string   out                      = "";
   std::string   tag                      = "updateContextAvailabilitySubscriptionRequest";
-  // FIXME PR
-  //bool          subscriptionRendered     = subscriptionId.rendered(requestType)
   bool          subscriptionRendered     = subscriptionId.rendered(UpdateContextAvailabilitySubscription);
   bool          restrictionRendered      = restrictions != 0;
   bool          durationRendered         = duration.get() != "";

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
@@ -51,6 +51,7 @@ UpdateContextAvailabilitySubscriptionRequest::UpdateContextAvailabilitySubscript
 */
 std::string UpdateContextAvailabilitySubscriptionRequest::render(RequestType requestType, const std::string& indent)
 {
+  // FIXME requestType
   std::string   out                      = "";
   std::string   tag                      = "updateContextAvailabilitySubscriptionRequest";
   bool          subscriptionRendered     = subscriptionId.rendered(requestType);
@@ -117,7 +118,7 @@ std::string UpdateContextAvailabilitySubscriptionRequest::check(const std::strin
   else
     return "OK";
 
-  return response.render(UpdateContextAvailabilitySubscription, indent, counter);
+  return response.render(indent, counter);
 }
 
 

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
@@ -50,11 +50,12 @@ UpdateContextAvailabilitySubscriptionRequest::UpdateContextAvailabilitySubscript
 * UpdateContextAvailabilitySubscriptionRequest::render - 
 */
 std::string UpdateContextAvailabilitySubscriptionRequest::render(RequestType requestType, const std::string& indent)
-{
-  // FIXME requestType
+{  
   std::string   out                      = "";
   std::string   tag                      = "updateContextAvailabilitySubscriptionRequest";
-  bool          subscriptionRendered     = subscriptionId.rendered(requestType);
+  // FIXME PR
+  //bool          subscriptionRendered     = subscriptionId.rendered(requestType)
+  bool          subscriptionRendered     = subscriptionId.rendered(UpdateContextAvailabilitySubscription);
   bool          restrictionRendered      = restrictions != 0;
   bool          durationRendered         = duration.get() != "";
   bool          attributeListRendered    = attributeList.size() != 0;

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
@@ -95,7 +95,7 @@ void UpdateContextAvailabilitySubscriptionRequest::present(const std::string& in
 *
 * UpdateContextAvailabilitySubscriptionRequest::check - 
 */
-std::string UpdateContextAvailabilitySubscriptionRequest::check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string UpdateContextAvailabilitySubscriptionRequest::check(const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string                                    res;
   UpdateContextAvailabilitySubscriptionResponse  response;
@@ -106,7 +106,7 @@ std::string UpdateContextAvailabilitySubscriptionRequest::check(ConnectionInfo* 
   {
     response.errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if (((res = entityIdVector.check(ciP, UpdateContextAvailabilitySubscription, indent, predetectedError, counter))      != "OK") ||
+  else if (((res = entityIdVector.check(UpdateContextAvailabilitySubscription, indent))                                 != "OK") ||
            ((res = attributeList.check(UpdateContextAvailabilitySubscription, indent, predetectedError, counter))       != "OK") ||
            ((res = duration.check(UpdateContextAvailabilitySubscription, indent, predetectedError, counter))            != "OK") ||
            ((res = restriction.check(UpdateContextAvailabilitySubscription, indent, predetectedError, counter))         != "OK") ||

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.h
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.h
@@ -56,7 +56,7 @@ typedef struct UpdateContextAvailabilitySubscriptionRequest
 
   std::string     render(RequestType requestType, const std::string& indent);
   void            present(const std::string& indent);
-  std::string     check(ConnectionInfo* ciP, RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string     check(const std::string& indent, const std::string& predetectedError, int counter);
   void            release(void);
 } UpdateContextAvailabilitySubscriptionRequest;
 

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.h
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.h
@@ -54,7 +54,7 @@ typedef struct UpdateContextAvailabilitySubscriptionRequest
 
   UpdateContextAvailabilitySubscriptionRequest();
 
-  std::string     render(RequestType requestType, const std::string& indent);
+  std::string     render(const std::string& indent);
   void            present(const std::string& indent);
   std::string     check(const std::string& indent, const std::string& predetectedError, int counter);
   void            release(void);

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.cpp
@@ -72,7 +72,7 @@ UpdateContextAvailabilitySubscriptionResponse::~UpdateContextAvailabilitySubscri
 *
 * UpdateContextAvailabilitySubscriptionResponse::render - 
 */
-std::string UpdateContextAvailabilitySubscriptionResponse::render(RequestType requestType, const std::string& indent, int counter)
+std::string UpdateContextAvailabilitySubscriptionResponse::render(const std::string& indent, int counter)
 {
   std::string  out                = "";
   std::string  tag                = "updateContextAvailabilitySubscriptionResponse";
@@ -96,7 +96,7 @@ std::string UpdateContextAvailabilitySubscriptionResponse::render(RequestType re
 *
 * UpdateContextAvailabilitySubscriptionResponse::check - 
 */
-std::string UpdateContextAvailabilitySubscriptionResponse::check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter)
+std::string UpdateContextAvailabilitySubscriptionResponse::check(const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string  res;
 
@@ -112,5 +112,5 @@ std::string UpdateContextAvailabilitySubscriptionResponse::check(RequestType req
   else
     return "OK";
 
-  return render(UpdateContextAvailabilitySubscription, indent, counter);
+  return render(indent, counter);
 }

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.h
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.h
@@ -49,8 +49,8 @@ typedef struct UpdateContextAvailabilitySubscriptionResponse
   UpdateContextAvailabilitySubscriptionResponse(StatusCode& _errorCode);
   ~UpdateContextAvailabilitySubscriptionResponse();
 
-  std::string render(RequestType requestType, const std::string& indent, int counter);
-  std::string check(RequestType requestType, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string render(const std::string& indent, int counter);
+  std::string check(const std::string& indent, const std::string& predetectedError, int counter);
 } UpdateContextAvailabilitySubscriptionResponse;
 
 #endif

--- a/src/lib/ngsiNotify/Notifier.cpp
+++ b/src/lib/ngsiNotify/Notifier.cpp
@@ -41,6 +41,7 @@
 #include "rest/httpRequestSend.h"
 #include "ngsiNotify/senderThread.h"
 #include "ngsiNotify/Notifier.h"
+#include "rest/uriParamNames.h"
 
 
 
@@ -115,7 +116,7 @@ void Notifier::sendNotifyContextAvailabilityRequest
 )
 {
     /* Render NotifyContextAvailabilityRequest */
-    std::string payload = ncar->render(NotifyContextAvailability, "");
+    std::string payload = ncar->render("");
 
     /* Parse URL */
     std::string  host;
@@ -443,7 +444,7 @@ std::vector<SenderThreadParams*>* Notifier::buildSenderParams
     std::string payloadString;
     if (renderFormat == NGSI_V1_LEGACY)
     {
-      payloadString = ncrP->render(&ci, NotifyContext, "");
+      payloadString = ncrP->render(ci.apiVersion, ci.uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ci.outMimeType == JSON, "");
     }
     else
     {

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -32,7 +32,6 @@
 #include "common/tag.h"
 #include "common/limits.h"
 #include "ngsi/Request.h"
-#include "rest/uriParamNames.h"
 #include "orionTypes/EntityType.h"
 
 

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -91,7 +91,7 @@ std::string EntityType::render
     out += startTag2(indent, key, false, false);
 
     if (collapsed || contextAttributeVector.size() == 0)
-    {     
+    {
       out += valueTag1(indent  + "  ", "name", type, false);
     }
     else

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -70,7 +70,10 @@ EntityType::EntityType(std::string _type): type(_type), count(0)
 */
 std::string EntityType::render
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  bool                asJsonOut,
+  bool                collapsed,
   const std::string&  indent,
   bool                comma,
   bool                typeNameBefore
@@ -79,23 +82,23 @@ std::string EntityType::render
   std::string  out = "";
   std::string  key = "type";
 
-  if ((typeNameBefore == true) && (ciP->outMimeType == JSON))
+  if (typeNameBefore && asJsonOut)
   {
     out += valueTag1(indent  + "  ", "name", type, true);
-    out += contextAttributeVector.render(ciP, EntityTypes, indent + "  ", true, true, true);
+    out += contextAttributeVector.render(apiVersion, asJsonObject, EntityTypes, indent + "  ", true, true, true);
   }
   else
   {
     out += startTag2(indent, key, false, false);
 
-    if (ciP->uriParam[URI_PARAM_COLLAPSE] == "true" || contextAttributeVector.size() == 0)
+    if (collapsed || contextAttributeVector.size() == 0)
     {     
       out += valueTag1(indent  + "  ", "name", type, false);
     }
     else
     {
       out += valueTag1(indent  + "  ", "name", type, true);
-      out += contextAttributeVector.render(ciP, EntityTypes, indent + "  ", false, true, true);
+      out += contextAttributeVector.render(apiVersion, asJsonObject, EntityTypes, indent + "  ", false, true, true);
     }
 
     out += endTag(indent, comma, false);

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -110,12 +110,7 @@ std::string EntityType::render
 *
 * EntityType::check -
 */
-std::string EntityType::check
-(
-  ConnectionInfo*     ciP,
-  const std::string&  indent,
-  const std::string&  predetectedError
-)
+std::string EntityType::check(const std::string& apiVersion, const std::string&  predetectedError)
 {
   if (predetectedError != "")
   {
@@ -126,8 +121,7 @@ std::string EntityType::check
     return "Empty Type";
   }
 
-  return contextAttributeVector.check(ciP, EntityTypes, indent, "", 0);
-
+  return contextAttributeVector.check(apiVersion, EntityTypes);
 }
 
 

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -156,7 +156,7 @@ void EntityType::release(void)
 *
 * EntityType::toJson -
 */
-std::string EntityType::toJson(ConnectionInfo* ciP, bool includeType)
+std::string EntityType::toJson(bool includeType)
 {
   std::string  out = "{";
   char         countV[STRING_SIZE_FOR_INT];

--- a/src/lib/orionTypes/EntityType.h
+++ b/src/lib/orionTypes/EntityType.h
@@ -47,7 +47,13 @@ class EntityType
   explicit EntityType(std::string _type);
 
   std::string   check(const std::string& apiVersion, const std::string& predetectedError);
-  std::string   render(ConnectionInfo* ciP, const std::string& indent, bool comma = false, bool typeNameBefore = false);  
+  std::string   render(const std::string&  apiVersion,
+                       bool                asJsonObject,
+                       bool                asJsonOut,
+                       bool                collapsed,
+                       const std::string&  indent,
+                       bool                comma = false,
+                       bool typeNameBefore = false);
   void          present(const std::string& indent);
   void          release(void);
   std::string   toJson(ConnectionInfo* ciP, bool includeType = false);

--- a/src/lib/orionTypes/EntityType.h
+++ b/src/lib/orionTypes/EntityType.h
@@ -28,7 +28,6 @@
 #include <string>
 
 #include "ngsi/ContextAttributeVector.h"
-#include "rest/ConnectionInfo.h"
 
 
 
@@ -56,7 +55,7 @@ class EntityType
                        bool typeNameBefore = false);
   void          present(const std::string& indent);
   void          release(void);
-  std::string   toJson(ConnectionInfo* ciP, bool includeType = false);
+  std::string   toJson(bool includeType = false);
 };
 
 #endif  // SRC_LIB_UTILITY_ENTITYTYPE_H_

--- a/src/lib/orionTypes/EntityType.h
+++ b/src/lib/orionTypes/EntityType.h
@@ -46,7 +46,7 @@ class EntityType
   EntityType();
   explicit EntityType(std::string _type);
 
-  std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
+  std::string   check(const std::string& apiVersion, const std::string& predetectedError);
   std::string   render(ConnectionInfo* ciP, const std::string& indent, bool comma = false, bool typeNameBefore = false);  
   void          present(const std::string& indent);
   void          release(void);

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -35,7 +35,6 @@
 #include "alarmMgr/alarmMgr.h"
 
 #include "ngsi/Request.h"
-#include "rest/uriParamNames.h"
 #include "orionTypes/EntityTypeResponse.h"
 
 

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -44,14 +44,21 @@
 *
 * EntityTypeResponse::render -
 */
-std::string EntityTypeResponse::render(ConnectionInfo* ciP, const std::string& indent)
+std::string EntityTypeResponse::render
+(
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  bool                asJsonOut,
+  bool                collapsed,
+  const std::string&  indent
+)
 {
   std::string out                 = "";
   std::string tag                 = "entityTypeAttributesResponse";
 
   out += startTag1(indent, tag, false);
 
-  out += entityType.render(ciP, indent + "  ", true, true);
+  out += entityType.render(apiVersion, asJsonObject, asJsonOut, collapsed, indent + "  ", true, true);
   out += statusCode.render(indent + "  ");
 
   out += endTag(indent);
@@ -67,7 +74,10 @@ std::string EntityTypeResponse::render(ConnectionInfo* ciP, const std::string& i
 */
 std::string EntityTypeResponse::check
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  bool                asJsonOut,
+  bool                collapsed,
   const std::string&  indent,
   const std::string&  predetectedError
 )
@@ -77,9 +87,8 @@ std::string EntityTypeResponse::check
   if (predetectedError != "")
   {
     statusCode.fill(SccBadRequest, predetectedError);
-  }
-  // FIXME PR
-  else if ((res = entityType.check(ciP->apiVersion, predetectedError)) != "OK")
+  }  
+  else if ((res = entityType.check(apiVersion, predetectedError)) != "OK")
   {
     alarmMgr.badInput(clientIp, res);
     statusCode.fill(SccBadRequest, res);
@@ -87,7 +96,7 @@ std::string EntityTypeResponse::check
   else
     return "OK";
 
-  return render(ciP, "");
+  return render(apiVersion, asJsonObject, asJsonOut, collapsed, "");
 }
 
 
@@ -121,7 +130,7 @@ void EntityTypeResponse::release(void)
 *
 * EntityTypeResponse::toJson -
 */
-std::string EntityTypeResponse::toJson(ConnectionInfo* ciP)
+std::string EntityTypeResponse::toJson(void)
 {
   std::string  out = "{";
   char         countV[STRING_SIZE_FOR_INT];

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -78,7 +78,8 @@ std::string EntityTypeResponse::check
   {
     statusCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = entityType.check(ciP, indent, predetectedError)) != "OK")
+  // FIXME PR
+  else if ((res = entityType.check(ciP->apiVersion, predetectedError)) != "OK")
   {
     alarmMgr.badInput(clientIp, res);
     statusCode.fill(SccBadRequest, res);

--- a/src/lib/orionTypes/EntityTypeResponse.h
+++ b/src/lib/orionTypes/EntityTypeResponse.h
@@ -44,9 +44,17 @@ class EntityTypeResponse
   EntityType    entityType;
   StatusCode    statusCode;
 
-  std::string   render(ConnectionInfo* ciP, const std::string& indent);
-  std::string   toJson(ConnectionInfo* ciP);
-  std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
+  std::string   render(const std::string&  apiVersion,
+                       bool                asJsonObject,
+                       bool                asJsonOut,
+                       bool                collapsed,
+                       const std::string&  indent);
+  std::string   toJson(void);
+  std::string   check(const std::string&  apiVersion,
+                      bool                asJsonObject,
+                      bool                asJsonOut,
+                      bool                collapsed,
+                      const std::string&  indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
 };

--- a/src/lib/orionTypes/EntityTypeVector.cpp
+++ b/src/lib/orionTypes/EntityTypeVector.cpp
@@ -55,7 +55,10 @@ EntityTypeVector::EntityTypeVector()
 */
 std::string EntityTypeVector::render
 (
-  ConnectionInfo*     ciP,
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  bool                asJsonOut,
+  bool                collapsed,
   const std::string&  indent,
   bool                comma
 )
@@ -69,7 +72,7 @@ std::string EntityTypeVector::render
 
     for (unsigned int ix = 0; ix < vec.size(); ++ix)
     {
-      out += vec[ix]->render(ciP, indent + "  ", ix != vec.size() - 1);
+      out += vec[ix]->render(apiVersion, asJsonObject, asJsonOut, collapsed, indent + "  ", ix != vec.size() - 1);
     }
     out += endTag(indent, comma, true);
   }

--- a/src/lib/orionTypes/EntityTypeVector.cpp
+++ b/src/lib/orionTypes/EntityTypeVector.cpp
@@ -83,18 +83,13 @@ std::string EntityTypeVector::render
 *
 * EntityTypeVector::check -
 */
-std::string EntityTypeVector::check
-(
-  ConnectionInfo*     ciP,
-  const std::string&  indent,
-  const std::string&  predetectedError
-)
+std::string EntityTypeVector::check(const std::string&  apiVersion, const std::string&  predetectedError)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     std::string res;
 
-    if ((res = vec[ix]->check(ciP, indent, predetectedError)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, predetectedError)) != "OK")
     {
      return res;
     }

--- a/src/lib/orionTypes/EntityTypeVector.cpp
+++ b/src/lib/orionTypes/EntityTypeVector.cpp
@@ -33,7 +33,6 @@
 #include "common/globals.h"
 #include "common/tag.h"
 #include "ngsi/Request.h"
-#include "rest/ConnectionInfo.h"
 #include "orionTypes/EntityType.h"
 #include "orionTypes/EntityTypeVector.h"
 

--- a/src/lib/orionTypes/EntityTypeVector.h
+++ b/src/lib/orionTypes/EntityTypeVector.h
@@ -47,7 +47,7 @@ class EntityTypeVector
   void          push_back(EntityType* item);
   unsigned int  size(void);
   void          release(void);
-  std::string   check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
+  std::string   check(const std::string& apiVersion, const std::string& predetectedError);
   std::string   render(ConnectionInfo* ciP, const std::string& indent, bool comma = false);  
 
   EntityType*   operator[] (unsigned int ix) const;

--- a/src/lib/orionTypes/EntityTypeVector.h
+++ b/src/lib/orionTypes/EntityTypeVector.h
@@ -48,7 +48,12 @@ class EntityTypeVector
   unsigned int  size(void);
   void          release(void);
   std::string   check(const std::string& apiVersion, const std::string& predetectedError);
-  std::string   render(ConnectionInfo* ciP, const std::string& indent, bool comma = false);  
+  std::string   render(const std::string&  apiVersion,
+                       bool                asJsonObject,
+                       bool                asJsonOut,
+                       bool                collapsed,
+                       const std::string&  indent,
+                       bool comma = false);
 
   EntityType*   operator[] (unsigned int ix) const;
 

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -34,7 +34,6 @@
 #include "alarmMgr/alarmMgr.h"
 
 #include "ngsi/Request.h"
-#include "rest/uriParamNames.h"
 #include "orionTypes/EntityTypeVectorResponse.h"
 
 

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -37,8 +37,6 @@
 #include "rest/uriParamNames.h"
 #include "orionTypes/EntityTypeVectorResponse.h"
 
-#include "rest/ConnectionInfo.h" // FIXME PR
-
 
 
 /* ****************************************************************************
@@ -137,13 +135,13 @@ void EntityTypeVectorResponse::release(void)
 *
 * EntityTypeVectorResponse::toJson - 
 */
-std::string EntityTypeVectorResponse::toJson(ConnectionInfo* ciP)
+std::string EntityTypeVectorResponse::toJson(bool values)
 {
   std::string  out = "[";
 
   for (unsigned int ix = 0; ix < entityTypeVector.vec.size(); ++ix)
   {
-    if (ciP->uriParamOptions["values"])
+    if (values)
     {
       out += JSON_STR(entityTypeVector.vec[ix]->type);
     }

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -43,7 +43,14 @@
 *
 * EntityTypeVectorResponse::render -
 */
-std::string EntityTypeVectorResponse::render(ConnectionInfo* ciP, const std::string& indent)
+std::string EntityTypeVectorResponse::render
+(
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  bool                asJsonOut,
+  bool                collapsed,
+  const std::string&  indent
+)
 {
   std::string out                 = "";
   std::string tag                 = "entityTypesResponse";
@@ -52,7 +59,7 @@ std::string EntityTypeVectorResponse::render(ConnectionInfo* ciP, const std::str
 
   if (entityTypeVector.size() > 0)
   {
-    out += entityTypeVector.render(ciP, indent + "  ", true);
+    out += entityTypeVector.render(apiVersion, asJsonObject, asJsonOut, collapsed, indent + "  ", true);
   }
 
   out += statusCode.render(indent + "  ");
@@ -68,7 +75,13 @@ std::string EntityTypeVectorResponse::render(ConnectionInfo* ciP, const std::str
 *
 * EntityTypeVectorResponse::check -
 */
-std::string EntityTypeVectorResponse::check(const std::string& apiVersion, const std::string& predetectedError)
+std::string EntityTypeVectorResponse::check
+(
+  const std::string&  apiVersion,
+  bool                asJsonObject,
+  bool                asJsonOut,
+  bool                collapsed,
+  const std::string&  predetectedError)
 {
   std::string res;
 
@@ -86,7 +99,7 @@ std::string EntityTypeVectorResponse::check(const std::string& apiVersion, const
     return "OK";
   }
 
-  return render(ciP, "");
+  return render(apiVersion, asJsonObject, asJsonOut, collapsed, "");
 }
 
 

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -68,12 +68,7 @@ std::string EntityTypeVectorResponse::render(ConnectionInfo* ciP, const std::str
 *
 * EntityTypeVectorResponse::check -
 */
-std::string EntityTypeVectorResponse::check
-(
-  ConnectionInfo*     ciP,
-  const std::string&  indent,
-  const std::string&  predetectedError
-)
+std::string EntityTypeVectorResponse::check(const std::string& apiVersion, const std::string& predetectedError)
 {
   std::string res;
 
@@ -81,7 +76,7 @@ std::string EntityTypeVectorResponse::check
   {
     statusCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = entityTypeVector.check(ciP, indent, predetectedError)) != "OK")
+  else if ((res = entityTypeVector.check(apiVersion, predetectedError)) != "OK")
   {
     alarmMgr.badInput(clientIp, res);
     statusCode.fill(SccBadRequest, res);
@@ -91,7 +86,9 @@ std::string EntityTypeVectorResponse::check
     return "OK";
   }
 
-  return render(ciP, "");
+  // FIXME P4: check calling a render... weird
+  //return render(ciP, "");
+  return "err";
 }
 
 

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -37,6 +37,8 @@
 #include "rest/uriParamNames.h"
 #include "orionTypes/EntityTypeVectorResponse.h"
 
+#include "rest/ConnectionInfo.h" // FIXME PR
+
 
 
 /* ****************************************************************************
@@ -147,7 +149,7 @@ std::string EntityTypeVectorResponse::toJson(ConnectionInfo* ciP)
     }
     else  // default
     {
-      out += entityTypeVector.vec[ix]->toJson(ciP, true);
+      out += entityTypeVector.vec[ix]->toJson(true);
     }
 
     if (ix != entityTypeVector.vec.size() - 1)

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -86,9 +86,7 @@ std::string EntityTypeVectorResponse::check(const std::string& apiVersion, const
     return "OK";
   }
 
-  // FIXME P4: check calling a render... weird
-  //return render(ciP, "");
-  return "err";
+  return render(ciP, "");
 }
 
 

--- a/src/lib/orionTypes/EntityTypeVectorResponse.h
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.h
@@ -56,7 +56,7 @@ class EntityTypeVectorResponse
                           const std::string&  predetectedError);
   void              present(const std::string& indent);
   void              release(void);
-  std::string       toJson(ConnectionInfo* ciP);
+  std::string       toJson(bool values);
 };
 
 #endif  // SRC_LIB_UTILITY_ENTITYTYPEVECTORRESPONSE_H_

--- a/src/lib/orionTypes/EntityTypeVectorResponse.h
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.h
@@ -45,7 +45,7 @@ class EntityTypeVectorResponse
   StatusCode        statusCode;
 
   std::string       render(ConnectionInfo* ciP, const std::string& indent);  
-  std::string       check(ConnectionInfo* ciP, const std::string& indent, const std::string& predetectedError);
+  std::string       check(const std::string& apiVersion, const std::string& predetectedError);
   void              present(const std::string& indent);
   void              release(void);
   std::string       toJson(ConnectionInfo* ciP);

--- a/src/lib/orionTypes/EntityTypeVectorResponse.h
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.h
@@ -44,8 +44,16 @@ class EntityTypeVectorResponse
   EntityTypeVector  entityTypeVector;
   StatusCode        statusCode;
 
-  std::string       render(ConnectionInfo* ciP, const std::string& indent);  
-  std::string       check(const std::string& apiVersion, const std::string& predetectedError);
+  std::string       render(const std::string&  apiVersion,
+                           bool                asJsonObject,
+                           bool                asJsonOut,
+                           bool                collapsed,
+                           const std::string&  indent);
+  std::string       check(const std::string&  apiVersion,
+                          bool                asJsonObject,
+                          bool                asJsonOut,
+                          bool                collapsed,
+                          const std::string&  predetectedError);
   void              present(const std::string& indent);
   void              release(void);
   std::string       toJson(ConnectionInfo* ciP);

--- a/src/lib/orionTypes/QueryContextResponseVector.cpp
+++ b/src/lib/orionTypes/QueryContextResponseVector.cpp
@@ -125,7 +125,7 @@ void QueryContextResponseVector::present(void)
 *
 * QueryContextResponseVector::render - 
 */
-std::string QueryContextResponseVector::render(ConnectionInfo* ciP, const std::string& indent, bool details, const std::string& detailsString)
+std::string QueryContextResponseVector::render(const std::string& apiVersion, bool asJsonObject, bool details, const std::string& detailsString)
 {
   QueryContextResponse* responseP = new QueryContextResponse();
   std::string           answer;
@@ -233,9 +233,7 @@ std::string QueryContextResponseVector::render(ConnectionInfo* ciP, const std::s
     }
   }
 
-
-  // FIXME PR
-  answer = responseP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, "");
+  answer = responseP->render(apiVersion, asJsonObject, "");
   responseP->release();
   delete responseP;
 

--- a/src/lib/orionTypes/QueryContextResponseVector.cpp
+++ b/src/lib/orionTypes/QueryContextResponseVector.cpp
@@ -34,8 +34,6 @@
 #include "orionTypes/QueryContextResponseVector.h"
 #include "ngsi/Request.h"
 
-#include "rest/uriParamNames.h"
-
 
 
 /* ****************************************************************************

--- a/src/lib/orionTypes/QueryContextResponseVector.cpp
+++ b/src/lib/orionTypes/QueryContextResponseVector.cpp
@@ -34,6 +34,8 @@
 #include "orionTypes/QueryContextResponseVector.h"
 #include "ngsi/Request.h"
 
+#include "rest/uriParamNames.h"
+
 
 
 /* ****************************************************************************
@@ -232,7 +234,8 @@ std::string QueryContextResponseVector::render(ConnectionInfo* ciP, const std::s
   }
 
 
-  answer = responseP->render(ciP, QueryContext, "");
+  // FIXME PR
+  answer = responseP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, "");
   responseP->release();
   delete responseP;
 

--- a/src/lib/orionTypes/QueryContextResponseVector.h
+++ b/src/lib/orionTypes/QueryContextResponseVector.h
@@ -44,7 +44,7 @@ typedef struct QueryContextResponseVector
   void                   push_back(QueryContextResponse* item);
   void                   release(void);
   void                   present(void);
-  std::string            render(ConnectionInfo* ciP, const std::string& indent, bool details, const std::string& detailsString);
+  std::string            render(const std::string& apiVersion, bool asJsonObject, bool details, const std::string& detailsString);
   void                   populate(QueryContextResponse* responseP);
 
   QueryContextResponse*  operator[](unsigned int ix) const;

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -655,13 +655,13 @@ std::string CompoundValueNode::check(void)
 *
 * render -
 */
-std::string CompoundValueNode::render(ConnectionInfo* ciP, const std::string& indent)
+std::string CompoundValueNode::render(const std::string& apiVersion, const std::string& indent)
 {
   std::string  out       = "";
   bool         jsonComma = siblingNo < (int) container->childV.size() - 1;
   std::string  key       = (container->valueType == orion::ValueTypeVector)? "item" : name;
 
-  if (ciP->apiVersion == "v2")
+  if (apiVersion == "v2")
   {
     return toJson(true); // FIXME P8: The info on comma-after-or-not is not available here ...
   }
@@ -705,7 +705,7 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, const std::string& in
     {
       for (uint64_t ix = 0; ix < childV.size(); ++ix)
       {
-        out += childV[ix]->render(ciP, indent);
+        out += childV[ix]->render(apiVersion, indent);
       }
     }
     else   // 02/03. Not toplevel
@@ -721,7 +721,7 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, const std::string& in
 
       for (uint64_t ix = 0; ix < childV.size(); ++ix)
       {
-        out += childV[ix]->render(ciP, indent + "  ");
+        out += childV[ix]->render(apiVersion, indent + "  ");
       }
 
       out += indent + "  ]\n";
@@ -736,7 +736,7 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, const std::string& in
     out += startTag2(indent, key, true, container->valueType == orion::ValueTypeObject);
     for (uint64_t ix = 0; ix < childV.size(); ++ix)
     {
-      out += childV[ix]->render(ciP, indent + "  ");
+      out += childV[ix]->render(apiVersion, indent + "  ");
     }
 
     out += endTag(indent, jsonComma, true, true);
@@ -746,7 +746,7 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, const std::string& in
     LM_T(LmtCompoundValueRender, ("I am a Vector (%s) and my container is TOPLEVEL", name.c_str()));
     for (uint64_t ix = 0; ix < childV.size(); ++ix)
     {
-      out += childV[ix]->render(ciP, indent);
+      out += childV[ix]->render(apiVersion, indent);
     }
   }
   else if ((valueType == orion::ValueTypeObject) && (container->valueType == orion::ValueTypeVector))
@@ -755,7 +755,7 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, const std::string& in
     out += startTag2(indent, "", false, false);
     for (uint64_t ix = 0; ix < childV.size(); ++ix)
     {
-      out += childV[ix]->render(ciP, indent + "  ");
+      out += childV[ix]->render(apiVersion, indent + "  ");
     }
 
     out += endTag(indent, jsonComma, false, true);
@@ -769,7 +769,7 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, const std::string& in
 
       for (uint64_t ix = 0; ix < childV.size(); ++ix)
       {
-        out += childV[ix]->render(ciP, indent + "  ");
+        out += childV[ix]->render(apiVersion, indent + "  ");
       }
 
       out += endTag(indent, jsonComma, false, true);
@@ -779,7 +779,7 @@ std::string CompoundValueNode::render(ConnectionInfo* ciP, const std::string& in
       LM_T(LmtCompoundValueRender, ("I am the TREE ROOT (%s)", name.c_str()));
       for (uint64_t ix = 0; ix < childV.size(); ++ix)
       {
-        out += childV[ix]->render(ciP, indent);
+        out += childV[ix]->render(apiVersion, indent);
       }
     }
   }

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -34,7 +34,6 @@
 #include "parse/forbiddenChars.h"
 
 #include "orionTypes/OrionValueType.h"
-#include "rest/ConnectionInfo.h"
 #include "parse/CompoundValueNode.h"
 
 

--- a/src/lib/parse/CompoundValueNode.h
+++ b/src/lib/parse/CompoundValueNode.h
@@ -30,8 +30,6 @@
 
 #include "orionTypes/OrionValueType.h"
 
-struct ConnectionInfo;
-
 
 namespace orion
 {

--- a/src/lib/parse/CompoundValueNode.h
+++ b/src/lib/parse/CompoundValueNode.h
@@ -160,7 +160,7 @@ class CompoundValueNode
   CompoundValueNode*  add(const orion::ValueType _type, const std::string& _name, bool _value);
   std::string         check(void);
   std::string         finish(void);
-  std::string         render(ConnectionInfo* ciP, const std::string& indent);
+  std::string         render(const std::string& apiVersion, const std::string& indent);
   std::string         toJson(bool isLastElement, bool comma = true);
 
   void                shortShow(const std::string& indent);

--- a/src/lib/parse/compoundValue.cpp
+++ b/src/lib/parse/compoundValue.cpp
@@ -34,7 +34,6 @@
 #include "ngsi/ParseData.h"
 #include "parse/CompoundValueNode.h"
 #include "parse/compoundValue.h"
-#include "rest/ConnectionInfo.h"
 
 
 

--- a/src/lib/parse/compoundValue.h
+++ b/src/lib/parse/compoundValue.h
@@ -27,7 +27,6 @@
 */
 #include <string>
 
-#include "rest/ConnectionInfo.h"
 #include "orionTypes/OrionValueType.h"
 #include "ngsi/ParseData.h"
 

--- a/src/lib/parse/textParse.cpp
+++ b/src/lib/parse/textParse.cpp
@@ -113,7 +113,8 @@ std::string textRequestTreat(ConnectionInfo* ciP, ParseData* parseDataP, Request
       return answer;
     }
 
-    if ((answer = parseDataP->av.attribute.check(ciP, EntityAttributeValueRequest, "", "", 0)) != "OK")
+    // FIXME PR
+    if ((answer = parseDataP->av.attribute.check(ciP->apiVersion, EntityAttributeValueRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
       return oe.setStatusCodeAndSmartRender(ciP);

--- a/src/lib/parse/textParse.cpp
+++ b/src/lib/parse/textParse.cpp
@@ -56,7 +56,7 @@ static std::string textParseAttributeValue(ConnectionInfo* ciP, ContextAttribute
     else
     {
       OrionError oe(SccBadRequest, "Missing citation-mark at end of string");
-      return oe.setStatusCodeAndSmartRender(ciP);
+      return oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
     }
   }
 
@@ -88,7 +88,7 @@ static std::string textParseAttributeValue(ConnectionInfo* ciP, ContextAttribute
   else  // 5. None of the above - it's an error
   {
     OrionError oe(SccBadRequest, "attribute value type not recognized");
-    return oe.setStatusCodeAndSmartRender(ciP);
+    return oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
   }
 
   return "OK";
@@ -113,18 +113,17 @@ std::string textRequestTreat(ConnectionInfo* ciP, ParseData* parseDataP, Request
       return answer;
     }
 
-    // FIXME PR
     if ((answer = parseDataP->av.attribute.check(ciP->apiVersion, EntityAttributeValueRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
-      return oe.setStatusCodeAndSmartRender(ciP);
+      return oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
     }
     break;
 
   default:
     OrionError oe(SccUnsupportedMediaType, "not supported content type: text/plain");
 
-    answer = oe.setStatusCodeAndSmartRender(ciP);
+    answer = oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
 
     alarmMgr.badInput(clientIp, "not supported content type: text/plain");
     break;

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -107,14 +107,14 @@ std::string OrionError::smartRender(const std::string& apiVersion)
 *
 * OrionError::setStatusCodeAndSmartRender -
 */
-std::string OrionError::setStatusCodeAndSmartRender(ConnectionInfo* ciP)
+std::string OrionError::setStatusCodeAndSmartRender(const std::string& apiVersion, HttpStatusCode* scP)
 {
-  if (ciP->apiVersion == "v2")
+  if (apiVersion == "v2")
   {
-    ciP->httpStatusCode = code;
+    *scP = code;
   }
 
-  return smartRender(ciP->apiVersion);
+  return smartRender(apiVersion);
 }
 
 

--- a/src/lib/rest/OrionError.h
+++ b/src/lib/rest/OrionError.h
@@ -48,7 +48,7 @@ public:
   OrionError(HttpStatusCode _code, const std::string& _details = "", const std::string& _reasonPhrase = "");
 
   std::string  smartRender(const std::string& apiVersion);
-  std::string  setStatusCodeAndSmartRender(ConnectionInfo* ciP);
+  std::string  setStatusCodeAndSmartRender(const std::string& apiVersion, HttpStatusCode* scP);
   std::string  toJson(void);
   std::string  render(void);
   void         fill(HttpStatusCode _code, const std::string& _details,  const std::string& _reasonPhrase = "");

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -596,7 +596,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
     {
       OrionError  oe(SccBadRequest, result);
 
-      std::string  response = oe.setStatusCodeAndSmartRender(ciP);
+      std::string  response = oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
 
       alarmMgr.badInput(clientIp, result);
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -670,7 +670,7 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
   if (servicePath[0] != '/')
   {
     OrionError oe(SccBadRequest, "Only /absolute/ Service Paths allowed [a service path must begin with /]");
-    ciP->answer = oe.setStatusCodeAndSmartRender(ciP);
+    ciP->answer = oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
     return 1;
   }
 
@@ -679,7 +679,7 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
   if (components > SERVICE_PATH_MAX_LEVELS)
   {
     OrionError oe(SccBadRequest, "too many components in ServicePath");
-    ciP->answer = oe.setStatusCodeAndSmartRender(ciP);
+    ciP->answer = oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
     return 2;
   }
 
@@ -688,7 +688,7 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
     if (strlen(compV[ix].c_str()) > SERVICE_PATH_MAX_COMPONENT_LEN)
     {
       OrionError oe(SccBadRequest, "component-name too long in ServicePath");
-      ciP->answer = oe.setStatusCodeAndSmartRender(ciP);
+      ciP->answer = oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
       return 3;
     }
 
@@ -706,7 +706,7 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
       if (!isalnum(comp[cIx]) && (comp[cIx] != '_'))
       {
         OrionError oe(SccBadRequest, "a component of ServicePath contains an illegal character");
-        ciP->answer = oe.setStatusCodeAndSmartRender(ciP);
+        ciP->answer = oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
         return 4;
       }
     }

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -231,7 +231,7 @@ std::string restErrorReplyGet(ConnectionInfo* ciP, const std::string& indent, co
    else if (tag == "updateContextResponse")
    {
       UpdateContextResponse ucr(errorCode);
-      reply = ucr.render(ciP, UpdateContext, indent);
+      reply = ucr.render(ciP, indent);
    }
    else if (tag == "notifyContextResponse")
    {

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -251,7 +251,7 @@ std::string restErrorReplyGet(ConnectionInfo* ciP, const std::string& indent, co
       LM_T(LmtRest, ("Unknown tag: '%s', request == '%s'", tag.c_str(), request.c_str()));
       
       ciP->httpStatusCode = oe.code;
-      reply = oe.setStatusCodeAndSmartRender(ciP);
+      reply = oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
    }
 
    return reply;

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -181,32 +181,32 @@ std::string restErrorReplyGet(ConnectionInfo* ciP, const std::string& indent, co
    if (tag == "registerContextResponse")
    {
       RegisterContextResponse rcr("000000000000000000000000", errorCode);
-      reply =  rcr.render(RegisterContext, indent);
+      reply =  rcr.render(indent);
    }
    else if (tag == "discoverContextAvailabilityResponse")
    {
       DiscoverContextAvailabilityResponse dcar(errorCode);
-      reply =  dcar.render(DiscoverContextAvailability, indent);
+      reply =  dcar.render(indent);
    }
    else if (tag == "subscribeContextAvailabilityResponse")
    {
       SubscribeContextAvailabilityResponse scar("000000000000000000000000", errorCode);
-      reply =  scar.render(SubscribeContextAvailability, indent);
+      reply =  scar.render(indent);
    }
    else if (tag == "updateContextAvailabilitySubscriptionResponse")
    {
       UpdateContextAvailabilitySubscriptionResponse ucas(errorCode);
-      reply =  ucas.render(UpdateContextAvailabilitySubscription, indent, 0);
+      reply =  ucas.render(indent, 0);
    }
    else if (tag == "unsubscribeContextAvailabilityResponse")
    {
       UnsubscribeContextAvailabilityResponse ucar(errorCode);
-      reply =  ucar.render(UnsubscribeContextAvailability, indent);
+      reply =  ucar.render(indent);
    }
    else if (tag == "notifyContextAvailabilityResponse")
    {
       NotifyContextAvailabilityResponse ncar(errorCode);
-      reply =  ncar.render(NotifyContextAvailability, indent);
+      reply =  ncar.render(indent);
    }
 
    else if (tag == "queryContextResponse")
@@ -217,17 +217,17 @@ std::string restErrorReplyGet(ConnectionInfo* ciP, const std::string& indent, co
    else if (tag == "subscribeContextResponse")
    {
       SubscribeContextResponse scr(errorCode);
-      reply =  scr.render(SubscribeContext, indent);
+      reply =  scr.render(indent);
    }
    else if (tag == "updateContextSubscriptionResponse")
    {
       UpdateContextSubscriptionResponse ucsr(errorCode);
-      reply =  ucsr.render(UpdateContextSubscription, indent);
+      reply =  ucsr.render(indent);
    }
    else if (tag == "unsubscribeContextResponse")
    {
       UnsubscribeContextResponse uncr(errorCode);
-      reply =  uncr.render(UnsubscribeContext, indent);
+      reply =  uncr.render(indent);
    }
    else if (tag == "updateContextResponse")
    {
@@ -237,7 +237,7 @@ std::string restErrorReplyGet(ConnectionInfo* ciP, const std::string& indent, co
    else if (tag == "notifyContextResponse")
    {
       NotifyContextResponse ncr(errorCode);
-      reply =  ncr.render(NotifyContext, indent);
+      reply =  ncr.render(indent);
    }
    else if (tag == "StatusCode")
    {

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -45,6 +45,7 @@
 
 #include "rest/rest.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/uriParamNames.h"
 #include "rest/HttpStatusCode.h"
 #include "rest/mhd.h"
 #include "rest/OrionError.h"
@@ -211,7 +212,7 @@ std::string restErrorReplyGet(ConnectionInfo* ciP, const std::string& indent, co
    else if (tag == "queryContextResponse")
    {
       QueryContextResponse qcr(errorCode);
-      reply =  qcr.render(ciP, QueryContext, indent);
+      reply =  qcr.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, indent);
    }
    else if (tag == "subscribeContextResponse")
    {
@@ -231,7 +232,7 @@ std::string restErrorReplyGet(ConnectionInfo* ciP, const std::string& indent, co
    else if (tag == "updateContextResponse")
    {
       UpdateContextResponse ucr(errorCode);
-      reply = ucr.render(ciP, indent);
+      reply = ucr.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, indent);
    }
    else if (tag == "notifyContextResponse")
    {

--- a/src/lib/serviceRoutines/getAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getAllEntitiesWithTypeAndId.cpp
@@ -134,7 +134,9 @@ std::string getAllEntitiesWithTypeAndId
 
   // 06. Translate QueryContextResponse to ContextElementResponse
   response.fill(&parseDataP->qcrs.res, entityId, entityType);
-  TIMED_RENDER(answer = response.render(ciP, RtContextElementResponse, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        RtContextElementResponse, ""));
 
   // 07. Cleanup and return result
   parseDataP->qcr.res.release();

--- a/src/lib/serviceRoutines/getAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getAllEntitiesWithTypeAndId.cpp
@@ -83,6 +83,8 @@ std::string getAllEntitiesWithTypeAndId
   EntityTypeInfo          typeInfo                = EntityTypeEmptyOrNotEmpty;
   ContextElementResponse  response;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   // 00. Default value for response: OK
   response.statusCode.fill(SccOk);
 
@@ -134,9 +136,7 @@ std::string getAllEntitiesWithTypeAndId
 
   // 06. Translate QueryContextResponse to ContextElementResponse
   response.fill(&parseDataP->qcrs.res, entityId, entityType);
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        RtContextElementResponse, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, RtContextElementResponse, ""));
 
   // 07. Cleanup and return result
   parseDataP->qcr.res.release();

--- a/src/lib/serviceRoutines/getAttributeValueInstance.cpp
+++ b/src/lib/serviceRoutines/getAttributeValueInstance.cpp
@@ -155,7 +155,9 @@ std::string getAttributeValueInstance
 
 
   // 5. Render the ContextAttributeResponse
-  TIMED_RENDER(answer = response.render(ciP, IndividualContextEntityAttribute, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        IndividualContextEntityAttribute, ""));
 
 
   // 6. Cleanup and return result

--- a/src/lib/serviceRoutines/getAttributeValueInstance.cpp
+++ b/src/lib/serviceRoutines/getAttributeValueInstance.cpp
@@ -87,6 +87,8 @@ std::string getAttributeValueInstance
   EntityTypeInfo            typeInfo       = EntityTypeEmptyOrNotEmpty;
   ContextAttributeResponse  response;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   // 0. Take care of URI params
   if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
   {
@@ -155,9 +157,7 @@ std::string getAttributeValueInstance
 
 
   // 5. Render the ContextAttributeResponse
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        IndividualContextEntityAttribute, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntityAttribute, ""));
 
 
   // 6. Cleanup and return result

--- a/src/lib/serviceRoutines/getAttributeValueInstanceWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getAttributeValueInstanceWithTypeAndId.cpp
@@ -85,6 +85,8 @@ std::string getAttributeValueInstanceWithTypeAndId
   std::string              entityTypeFromParam  = ciP->uriParam[URI_PARAM_ENTITY_TYPE];
   EntityTypeInfo           typeInfo             = EntityTypeEmptyOrNotEmpty;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
 
   // 01. Get values from URL (entityId::type, exist, !exist)
   if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
@@ -122,9 +124,7 @@ std::string getAttributeValueInstanceWithTypeAndId
     response.fill(&parseDataP->qcrs.res, entityId, entityTypeFromPath, attributeName, metaID);
   }
 
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        AttributeValueInstance, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, AttributeValueInstance, ""));
 
   parseDataP->qcr.res.release();
   parseDataP->qcrs.res.release();

--- a/src/lib/serviceRoutines/getAttributeValueInstanceWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getAttributeValueInstanceWithTypeAndId.cpp
@@ -122,7 +122,9 @@ std::string getAttributeValueInstanceWithTypeAndId
     response.fill(&parseDataP->qcrs.res, entityId, entityTypeFromPath, attributeName, metaID);
   }
 
-  TIMED_RENDER(answer = response.render(ciP, AttributeValueInstance, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        AttributeValueInstance, ""));
 
   parseDataP->qcr.res.release();
   parseDataP->qcrs.res.release();

--- a/src/lib/serviceRoutines/getAttributesForEntityType.cpp
+++ b/src/lib/serviceRoutines/getAttributesForEntityType.cpp
@@ -62,6 +62,8 @@ std::string getAttributesForEntityType
   EntityTypeResponse  response;
   std::string         entityTypeName = compV[2];
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   response.statusCode.fill(SccOk);
 
   //
@@ -74,7 +76,7 @@ std::string getAttributesForEntityType
 
   std::string rendered;
   TIMED_RENDER(rendered = response.render(ciP->apiVersion,
-                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                          asJsonObject,
                                           ciP->outMimeType == JSON,
                                           ciP->uriParam[URI_PARAM_COLLAPSE] == "true",
                                           ""));

--- a/src/lib/serviceRoutines/getAttributesForEntityType.cpp
+++ b/src/lib/serviceRoutines/getAttributesForEntityType.cpp
@@ -73,7 +73,12 @@ std::string getAttributesForEntityType
   TIMED_MONGO(mongoAttributesForEntityType(entityTypeName, &response, ciP->tenant, ciP->servicePathV, ciP->uriParam, true, ciP->apiVersion));
 
   std::string rendered;
-  TIMED_RENDER(rendered = response.render(ciP, ""));
+  TIMED_RENDER(rendered = response.render(ciP->apiVersion,
+                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                          ciP->outMimeType == JSON,
+                                          ciP->uriParam[URI_PARAM_COLLAPSE] == "true",
+                                          ""));
+
   response.release();
 
   return rendered;

--- a/src/lib/serviceRoutines/getContextEntitiesByEntityIdAndType.cpp
+++ b/src/lib/serviceRoutines/getContextEntitiesByEntityIdAndType.cpp
@@ -98,14 +98,14 @@ std::string getContextEntitiesByEntityIdAndType
     parseDataP->dcars.res.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     alarmMgr.badInput(clientIp, "entity::type cannot be empty for this request");
 
-    TIMED_RENDER(answer = parseDataP->dcars.res.render(ContextEntitiesByEntityIdAndType, ""));
+    TIMED_RENDER(answer = parseDataP->dcars.res.render(""));
   }
   else if ((entityTypeFromUriParam != entityType) && (entityTypeFromUriParam != ""))
   {
     parseDataP->dcars.res.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     alarmMgr.badInput(clientIp, "non-matching entity::types in URL");
 
-    TIMED_RENDER(answer = parseDataP->dcars.res.render(ContextEntitiesByEntityIdAndType, ""));
+    TIMED_RENDER(answer = parseDataP->dcars.res.render(""));
   }
   else
   {

--- a/src/lib/serviceRoutines/getEntityByIdAttributeByNameWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getEntityByIdAttributeByNameWithTypeAndId.cpp
@@ -101,14 +101,14 @@ std::string getEntityByIdAttributeByNameWithTypeAndId
     parseDataP->dcars.res.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     alarmMgr.badInput(clientIp, "entity::type cannot be empty for this request");
 
-    TIMED_RENDER(answer = parseDataP->dcars.res.render(IndividualContextEntityAttributeWithTypeAndId, ""));
+    TIMED_RENDER(answer = parseDataP->dcars.res.render(""));
   }
   else if ((entityTypeFromUriParam != entityType) && (entityTypeFromUriParam != ""))
   {
     parseDataP->dcars.res.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     alarmMgr.badInput(clientIp, "non-matching entity::types in URL");
 
-    TIMED_RENDER(answer = parseDataP->dcars.res.render(IndividualContextEntityAttributeWithTypeAndId, ""));
+    TIMED_RENDER(answer = parseDataP->dcars.res.render(""));
   }
   else
   {

--- a/src/lib/serviceRoutines/getEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getEntityTypes.cpp
@@ -61,6 +61,8 @@ std::string getEntityTypes
   unsigned int              totalTypes   = 0;
   unsigned int*             totalTypesP  = NULL;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   response.statusCode.fill(SccOk);
 
   // NGSIv1 uses details=on to request count
@@ -79,7 +81,7 @@ std::string getEntityTypes
 
   std::string rendered;
   TIMED_RENDER(rendered = response.render(ciP->apiVersion,
-                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                          asJsonObject,
                                           ciP->outMimeType == JSON,
                                           ciP->uriParam[URI_PARAM_COLLAPSE] == "true",
                                           ""));

--- a/src/lib/serviceRoutines/getEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getEntityTypes.cpp
@@ -78,7 +78,11 @@ std::string getEntityTypes
   TIMED_MONGO(mongoEntityTypes(&response, ciP->tenant, ciP->servicePathV, ciP->uriParam, ciP->apiVersion, totalTypesP, true));
 
   std::string rendered;
-  TIMED_RENDER(rendered = response.render(ciP, ""));
+  TIMED_RENDER(rendered = response.render(ciP->apiVersion,
+                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                          ciP->outMimeType == JSON,
+                                          ciP->uriParam[URI_PARAM_COLLAPSE] == "true",
+                                          ""));
 
   response.release();
 

--- a/src/lib/serviceRoutines/getIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntity.cpp
@@ -79,6 +79,8 @@ std::string getIndividualContextEntity
   EntityTypeInfo          typeInfo    = EntityTypeEmptyOrNotEmpty;
   ContextElementResponse  response;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   // 0. Take care of URI params
   if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
   {
@@ -113,9 +115,7 @@ std::string getIndividualContextEntity
 
 
   // 5. Render the ContextElementResponse
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
 
 
   // 6. Cleanup and return result

--- a/src/lib/serviceRoutines/getIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntity.cpp
@@ -113,7 +113,9 @@ std::string getIndividualContextEntity
 
 
   // 5. Render the ContextElementResponse
-  TIMED_RENDER(answer = response.render(ciP, IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        IndividualContextEntity, ""));
 
 
   // 6. Cleanup and return result

--- a/src/lib/serviceRoutines/getIndividualContextEntityAttribute.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntityAttribute.cpp
@@ -80,6 +80,8 @@ std::string getIndividualContextEntityAttribute
   std::string               attributeName  = compV[4];
   ContextAttributeResponse  response;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   // 0. Take care of URI params
   if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
   {
@@ -120,9 +122,7 @@ std::string getIndividualContextEntityAttribute
 
 
   // 5. Render the ContextAttributeResponse
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        IndividualContextEntityAttribute, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntityAttribute, ""));
 
 
   // 6. Cleanup and return result

--- a/src/lib/serviceRoutines/getIndividualContextEntityAttribute.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntityAttribute.cpp
@@ -120,7 +120,9 @@ std::string getIndividualContextEntityAttribute
 
 
   // 5. Render the ContextAttributeResponse
-  TIMED_RENDER(answer = response.render(ciP, IndividualContextEntityAttribute, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        IndividualContextEntityAttribute, ""));
 
 
   // 6. Cleanup and return result

--- a/src/lib/serviceRoutines/getIndividualContextEntityAttributeWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntityAttributeWithTypeAndId.cpp
@@ -81,6 +81,8 @@ std::string getIndividualContextEntityAttributeWithTypeAndId
   EntityTypeInfo            typeInfo                = EntityTypeEmptyOrNotEmpty;
   ContextAttributeResponse  response;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
 
   // 01. Get values from URL (entityId::type, esist, !exist)
   if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
@@ -133,9 +135,8 @@ std::string getIndividualContextEntityAttributeWithTypeAndId
 
 
   // 07. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        RtContextAttributeResponse, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, RtContextAttributeResponse, ""));
+
 
   parseDataP->qcr.res.release();
   parseDataP->qcrs.res.release();

--- a/src/lib/serviceRoutines/getIndividualContextEntityAttributeWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntityAttributeWithTypeAndId.cpp
@@ -133,7 +133,9 @@ std::string getIndividualContextEntityAttributeWithTypeAndId
 
 
   // 07. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP, RtContextAttributeResponse, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        RtContextAttributeResponse, ""));
 
   parseDataP->qcr.res.release();
   parseDataP->qcrs.res.release();

--- a/src/lib/serviceRoutines/getNgsi10ContextEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getNgsi10ContextEntityTypes.cpp
@@ -95,7 +95,8 @@ std::string getNgsi10ContextEntityTypes
     parseDataP->qcrs.res.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     alarmMgr.badInput(clientIp, "entity::type cannot be empty for this request");
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP, Ngsi10ContextEntityTypes, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
+                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
 
     parseDataP->qcr.res.release();
     return answer;
@@ -105,7 +106,8 @@ std::string getNgsi10ContextEntityTypes
     parseDataP->qcrs.res.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     alarmMgr.badInput(clientIp, "non-matching entity::types in URL");
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP, Ngsi10ContextEntityTypes, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
+                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
 
     parseDataP->qcr.res.release();
     return answer;
@@ -125,7 +127,8 @@ std::string getNgsi10ContextEntityTypes
   {
     parseDataP->qcrs.res.errorCode.details = std::string("entityId::type /") + typeName + "/ non-existent";
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP, Ngsi10ContextEntityTypes, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
+                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
   }
 
 

--- a/src/lib/serviceRoutines/getNgsi10ContextEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getNgsi10ContextEntityTypes.cpp
@@ -77,6 +77,8 @@ std::string getNgsi10ContextEntityTypes
   EntityTypeInfo  typeInfo              = EntityTypeEmptyOrNotEmpty;
   std::string     typeNameFromUriParam  = ciP->uriParam[URI_PARAM_ENTITY_TYPE];
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
 
   // 01. Get values from URL (entityId::type, esist, !exist)
   if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
@@ -95,8 +97,7 @@ std::string getNgsi10ContextEntityTypes
     parseDataP->qcrs.res.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     alarmMgr.badInput(clientIp, "entity::type cannot be empty for this request");
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
-                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion, asJsonObject, ""));
 
     parseDataP->qcr.res.release();
     return answer;
@@ -106,8 +107,7 @@ std::string getNgsi10ContextEntityTypes
     parseDataP->qcrs.res.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     alarmMgr.badInput(clientIp, "non-matching entity::types in URL");
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
-                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion, asJsonObject, ""));
 
     parseDataP->qcr.res.release();
     return answer;
@@ -127,8 +127,7 @@ std::string getNgsi10ContextEntityTypes
   {
     parseDataP->qcrs.res.errorCode.details = std::string("entityId::type /") + typeName + "/ non-existent";
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
-                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion, asJsonObject, ""));
   }
 
 

--- a/src/lib/serviceRoutines/getNgsi10ContextEntityTypesAttribute.cpp
+++ b/src/lib/serviceRoutines/getNgsi10ContextEntityTypesAttribute.cpp
@@ -78,6 +78,8 @@ std::string getNgsi10ContextEntityTypesAttribute
   EntityTypeInfo  typeInfo              = EntityTypeEmptyOrNotEmpty;
   std::string     typeNameFromUriParam  = ciP->uriParam[URI_PARAM_ENTITY_TYPE];
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
 
   // 01. Get values from URL (entityId::type, esist, !exist)
   if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
@@ -96,8 +98,7 @@ std::string getNgsi10ContextEntityTypesAttribute
     parseDataP->qcrs.res.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     alarmMgr.badInput(clientIp, "entity::type cannot be empty for this request");
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
-                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion, asJsonObject, ""));
     parseDataP->qcr.res.release();
     return answer;
   }
@@ -106,8 +107,7 @@ std::string getNgsi10ContextEntityTypesAttribute
     parseDataP->qcrs.res.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     alarmMgr.badInput(clientIp, "non-matching entity::types in URL");
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
-                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion, asJsonObject, ""));
     parseDataP->qcr.res.release();
     return answer;
   }
@@ -126,8 +126,7 @@ std::string getNgsi10ContextEntityTypesAttribute
   {
     parseDataP->qcrs.res.errorCode.details = "entityId::type/attribute::name pair not found";
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
-                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion, asJsonObject, ""));
   }
 
 

--- a/src/lib/serviceRoutines/getNgsi10ContextEntityTypesAttribute.cpp
+++ b/src/lib/serviceRoutines/getNgsi10ContextEntityTypesAttribute.cpp
@@ -96,7 +96,8 @@ std::string getNgsi10ContextEntityTypesAttribute
     parseDataP->qcrs.res.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     alarmMgr.badInput(clientIp, "entity::type cannot be empty for this request");
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP, Ngsi10ContextEntityTypes, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
+                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
     parseDataP->qcr.res.release();
     return answer;
   }
@@ -105,7 +106,8 @@ std::string getNgsi10ContextEntityTypesAttribute
     parseDataP->qcrs.res.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     alarmMgr.badInput(clientIp, "non-matching entity::types in URL");
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP, Ngsi10ContextEntityTypes, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
+                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
     parseDataP->qcr.res.release();
     return answer;
   }
@@ -124,7 +126,8 @@ std::string getNgsi10ContextEntityTypesAttribute
   {
     parseDataP->qcrs.res.errorCode.details = "entityId::type/attribute::name pair not found";
 
-    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP, Ngsi10ContextEntityTypes, ""));
+    TIMED_RENDER(answer = parseDataP->qcrs.res.render(ciP->apiVersion,
+                                                      ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
   }
 
 

--- a/src/lib/serviceRoutines/postAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/postAllEntitiesWithTypeAndId.cpp
@@ -109,7 +109,9 @@ std::string postAllEntitiesWithTypeAndId
     alarmMgr.badInput(clientIp, "unknown field");
     response.errorCode.fill(SccBadRequest, "invalid payload: unknown fields");
 
-    TIMED_RENDER(out = response.render(ciP, IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion,
+                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                       IndividualContextEntity, ""));
 
     return out;
   }
@@ -123,7 +125,9 @@ std::string postAllEntitiesWithTypeAndId
     response.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     response.entity.fill(entityId, entityType, "false");
 
-    TIMED_RENDER(answer = response.render(ciP, AllEntitiesWithTypeAndId, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                          AllEntitiesWithTypeAndId, ""));
 
     parseDataP->acer.res.release();
     return answer;
@@ -135,7 +139,9 @@ std::string postAllEntitiesWithTypeAndId
     response.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     response.entity.fill(entityId, entityType, "false");
 
-    TIMED_RENDER(answer = response.render(ciP, AllEntitiesWithTypeAndId, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                          AllEntitiesWithTypeAndId, ""));
 
     parseDataP->acer.res.release();
     return answer;
@@ -158,7 +164,9 @@ std::string postAllEntitiesWithTypeAndId
 
 
   // 07. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP, IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        IndividualContextEntity, ""));
 
   parseDataP->upcr.res.release();
   response.release();

--- a/src/lib/serviceRoutines/postAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/postAllEntitiesWithTypeAndId.cpp
@@ -86,6 +86,8 @@ std::string postAllEntitiesWithTypeAndId
   std::string                   answer;
   AppendContextElementResponse  response;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   // FIXME P1: AttributeDomainName skipped
   // FIXME P1: domainMetadataVector skipped
 
@@ -101,7 +103,7 @@ std::string postAllEntitiesWithTypeAndId
   }
 
 
-  // 02. Check that the entity is NOT filled in in the payload
+  // 02. Check that the entity is NOT filled in the payload
   if ((reqP->entity.id != "") || (reqP->entity.type != "") || (reqP->entity.isPattern != ""))
   {
     std::string  out;
@@ -109,9 +111,7 @@ std::string postAllEntitiesWithTypeAndId
     alarmMgr.badInput(clientIp, "unknown field");
     response.errorCode.fill(SccBadRequest, "invalid payload: unknown fields");
 
-    TIMED_RENDER(out = response.render(ciP->apiVersion,
-                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                       IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
 
     return out;
   }
@@ -125,9 +125,7 @@ std::string postAllEntitiesWithTypeAndId
     response.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     response.entity.fill(entityId, entityType, "false");
 
-    TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                          AllEntitiesWithTypeAndId, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, AllEntitiesWithTypeAndId, ""));
 
     parseDataP->acer.res.release();
     return answer;
@@ -139,9 +137,7 @@ std::string postAllEntitiesWithTypeAndId
     response.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     response.entity.fill(entityId, entityType, "false");
 
-    TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                          AllEntitiesWithTypeAndId, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, AllEntitiesWithTypeAndId, ""));
 
     parseDataP->acer.res.release();
     return answer;
@@ -164,9 +160,7 @@ std::string postAllEntitiesWithTypeAndId
 
 
   // 07. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
 
   parseDataP->upcr.res.release();
   response.release();

--- a/src/lib/serviceRoutines/postContextEntitiesByEntityIdAndType.cpp
+++ b/src/lib/serviceRoutines/postContextEntitiesByEntityIdAndType.cpp
@@ -96,7 +96,7 @@ std::string postContextEntitiesByEntityIdAndType
     response.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     response.registrationId.set("000000000000000000000000");
 
-    TIMED_RENDER(answer = response.render(ContextEntitiesByEntityIdAndType, ""));
+    TIMED_RENDER(answer = response.render(""));
 
     parseDataP->rpr.res.release();
 
@@ -109,7 +109,7 @@ std::string postContextEntitiesByEntityIdAndType
     response.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     response.registrationId.set("000000000000000000000000");
 
-    TIMED_RENDER(answer = response.render(ContextEntitiesByEntityIdAndType, ""));
+    TIMED_RENDER(answer = response.render(""));
 
     parseDataP->rpr.res.release();
 

--- a/src/lib/serviceRoutines/postDiscoverContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postDiscoverContextAvailability.cpp
@@ -56,7 +56,7 @@ std::string postDiscoverContextAvailability
   std::string                           answer;
 
   TIMED_MONGO(ciP->httpStatusCode = mongoDiscoverContextAvailability(&parseDataP->dcar.res, dcarP, ciP->tenant, ciP->uriParam, ciP->servicePathV));
-  TIMED_RENDER(answer = dcarP->render(DiscoverContextAvailability, ""));
+  TIMED_RENDER(answer = dcarP->render(""));
 
   return answer;
 }

--- a/src/lib/serviceRoutines/postEntityByIdAttributeByNameWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/postEntityByIdAttributeByNameWithTypeAndId.cpp
@@ -100,14 +100,14 @@ std::string postEntityByIdAttributeByNameWithTypeAndId
     parseDataP->rcrs.res.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
     alarmMgr.badInput(clientIp, "entity::type cannot be empty for this request");
 
-    TIMED_RENDER(answer = parseDataP->rcrs.res.render(IndividualContextEntityAttributeWithTypeAndId, ""));
+    TIMED_RENDER(answer = parseDataP->rcrs.res.render(""));
   }
   else if ((entityTypeFromUriParam != entityType) && (entityTypeFromUriParam != ""))
   {
     parseDataP->rcrs.res.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
     alarmMgr.badInput(clientIp, "non-matching entity::types in URL");
 
-    TIMED_RENDER(answer = parseDataP->rcrs.res.render(IndividualContextEntityAttributeWithTypeAndId, ""));
+    TIMED_RENDER(answer = parseDataP->rcrs.res.render(""));
   }
   else
   {

--- a/src/lib/serviceRoutines/postIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/postIndividualContextEntity.cpp
@@ -98,6 +98,8 @@ std::string postIndividualContextEntity
   std::string                   answer;
   std::string                   out;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   //
   // 01. Check that total input in consistent and correct
   //
@@ -110,9 +112,7 @@ std::string postIndividualContextEntity
     alarmMgr.badInput(clientIp, error);
     response.errorCode.fill(SccBadRequest, error);
 
-    TIMED_RENDER(out = response.render(ciP->apiVersion,
-                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                       IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
     return out;
   }  
   entityId = (entityIdFromPayload != "")? entityIdFromPayload : entityIdFromURL;
@@ -125,9 +125,7 @@ std::string postIndividualContextEntity
     alarmMgr.badInput(clientIp, error);
     response.errorCode.fill(SccBadRequest, error);
 
-    TIMED_RENDER(out = response.render(ciP->apiVersion,
-                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                       IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
     return out;
   }
   entityType = (entityTypeFromPayload != "")? entityTypeFromPayload :entityTypeFromURL;
@@ -141,9 +139,7 @@ std::string postIndividualContextEntity
     alarmMgr.badInput(clientIp, error);
     response.errorCode.fill(SccBadRequest, error);
 
-    TIMED_RENDER(out = response.render(ciP->apiVersion,
-                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                       IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
     return out;
   }
 
@@ -155,9 +151,7 @@ std::string postIndividualContextEntity
     alarmMgr.badInput(clientIp, error);
     response.errorCode.fill(SccBadRequest, error);
 
-    TIMED_RENDER(out = response.render(ciP->apiVersion,
-                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                       IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
     return out;
   }
 
@@ -179,9 +173,7 @@ std::string postIndividualContextEntity
   response.fill(&parseDataP->upcrs.res);
 
   // 05. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
 
   response.release();
   parseDataP->upcr.res.release();

--- a/src/lib/serviceRoutines/postIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/postIndividualContextEntity.cpp
@@ -110,7 +110,9 @@ std::string postIndividualContextEntity
     alarmMgr.badInput(clientIp, error);
     response.errorCode.fill(SccBadRequest, error);
 
-    TIMED_RENDER(out = response.render(ciP, IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion,
+                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                       IndividualContextEntity, ""));
     return out;
   }  
   entityId = (entityIdFromPayload != "")? entityIdFromPayload : entityIdFromURL;
@@ -123,7 +125,9 @@ std::string postIndividualContextEntity
     alarmMgr.badInput(clientIp, error);
     response.errorCode.fill(SccBadRequest, error);
 
-    TIMED_RENDER(out = response.render(ciP, IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion,
+                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                       IndividualContextEntity, ""));
     return out;
   }
   entityType = (entityTypeFromPayload != "")? entityTypeFromPayload :entityTypeFromURL;
@@ -137,7 +141,9 @@ std::string postIndividualContextEntity
     alarmMgr.badInput(clientIp, error);
     response.errorCode.fill(SccBadRequest, error);
 
-    TIMED_RENDER(out = response.render(ciP, IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion,
+                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                       IndividualContextEntity, ""));
     return out;
   }
 
@@ -149,7 +155,9 @@ std::string postIndividualContextEntity
     alarmMgr.badInput(clientIp, error);
     response.errorCode.fill(SccBadRequest, error);
 
-    TIMED_RENDER(out = response.render(ciP, IndividualContextEntity, ""));
+    TIMED_RENDER(out = response.render(ciP->apiVersion,
+                                       ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                       IndividualContextEntity, ""));
     return out;
   }
 
@@ -171,7 +179,9 @@ std::string postIndividualContextEntity
   response.fill(&parseDataP->upcrs.res);
 
   // 05. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP, IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        IndividualContextEntity, ""));
 
   response.release();
   parseDataP->upcr.res.release();

--- a/src/lib/serviceRoutines/postNotifyContext.cpp
+++ b/src/lib/serviceRoutines/postNotifyContext.cpp
@@ -56,7 +56,7 @@ std::string postNotifyContext
   std::string            answer;
 
   TIMED_MONGO(ciP->httpStatusCode = mongoNotifyContext(&parseDataP->ncr.res, &ncr, ciP->tenant, ciP->httpHeaders.xauthToken, ciP->servicePathV, ciP->httpHeaders.correlator));
-  TIMED_RENDER(answer = ncr.render(NotifyContext, ""));
+  TIMED_RENDER(answer = ncr.render(""));
 
   return answer;
 }

--- a/src/lib/serviceRoutines/postNotifyContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postNotifyContextAvailability.cpp
@@ -68,7 +68,7 @@ std::string postNotifyContextAvailability
     ncar.responseCode.fill(SccBadRequest, "more than one service path for notification");
     alarmMgr.badInput(clientIp, "more than one service path for a notification");
 
-    TIMED_RENDER(answer = ncar.render(NotifyContextAvailability, ""));
+    TIMED_RENDER(answer = ncar.render(""));
 
     return answer;
   }
@@ -82,13 +82,13 @@ std::string postNotifyContextAvailability
   {
     ncar.responseCode.fill(SccBadRequest, res);
 
-    TIMED_RENDER(answer = ncar.render(NotifyContextAvailability, ""));
+    TIMED_RENDER(answer = ncar.render(""));
 
     return answer;
   }
 
   TIMED_MONGO(ciP->httpStatusCode = mongoNotifyContextAvailability(&parseDataP->ncar.res, &ncar, ciP->uriParam, ciP->httpHeaders.correlator, ciP->tenant, ciP->servicePathV[0]));
-  TIMED_RENDER(answer = ncar.render(NotifyContextAvailability, ""));
+  TIMED_RENDER(answer = ncar.render(""));
 
   return answer;
 }

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -104,7 +104,7 @@ static void queryForward(ConnectionInfo* ciP, QueryContextRequest* qcrP, QueryCo
   // 2. Render the string of the request we want to forward
   //
   std::string  payload;
-  TIMED_RENDER(payload = qcrP->render(QueryContext, ""));
+  TIMED_RENDER(payload = qcrP->render(""));
 
   char* cleanPayload = (char*) payload.c_str();;
 
@@ -359,7 +359,7 @@ std::string postQueryContext
   //
   if (forwardsPending(qcrsP) == false)
   {
-    TIMED_RENDER(answer = qcrsP->render(ciP, QueryContext, ""));
+    TIMED_RENDER(answer = qcrsP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
 
     qcrP->release();
     return answer;

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -287,6 +287,7 @@ std::string postQueryContext
   long long                   count = 0;
   long long*                  countP = NULL;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
 
   //
   // 00. Count or not count? That is the question ...
@@ -356,10 +357,10 @@ std::string postQueryContext
   //
   // Now, the request is 'simple' if all providingApplicationLists of the ContextElements are empty and
   // no ContextAttribute has any providingApplication.
-  //
+  //  
   if (forwardsPending(qcrsP) == false)
   {
-    TIMED_RENDER(answer = qcrsP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = qcrsP->render(ciP->apiVersion, asJsonObject, ""));
 
     qcrP->release();
     return answer;
@@ -516,7 +517,7 @@ std::string postQueryContext
   std::string detailsString  = ciP->uriParam[URI_PARAM_PAGINATION_DETAILS];
   bool        details        = (strcasecmp("on", detailsString.c_str()) == 0)? true : false;
 
-  TIMED_RENDER(answer = responseV.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, details, qcrsP->errorCode.details));
+  TIMED_RENDER(answer = responseV.render(ciP->apiVersion, asJsonObject, details, qcrsP->errorCode.details));
 
 
   //

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -516,7 +516,7 @@ std::string postQueryContext
   std::string detailsString  = ciP->uriParam[URI_PARAM_PAGINATION_DETAILS];
   bool        details        = (strcasecmp("on", detailsString.c_str()) == 0)? true : false;
 
-  TIMED_RENDER(answer = responseV.render(ciP, "", details, qcrsP->errorCode.details));
+  TIMED_RENDER(answer = responseV.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, details, qcrsP->errorCode.details));
 
 
   //

--- a/src/lib/serviceRoutines/postRegisterContext.cpp
+++ b/src/lib/serviceRoutines/postRegisterContext.cpp
@@ -91,7 +91,7 @@ std::string postRegisterContext
     alarmMgr.badInput(clientIp, "more than one service path for a registration");
     rcr.errorCode.fill(SccBadRequest, "more than one service path for notification");
 
-    TIMED_RENDER(answer = rcr.render(RegisterContext, ""));
+    TIMED_RENDER(answer = rcr.render(""));
 
     return answer;
   }
@@ -105,12 +105,12 @@ std::string postRegisterContext
   {
     rcr.errorCode.fill(SccBadRequest, res);
 
-    TIMED_RENDER(answer = rcr.render(RegisterContext, ""));
+    TIMED_RENDER(answer = rcr.render(""));
     return answer;
   }
 
   TIMED_MONGO(ciP->httpStatusCode = mongoRegisterContext(&parseDataP->rcr.res, &rcr, ciP->uriParam, ciP->httpHeaders.correlator, ciP->tenant, ciP->servicePathV[0]));
-  TIMED_RENDER(answer = rcr.render(RegisterContext, ""));
+  TIMED_RENDER(answer = rcr.render(""));
 
   return answer;
 }

--- a/src/lib/serviceRoutines/postSubscribeContext.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContext.cpp
@@ -77,12 +77,12 @@ std::string postSubscribeContext
 
     scr.subscribeError.errorCode.fill(SccBadRequest, "max one service-path allowed for subscriptions");
 
-    TIMED_RENDER(answer = scr.render(SubscribeContext, ""));
+    TIMED_RENDER(answer = scr.render(""));
     return answer;
   }
 
   TIMED_MONGO(ciP->httpStatusCode = mongoSubscribeContext(&parseDataP->scr.res, &scr, ciP->tenant, ciP->httpHeaders.xauthToken, ciP->servicePathV, ciP->httpHeaders.correlator));
-  TIMED_RENDER(answer = scr.render(SubscribeContext, ""));
+  TIMED_RENDER(answer = scr.render(""));
 
   parseDataP->scr.res.release();
 

--- a/src/lib/serviceRoutines/postSubscribeContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContextAvailability.cpp
@@ -57,7 +57,7 @@ std::string postSubscribeContextAvailability
                                                                       ciP->uriParam,
                                                                       ciP->httpHeaders.correlator,
                                                                       ciP->tenant));
-  TIMED_RENDER(answer = scar.render(SubscribeContextAvailability, ""));
+  TIMED_RENDER(answer = scar.render(""));
 
   return answer;
 }

--- a/src/lib/serviceRoutines/postUnsubscribeContext.cpp
+++ b/src/lib/serviceRoutines/postUnsubscribeContext.cpp
@@ -52,7 +52,7 @@ std::string postUnsubscribeContext
   std::string                 answer;
 
   TIMED_MONGO(ciP->httpStatusCode = mongoUnsubscribeContext(&parseDataP->uncr.res, &uncr, ciP->tenant));
-  TIMED_RENDER(answer = uncr.render(UnsubscribeContext, ""));
+  TIMED_RENDER(answer = uncr.render(""));
 
   return answer;
 }

--- a/src/lib/serviceRoutines/postUnsubscribeContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postUnsubscribeContextAvailability.cpp
@@ -52,7 +52,7 @@ std::string postUnsubscribeContextAvailability
   std::string                             answer;
 
   TIMED_MONGO(ciP->httpStatusCode = mongoUnsubscribeContextAvailability(&parseDataP->ucar.res, &ucar, ciP->tenant));
-  TIMED_RENDER(answer = ucar.render(UnsubscribeContextAvailability, ""));
+  TIMED_RENDER(answer = ucar.render(""));
 
   return answer;
 }

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -133,7 +133,7 @@ static void updateForward(ConnectionInfo* ciP, UpdateContextRequest* upcrP, Upda
 
   ciP->outMimeType  = JSON;
 
-  TIMED_RENDER(payload = upcrP->render(ciP, UpdateContext, ""));
+  TIMED_RENDER(payload = upcrP->render(ciP, ""));
 
   ciP->outMimeType  = outMimeType;
   cleanPayload      = (char*) payload.c_str();
@@ -454,7 +454,7 @@ std::string postUpdateContext
     upcrsP->errorCode.fill(SccBadRequest, "more than one service path in context update request");
     alarmMgr.badInput(clientIp, "more than one service path for an update request");
 
-    TIMED_RENDER(answer = upcrsP->render(ciP, UpdateContext, ""));
+    TIMED_RENDER(answer = upcrsP->render(ciP, ""));
 
     return answer;
   }
@@ -468,7 +468,7 @@ std::string postUpdateContext
   {
     upcrsP->errorCode.fill(SccBadRequest, res);
 
-    TIMED_RENDER(answer = upcrsP->render(ciP, UpdateContext, ""));
+    TIMED_RENDER(answer = upcrsP->render(ciP, ""));
 
     return answer;
   }
@@ -500,7 +500,7 @@ std::string postUpdateContext
   bool forwarding = forwardsPending(upcrsP);
   if (forwarding == false)
   {
-    TIMED_RENDER(answer = upcrsP->render(ciP, UpdateContext, ""));
+    TIMED_RENDER(answer = upcrsP->render(ciP, ""));
 
     upcrP->release();
     return answer;
@@ -713,7 +713,7 @@ std::string postUpdateContext
   {
     // Note that v2 case doesn't use an actual response (so no need to waste time rendering it).
     // We render in the v1 case only
-    TIMED_RENDER(answer = response.render(ciP, UpdateContext, ""));
+    TIMED_RENDER(answer = response.render(ciP, ""));
   }
 
   //

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -107,6 +107,8 @@ static void updateForward(ConnectionInfo* ciP, UpdateContextRequest* upcrP, Upda
   int              port;
   std::string      prefix;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   //
   // 1. Parse the providing application to extract IP, port and URI-path
   //
@@ -134,7 +136,7 @@ static void updateForward(ConnectionInfo* ciP, UpdateContextRequest* upcrP, Upda
 
   ciP->outMimeType  = JSON;
 
-  TIMED_RENDER(payload = upcrP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+  TIMED_RENDER(payload = upcrP->render(ciP->apiVersion, asJsonObject, ""));
 
   ciP->outMimeType  = outMimeType;
   cleanPayload      = (char*) payload.c_str();
@@ -441,6 +443,7 @@ std::string postUpdateContext
   UpdateContextRequest*   upcrP  = &parseDataP->upcr.res;
   std::string             answer;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
 
   //
   // 01. Check service-path consistency
@@ -455,7 +458,7 @@ std::string postUpdateContext
     upcrsP->errorCode.fill(SccBadRequest, "more than one service path in context update request");
     alarmMgr.badInput(clientIp, "more than one service path for an update request");
 
-    TIMED_RENDER(answer = upcrsP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = upcrsP->render(ciP->apiVersion, asJsonObject, ""));
 
     return answer;
   }
@@ -469,7 +472,7 @@ std::string postUpdateContext
   {
     upcrsP->errorCode.fill(SccBadRequest, res);
 
-    TIMED_RENDER(answer = upcrsP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = upcrsP->render(ciP->apiVersion, asJsonObject, ""));
 
     return answer;
   }
@@ -501,7 +504,7 @@ std::string postUpdateContext
   bool forwarding = forwardsPending(upcrsP);
   if (forwarding == false)
   {
-    TIMED_RENDER(answer = upcrsP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = upcrsP->render(ciP->apiVersion, asJsonObject, ""));
 
     upcrP->release();
     return answer;
@@ -714,7 +717,7 @@ std::string postUpdateContext
   {
     // Note that v2 case doesn't use an actual response (so no need to waste time rendering it).
     // We render in the v1 case only
-    TIMED_RENDER(answer = response.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, ""));
   }
 
   //

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -42,6 +42,7 @@
 #include "orionTypes/UpdateContextRequestVector.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/httpRequestSend.h"
+#include "rest/uriParamNames.h"
 #include "serviceRoutines/postUpdateContext.h"
 
 
@@ -133,7 +134,7 @@ static void updateForward(ConnectionInfo* ciP, UpdateContextRequest* upcrP, Upda
 
   ciP->outMimeType  = JSON;
 
-  TIMED_RENDER(payload = upcrP->render(ciP, ""));
+  TIMED_RENDER(payload = upcrP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
 
   ciP->outMimeType  = outMimeType;
   cleanPayload      = (char*) payload.c_str();
@@ -454,7 +455,7 @@ std::string postUpdateContext
     upcrsP->errorCode.fill(SccBadRequest, "more than one service path in context update request");
     alarmMgr.badInput(clientIp, "more than one service path for an update request");
 
-    TIMED_RENDER(answer = upcrsP->render(ciP, ""));
+    TIMED_RENDER(answer = upcrsP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
 
     return answer;
   }
@@ -468,7 +469,7 @@ std::string postUpdateContext
   {
     upcrsP->errorCode.fill(SccBadRequest, res);
 
-    TIMED_RENDER(answer = upcrsP->render(ciP, ""));
+    TIMED_RENDER(answer = upcrsP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
 
     return answer;
   }
@@ -500,7 +501,7 @@ std::string postUpdateContext
   bool forwarding = forwardsPending(upcrsP);
   if (forwarding == false)
   {
-    TIMED_RENDER(answer = upcrsP->render(ciP, ""));
+    TIMED_RENDER(answer = upcrsP->render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
 
     upcrP->release();
     return answer;
@@ -713,7 +714,7 @@ std::string postUpdateContext
   {
     // Note that v2 case doesn't use an actual response (so no need to waste time rendering it).
     // We render in the v1 case only
-    TIMED_RENDER(answer = response.render(ciP, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, ""));
   }
 
   //

--- a/src/lib/serviceRoutines/postUpdateContextAvailabilitySubscription.cpp
+++ b/src/lib/serviceRoutines/postUpdateContextAvailabilitySubscription.cpp
@@ -58,7 +58,7 @@ std::string postUpdateContextAvailabilitySubscription
                                                                                ciP->httpHeaders.correlator,
                                                                                ciP->tenant));
 
-  TIMED_RENDER(answer = ucas.render(UpdateContextAvailabilitySubscription, "", 0));
+  TIMED_RENDER(answer = ucas.render("", 0));
 
   return answer;
 }

--- a/src/lib/serviceRoutines/postUpdateContextSubscription.cpp
+++ b/src/lib/serviceRoutines/postUpdateContextSubscription.cpp
@@ -61,7 +61,7 @@ std::string postUpdateContextSubscription
                                                                    ciP->servicePathV,
                                                                    ciP->httpHeaders.correlator));
 
-  TIMED_RENDER(answer = ucsr.render(UpdateContextSubscription, ""));
+  TIMED_RENDER(answer = ucsr.render(""));
 
   return answer;
 }

--- a/src/lib/serviceRoutines/putAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/putAllEntitiesWithTypeAndId.cpp
@@ -79,6 +79,8 @@ extern std::string putAllEntitiesWithTypeAndId
   std::string                   answer;
   UpdateContextElementResponse  response;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   // FIXME P1: AttributeDomainName skipped
   // FIXME P1: domainMetadataVector skipped
 
@@ -99,18 +101,14 @@ extern std::string putAllEntitiesWithTypeAndId
   {
     alarmMgr.badInput(clientIp, "entity::type cannot be empty for this request");
     response.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
-    TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                          AllEntitiesWithTypeAndId, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, AllEntitiesWithTypeAndId, ""));
     return answer;
   }
   else if ((typeNameFromUriParam != entityType) && (typeNameFromUriParam != ""))
   {
     alarmMgr.badInput(clientIp, "non-matching entity::types in URL");
     response.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
-    TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                          AllEntitiesWithTypeAndId, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, AllEntitiesWithTypeAndId, ""));
     return answer;
   }
 
@@ -128,9 +126,7 @@ extern std::string putAllEntitiesWithTypeAndId
 
 
   // 06. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
 
   parseDataP->upcr.res.release();
   response.release();

--- a/src/lib/serviceRoutines/putAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/putAllEntitiesWithTypeAndId.cpp
@@ -99,14 +99,18 @@ extern std::string putAllEntitiesWithTypeAndId
   {
     alarmMgr.badInput(clientIp, "entity::type cannot be empty for this request");
     response.errorCode.fill(SccBadRequest, "entity::type cannot be empty for this request");
-    TIMED_RENDER(answer = response.render(ciP, AllEntitiesWithTypeAndId, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                          AllEntitiesWithTypeAndId, ""));
     return answer;
   }
   else if ((typeNameFromUriParam != entityType) && (typeNameFromUriParam != ""))
   {
     alarmMgr.badInput(clientIp, "non-matching entity::types in URL");
     response.errorCode.fill(SccBadRequest, "non-matching entity::types in URL");
-    TIMED_RENDER(answer = response.render(ciP, AllEntitiesWithTypeAndId, ""));
+    TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                          ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                          AllEntitiesWithTypeAndId, ""));
     return answer;
   }
 
@@ -124,7 +128,9 @@ extern std::string putAllEntitiesWithTypeAndId
 
 
   // 06. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP, IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        IndividualContextEntity, ""));
 
   parseDataP->upcr.res.release();
   response.release();

--- a/src/lib/serviceRoutines/putIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/putIndividualContextEntity.cpp
@@ -77,6 +77,8 @@ std::string putIndividualContextEntity
   UpdateContextElementResponse  response;
   std::string                   entityType;
 
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+
   // 01. Take care of URI params
   entityType = ciP->uriParam[URI_PARAM_ENTITY_TYPE];
 
@@ -97,9 +99,8 @@ std::string putIndividualContextEntity
 
 
   // 05. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP->apiVersion,
-                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                        IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion, asJsonObject, IndividualContextEntity, ""));
+
 
   response.release();
   parseDataP->upcr.res.release();

--- a/src/lib/serviceRoutines/putIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/putIndividualContextEntity.cpp
@@ -97,7 +97,9 @@ std::string putIndividualContextEntity
 
 
   // 05. Cleanup and return result
-  TIMED_RENDER(answer = response.render(ciP, IndividualContextEntity, ""));
+  TIMED_RENDER(answer = response.render(ciP->apiVersion,
+                                        ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
+                                        IndividualContextEntity, ""));
 
   response.release();
   parseDataP->upcr.res.release();

--- a/src/lib/serviceRoutinesV2/getEntities.cpp
+++ b/src/lib/serviceRoutinesV2/getEntities.cpp
@@ -321,7 +321,7 @@ std::string getEntities
     }
     else
     {
-      TIMED_RENDER(answer = entities.render(ciP, EntitiesResponse));
+      TIMED_RENDER(answer = entities.render(ciP));
       ciP->httpStatusCode = SccOk;
     }
   }

--- a/src/lib/serviceRoutinesV2/getEntities.cpp
+++ b/src/lib/serviceRoutinesV2/getEntities.cpp
@@ -321,7 +321,7 @@ std::string getEntities
     }
     else
     {
-      TIMED_RENDER(answer = entities.render(ciP));
+      TIMED_RENDER(answer = entities.render(ciP->uriParamOptions, ciP->uriParam));
       ciP->httpStatusCode = SccOk;
     }
   }

--- a/src/lib/serviceRoutinesV2/getEntity.cpp
+++ b/src/lib/serviceRoutinesV2/getEntity.cpp
@@ -102,7 +102,7 @@ std::string getEntity
   entity.fill(&parseDataP->qcrs.res);
 
   std::string answer;
-  TIMED_RENDER(answer = entity.render(ciP, EntityResponse, false));
+  TIMED_RENDER(answer = entity.render(ciP, false));
 
   if (parseDataP->qcrs.res.errorCode.code == SccOk && parseDataP->qcrs.res.contextElementResponseVector.size() > 1)
   {

--- a/src/lib/serviceRoutinesV2/getEntity.cpp
+++ b/src/lib/serviceRoutinesV2/getEntity.cpp
@@ -102,7 +102,7 @@ std::string getEntity
   entity.fill(&parseDataP->qcrs.res);
 
   std::string answer;
-  TIMED_RENDER(answer = entity.render(ciP, false));
+  TIMED_RENDER(answer = entity.render(ciP->uriParamOptions, ciP->uriParam, false));
 
   if (parseDataP->qcrs.res.errorCode.code == SccOk && parseDataP->qcrs.res.contextElementResponseVector.size() > 1)
   {

--- a/src/lib/serviceRoutinesV2/getEntityAllTypes.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAllTypes.cpp
@@ -40,7 +40,7 @@
 *
 * getEntityAllTypes -
 *
-* GET /v2/type
+* GET /v2/types
 *
 * Payload In:  None
 * Payload Out: EntityTypeVectorResponse
@@ -77,7 +77,7 @@ std::string getEntityAllTypes
   {
     TIMED_MONGO(mongoEntityTypes(&response, ciP->tenant, ciP->servicePathV, ciP->uriParam, ciP->apiVersion, totalTypesP, noAttrDetail));
   }
-  TIMED_RENDER(answer = response.toJson(ciP));
+  TIMED_RENDER(answer = response.toJson(ciP->uriParamOptions[OPT_VALUES]));
 
   if (ciP->uriParamOptions[OPT_COUNT])
   {

--- a/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
@@ -85,7 +85,15 @@ std::string getEntityAttribute
   // 03. Render entity attribute response
   attribute.fill(&parseDataP->qcrs.res, compV[4]);
 
-  TIMED_RENDER(answer = attribute.render(ciP, EntityAttributeResponse));
+  TIMED_RENDER(answer = attribute.render(ciP->apiVersion,
+                                         ciP->httpHeaders.accepted("text/plain"),
+                                         ciP->httpHeaders.accepted("application/json"),
+                                         ciP->httpHeaders.outformatSelect(),
+                                         &(ciP->outMimeType),
+                                         &(ciP->httpStatusCode),
+                                         ciP->uriParamOptions[OPT_KEY_VALUES],
+                                         ciP->uriParam[URI_PARAM_METADATA],
+                                         EntityAttributeResponse));
 
   if (attribute.oe.reasonPhrase == "TooManyResults")
   {

--- a/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
@@ -39,6 +39,7 @@
 #include "serviceRoutinesV2/getEntityAttribute.h"
 #include "parse/forbiddenChars.h"
 #include "rest/OrionError.h"
+#include "rest/uriParamNames.h"
 
 
 
@@ -103,7 +104,15 @@ std::string getEntityAttributeValue
       // Do not use attribute name, change to 'value'
       attribute.pcontextAttribute->name = "value";
 
-      TIMED_RENDER(answer = attribute.render(ciP, EntityAttributeValueRequest, false));
+      TIMED_RENDER(answer = attribute.render(ciP->apiVersion,
+                                             ciP->httpHeaders.accepted("text/plain"),
+                                             ciP->httpHeaders.accepted("application/json"),
+                                             ciP->httpHeaders.outformatSelect(),
+                                             &(ciP->outMimeType),
+                                             &(ciP->httpStatusCode),
+                                             ciP->uriParamOptions[OPT_KEY_VALUES],
+                                             ciP->uriParam[URI_PARAM_METADATA],
+                                             EntityAttributeValueRequest, false));
     }
     else
     {

--- a/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
@@ -109,7 +109,8 @@ std::string getEntityAttributeValue
     {
       if (attribute.pcontextAttribute->compoundValueP != NULL)
       {
-        TIMED_RENDER(answer = attribute.pcontextAttribute->compoundValueP->render(ciP, ""));
+        // FIXME PR
+        TIMED_RENDER(answer = attribute.pcontextAttribute->compoundValueP->render(ciP->apiVersion, ""));
 
         if (attribute.pcontextAttribute->compoundValueP->isObject())
         {

--- a/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
@@ -112,7 +112,8 @@ std::string getEntityAttributeValue
                                              &(ciP->httpStatusCode),
                                              ciP->uriParamOptions[OPT_KEY_VALUES],
                                              ciP->uriParam[URI_PARAM_METADATA],
-                                             EntityAttributeValueRequest, false));
+                                             EntityAttributeValueRequest,
+                                             false));
     }
     else
     {

--- a/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
@@ -109,7 +109,6 @@ std::string getEntityAttributeValue
     {
       if (attribute.pcontextAttribute->compoundValueP != NULL)
       {
-        // FIXME PR
         TIMED_RENDER(answer = attribute.pcontextAttribute->compoundValueP->render(ciP->apiVersion, ""));
 
         if (attribute.pcontextAttribute->compoundValueP->isObject())

--- a/src/lib/serviceRoutinesV2/getEntityType.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityType.cpp
@@ -81,7 +81,7 @@ std::string getEntityType
   }
   else
   {
-    TIMED_RENDER(answer = response.toJson(ciP));
+    TIMED_RENDER(answer = response.toJson());
   }
 
   response.release();

--- a/src/lib/serviceRoutinesV2/postBatchQuery.cpp
+++ b/src/lib/serviceRoutinesV2/postBatchQuery.cpp
@@ -97,7 +97,7 @@ std::string postBatchQuery
   {
     entities.fill(&parseDataP->qcrs.res);
 
-    TIMED_RENDER(answer = entities.render(ciP, EntitiesResponse));
+    TIMED_RENDER(answer = entities.render(ciP));
   }
 
   // 04. Cleanup and return result

--- a/src/lib/serviceRoutinesV2/postBatchQuery.cpp
+++ b/src/lib/serviceRoutinesV2/postBatchQuery.cpp
@@ -97,7 +97,7 @@ std::string postBatchQuery
   {
     entities.fill(&parseDataP->qcrs.res);
 
-    TIMED_RENDER(answer = entities.render(ciP));
+    TIMED_RENDER(answer = entities.render(ciP->uriParamOptions, ciP->uriParam));
   }
 
   // 04. Cleanup and return result

--- a/src/lib/serviceRoutinesV2/postSubscriptions.cpp
+++ b/src/lib/serviceRoutinesV2/postSubscriptions.cpp
@@ -58,7 +58,7 @@ extern std::string postSubscriptions
     alarmMgr.badInput(clientIp, errMsg);
     scr.subscribeError.errorCode.fill(SccBadRequest, "max one service-path allowed for subscriptions");
 
-    TIMED_RENDER(answer = scr.render(SubscribeContext, ""));
+    TIMED_RENDER(answer = scr.render(""));
     return answer;
   }
 

--- a/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
@@ -77,7 +77,8 @@ std::string putEntityAttributeValue
   parseDataP->av.attribute.type = "";  // Overwrite 'none', as no type can be given in 'value' payload
   parseDataP->av.attribute.onlyValue = true;
 
-  std::string err = parseDataP->av.attribute.check(ciP,ciP->requestType,"","", 0);
+  // FIXME PR
+  std::string err = parseDataP->av.attribute.check(ciP->apiVersion, ciP->requestType);
   if (err != "OK")
   {
     OrionError oe(SccBadRequest, err, "BadRequest");

--- a/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
@@ -77,7 +77,6 @@ std::string putEntityAttributeValue
   parseDataP->av.attribute.type = "";  // Overwrite 'none', as no type can be given in 'value' payload
   parseDataP->av.attribute.onlyValue = true;
 
-  // FIXME PR
   std::string err = parseDataP->av.attribute.check(ciP->apiVersion, ciP->requestType);
   if (err != "OK")
   {

--- a/test/unittests/apiTypesV2/Entities_test.cpp
+++ b/test/unittests/apiTypesV2/Entities_test.cpp
@@ -58,8 +58,6 @@ TEST(Entities, present)
 */
 TEST(Entities, check)
 {
-  ConnectionInfo ci;
-
   utInit();
 
   Entity* enP;
@@ -80,8 +78,8 @@ TEST(Entities, check)
   Entities ens2;
   ens2.vec.push_back(enP);
 
-  EXPECT_EQ("OK", ens1.check(&ci, EntitiesRequest));
-  EXPECT_EQ("No Entity ID", ens2.check(&ci, EntitiesRequest));
+  EXPECT_EQ("OK", ens1.check("v1", EntitiesRequest));
+  EXPECT_EQ("No Entity ID", ens2.check("v1", EntitiesRequest));
 
   utExit();
 }

--- a/test/unittests/apiTypesV2/EntityVector_test.cpp
+++ b/test/unittests/apiTypesV2/EntityVector_test.cpp
@@ -57,8 +57,6 @@ TEST(EntityVector, present)
 */
 TEST(EntityVector, check)
 {
-  ConnectionInfo ci;
-
   utInit();
 
   Entity* enP;
@@ -79,8 +77,8 @@ TEST(EntityVector, check)
   EntityVector enV2;
   enV2.push_back(enP);
 
-  EXPECT_EQ("OK", enV1.check(&ci, EntitiesRequest));
-  EXPECT_EQ("No Entity ID", enV2.check(&ci, EntitiesRequest));
+  EXPECT_EQ("OK", enV1.check("v1", EntitiesRequest));
+  EXPECT_EQ("No Entity ID", enV2.check("v1", EntitiesRequest));
 
   utExit();
 }

--- a/test/unittests/apiTypesV2/Entity_test.cpp
+++ b/test/unittests/apiTypesV2/Entity_test.cpp
@@ -54,7 +54,6 @@ TEST(Entity, present)
 */
 TEST(Entity, check)
 {
-  ConnectionInfo ci;
 
   utInit();
 
@@ -66,21 +65,21 @@ TEST(Entity, check)
   ContextAttribute* caP = new ContextAttribute("A", "T", "val");
   enP->attributeVector.push_back(caP);
 
-  EXPECT_EQ("OK", enP->check(&ci, EntitiesRequest));
+  EXPECT_EQ("OK", enP->check("v1", EntitiesRequest));
 
   enP->id = "";
-  EXPECT_EQ("No Entity ID", enP->check(&ci, EntitiesRequest));
+  EXPECT_EQ("No Entity ID", enP->check("v1", EntitiesRequest));
 
   enP->id = "E<1>";
-  EXPECT_EQ("Invalid characters in entity id", enP->check(&ci, EntitiesRequest));
+  EXPECT_EQ("Invalid characters in entity id", enP->check("v1", EntitiesRequest));
   enP->id = "E";
 
   enP->type = "T<1>";
-  EXPECT_EQ("Invalid characters in entity type", enP->check(&ci, EntitiesRequest));
+  EXPECT_EQ("Invalid characters in entity type", enP->check("v1", EntitiesRequest));
   enP->type = "T";
 
   enP->isPattern = "<false>";
-  EXPECT_EQ("Invalid characters in entity isPattern", enP->check(&ci, EntitiesRequest));
+  EXPECT_EQ("Invalid characters in entity isPattern", enP->check("v1", EntitiesRequest));
 
   utExit();
 }

--- a/test/unittests/convenience/AppendContextElementRequest_test.cpp
+++ b/test/unittests/convenience/AppendContextElementRequest_test.cpp
@@ -44,17 +44,15 @@ TEST(AppendContextElementRequest, render_json)
    AppendContextElementRequest  acer;
    std::string                  out;
    ContextAttribute             ca("caName", "caType", "121");
-   Metadata                     md("mdName", "mdType", "122");
    const char*                  outfile = "ngsi10.appendContextElementRequest.adn.valid.json";
-   ConnectionInfo               ci;
+
 
    utInit();
 
    acer.attributeDomainName.set("ADN");
    acer.contextAttributeVector.push_back(&ca);
    
-   ci.outMimeType = JSON;
-   out = acer.render(&ci, UpdateContext, "");
+   out = acer.render("v1", false, UpdateContext, "");
 
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
@@ -77,7 +75,6 @@ TEST(AppendContextElementRequest, check_json)
    const char*                  outfile1 = "ngsi10.appendContextElementResponse.predetectedError.valid.json";
    const char*                  outfile2 = "ngsi10.appendContextElementResponse.missingAttributeName.valid.json";
    const char*                  outfile3 = "ngsi10.appendContextElementResponse.missingMetadataName.valid.json";
-   ConnectionInfo               ci;
 
    utInit();
 
@@ -86,14 +83,13 @@ TEST(AppendContextElementRequest, check_json)
    acer.domainMetadataVector.push_back(&md);
 
    // 1. ok
-   ci.outMimeType = JSON;
-   out = acer.check(&ci, AppendContextElement, "", "", 0);
+   out = acer.check("v1", false, AppendContextElement, "", "", 0);
    EXPECT_STREQ("OK", out.c_str());
 
 
    // 2. Predetected error 
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
-   out = acer.check(&ci, AppendContextElement, "", "Error is predetected", 0);
+   out = acer.check("v1", false, AppendContextElement, "", "Error is predetected", 0);
    EXPECT_STREQ(expectedBuf, out.c_str());
    
 
@@ -101,7 +97,7 @@ TEST(AppendContextElementRequest, check_json)
    ContextAttribute  ca2("", "caType", "121");
 
    acer.contextAttributeVector.push_back(&ca2);
-   out = acer.check(&ci, AppendContextElement, "", "", 0);
+   out = acer.check("v1", false, AppendContextElement, "", "", 0);
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";   
    EXPECT_STREQ(expectedBuf, out.c_str());
    ca2.name = "ca2Name";
@@ -111,7 +107,7 @@ TEST(AppendContextElementRequest, check_json)
    Metadata  md2("", "mdType", "122");
 
    acer.domainMetadataVector.push_back(&md2);
-   out = acer.check(&ci, AppendContextElement, "", "", 0);
+   out = acer.check("v1", false, AppendContextElement, "", "", 0);
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile3)) << "Error getting test data from '" << outfile3 << "'";   
    EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/AppendContextElementResponse_test.cpp
+++ b/test/unittests/convenience/AppendContextElementResponse_test.cpp
@@ -46,19 +46,17 @@ TEST(AppendContextElementResponse, render_json)
   std::string                   out;
   const char*                   outfile1 = "ngsi10.appendContextElementResponse.empty.valid.json";
   const char*                   outfile2 = "ngsi10.appendContextElementResponse.badRequest.valid.json";
-  ConnectionInfo                ci;
 
   utInit();
 
   // 1. empty acer
-  ci.outMimeType = JSON;
-  out = acer.render(&ci, AppendContextElement, "");
+  out = acer.render("v1", false, AppendContextElement, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. errorCode 'active'
   acer.errorCode.fill(SccBadRequest, "very bad request");
-  out = acer.render(&ci, AppendContextElement, "");
+  out = acer.render("v1", false, AppendContextElement, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -79,26 +77,24 @@ TEST(AppendContextElementResponse, check_json)
   std::string                   out;
   const char*                   outfile1 = "ngsi10.appendContextElementRequest.check1.postponed.json";
   const char*                   outfile2 = "ngsi10.appendContextElementRequest.check2.postponed.json";
-  ConnectionInfo                ci;
 
   utInit();
 
   // 1. predetected error
-  ci.outMimeType = JSON;
-  out = acer.check(&ci, IndividualContextEntity, "", "PRE ERR", 0);
+  out = acer.check("v1", false, IndividualContextEntity, "", "PRE ERR", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. bad contextAttributeResponseVector
   car.contextAttributeVector.push_back(&ca);
   acer.contextAttributeResponseVector.push_back(&car);
-  out = acer.check(&ci, IndividualContextEntity, "", "", 0);
+  out = acer.check("v1", false, IndividualContextEntity, "", "", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 3. OK
   ca.name = "NAME";
-  out = acer.check(&ci, IndividualContextEntity, "", "", 0);
+  out = acer.check("v1", false, IndividualContextEntity, "", "", 0);
   EXPECT_EQ("OK", out);
 
   utExit();

--- a/test/unittests/convenience/ContextAttributeResponseVector_test.cpp
+++ b/test/unittests/convenience/ContextAttributeResponseVector_test.cpp
@@ -48,19 +48,17 @@ TEST(ContextAttributeResponseVector, render_json)
   ContextAttributeResponse        car;  
   std::string                     out;
   const char*                     outfile = "ngsi10.contextResponseList.render.invalid.json";
-  ConnectionInfo                  ci;
 
   // 1. empty vector
-  ci.outMimeType = JSON;
   car.statusCode.fill(SccBadRequest, "Empty Vector");
-  out = carV.render(&ci, ContextEntityAttributes, "");
+  out = carV.render("v1", false, ContextEntityAttributes, "");
   EXPECT_STREQ("", out.c_str());
 
   // 2. normal case
   car.contextAttributeVector.push_back(&ca);
   carV.push_back(&car);
 
-  out = carV.render(&ci, ContextEntityAttributes, "");
+  out = carV.render("v1", false, ContextEntityAttributes, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 }
@@ -79,25 +77,23 @@ TEST(ContextAttributeResponseVector, check_json)
   std::string                     out;
   const char*                     outfile1 = "ngsi10.contextAttributeResponse.check1.valid.json";
   const char*                     outfile2 = "ngsi10.contextAttributeResponse.check2.valid.json";
-  ConnectionInfo                  ci(JSON);
 
   // 1. ok
   car.contextAttributeVector.push_back(&ca);
   carV.push_back(&car);
-  out = carV.check(&ci, UpdateContextAttribute, "", "", 0);
+  out = carV.check("v1", false, UpdateContextAttribute, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   // 2. Predetected Error
-  out = carV.check(&ci, UpdateContextAttribute, "", "PRE ERROR", 0);
+  out = carV.check("v1", false, UpdateContextAttribute, "", "PRE ERROR", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
-
 
   // 3. Bad ContextAttribute
   ContextAttribute  ca2("", "caType", "caValue");
 
   car.contextAttributeVector.push_back(&ca2);
-  out = carV.check(&ci, UpdateContextAttribute, "", "", 0);
+  out = carV.check("v1", false, UpdateContextAttribute, "", "", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 }

--- a/test/unittests/convenience/ContextAttributeResponse_test.cpp
+++ b/test/unittests/convenience/ContextAttributeResponse_test.cpp
@@ -44,15 +44,13 @@ TEST(ContextAttributeResponse, render_json)
   ContextAttribute          ca("caName", "caType", "caValue");
   ContextAttributeResponse  car;
   std::string               out;
-  ConnectionInfo            ci;
 
   utInit();
 
   car.contextAttributeVector.push_back(&ca);
   car.statusCode.fill(SccOk, "OK"); 
 
-  ci.outMimeType = JSON;
-  out = car.render(&ci, ContextEntityAttributes, "");
+  out = car.render("v1", false, ContextEntityAttributes, "");
 
   utExit();
 }
@@ -70,7 +68,6 @@ TEST(ContextAttributeResponse, check_json)
   std::string               out;
   const char*               outfile1 = "ngsi10.contextAttributeResponse.check3.valid.json";
   const char*               outfile2 = "ngsi10.contextAttributeResponse.check4.valid.json";
-  ConnectionInfo            ci;
 
   utInit();
 
@@ -78,13 +75,12 @@ TEST(ContextAttributeResponse, check_json)
   car.contextAttributeVector.push_back(&ca);
   car.statusCode.fill(SccOk, "OK"); 
 
-  ci.outMimeType = JSON;
-  out = car.check(&ci, UpdateContextAttribute, "", "", 0);
+  out = car.check("v1", false, UpdateContextAttribute, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
 
   // 2. predetectedError
-  out = car.check(&ci, UpdateContextAttribute, "", "PRE Error", 0);
+  out = car.check("v1", false, UpdateContextAttribute, "", "PRE Error", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -94,7 +90,7 @@ TEST(ContextAttributeResponse, check_json)
   car.contextAttributeVector.push_back(&ca2);
   
   LM_M(("car.contextAttributeVector.size: %d - calling ContextAttributeResponse::check", car.contextAttributeVector.size()));
-  out = car.check(&ci, UpdateContextAttribute, "", "", 0);
+  out = car.check("v1", false, UpdateContextAttribute, "", "", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/RegisterProviderRequest_test.cpp
+++ b/test/unittests/convenience/RegisterProviderRequest_test.cpp
@@ -73,14 +73,14 @@ TEST(RegisterProviderRequest, json_ok)
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile2)) << "Error getting test data from '" << outFile2 << "'";
 
   reqData.rpr.res.metadataVector[0]->name = "";
-  checked = reqData.rpr.res.check(&ci, DiscoverContextAvailability, "", "", 0);
+  checked = reqData.rpr.res.check("v1", DiscoverContextAvailability, "", "", 0);
   EXPECT_STREQ(expectedBuf, checked.c_str());
 
 
   // 3. sending a 'predetected error' to the check function
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile3)) << "Error getting test data from '" << outFile3 << "'";
 
-  checked   = reqData.rpr.res.check(&ci, DiscoverContextAvailability, "", "forced predetectedError", 0);
+  checked   = reqData.rpr.res.check("v1", DiscoverContextAvailability, "", "forced predetectedError", 0);
   EXPECT_STREQ(expectedBuf, checked.c_str());
 
   // Just for coverage

--- a/test/unittests/convenience/UpdateContextAttributeRequest_test.cpp
+++ b/test/unittests/convenience/UpdateContextAttributeRequest_test.cpp
@@ -45,15 +45,13 @@ TEST(UpdateContextAttributeRequest, render_json)
 
   utInit();
 
-  ConnectionInfo* ciP = NULL;
-
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
 
   ucar.type         = "TYPE";
   ucar.contextValue = "Context Value";
 
   ucar.metadataVector.push_back(&mdata);
-  out = ucar.render(ciP, "");
+  out = ucar.render("v1", "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();
@@ -73,7 +71,6 @@ TEST(UpdateContextAttributeRequest, check_json)
   std::string                    out;
   const char*                    outfile1 = "ngsi10.updateContextAttributeRequest.check1.valid.json";
   const char*                    outfile2 = "ngsi10.updateContextAttributeRequest.check3.valid.json";
-  ConnectionInfo                 ci;
 
   utInit();
 
@@ -81,23 +78,23 @@ TEST(UpdateContextAttributeRequest, check_json)
 
   // 1. predetectedError
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
-  out = ucar.check(&ci, UpdateContextAttribute, "", "PRE Error", 0);
+  out = ucar.check("v1", UpdateContextAttribute, "", "PRE Error", 0);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   
   // 2. empty contextValue
-  out = ucar.check(&ci, UpdateContextAttribute, "", "", 0);
+  out = ucar.check("v1", UpdateContextAttribute, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   // 3. OK
   ucar.contextValue = "CValue";
-  out = ucar.check(&ci, UpdateContextAttribute, "", "", 0);
+  out = ucar.check("v1", UpdateContextAttribute, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   // 4. bad metadata
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   ucar.metadataVector.push_back(&mdata2);
-  out = ucar.check(&ci, UpdateContextAttribute, "", "", 0);
+  out = ucar.check("v1", UpdateContextAttribute, "", "", 0);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/convenience/UpdateContextElementRequest_test.cpp
+++ b/test/unittests/convenience/UpdateContextElementRequest_test.cpp
@@ -45,7 +45,6 @@ TEST(UpdateContextElementRequest, render_json)
   ContextAttribute                ca("caName", "caType", "caValue");
   std::string                     out;
   const char*                     outfile = "ngsi10.updateContextElementRequest.render.valid.json";
-  ConnectionInfo                  ci(JSON);
 
   utInit();
 
@@ -55,7 +54,7 @@ TEST(UpdateContextElementRequest, render_json)
   ucer.attributeDomainName.set("ADN");
   ucer.contextAttributeVector.push_back(&ca);
 
-  out = ucer.render(&ci, UpdateContext, "");
+  out = ucer.render("v1", false, UpdateContext, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();
@@ -74,7 +73,6 @@ TEST(UpdateContextElementRequest, check_json)
   std::string                     out;
   const char*                     outfile1  = "ngsi10.updateContextElementRequest.check1.valid.json";
   const char*                     outfile2  = "ngsi10.updateContextElementRequest.check2.valid.json";
-  ConnectionInfo                  ci(JSON);
 
   utInit();
 
@@ -82,12 +80,12 @@ TEST(UpdateContextElementRequest, check_json)
 
   // 1. predetectedError
   ucer.contextAttributeVector.push_back(&ca);
-  out = ucer.check(&ci, UpdateContextElement, "", "PRE Error", 0);
+  out = ucer.check("v1", false, UpdateContextElement, "", "PRE Error", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. ok
-  out = ucer.check(&ci, UpdateContextElement, "", "", 0);
+  out = ucer.check("v1", false, UpdateContextElement, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   // 3. bad attributeDomainName
@@ -97,7 +95,7 @@ TEST(UpdateContextElementRequest, check_json)
   // 4. bad contextAttributeVector
   ContextAttribute                ca2("", "caType", "caValue");
   ucer.contextAttributeVector.push_back(&ca2);
-  out = ucer.check(&ci, UpdateContextElement, "", "", 0);
+  out = ucer.check("v1", false, UpdateContextElement, "", "", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/UpdateContextElementResponse_test.cpp
+++ b/test/unittests/convenience/UpdateContextElementResponse_test.cpp
@@ -46,14 +46,13 @@ TEST(UpdateContextElementResponse, render_json)
   ContextAttribute                ca("caName", "caType", "caValue");
   std::string                     out;
   const char*                     outfile = "ngsi10.updateContextElementResponse.ok.valid.json";
-  ConnectionInfo                  ci(JSON);
 
   // Just the normal case
   ucer.contextAttributeResponseVector.push_back(&car);
   car.contextAttributeVector.push_back(&ca);
   car.statusCode.fill(SccOk, "details");
 
-  out = ucer.render(&ci, UpdateContext, "");
+  out = ucer.render("v1", false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 }
@@ -72,22 +71,21 @@ TEST(UpdateContextElementResponse, check_json)
   std::string                   out;
   const char*                   outfile1 = "ngsi10.updateContextElementResponse.check1.valid.json";
   const char*                   outfile2 = "ngsi10.updateContextElementResponse.check2.valid.json";
-  ConnectionInfo                ci(JSON);
 
   // 1. predetected error
-  out = ucer.check(&ci, IndividualContextEntity, "", "PRE ERR", 0);
+  out = ucer.check("v1", false, IndividualContextEntity, "", "PRE ERR", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. bad contextAttributeResponseVector
   car.contextAttributeVector.push_back(&ca);
   ucer.contextAttributeResponseVector.push_back(&car);
-  out = ucer.check(&ci, IndividualContextEntity, "", "", 0);
+  out = ucer.check("v1", false, IndividualContextEntity, "", "", 0);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 3. OK
   ca.name = "NAME";
-  out = ucer.check(&ci, IndividualContextEntity, "", "", 0);
+  out = ucer.check("v1", false, IndividualContextEntity, "", "", 0);
   EXPECT_EQ("OK", out);
 }

--- a/test/unittests/ngsi/ContextAttributeVector_test.cpp
+++ b/test/unittests/ngsi/ContextAttributeVector_test.cpp
@@ -40,13 +40,11 @@
 TEST(ContextAttributeVector, render)
 {
   ContextAttributeVector  cav;
-  ContextAttribute        ca("Name", "Type", "Value");
   std::string             out;
-  ConnectionInfo          ci(JSON);
 
   utInit();
 
-  out = cav.render(&ci, UpdateContextAttribute, "");
+  out = cav.render("v1", false, UpdateContextAttribute, "");
   EXPECT_STREQ("", out.c_str());
 
   // Just to exercise the code ...

--- a/test/unittests/ngsi/ContextAttributeVector_test.cpp
+++ b/test/unittests/ngsi/ContextAttributeVector_test.cpp
@@ -26,7 +26,6 @@
 #include "logMsg/traceLevels.h"
 
 #include "ngsi/ContextAttributeVector.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi/ContextAttribute_test.cpp
+++ b/test/unittests/ngsi/ContextAttribute_test.cpp
@@ -26,7 +26,6 @@
 #include "logMsg/traceLevels.h"
 
 #include "ngsi/ContextAttributeVector.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi/ContextAttribute_test.cpp
+++ b/test/unittests/ngsi/ContextAttribute_test.cpp
@@ -40,22 +40,21 @@ TEST(ContextAttribute, checkOne)
 {
   ContextAttribute  ca;
   std::string       res;
-  ConnectionInfo    ci;
 
   utInit();
 
   ca.name = "";
-  res     = ca.check(&ci, RegisterContext, "", "", 0);
+  res     = ca.check("v1", RegisterContext);
   EXPECT_TRUE(res == "missing attribute name");
 
   ca.name  = "Algo, lo que sea!";
   ca.stringValue = ""; // FIXME P10: automacit value -> stringValue change, please review to check if it is safe
 
-  res     = ca.check(&ci, RegisterContext, "", "", 0);
+  res     = ca.check("v1", RegisterContext);
   EXPECT_TRUE(res == "OK");
   
   ca.stringValue = "Algun valor cualquiera"; // FIXME P10: automacit value -> stringValue change, please review to check if it is safe
-  res     = ca.check(&ci, RegisterContext, "", "", 0);
+  res     = ca.check("v1", RegisterContext);
   EXPECT_TRUE(res == "OK");
 
   utExit();
@@ -73,7 +72,6 @@ TEST(ContextAttribute, checkVector)
   ContextAttribute        ca0;
   ContextAttribute        ca1;
   std::string             res;
-  ConnectionInfo          ci;
 
   utInit();
 
@@ -85,7 +83,7 @@ TEST(ContextAttribute, checkVector)
   caVector.push_back(&ca0);
   caVector.push_back(&ca1);
 
-  res     = caVector.check(&ci, RegisterContext, "", "", 0);
+  res     = caVector.check("v1", RegisterContext);
   EXPECT_TRUE(res == "OK");
 
   utExit();
@@ -102,12 +100,10 @@ TEST(ContextAttribute, render)
   ContextAttribute  ca("NAME", "TYPE", "VALUE");
   std::string       out;
   const char*       outfile1 = "ngsi.contextAttribute.render.middle.json";
-  ConnectionInfo    ci(JSON);
 
   utInit();
 
-  ci.outMimeType = JSON;
-  out = ca.render(&ci, UpdateContext, "");
+  out = ca.render("v1", false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/ngsi/ContextElementResponseVector_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponseVector_test.cpp
@@ -41,11 +41,10 @@ TEST(ContextElementResponseVector, check)
   ContextElementResponseVector  cerv;
   ContextElementResponse        cer;
   std::string                   out;
-  ConnectionInfo                ci;
 
   utInit();
 
-  out = cerv.check(&ci, UpdateContext, "", "", 0);
+  out = cerv.check("v1", UpdateContext, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   cer.contextElement.entityId.id         = "ID";
@@ -54,7 +53,7 @@ TEST(ContextElementResponseVector, check)
   cer.statusCode.fill(SccOk, "details");
 
   cerv.push_back(&cer);
-  out = cerv.check(&ci, UpdateContext, "", "", 0);
+  out = cerv.check("v1", UpdateContext, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   utExit();
@@ -72,11 +71,10 @@ TEST(ContextElementResponseVector, render)
   ContextElementResponseVector  cerv;
   ContextElementResponse        cer;
   std::string                   out;
-  ConnectionInfo                ci(JSON);
 
   utInit();
 
-  out = cerv.render(&ci, UpdateContextElement, "");
+  out = cerv.render("v1", false, UpdateContextElement, "");
   EXPECT_STREQ("", out.c_str());
 
   cer.contextElement.entityId.id         = "ID";

--- a/test/unittests/ngsi/ContextElementResponseVector_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponseVector_test.cpp
@@ -26,7 +26,6 @@
 #include "logMsg/traceLevels.h"
 
 #include "ngsi/ContextElementResponseVector.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi/ContextElementResponse_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponse_test.cpp
@@ -26,7 +26,6 @@
 #include "logMsg/traceLevels.h"
 
 #include "ngsi/ContextElementResponse.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi/ContextElementResponse_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponse_test.cpp
@@ -40,22 +40,21 @@ TEST(ContextElementResponse, check)
 {
    ContextElementResponse  cer;
    std::string             out;
-   ConnectionInfo          ci;
    
    utInit();
 
-   out = cer.check(&ci, UpdateContext, "", "", 0);
+   out = cer.check("v1", UpdateContext, "", "", 0);
    EXPECT_STREQ("empty entityId:id", out.c_str());
 
    cer.contextElement.entityId.id         = "ID";
    cer.contextElement.entityId.type       = "Type";
    cer.contextElement.entityId.isPattern  = "false";
 
-   out = cer.check(&ci, UpdateContext, "", "", 0);
+   out = cer.check("v1", UpdateContext, "", "", 0);
    EXPECT_STREQ("no code", out.c_str());
 
    cer.statusCode.fill(SccOk, "details");
-   out = cer.check(&ci, UpdateContext, "", "", 0);
+   out = cer.check("v1", UpdateContext, "", "", 0);
    EXPECT_STREQ("OK", out.c_str());
 
    utExit();
@@ -72,7 +71,6 @@ TEST(ContextElementResponse, render)
   ContextElementResponse  cer;
   const char*             outfile = "ngsi.contextElementResponse.render.middle.json";
   std::string             out;
-  ConnectionInfo          ci(JSON);
 
    utInit();
 
@@ -82,7 +80,7 @@ TEST(ContextElementResponse, render)
 
    cer.statusCode.fill(SccOk, "details");
 
-   out = cer.render(&ci, UpdateContextElement, "");
+   out = cer.render("v1", false, UpdateContextElement, "");
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/ngsi/ContextElementVector_test.cpp
+++ b/test/unittests/ngsi/ContextElementVector_test.cpp
@@ -26,7 +26,6 @@
 #include "logMsg/traceLevels.h"
 
 #include "ngsi/ContextElementVector.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi/ContextElementVector_test.cpp
+++ b/test/unittests/ngsi/ContextElementVector_test.cpp
@@ -43,15 +43,14 @@ TEST(ContextElementVector, render)
   EntityId              eId("E_ID", "E_TYPE");
   std::string           rendered;
   ContextElementVector  ceV;
-  ConnectionInfo        ci(JSON);
 
-  rendered = ceV.render(&ci, UpdateContextElement, "", false);
+  rendered = ceV.render("v1", false, UpdateContextElement, "", false);
   EXPECT_STREQ("", rendered.c_str());
 
   ceP->entityId = eId;
   ceV.push_back(ceP);
 
-  rendered = ceV.render(&ci, UpdateContextElement, "", false);
+  rendered = ceV.render("v1", false, UpdateContextElement, "", false);
 
   ceV.release();
 }

--- a/test/unittests/ngsi/ContextElement_test.cpp
+++ b/test/unittests/ngsi/ContextElement_test.cpp
@@ -38,50 +38,46 @@
 TEST(ContextElement, check)
 {
   ContextElement ce;
-  ConnectionInfo               ci;
 
   utInit();
 
   ce.entityId.id = "";
-  EXPECT_EQ(ce.check(&ci, UpdateContext, "", "", 0), "empty entityId:id");
+  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "empty entityId:id");
 
   ce.entityId.id = "id";
-  EXPECT_EQ(ce.check(&ci, UpdateContext, "", "", 0), "OK");
+  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "OK");
 
   ContextAttribute a;
   a.name  = "";
   a.stringValue = "V";
   ce.contextAttributeVector.push_back(&a);
-  EXPECT_EQ(ce.check(&ci, UpdateContext, "", "", 0), "missing attribute name");
+  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "missing attribute name");
   a.name = "name";
   
   Metadata m;
   m.name  = "";
   m.stringValue = "V";
   ce.domainMetadataVector.push_back(&m);
-  EXPECT_EQ(ce.check(&ci, UpdateContext, "", "", 0), "missing metadata name");
+  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "missing metadata name");
   m.name = "NAME";
-  EXPECT_EQ(ce.check(&ci, UpdateContext, "", "", 0), "OK");
+  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "OK");
 
   ContextElement ce2;
   ce2.entityId.id = "id";
 
   ContextElementVector ceVector;
 
-  EXPECT_EQ(ceVector.check(&ci, UpdateContext, "", "", 0), "No context elements");
+  EXPECT_EQ(ceVector.check("v1", UpdateContext, "", "", 0), "No context elements");
 
   ceVector.push_back(&ce);
   ceVector.push_back(&ce2);
-  EXPECT_EQ(ceVector.check(&ci, UpdateContext, "", "", 0), "OK");
+  EXPECT_EQ(ceVector.check("v1", UpdateContext, "", "", 0), "OK");
 
   // render
   const char*     outfile1 = "ngsi.contextelement.check.middle.json";
   std::string     out;
 
-  ci = ConnectionInfo(JSON);
-
-  ci.outMimeType = JSON;
-  out = ce2.render(&ci, UpdateContextElement, "", false);
+  out = ce2.render("v1", false, UpdateContextElement, "", false);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -90,7 +86,7 @@ TEST(ContextElement, check)
   ce2.present("", 1);
 
   m.name  = "";
-  EXPECT_EQ("missing metadata name", ceVector.check(&ci, UpdateContext, "", "", 0));
+  EXPECT_EQ("missing metadata name", ceVector.check("v1", UpdateContext, "", "", 0));
 
   utExit();
 }

--- a/test/unittests/ngsi/ContextRegistrationResponseVector_test.cpp
+++ b/test/unittests/ngsi/ContextRegistrationResponseVector_test.cpp
@@ -29,8 +29,6 @@
 
 #include "ngsi/ContextRegistrationResponseVector.h"
 
-#include "rest/ConnectionInfo.h"
-
 
 
 /* ****************************************************************************

--- a/test/unittests/ngsi/ContextRegistrationResponseVector_test.cpp
+++ b/test/unittests/ngsi/ContextRegistrationResponseVector_test.cpp
@@ -42,7 +42,6 @@ TEST(ContextRegistrationResponseVector, all)
   ContextRegistrationResponse        crr;
   ContextRegistrationResponseVector  crrV;
   std::string                        rendered;
-  ConnectionInfo                     ci;
 
   crr.contextRegistration.providingApplication.set("10.1.1.1://nada");
 
@@ -56,18 +55,18 @@ TEST(ContextRegistrationResponseVector, all)
   crrV.present("");
 
   // check OK
-  rendered = crrV.check(&ci, RegisterContext, "", "", 0);
+  rendered = crrV.check("v1", RegisterContext, "", "", 0);
   EXPECT_EQ("OK", rendered);
 
   // Now telling the crr that we've found an instance of '<entityIdList></entityIdList>
   // but without any entities inside the vector
   crr.contextRegistration.entityIdVectorPresent = true;
-  rendered = crrV.check(&ci, RegisterContext, "", "", 0);
+  rendered = crrV.check("v1", RegisterContext, "", "", 0);
   EXPECT_EQ("Empty entityIdVector", rendered);
 
   EntityId             eId;   // Empty ID
 
   crr.contextRegistration.entityIdVector.push_back(&eId);
-  rendered = crrV.check(&ci, RegisterContext, "", "", 0);
+  rendered = crrV.check("v1", RegisterContext, "", "", 0);
   EXPECT_EQ("empty entityId:id", rendered);
 }

--- a/test/unittests/ngsi/ContextRegistrationResponse_test.cpp
+++ b/test/unittests/ngsi/ContextRegistrationResponse_test.cpp
@@ -68,11 +68,10 @@ TEST(ContextRegistrationResponse, check)
   ContextRegistrationResponse  crr;
   std::string                  checked;
   std::string                  expected = "no providing application";
-  ConnectionInfo               ci;
 
   utInit();
 
-  checked = crr.check(&ci, RegisterContext, "", "", 0);
+  checked = crr.check("v1", RegisterContext, "", "", 0);
   EXPECT_STREQ(expected.c_str(), checked.c_str());
 
   utExit();

--- a/test/unittests/ngsi/Metadata_test.cpp
+++ b/test/unittests/ngsi/Metadata_test.cpp
@@ -89,17 +89,16 @@ TEST(Metadata, check)
   Metadata        m2("Name", "Type", "");
   Metadata        m3("Name", "Type", "Value");
   std::string     checked;
-  ConnectionInfo  ci;
 
   utInit();
 
-  checked = m1.check(&ci, RegisterContext, "", "", 0);
+  checked = m1.check("v1");
   EXPECT_STREQ("missing metadata name", checked.c_str());
 
-  checked = m2.check(&ci, RegisterContext, "", "", 0);
+  checked = m2.check("v1");
   EXPECT_STREQ("missing metadata value", checked.c_str());
   
-  checked = m3.check(&ci, RegisterContext, "", "", 0);
+  checked = m3.check("v1");
   EXPECT_STREQ("OK", checked.c_str());
 
   utExit();

--- a/test/unittests/ngsi10/NotifyContextRequest_test.cpp
+++ b/test/unittests/ngsi10/NotifyContextRequest_test.cpp
@@ -31,7 +31,6 @@
 #include "ngsi/StatusCode.h"
 #include "ngsi10/NotifyContextRequest.h"
 #include "ngsi10/NotifyContextResponse.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi10/NotifyContextRequest_test.cpp
+++ b/test/unittests/ngsi10/NotifyContextRequest_test.cpp
@@ -69,7 +69,7 @@ TEST(NotifyContextRequest, json_ok)
   //
   ncrP->present("");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
-  rendered = ncrP->render(&ci, NotifyContext, "");
+  rendered = ncrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   ncrP->release();
@@ -141,8 +141,7 @@ TEST(NotifyContextRequest, json_render)
   const char*              filename3  = "ngsi10.notifyContextRequest.jsonRender3.valid.json";
   NotifyContextRequest*    ncrP;
   ContextElementResponse*  cerP;
-  std::string              rendered;
-  ConnectionInfo           ci(JSON);
+  std::string              rendered;  
 
   utInit();
   
@@ -153,7 +152,7 @@ TEST(NotifyContextRequest, json_render)
 
   // 1. Without ContextResponseList
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  rendered = ncrP->render(&ci, QueryContext, "");
+  rendered = ncrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -164,7 +163,7 @@ TEST(NotifyContextRequest, json_render)
   cerP->statusCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  rendered = ncrP->render(&ci, QueryContext, "");
+  rendered = ncrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -175,7 +174,7 @@ TEST(NotifyContextRequest, json_render)
   cerP->statusCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  rendered = ncrP->render(&ci, QueryContext, "");
+  rendered = ncrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   utExit();

--- a/test/unittests/ngsi10/QueryContextRequest_test.cpp
+++ b/test/unittests/ngsi10/QueryContextRequest_test.cpp
@@ -96,7 +96,7 @@ TEST(QueryContextRequest, ok_json)
   qcrP->present(""); // No output
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
-  rendered = qcrP->render(QueryContext, "");
+  rendered = qcrP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   qcrP->present("");

--- a/test/unittests/ngsi10/QueryContextRequest_test.cpp
+++ b/test/unittests/ngsi10/QueryContextRequest_test.cpp
@@ -26,7 +26,6 @@
 #include "logMsg/traceLevels.h"
 
 #include "common/globals.h"
-#include "rest/ConnectionInfo.h"
 #include "ngsi/Request.h"
 #include "jsonParse/jsonRequest.h"
 #include "serviceRoutines/postQueryContext.h"

--- a/test/unittests/ngsi10/QueryContextResponse_test.cpp
+++ b/test/unittests/ngsi10/QueryContextResponse_test.cpp
@@ -25,7 +25,6 @@
 #include "gtest/gtest.h"
 
 #include "ngsi10/QueryContextResponse.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi10/QueryContextResponse_test.cpp
+++ b/test/unittests/ngsi10/QueryContextResponse_test.cpp
@@ -56,7 +56,6 @@ TEST(QueryContextResponse, json_render)
   Metadata*                mdP;
   ContextAttribute*        caP;
   std::string              out;
-  ConnectionInfo           ci(JSON);
 
   utInit();
 
@@ -71,7 +70,7 @@ TEST(QueryContextResponse, json_render)
   qcrP->contextElementResponseVector.push_back(cerP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -80,7 +79,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -91,7 +90,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -101,7 +100,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -112,7 +111,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.attributeDomainName.set("AttrDomain");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -122,7 +121,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -133,7 +132,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename7)) << "Error getting test data from '" << filename7 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -143,7 +142,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename8)) << "Error getting test data from '" << filename8 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -153,7 +152,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename9)) << "Error getting test data from '" << filename9 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -163,7 +162,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename10)) << "Error getting test data from '" << filename10 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   
 
@@ -176,7 +175,7 @@ TEST(QueryContextResponse, json_render)
   qcrP->contextElementResponseVector.push_back(cerP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename11)) << "Error getting test data from '" << filename11 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -186,7 +185,7 @@ TEST(QueryContextResponse, json_render)
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename12)) << "Error getting test data from '" << filename12 << "'";
   qcrP->errorCode.code = SccNone;
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -194,13 +193,13 @@ TEST(QueryContextResponse, json_render)
   qcrP->errorCode.fill(SccBadRequest, "no details");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename13)) << "Error getting test data from '" << filename13 << "'";
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 14. contextElementResponseVector is released and the render method should give an almost empty response
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename14)) << "Error getting test data from '" << filename14 << "'";
   qcrP->contextElementResponseVector.release();
-  out = qcrP->render(&ci, QueryContext, "");
+  out = qcrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 

--- a/test/unittests/ngsi10/SubscribeContextRequest_test.cpp
+++ b/test/unittests/ngsi10/SubscribeContextRequest_test.cpp
@@ -27,7 +27,6 @@
 
 #include "common/globals.h"
 #include "ngsi/ParseData.h"
-#include "rest/ConnectionInfo.h"
 #include "jsonParse/jsonRequest.h"
 
 #include "unittest.h"

--- a/test/unittests/ngsi10/SubscribeContextResponse_test.cpp
+++ b/test/unittests/ngsi10/SubscribeContextResponse_test.cpp
@@ -82,7 +82,7 @@ TEST(SubscribeContextResponse, json_render)
   scrP->subscribeError.errorCode.fill(SccBadRequest, "details");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = scrP->render(SubscribeContext, "");
+  out = scrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -92,7 +92,7 @@ TEST(SubscribeContextResponse, json_render)
   scrP->subscribeError.subscriptionId.set("012345678901234567890123");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = scrP->render(SubscribeContext, "");
+  out = scrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   scrP->subscribeError.errorCode.fill(SccNone);
@@ -103,7 +103,7 @@ TEST(SubscribeContextResponse, json_render)
   scrP->subscribeResponse.subscriptionId.set("012345678901234567890123");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  out = scrP->render(SubscribeContext, "");
+  out = scrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -112,7 +112,7 @@ TEST(SubscribeContextResponse, json_render)
   scrP->subscribeResponse.throttling.set("PT1M");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  out = scrP->render(SubscribeContext, "");
+  out = scrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -122,7 +122,7 @@ TEST(SubscribeContextResponse, json_render)
   scrP->subscribeResponse.duration.set("PT1H");
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  out = scrP->render(SubscribeContext, "");
+  out = scrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -131,7 +131,7 @@ TEST(SubscribeContextResponse, json_render)
   scrP->subscribeResponse.throttling.set("PT1M");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  out = scrP->render(SubscribeContext, "");
+  out = scrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/ngsi10/UnsubscribeContextRequest_test.cpp
+++ b/test/unittests/ngsi10/UnsubscribeContextRequest_test.cpp
@@ -28,7 +28,6 @@
 #include "testDataFromFile.h"
 #include "common/globals.h"
 #include "ngsi/ParseData.h"
-#include "rest/ConnectionInfo.h"
 #include "jsonParse/jsonRequest.h"
 
 #include "unittest.h"
@@ -61,7 +60,7 @@ TEST(UnsubscribeContextRequest, badSubscriptionId_json)
   ucrP->present("");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
-  out = ucrP->render(UnsubscribeContext, "");
+  out = ucrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   ucrP->release();

--- a/test/unittests/ngsi10/UnsubscribeContextResponse_test.cpp
+++ b/test/unittests/ngsi10/UnsubscribeContextResponse_test.cpp
@@ -77,7 +77,7 @@ TEST(UnsubscribeContextResponse, jsonRender)
   uncrP->statusCode.fill(SccBadRequest, "details");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), infile1)) << "Error getting test data from '" << infile1 << "'";
-  out = uncrP->render(QueryContext, "");
+  out = uncrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -86,7 +86,7 @@ TEST(UnsubscribeContextResponse, jsonRender)
   uncrP->statusCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), infile2)) << "Error getting test data from '" << infile2 << "'";
-  out = uncrP->render(QueryContext, "");
+  out = uncrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   delete uncrP;

--- a/test/unittests/ngsi10/UpdateContextRequest_test.cpp
+++ b/test/unittests/ngsi10/UpdateContextRequest_test.cpp
@@ -27,9 +27,7 @@
 
 #include "testDataFromFile.h"
 #include "common/globals.h"
-#include "rest/ConnectionInfo.h"
 #include "jsonParse/jsonRequest.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi10/UpdateContextResponse_test.cpp
+++ b/test/unittests/ngsi10/UpdateContextResponse_test.cpp
@@ -79,7 +79,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->errorCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = ucrP->render(&ci, UpdateContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -87,7 +87,7 @@ TEST(UpdateContextResponse, jsonRender)
   // Test 02. UpdateContextResponse::errorCode NOT OK and contextElementResponseVector filled id (with details)
   ucrP->errorCode.fill(SccBadRequest, "no details");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = ucrP->render(&ci, UpdateContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   ucrP->errorCode.fill(SccOk); // Cleanup
 
@@ -101,7 +101,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->contextElementResponseVector.push_back(cerP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  out = ucrP->render(&ci, UpdateContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -111,7 +111,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  out = ucrP->render(&ci, UpdateContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -122,7 +122,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  out = ucrP->render(&ci, QueryContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   
@@ -132,7 +132,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  out = ucrP->render(&ci, QueryContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   
 
@@ -142,7 +142,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.attributeDomainName.set("AttrDomain");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename7)) << "Error getting test data from '" << filename7 << "'";
-  out = ucrP->render(&ci, QueryContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -152,7 +152,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename8)) << "Error getting test data from '" << filename8 << "'";
-  out = ucrP->render(&ci, QueryContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -163,7 +163,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename9)) << "Error getting test data from '" << filename9 << "'";
-  out = ucrP->render(&ci, QueryContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -173,7 +173,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename10)) << "Error getting test data from '" << filename10 << "'";
-  out = ucrP->render(&ci, QueryContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -183,7 +183,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename11)) << "Error getting test data from '" << filename11 << "'";
-  out = ucrP->render(&ci, QueryContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -193,7 +193,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename12)) << "Error getting test data from '" << filename12 << "'";
-  out = ucrP->render(&ci, QueryContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -206,7 +206,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->contextElementResponseVector.push_back(cerP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename13)) << "Error getting test data from '" << filename13 << "'";
-  out = ucrP->render(&ci, QueryContext, "");
+  out = ucrP->render(&ci, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/ngsi10/UpdateContextResponse_test.cpp
+++ b/test/unittests/ngsi10/UpdateContextResponse_test.cpp
@@ -54,7 +54,6 @@ TEST(UpdateContextResponse, jsonRender)
   Metadata*                mdP;
   ContextAttribute*        caP;
   std::string              out;
-  ConnectionInfo           ci(JSON);
 
   // Preparations
   utInit();
@@ -79,7 +78,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->errorCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -87,7 +86,7 @@ TEST(UpdateContextResponse, jsonRender)
   // Test 02. UpdateContextResponse::errorCode NOT OK and contextElementResponseVector filled id (with details)
   ucrP->errorCode.fill(SccBadRequest, "no details");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   ucrP->errorCode.fill(SccOk); // Cleanup
 
@@ -101,7 +100,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->contextElementResponseVector.push_back(cerP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -111,7 +110,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -122,7 +121,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   
@@ -132,7 +131,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   
 
@@ -142,7 +141,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.attributeDomainName.set("AttrDomain");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename7)) << "Error getting test data from '" << filename7 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -152,7 +151,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename8)) << "Error getting test data from '" << filename8 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -163,7 +162,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename9)) << "Error getting test data from '" << filename9 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -173,7 +172,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename10)) << "Error getting test data from '" << filename10 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -183,7 +182,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename11)) << "Error getting test data from '" << filename11 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -193,7 +192,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename12)) << "Error getting test data from '" << filename12 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -206,7 +205,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->contextElementResponseVector.push_back(cerP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename13)) << "Error getting test data from '" << filename13 << "'";
-  out = ucrP->render(&ci, "");
+  out = ucrP->render("v1", false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/ngsi10/UpdateContextResponse_test.cpp
+++ b/test/unittests/ngsi10/UpdateContextResponse_test.cpp
@@ -23,7 +23,6 @@
 * Author: Ken Zangelin
 */
 #include "ngsi10/UpdateContextResponse.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi10/UpdateContextSubscriptionRequest_test.cpp
+++ b/test/unittests/ngsi10/UpdateContextSubscriptionRequest_test.cpp
@@ -26,7 +26,6 @@
 #include "logMsg/traceLevels.h"
 
 #include "common/globals.h"
-#include "rest/ConnectionInfo.h"
 #include "jsonParse/jsonRequest.h"
 
 #include "unittest.h"
@@ -78,12 +77,12 @@ TEST(UpdateContextSubscriptionRequest, badLength_json)
   ucsrP->present(""); // No output
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile3)) << "Error getting test data from '" << outfile3 << "'";
-  out  = ucsrP->check(UpdateContextSubscription, "", "FORCED ERROR", 0);
+  out  = ucsrP->check("", "FORCED ERROR", 0);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   ucsrP->duration.set("XXXYYYZZZ");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile4)) << "Error getting test data from '" << outfile4 << "'";
-  out  = ucsrP->check(UpdateContextSubscription, "", "", 0);
+  out  = ucsrP->check("", "", 0);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   ucsrP->present("");

--- a/test/unittests/ngsi10/UpdateContextSubscriptionResponse_test.cpp
+++ b/test/unittests/ngsi10/UpdateContextSubscriptionResponse_test.cpp
@@ -62,7 +62,7 @@ TEST(UpdateContextSubscriptionResponse, json_render)
   ucsrP->subscribeError.errorCode.fill(SccBadRequest, "details");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = ucsrP->render(QueryContext, "");
+  out = ucsrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -72,7 +72,7 @@ TEST(UpdateContextSubscriptionResponse, json_render)
   ucsrP->subscribeError.subscriptionId.set("012345678901234567890123");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = ucsrP->render(QueryContext, "");
+  out = ucsrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   ucsrP->subscribeError.errorCode.fill(SccNone);
@@ -83,7 +83,7 @@ TEST(UpdateContextSubscriptionResponse, json_render)
   ucsrP->subscribeResponse.subscriptionId.set("012345678901234567890123");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  out = ucsrP->render(QueryContext, "");
+  out = ucsrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -92,7 +92,7 @@ TEST(UpdateContextSubscriptionResponse, json_render)
   ucsrP->subscribeResponse.throttling.set("PT1M");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  out = ucsrP->render(QueryContext, "");
+  out = ucsrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -102,7 +102,7 @@ TEST(UpdateContextSubscriptionResponse, json_render)
   ucsrP->subscribeResponse.duration.set("PT1H");
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  out = ucsrP->render(QueryContext, "");
+  out = ucsrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -111,7 +111,7 @@ TEST(UpdateContextSubscriptionResponse, json_render)
   ucsrP->subscribeResponse.throttling.set("PT1M");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  out = ucsrP->render(QueryContext, "");
+  out = ucsrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/ngsi9/DiscoverContextAvailabilityRequest_test.cpp
+++ b/test/unittests/ngsi9/DiscoverContextAvailabilityRequest_test.cpp
@@ -30,7 +30,6 @@
 #include "ngsi/ParseData.h"
 #include "common/globals.h"
 #include "jsonParse/jsonRequest.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi9/DiscoverContextAvailabilityResponse_test.cpp
+++ b/test/unittests/ngsi9/DiscoverContextAvailabilityResponse_test.cpp
@@ -54,10 +54,10 @@ TEST(DiscoverContextAvailabilityResponse, render)
 
   utInit();
 
-  out = dcar1.render(DiscoverContextAvailability, "");
+  out = dcar1.render("");
   EXPECT_EQ(SccReceiverInternalError, dcar1.errorCode.code);
 
-  out = dcar2.render(DiscoverContextAvailability, "");
+  out = dcar2.render("");
   EXPECT_EQ(SccBadRequest, dcar2.errorCode.code);
 
   utExit();
@@ -113,13 +113,13 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
   free(dcarP);
@@ -134,7 +134,7 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   // No release here - the data stays - to be used in the following test scenario
 
@@ -148,12 +148,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
 
@@ -167,7 +167,7 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   // No release here - the data stays - to be used in the following test scenario
   
@@ -179,12 +179,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   crrP->contextRegistration.providingApplication.set("http://tid.test.com/unitTest5");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
 
@@ -198,7 +198,7 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   // No release here - the data stays - to be used in the following test scenario
 
@@ -211,12 +211,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   crrP->contextRegistration.providingApplication.set("http://tid.test.com/unitTest7");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename7)) << "Error getting test data from '" << filename7 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
 
@@ -230,7 +230,7 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename8)) << "Error getting test data from '" << filename8 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   // No release here - the data stays - to be used in the following test scenario
 
@@ -243,12 +243,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   crrP->contextRegistration.providingApplication.set("http://tid.test.com/unitTest9");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename9)) << "Error getting test data from '" << filename9 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
 
@@ -260,7 +260,7 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename10)) << "Error getting test data from '" << filename10 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   // No release here - the data stays - to be used in the following test scenario
 
@@ -273,12 +273,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   crrP->contextRegistration.providingApplication.set("http://tid.test.com/unitTest11");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename11)) << "Error getting test data from '" << filename11 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
 
@@ -292,7 +292,7 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename12)) << "Error getting test data from '" << filename12 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   // No release here - the data stays - to be used in the following test scenario
 
@@ -304,12 +304,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   crrP->contextRegistration.registrationMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename13)) << "Error getting test data from '" << filename13 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
 
@@ -323,7 +323,7 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename14)) << "Error getting test data from '" << filename14 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   // No release here - the data stays - to be used in the following test scenario
 
@@ -336,7 +336,7 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   crrP->contextRegistration.providingApplication.set("http://tid.test.com/unitTest15");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename15)) << "Error getting test data from '" << filename15 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   // No release here - the data stays - to be used in the following test scenario 17
 
@@ -348,12 +348,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   crrP->contextRegistration.providingApplication.set("http://tid.test.com/unitTest17");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename17)) << "Error getting test data from '" << filename17 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
 
@@ -369,12 +369,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename16)) << "Error getting test data from '" << filename16 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
 
@@ -383,11 +383,11 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->errorCode.fill(SccBadRequest, "DiscoverContextAvailabilityResponse Unit Test 18");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename18)) << "Error getting test data from '" << filename18 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
@@ -397,12 +397,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->errorCode.fill(SccBadRequest);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename19)) << "Error getting test data from '" << filename19 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   dcarP->release();  // ... otherwise the 500 remains and "pollutes" next tests
 
@@ -423,12 +423,12 @@ TEST(DiscoverContextAvailabilityResponse, jsonRender)
   dcarP->responseVector.push_back(crrP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename20)) << "Error getting test data from '" << filename20 << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   dcarP->release();
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), emptyFilename)) << "Error getting test data from '" << emptyFilename << "'";
-  rendered = dcarP->render(DiscoverContextAvailability, "");
+  rendered = dcarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   free(dcarP);

--- a/test/unittests/ngsi9/NotifyContextAvailabilityRequest_test.cpp
+++ b/test/unittests/ngsi9/NotifyContextAvailabilityRequest_test.cpp
@@ -28,7 +28,6 @@
 #include "ngsi/ParseData.h"
 #include "common/globals.h"
 #include "jsonParse/jsonRequest.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi9/NotifyContextAvailabilityRequest_test.cpp
+++ b/test/unittests/ngsi9/NotifyContextAvailabilityRequest_test.cpp
@@ -61,7 +61,7 @@ TEST(NotifyContextAvailabilityRequest, ok_json)
 
   const char*     outfile = "ngsi9.notifyContextAvailabilityRequest.ok.valid.json";
 
-  out = ncarP->render(NotifyContext, "");
+  out = ncarP->render("");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -81,11 +81,10 @@ TEST(NotifyContextAvailabilityRequest, check)
 {
   NotifyContextAvailabilityRequest  ncr;
   std::string                       out;
-  ConnectionInfo                    ci;
 
   utInit();
 
-  out = ncr.check(&ci, NotifyContextAvailability, "", "", 0);
+  out = ncr.check("v1", "", "", 0);
   EXPECT_EQ("OK", out);
    
   utExit();
@@ -128,7 +127,7 @@ TEST(NotifyContextAvailabilityRequest, json_render)
 
   // Test 1. contextRegistrationResponseVector with ONE contextRegistrationResponse instance
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  rendered = ncarP->render(QueryContext, "");
+  rendered = ncarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   
 
@@ -149,7 +148,7 @@ TEST(NotifyContextAvailabilityRequest, json_render)
   crrP->contextRegistration.providingApplication.set("http://www.tid.es/NotifyContextAvailabilityRequestTest2");
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  rendered = ncarP->render(QueryContext, "");
+  rendered = ncarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   
   utExit();

--- a/test/unittests/ngsi9/NotifyContextAvailabilityResponse_test.cpp
+++ b/test/unittests/ngsi9/NotifyContextAvailabilityResponse_test.cpp
@@ -45,7 +45,7 @@ TEST(NotifyContextAvailabilityResponse, all)
   EXPECT_EQ(ncr1.responseCode.code, SccOk);
   EXPECT_EQ(ncr2.responseCode.code, SccBadRequest);
 
-  ncr1.render(NotifyContextAvailability, "");
+  ncr1.render("");
   ncr1.present("");
   ncr1.release();
 }

--- a/test/unittests/ngsi9/RegisterContextRequest_test.cpp
+++ b/test/unittests/ngsi9/RegisterContextRequest_test.cpp
@@ -30,7 +30,6 @@
 #include "common/globals.h"
 #include "jsonParse/jsonRequest.h"
 #include "ngsi/ParseData.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 
@@ -96,7 +95,7 @@ TEST(RegisterContextRequest, json_ok)
   std::string result = jsonTreat(testBuf, &ci, &parseData, RegisterContext, "registerContextRequest", &reqP);
   EXPECT_EQ("OK", result) << "this test should be OK";
 
-  out = rcrP->render(RegisterContext, "");
+  out = rcrP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   reqP->release(&parseData);

--- a/test/unittests/ngsi9/RegisterContextResponse_test.cpp
+++ b/test/unittests/ngsi9/RegisterContextResponse_test.cpp
@@ -61,7 +61,7 @@ TEST(RegisterContextResponse, constructors)
   EXPECT_EQ("012345678901234567890123", rcr4.registrationId.get());
   EXPECT_EQ(SccBadRequest, rcr4.errorCode.code);
     
-  out = rcr5.check(RegisterContext, "", "", 0);
+  out = rcr5.check("", "", 0);
   EXPECT_EQ(expected5, out);
 
   rcr2.present("");
@@ -87,27 +87,27 @@ TEST(RegisterContextResponse, jsonRender)
   // 1. Only registrationId
   rcr.registrationId.set("012345678901234567890123");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  rendered = rcr.render(RegisterContext, "");
+  rendered = rcr.render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   // 2. registrationId and duration
   rcr.duration.set("PT1S");
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  rendered = rcr.render(RegisterContext, "");
+  rendered = rcr.render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   // 3. registrationId and errorCode
   rcr.duration.set("");
   rcr.errorCode.fill(SccBadRequest, "no details");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  rendered = rcr.render(RegisterContext, "");
+  rendered = rcr.render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
   
   // 4. registrationId and duration and errorCode
   rcr.duration.set("PT2S");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  rendered = rcr.render(RegisterContext, "");
+  rendered = rcr.render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   utExit();

--- a/test/unittests/ngsi9/SubscribeAvailabilityRequest_test.cpp
+++ b/test/unittests/ngsi9/SubscribeAvailabilityRequest_test.cpp
@@ -28,7 +28,6 @@
 #include "common/globals.h"
 #include "jsonParse/jsonRequest.h"
 #include "ngsi/ParseData.h"
-#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 

--- a/test/unittests/ngsi9/SubscribeContextAvailabilityResponse_test.cpp
+++ b/test/unittests/ngsi9/SubscribeContextAvailabilityResponse_test.cpp
@@ -83,7 +83,7 @@ TEST(SubscribeContextAvailabilityResponse, jsonRender)
   scarP->subscriptionId.set("012345678901234567890123");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  rendered = scarP->render(SubscribeContextAvailability, "");
+  rendered = scarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   
@@ -91,7 +91,7 @@ TEST(SubscribeContextAvailabilityResponse, jsonRender)
   scarP->errorCode.fill(SccBadRequest);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  rendered = scarP->render(SubscribeContextAvailability, "");
+  rendered = scarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -100,7 +100,7 @@ TEST(SubscribeContextAvailabilityResponse, jsonRender)
   scarP->duration.set("PT1H");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  rendered = scarP->render(SubscribeContextAvailability, "");
+  rendered = scarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -108,7 +108,7 @@ TEST(SubscribeContextAvailabilityResponse, jsonRender)
   scarP->errorCode.fill(SccBadRequest, "no details");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  rendered = scarP->render(SubscribeContextAvailability, "");
+  rendered = scarP->render("");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 

--- a/test/unittests/ngsi9/UnsubscribeContextAvailabilityRequest_test.cpp
+++ b/test/unittests/ngsi9/UnsubscribeContextAvailabilityRequest_test.cpp
@@ -28,7 +28,6 @@
 #include "testDataFromFile.h"
 #include "common/globals.h"
 #include "ngsi/ParseData.h"
-#include "rest/ConnectionInfo.h"
 #include "jsonParse/jsonRequest.h"
 
 #include "ngsi/SubscriptionId.h"
@@ -56,7 +55,7 @@ TEST(UnsubscribeContextAvailabilityRequest, constructorAndCheck)
 
   std::string   out;  
 
-  out = ucar2.check(UnsubscribeContextAvailability, "", "", 0);
+  out = ucar2.check("", "", 0);
   EXPECT_EQ("OK", out);
 
   utExit();

--- a/test/unittests/ngsi9/UnsubscribeContextAvailabilityResponse_test.cpp
+++ b/test/unittests/ngsi9/UnsubscribeContextAvailabilityResponse_test.cpp
@@ -79,7 +79,7 @@ TEST(UnsubscribeContextAvailabilityResponse, jsonRender)
   ucasP->statusCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = ucasP->render(UpdateContextAvailabilitySubscription, "");
+  out = ucasP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   
@@ -87,7 +87,7 @@ TEST(UnsubscribeContextAvailabilityResponse, jsonRender)
   ucasP->statusCode.fill(SccBadRequest, "no details");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = ucasP->render(UpdateContextAvailabilitySubscription, "");
+  out = ucasP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   free(ucasP);

--- a/test/unittests/ngsi9/UpdateContextAvailabilitySubscriptionRequest_test.cpp
+++ b/test/unittests/ngsi9/UpdateContextAvailabilitySubscriptionRequest_test.cpp
@@ -68,12 +68,12 @@ TEST(UpdateContextAvailabilitySubscriptionRequest, json_ok)
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
-  out = ucasP->check(&ci, UpdateContextAvailabilitySubscription, "", "predetected error", 0);
+  out = ucasP->check("", "predetected error", 0);
   EXPECT_STREQ(expectedBuf, out.c_str());
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile3)) << "Error getting test data from '" << outfile3 << "'";
   ucasP->duration.set("eeeee");
-  out = ucasP->check(&ci, UpdateContextAvailabilitySubscription, "", "", 0);
+  out = ucasP->check("", "", 0);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/ngsi9/UpdateContextAvailabilitySubscriptionRequest_test.cpp
+++ b/test/unittests/ngsi9/UpdateContextAvailabilitySubscriptionRequest_test.cpp
@@ -63,7 +63,7 @@ TEST(UpdateContextAvailabilitySubscriptionRequest, json_ok)
   UpdateContextAvailabilitySubscriptionRequest* ucasP = &parseData.ucas.res;
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
-  out = ucasP->render(UpdateContextAvailabilitySubscription, "");
+  out = ucasP->render("");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";

--- a/test/unittests/ngsi9/UpdateContextAvailabilitySubscriptionRequest_test.cpp
+++ b/test/unittests/ngsi9/UpdateContextAvailabilitySubscriptionRequest_test.cpp
@@ -28,7 +28,6 @@
 #include "common/globals.h"
 #include "jsonParse/jsonRequest.h"
 #include "ngsi/ParseData.h"
-#include "rest/ConnectionInfo.h"
 #include "ngsi9/UpdateContextAvailabilitySubscriptionResponse.h"
 
 #include "unittest.h"
@@ -126,7 +125,7 @@ TEST(UpdateContextAvailabilitySubscriptionRequest, response)
 
   ucas.subscriptionId.set("012345678901234567890123");
 
-  out = ucas.check(UpdateContextAvailabilitySubscription, "", "", 0);
+  out = ucas.check("", "", 0);
   EXPECT_EQ("OK", out);
   
   utExit();

--- a/test/unittests/ngsi9/UpdateContextAvailabilitySubscriptionResponse_test.cpp
+++ b/test/unittests/ngsi9/UpdateContextAvailabilitySubscriptionResponse_test.cpp
@@ -58,7 +58,7 @@ TEST(UpdateContextAvailabilitySubscriptionResponse, jsonRender)
   ucasP->subscriptionId.set("012345678901234567890123");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  rendered = ucasP->render(UpdateContextAvailabilitySubscription, "", 1);
+  rendered = ucasP->render("", 1);
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   
@@ -66,7 +66,7 @@ TEST(UpdateContextAvailabilitySubscriptionResponse, jsonRender)
   ucasP->errorCode.fill(SccBadRequest);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  rendered = ucasP->render(UpdateContextAvailabilitySubscription, "", 1);
+  rendered = ucasP->render("", 1);
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -75,7 +75,7 @@ TEST(UpdateContextAvailabilitySubscriptionResponse, jsonRender)
   ucasP->duration.set("PT1H");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  rendered = ucasP->render(UpdateContextAvailabilitySubscription, "", 1);
+  rendered = ucasP->render("", 1);
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -83,7 +83,7 @@ TEST(UpdateContextAvailabilitySubscriptionResponse, jsonRender)
   ucasP->errorCode.fill(SccBadRequest, "no details");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  rendered = ucasP->render(UpdateContextAvailabilitySubscription, "", 1);
+  rendered = ucasP->render("", 1);
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 

--- a/test/unittests/orionTypes/EntityTypeResponse_test.cpp
+++ b/test/unittests/orionTypes/EntityTypeResponse_test.cpp
@@ -50,20 +50,17 @@ TEST(EntityTypeResponse, present)
 */
 TEST(EntityTypeResponse, check)
 {
-  ConnectionInfo ci;
-
   utInit();
 
-  ci.outMimeType = JSON;
   EntityTypeResponse etR1;
   EntityTypeResponse etR2;
 
   etR1.entityType.type = "myType";
   etR2.entityType.type = "";
 
-  EXPECT_EQ("OK", etR1.check(&ci, "", ""));
-  EXPECT_NE("OK", etR2.check(&ci, "", ""));
-  EXPECT_NE("OK", etR1.check(&ci, "", "foo"));
+  EXPECT_EQ("OK", etR1.check("v1", false, false, false, "", ""));
+  EXPECT_NE("OK", etR2.check("v1", false, false, false, "", ""));
+  EXPECT_NE("OK", etR1.check("v1", false, false, false, "", "foo"));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityTypeVectorResponse_test.cpp
+++ b/test/unittests/orionTypes/EntityTypeVectorResponse_test.cpp
@@ -52,11 +52,7 @@ TEST(EntityTypeVectorResponse, present)
 */
 TEST(EntityTypeVectorResponse, check)
 {
-  ConnectionInfo ci;
-
   utInit();
-
-  ci.outMimeType = JSON;
 
   EntityType et1("myType");
   EntityType et2("");
@@ -69,11 +65,11 @@ TEST(EntityTypeVectorResponse, check)
   EntityTypeVectorResponse etRV2;
   etRV2.entityTypeVector.push_back((&et2));
 
-  EXPECT_EQ("OK", etRV1.check(&ci, "", ""));
+  EXPECT_EQ("OK", etRV1.check("v1", false, false, false, ""));
 
-  EXPECT_NE("OK", etRV1.check(&ci, "", "foo"));
+  EXPECT_NE("OK", etRV1.check("v1", false, false, false, "foo"));
 
-  EXPECT_NE("OK", etRV2.check(&ci, "", ""));
+  EXPECT_NE("OK", etRV2.check("v1", false, false, false, ""));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityTypeVector_test.cpp
+++ b/test/unittests/orionTypes/EntityTypeVector_test.cpp
@@ -49,11 +49,7 @@ TEST(EntityTypeVector, present)
 */
 TEST(EntityTypeVector, check)
 {
-  ConnectionInfo ci;
-
   utInit();
-
-  ci.outMimeType = JSON;
 
   EntityType et1("myType");
   EntityType et2("");
@@ -66,11 +62,11 @@ TEST(EntityTypeVector, check)
   EntityTypeVector etV2;
   etV2.push_back(&et2);
 
-  EXPECT_EQ("OK", etV1.check(&ci, "", ""));
+  EXPECT_EQ("OK", etV1.check("v1", ""));
 
-  EXPECT_EQ("foo", etV1.check(&ci, "", "foo"));
+  EXPECT_EQ("foo", etV1.check("v1", "foo"));
 
-  EXPECT_EQ("Empty Type", etV2.check(&ci, "", ""));
+  EXPECT_EQ("Empty Type", etV2.check("v1", ""));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityType_test.cpp
+++ b/test/unittests/orionTypes/EntityType_test.cpp
@@ -48,17 +48,14 @@ TEST(EntityType, present)
 */
 TEST(EntityType, check)
 {
-  ConnectionInfo ci;
-
   utInit();
 
-  ci.outMimeType = JSON;
   EntityType et1("myType");
   EntityType et2("");
 
-  EXPECT_EQ("OK", et1.check(&ci, "", ""));
-  EXPECT_EQ("Empty Type", et2.check(&ci, "", ""));
-  EXPECT_EQ("foo", et1.check(&ci, "", "foo"));
+  EXPECT_EQ("OK", et1.check("v1", ""));
+  EXPECT_EQ("Empty Type", et2.check("v1", ""));
+  EXPECT_EQ("foo", et1.check("v1", "foo"));
 
   utExit();
 }

--- a/test/unittests/parse/CompoundValueNode_test.cpp
+++ b/test/unittests/parse/CompoundValueNode_test.cpp
@@ -114,10 +114,6 @@ TEST(CompoundValueNode, vectorInvalidAndOk)
 
   utInit();
 
-  ConnectionInfo ci;
-
-  ci.apiVersion = "v1";
-
   tree->add(vec);
   vec->add(item1);
   vec->add(orion::ValueTypeString, "vecitem", "a");
@@ -132,7 +128,7 @@ TEST(CompoundValueNode, vectorInvalidAndOk)
   std::string rendered;
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile2)) << "Error getting test data from '" << outFile2 << "'";
-  rendered = tree->render(&ci, "");
+  rendered = tree->render("v1", "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   tree->shortShow("");
@@ -164,9 +160,6 @@ TEST(CompoundValueNode, structInvalidAndOk)
 
   utInit();
 
-  ConnectionInfo ci;
-  ci.apiVersion = "v1";
-
   tree->add(str);
   str->add(item1);
   str->add(item2);
@@ -181,7 +174,7 @@ TEST(CompoundValueNode, structInvalidAndOk)
   std::string rendered;
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile2)) << "Error getting test data from '" << outFile2 << "'";
-  rendered = tree->render(&ci, "");
+  rendered = tree->render("v1", "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   tree->shortShow("");

--- a/test/unittests/parse/compoundValue_test.cpp
+++ b/test/unittests/parse/compoundValue_test.cpp
@@ -409,7 +409,7 @@ TEST(compoundValue, updateTwoStructsJson)
   EXPECT_TRUE(caP->compoundValueP != NULL);
 
   ci.outMimeType = JSON;
-  rendered = caP->render(&ci, UpdateContext, "");
+  rendered = caP->render("v1", false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), renderedFile)) << "Error getting test data from '" << renderedFile << "'";
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
@@ -557,7 +557,7 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_TRUE(caP->compoundValueP != NULL);
 
   ci.outMimeType = JSON;
-  rendered = caP->render(&ci, UpdateContext, "");
+  rendered = caP->render("v1", false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), renderedFile)) << "Error getting test data from '" << renderedFile << "'";
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
@@ -965,7 +965,7 @@ TEST(compoundValue, tenCompounds)
   utInit();
 
   upcrP = &reqData.upcr.res;
-  rendered = upcrP->render(&ci, UpdateContext, "");
+  rendered = upcrP->render(&ci, "");
 
   utExit();
 }

--- a/test/unittests/parse/compoundValue_test.cpp
+++ b/test/unittests/parse/compoundValue_test.cpp
@@ -958,14 +958,13 @@ TEST(compoundValue, updateOneStringAndOneVectorInSeparateContextValuesJson)
 TEST(compoundValue, tenCompounds)
 {
   ParseData                  reqData;
-  ConnectionInfo             ci("/ngsi10/updateContext", "POST", "1.1");
   UpdateContextRequest*      upcrP;
   std::string                rendered;
    
   utInit();
 
   upcrP = &reqData.upcr.res;
-  rendered = upcrP->render(&ci, "");
+  rendered = upcrP->render("v1", false, "");
 
   utExit();
 }

--- a/test/unittests/rest/OrionError_test.cpp
+++ b/test/unittests/rest/OrionError_test.cpp
@@ -25,6 +25,7 @@
 #include "logMsg/logMsg.h"
 
 #include "rest/OrionError.h"
+#include "rest/ConnectionInfo.h"
 
 #include "unittest.h"
 


### PR DESCRIPTION
This PR is mainly a simplification of the render() and check() method signatures for classes in libraries ngsi/, ngsi10/, ngsi9/, orionTypes/ and apiTypesV2/, improving modularity and decoupling. In particular:

* ConnectionInfo module has been decoupled. Only the needed parameters are passed to the methods (most of then in parametes, only a couple of methods use out parameters), not the whole ConnectionInfo. Thus, the signature of the method is now a clear specification of what the method exactly needs to work.
* RequestType arguments removed in ngsi9/ and ngsi10/ classes. The request type itself is provided by the class itself, no need to overload check() and render() with it.

_How to read this PR:_

* Most important: "no functional test were harmed in the filming of this PR" :) This ensures the refactor keeps 100% functional regression.
* Looks only the .h files. The .cpp are not very important in this PR.