### PR TITLE
Refactor rendering logic

### DIFF
--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -77,96 +77,96 @@ std::string Entity::render
   bool                                 comma
 )
 {
+  if ((oe.details != "") || ((oe.reasonPhrase != "OK") && (oe.reasonPhrase != "")))
+  {
+    return oe.toJson();
+  }
+
   RenderFormat  renderFormat = NGSI_V2_NORMALIZED;
 
   if      (uriParamOptions[OPT_KEY_VALUES]    == true)  { renderFormat = NGSI_V2_KEYVALUES;     }
   else if (uriParamOptions[OPT_VALUES]        == true)  { renderFormat = NGSI_V2_VALUES;        }
   else if (uriParamOptions[OPT_UNIQUE_VALUES] == true)  { renderFormat = NGSI_V2_UNIQUE_VALUES; }
 
-  if ((oe.details == "") && ((oe.reasonPhrase == "OK") || (oe.reasonPhrase == "")))
+  std::string out;
+  std::vector<std::string> metadataFilter;
+  std::vector<std::string> attrsFilter;
+
+  if (uriParam[URI_PARAM_METADATA] != "")
   {
-    std::string out;
-    std::vector<std::string> metadataFilter;
-    std::vector<std::string> attrsFilter;
-
-    if (uriParam[URI_PARAM_METADATA] != "")
-    {
-      stringSplit(uriParam[URI_PARAM_METADATA], ',', metadataFilter);
-    }
-
-    if (uriParam[URI_PARAM_ATTRIBUTES] != "")
-    {
-      stringSplit(uriParam[URI_PARAM_ATTRIBUTES], ',', attrsFilter);
-    }
-
-    // Add special attributes representing entity dates
-    if ((creDate != 0) && (uriParamOptions[DATE_CREATED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_CREATED) != attrsFilter.end())))
-    {
-      ContextAttribute* caP = new ContextAttribute(DATE_CREATED, DATE_TYPE, creDate);
-      attributeVector.push_back(caP);
-    }
-    if ((modDate != 0) && (uriParamOptions[DATE_MODIFIED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_MODIFIED) != attrsFilter.end())))
-    {
-      ContextAttribute* caP = new ContextAttribute(DATE_MODIFIED, DATE_TYPE, modDate);
-      attributeVector.push_back(caP);
-    }
-
-    if ((renderFormat == NGSI_V2_VALUES) || (renderFormat == NGSI_V2_UNIQUE_VALUES))
-    {
-      out = "[";
-      if (attributeVector.size() != 0)
-      {
-        out += attributeVector.toJson(renderFormat, attrsFilter, metadataFilter, false);
-      }
-      out += "]";        
-    }
-    else
-    {
-      out = "{";
-
-      if (renderId)
-      {
-        out += JSON_VALUE("id", id);
-        out += ",";
-
-        /* This is needed for entities coming from NGSIv1 (which allows empty or missing types) */
-        out += JSON_STR("type") + ":" + ((type != "")? JSON_STR(type) : JSON_STR(DEFAULT_ENTITY_TYPE));
-      }
-
-      std::string attrsOut;
-      if (attributeVector.size() != 0)
-      {
-        attrsOut += attributeVector.toJson(renderFormat, attrsFilter, metadataFilter, false);
-      }
-
-      //
-      // Note that just attributeVector.size() != 0 (used in previous versions) cannot be used
-      // as ciP->uriParam["attrs"] filter could remove all the attributes
-      //
-      if (attrsOut != "")
-      {
-        if (renderId)
-        {
-          out +=  "," + attrsOut;
-        }
-        else
-        {
-          out += attrsOut;
-        }
-      }
-
-      out += "}";
-    }
-
-    if (comma)
-    {
-      out += ",";
-    }
-
-    return out;
+    stringSplit(uriParam[URI_PARAM_METADATA], ',', metadataFilter);
   }
 
-  return oe.toJson();
+  if (uriParam[URI_PARAM_ATTRIBUTES] != "")
+  {
+    stringSplit(uriParam[URI_PARAM_ATTRIBUTES], ',', attrsFilter);
+  }
+
+  // Add special attributes representing entity dates
+  if ((creDate != 0) && (uriParamOptions[DATE_CREATED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_CREATED) != attrsFilter.end())))
+  {
+    ContextAttribute* caP = new ContextAttribute(DATE_CREATED, DATE_TYPE, creDate);
+    attributeVector.push_back(caP);
+  }
+  if ((modDate != 0) && (uriParamOptions[DATE_MODIFIED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_MODIFIED) != attrsFilter.end())))
+  {
+    ContextAttribute* caP = new ContextAttribute(DATE_MODIFIED, DATE_TYPE, modDate);
+    attributeVector.push_back(caP);
+  }
+
+  if ((renderFormat == NGSI_V2_VALUES) || (renderFormat == NGSI_V2_UNIQUE_VALUES))
+  {
+    out = "[";
+    if (attributeVector.size() != 0)
+    {
+      out += attributeVector.toJson(renderFormat, attrsFilter, metadataFilter, false);
+    }
+    out += "]";
+  }
+  else
+  {
+    out = "{";
+
+    if (renderId)
+    {
+      out += JSON_VALUE("id", id);
+      out += ",";
+
+      /* This is needed for entities coming from NGSIv1 (which allows empty or missing types) */
+      out += JSON_STR("type") + ":" + ((type != "")? JSON_STR(type) : JSON_STR(DEFAULT_ENTITY_TYPE));
+    }
+
+    std::string attrsOut;
+    if (attributeVector.size() != 0)
+    {
+      attrsOut += attributeVector.toJson(renderFormat, attrsFilter, metadataFilter, false);
+    }
+
+    //
+    // Note that just attributeVector.size() != 0 (used in previous versions) cannot be used
+    // as ciP->uriParam["attrs"] filter could remove all the attributes
+    //
+    if (attrsOut != "")
+    {
+      if (renderId)
+      {
+        out +=  "," + attrsOut;
+      }
+      else
+      {
+        out += attrsOut;
+      }
+    }
+
+    out += "}";
+  }
+
+  if (comma)
+  {
+    out += ",";
+  }
+
+  return out;
 }
 
 

--- a/src/lib/common/tag.cpp
+++ b/src/lib/common/tag.cpp
@@ -269,6 +269,8 @@ std::string endTag
 *
 * valueTag -  
 *
+* Function version for string values
+*
 */
 std::string valueTag
 (
@@ -335,7 +337,10 @@ std::string valueTag
 
 /* ****************************************************************************
 *
-* valueTag -  
+* valueTag -
+*
+* Function version for integer values
+*
 */
 std::string valueTag
 (
@@ -350,59 +355,6 @@ std::string valueTag
   snprintf(val, sizeof(val), "%d", value);
 
   return valueTag(indent, key, val, showComma, false, false);
-
-#if 0
-  char val[32];
-
-  snprintf(val, sizeof(val), "%d", value);
-
-  if (showComma == true)
-  {
-    return indent + "\"" + key + "\" : \"" + val + "\",\n";
-  }
-
-  return indent + "\"" + key + "\" : \"" + val + "\"\n";
-#endif
 }
 
 
-#if 0
-/* ****************************************************************************
-*
-* valueTag -  
-*/
-std::string valueTag2
-(
-  const std::string&  indent,
-  const std::string&  key,
-  const std::string&  value,
-  bool                showComma,
-  bool                withoutQuotes
-)
-{
-  //return valueTag(indent, key, value, showComma, false, withoutQuotes);
-
-  std::string eValue = jsonInvalidCharsTransformation(value);
-
-  eValue = withoutQuotes? eValue : JSON_STR(eValue);
-
-  if (key == "")
-  {
-    if (showComma == true)
-    {
-      return indent + eValue + ",\n";
-    }
-    else
-    {
-      return indent + eValue + "\n";
-    }
-  }
-
-  if (showComma == true)
-  {
-    return indent + "\"" + key + "\" : " + eValue + ",\n";
-  }
-
-  return indent + "\"" + key + "\" : " + eValue + "\n";
-}
-#endif

--- a/src/lib/common/tag.cpp
+++ b/src/lib/common/tag.cpp
@@ -210,24 +210,14 @@ std::string jsonInvalidCharsTransformation(const std::string& input)
 *
 * startTag1 -
 */
+#if 0
 std::string startTag1
 (
   const std::string&  indent,
   const std::string&  key,
-  bool                showKey,
-  bool                isToplevel
+  bool                showKey
 )
 {
-  if (isToplevel)
-  {
-    if (showKey == false)
-    {
-      return indent + "{\n" + indent + "  {\n";
-    }
- 
-    return indent + "{\n" + indent + "  " + "\"" + key + "\" : {\n";
-  }
-
   if (showKey == false)
   {
     return indent + "{\n";
@@ -235,14 +225,15 @@ std::string startTag1
 
   return indent + "\"" + key + "\" : {\n";
 }
+#endif
 
 
 
 /* ****************************************************************************
 *
-* startTag2 -
+* startTag -
 */
-std::string startTag2
+std::string startTag
 (
   const std::string&  indent,
   const std::string&  key,
@@ -279,21 +270,14 @@ std::string endTag
   const std::string&  indent,
   bool                comma,
   bool                isVector,
-  bool                nl,
-  bool                isToplevel
+  bool                nl
 )
 {
-  if (isToplevel)
-  {
-    return indent + "}\n}\n";
-  }
-
   std::string out = indent;
 
   out += isVector?    "]"  : "}";
   out += comma?       ","  : "";
   out += nl?          "\n" : "";
-  out += isToplevel?  "}"  : "";
 
   return out;
 }

--- a/src/lib/common/tag.cpp
+++ b/src/lib/common/tag.cpp
@@ -255,8 +255,10 @@ std::string endTag
 {
   std::string out = indent;
 
-  out += isVector?    "]"  : "}";
-  out += comma?       ","  : "";
+  out += isVector?  "]"  : "}";
+  out += comma?     ","  : "";
+
+  out += "\n";
 
   return out;
 }
@@ -268,7 +270,7 @@ std::string endTag
 * valueTag -  
 *
 */
-std::string valueTag1
+std::string valueTag
 (
   const std::string&  indent,
   const std::string&  key,
@@ -347,16 +349,24 @@ std::string valueTag
 
   snprintf(val, sizeof(val), "%d", value);
 
+  return valueTag(indent, key, val, showComma, false, false);
+
+#if 0
+  char val[32];
+
+  snprintf(val, sizeof(val), "%d", value);
+
   if (showComma == true)
   {
     return indent + "\"" + key + "\" : \"" + val + "\",\n";
   }
 
   return indent + "\"" + key + "\" : \"" + val + "\"\n";
+#endif
 }
 
 
-
+#if 0
 /* ****************************************************************************
 *
 * valueTag -  
@@ -370,6 +380,8 @@ std::string valueTag2
   bool                withoutQuotes
 )
 {
+  //return valueTag(indent, key, value, showComma, false, withoutQuotes);
+
   std::string eValue = jsonInvalidCharsTransformation(value);
 
   eValue = withoutQuotes? eValue : JSON_STR(eValue);
@@ -393,3 +405,4 @@ std::string valueTag2
 
   return indent + "\"" + key + "\" : " + eValue + "\n";
 }
+#endif

--- a/src/lib/common/tag.cpp
+++ b/src/lib/common/tag.cpp
@@ -250,15 +250,13 @@ std::string endTag
 (
   const std::string&  indent,
   bool                comma,
-  bool                isVector,
-  bool                nl
+  bool                isVector
 )
 {
   std::string out = indent;
 
   out += isVector?    "]"  : "}";
   out += comma?       ","  : "";
-  out += nl?          "\n" : "";
 
   return out;
 }

--- a/src/lib/common/tag.cpp
+++ b/src/lib/common/tag.cpp
@@ -217,9 +217,9 @@ std::string startTag
   bool                isVector
 )
 {
-  // Empty key is legal JSON. However, doesn't use that kind of JSON in Orion,
-  // so we can this instead of a showkey boolean parameter, keeping the function
-  // signature simpler
+  // Empty key is legal JSON. However, Orion doesn't use that kind of keys,
+  // so we can use an empty key string as argument instead of a showkey boolean
+  // parameter, keeping the function signature simpler
   bool showKey = (key != "");
 
   if (isVector && showKey)

--- a/src/lib/common/tag.cpp
+++ b/src/lib/common/tag.cpp
@@ -208,39 +208,20 @@ std::string jsonInvalidCharsTransformation(const std::string& input)
 
 /* ****************************************************************************
 *
-* startTag1 -
-*/
-#if 0
-std::string startTag1
-(
-  const std::string&  indent,
-  const std::string&  key,
-  bool                showKey
-)
-{
-  if (showKey == false)
-  {
-    return indent + "{\n";
-  }
-
-  return indent + "\"" + key + "\" : {\n";
-}
-#endif
-
-
-
-/* ****************************************************************************
-*
 * startTag -
 */
 std::string startTag
 (
   const std::string&  indent,
   const std::string&  key,
-  bool                isVector,
-  bool                showKey
+  bool                isVector
 )
 {
+  // Empty key is legal JSON. However, doesn't use that kind of JSON in Orion,
+  // so we can this instead of a showkey boolean parameter, keeping the function
+  // signature simpler
+  bool showKey = (key != "");
+
   if (isVector && showKey)
   {
     return indent + "\"" + key + "\" : [\n";

--- a/src/lib/common/tag.h
+++ b/src/lib/common/tag.h
@@ -69,29 +69,12 @@ extern std::string jsonInvalidCharsTransformation(const std::string& input);
 *
 * startTag -  
 *
-* FIXME P3: in the past, this entire family of functions was named just startTag().
-* However, changes in the function signature due to XML format removal have caused
-* that different startTag() instances end with the same (or conflicting, due to
-* optional parameters) signatures. Thus, we use startTag1() and startTag() to
-* distinguish. I know they are awful names :), we should find better ones, but given
-* this is NGSIv1 functionality that will be deprecated in the future, the priority
-* to do this is low.
 */
-#if 0
-extern std::string startTag1
-(
-  const std::string&  indent,
-  const std::string&  key,
-  bool                showKey    = true
-);
-#endif
-
 extern std::string startTag
 (
   const std::string&  indent,
-  const std::string&  key,
-  bool                isVector         = false,
-  bool                showKey          = true
+  const std::string&  key      = "",
+  bool                isVector = false
 );
 
 

--- a/src/lib/common/tag.h
+++ b/src/lib/common/tag.h
@@ -96,13 +96,6 @@ extern std::string endTag
 *
 * valueTag -  
 *
-* FIXME P3: in the past, this entire family of functions was named just valueTag().
-* However, changes in the function signature due to XML format removal have caused
-* that different valueTag() instances end with the same (or conflicting, due to
-* optional parameters) signatures. Thus, we use valueTag() and valueTag() to
-* distinguish. I know they are awful names :), we should find better ones, but given
-* this is NGSIv1 functionality that will be deprecated in the future, the priority
-* to do this is low.
 */
 extern std::string valueTag
 (
@@ -121,17 +114,6 @@ extern std::string valueTag
   int                 value,
   bool                showComma     = false
 );
-
-#if 0
-extern std::string valueTag2
-(
-  const std::string&  indent,
-  const std::string&  key,
-  const std::string&  value,
-  bool                showComma     = false,
-  bool                withoutQuotes = false
-);
-#endif
 
 
 

--- a/src/lib/common/tag.h
+++ b/src/lib/common/tag.h
@@ -104,7 +104,7 @@ extern std::string endTag
 * this is NGSIv1 functionality that will be deprecated in the future, the priority
 * to do this is low.
 */
-extern std::string valueTag1
+extern std::string valueTag
 (
   const std::string&  indent,
   const std::string&  key,
@@ -122,6 +122,7 @@ extern std::string valueTag
   bool                showComma     = false
 );
 
+#if 0
 extern std::string valueTag2
 (
   const std::string&  indent,
@@ -130,6 +131,7 @@ extern std::string valueTag2
   bool                showComma     = false,
   bool                withoutQuotes = false
 );
+#endif
 
 
 

--- a/src/lib/common/tag.h
+++ b/src/lib/common/tag.h
@@ -72,20 +72,21 @@ extern std::string jsonInvalidCharsTransformation(const std::string& input);
 * FIXME P3: in the past, this entire family of functions was named just startTag().
 * However, changes in the function signature due to XML format removal have caused
 * that different startTag() instances end with the same (or conflicting, due to
-* optional parameters) signatures. Thus, we use startTag1() and startTag2() to
+* optional parameters) signatures. Thus, we use startTag1() and startTag() to
 * distinguish. I know they are awful names :), we should find better ones, but given
 * this is NGSIv1 functionality that will be deprecated in the future, the priority
 * to do this is low.
 */
+#if 0
 extern std::string startTag1
 (
   const std::string&  indent,
   const std::string&  key,
-  bool                showKey    = true,
-  bool                isToplevel = false
+  bool                showKey    = true
 );
+#endif
 
-extern std::string startTag2
+extern std::string startTag
 (
   const std::string&  indent,
   const std::string&  key,
@@ -104,8 +105,7 @@ extern std::string endTag
   const std::string&  indent,
   bool                comma      = false,
   bool                isVector   = false,
-  bool                nl         = true,
-  bool                isToplevel = false
+  bool                nl         = true
 );
 
 

--- a/src/lib/common/tag.h
+++ b/src/lib/common/tag.h
@@ -87,8 +87,7 @@ extern std::string endTag
 (
   const std::string&  indent,
   bool                comma      = false,
-  bool                isVector   = false,
-  bool                nl         = true
+  bool                isVector   = false
 );
 
 

--- a/src/lib/convenience/AppendContextElementRequest.cpp
+++ b/src/lib/convenience/AppendContextElementRequest.cpp
@@ -54,7 +54,7 @@ std::string AppendContextElementRequest::render(const std::string& apiVersion, b
   std::string tag = "appendContextElementRequest";
   std::string out = "";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   if (entity.id != "")
   {

--- a/src/lib/convenience/AppendContextElementRequest.cpp
+++ b/src/lib/convenience/AppendContextElementRequest.cpp
@@ -51,10 +51,9 @@ AppendContextElementRequest::AppendContextElementRequest()
 */
 std::string AppendContextElementRequest::render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
 {
-  std::string tag = "appendContextElementRequest";
   std::string out = "";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   if (entity.id != "")
   {

--- a/src/lib/convenience/AppendContextElementResponse.cpp
+++ b/src/lib/convenience/AppendContextElementResponse.cpp
@@ -62,7 +62,7 @@ std::string AppendContextElementResponse::render
   std::string tag = "appendContextElementResponse";
   std::string out = "";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   if ((errorCode.code != SccNone) && (errorCode.code != SccOk))
   {

--- a/src/lib/convenience/AppendContextElementResponse.cpp
+++ b/src/lib/convenience/AppendContextElementResponse.cpp
@@ -59,10 +59,9 @@ std::string AppendContextElementResponse::render
   RequestType         requestType,
   const std::string& indent)
 {
-  std::string tag = "appendContextElementResponse";
   std::string out = "";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   if ((errorCode.code != SccNone) && (errorCode.code != SccOk))
   {

--- a/src/lib/convenience/ContextAttributeResponse.cpp
+++ b/src/lib/convenience/ContextAttributeResponse.cpp
@@ -50,10 +50,9 @@ std::string ContextAttributeResponse::render
   const std::string&  indent
 )
 {
-  std::string tag = "contextAttributeResponse";
   std::string out = "";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += contextAttributeVector.render(apiVersion, asJsonObject, request, indent + "  ", true);
   out += statusCode.render(indent + "  ");
   out += endTag(indent);

--- a/src/lib/convenience/ContextAttributeResponse.cpp
+++ b/src/lib/convenience/ContextAttributeResponse.cpp
@@ -53,7 +53,7 @@ std::string ContextAttributeResponse::render
   std::string tag = "contextAttributeResponse";
   std::string out = "";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += contextAttributeVector.render(apiVersion, asJsonObject, request, indent + "  ", true);
   out += statusCode.render(indent + "  ");
   out += endTag(indent);

--- a/src/lib/convenience/ContextAttributeResponseVector.cpp
+++ b/src/lib/convenience/ContextAttributeResponseVector.cpp
@@ -50,13 +50,10 @@ std::string ContextAttributeResponseVector::render
 
   if (vec.size() == 0)
   {
-    if (request == IndividualContextEntityAttributes)
-      return indent + "<contextAttributeList></contextAttributeList>\n";
-
     return "";
   }
 
-  out += startTag2(indent, key, true);
+  out += startTag(indent, key, true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     out += vec[ix]->render(apiVersion, asJsonObject, request, indent + "  ");

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -68,7 +68,7 @@ std::string RegisterProviderRequest::render(std::string indent)
   bool         commaAfterDuration             = commaAfterProvidingApplication || providingApplicationRendered;
   bool         commaAfterMetadataVector       = commaAfterDuration || durationRendered;
 
-  out += startTag(indent, "", false, false);
+  out += startTag(indent);
   out += metadataVector.render(      indent + "  ", commaAfterMetadataVector);
   out += duration.render(            indent + "  ", commaAfterDuration);
   out += providingApplication.render(indent + "  ", commaAfterProvidingApplication);

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -68,7 +68,7 @@ std::string RegisterProviderRequest::render(std::string indent)
   bool         commaAfterDuration             = commaAfterProvidingApplication || providingApplicationRendered;
   bool         commaAfterMetadataVector       = commaAfterDuration || durationRendered;
 
-  out += startTag2(indent, "", false, false);
+  out += startTag(indent, "", false, false);
   out += metadataVector.render(      indent + "  ", commaAfterMetadataVector);
   out += duration.render(            indent + "  ", commaAfterDuration);
   out += providingApplication.render(indent + "  ", commaAfterProvidingApplication);

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -43,7 +43,6 @@
 */
 UpdateContextAttributeRequest::UpdateContextAttributeRequest()
 {
-  metadataVector.keyNameSet("metadata");
   compoundValueP = NULL;
   valueType = orion::ValueTypeNone;
 }

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -61,7 +61,7 @@ std::string UpdateContextAttributeRequest::render(const std::string& apiVersion,
   std::string indent2 = indent + "  ";
   bool        commaAfterContextValue = metadataVector.size() != 0;
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += valueTag1(indent2, "type", type, true);
 
   if (compoundValueP == NULL)
@@ -77,7 +77,7 @@ std::string UpdateContextAttributeRequest::render(const std::string& apiVersion,
       isCompoundVector = true;
     }
 
-    out += startTag2(indent + "  ", "value", isCompoundVector, true);
+    out += startTag(indent + "  ", "value", isCompoundVector, true);
     out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -60,11 +60,11 @@ std::string UpdateContextAttributeRequest::render(const std::string& apiVersion,
   bool        commaAfterContextValue = metadataVector.size() != 0;
 
   out += startTag(indent);
-  out += valueTag1(indent2, "type", type, true);
+  out += valueTag(indent2, "type", type, true);
 
   if (compoundValueP == NULL)
   {
-    out += valueTag1(indent2, "contextValue", contextValue, true);
+    out += valueTag(indent2, "contextValue", contextValue, true);
   }
   else
   {

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -56,12 +56,11 @@ UpdateContextAttributeRequest::UpdateContextAttributeRequest()
 */
 std::string UpdateContextAttributeRequest::render(const std::string& apiVersion, std::string indent)
 {
-  std::string tag = "updateContextAttributeRequest";
   std::string out = "";
   std::string indent2 = indent + "  ";
   bool        commaAfterContextValue = metadataVector.size() != 0;
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += valueTag1(indent2, "type", type, true);
 
   if (compoundValueP == NULL)
@@ -77,7 +76,7 @@ std::string UpdateContextAttributeRequest::render(const std::string& apiVersion,
       isCompoundVector = true;
     }
 
-    out += startTag(indent + "  ", "value", isCompoundVector, true);
+    out += startTag(indent + "  ", "value", isCompoundVector);
     out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }

--- a/src/lib/convenience/UpdateContextElementRequest.cpp
+++ b/src/lib/convenience/UpdateContextElementRequest.cpp
@@ -44,7 +44,7 @@ std::string UpdateContextElementRequest::render(const std::string& apiVersion, b
   std::string tag = "updateContextElementRequest";
   std::string out = "";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += attributeDomainName.render(indent + "  ", true);
   out += contextAttributeVector.render(apiVersion, asJsonObject, requestType, indent + "  ");
   out += endTag(indent);

--- a/src/lib/convenience/UpdateContextElementRequest.cpp
+++ b/src/lib/convenience/UpdateContextElementRequest.cpp
@@ -41,10 +41,9 @@
 */
 std::string UpdateContextElementRequest::render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
 {
-  std::string tag = "updateContextElementRequest";
   std::string out = "";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += attributeDomainName.render(indent + "  ", true);
   out += contextAttributeVector.render(apiVersion, asJsonObject, requestType, indent + "  ");
   out += endTag(indent);

--- a/src/lib/convenience/UpdateContextElementResponse.cpp
+++ b/src/lib/convenience/UpdateContextElementResponse.cpp
@@ -58,10 +58,9 @@ std::string UpdateContextElementResponse::render
   const std::string&  indent
 )
 {
-  std::string tag = "updateContextElementResponse";
   std::string out = "";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   if ((errorCode.code != SccNone) && (errorCode.code != SccOk))
   {

--- a/src/lib/convenience/UpdateContextElementResponse.cpp
+++ b/src/lib/convenience/UpdateContextElementResponse.cpp
@@ -61,7 +61,7 @@ std::string UpdateContextElementResponse::render
   std::string tag = "updateContextElementResponse";
   std::string out = "";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   if ((errorCode.code != SccNone) && (errorCode.code != SccOk))
   {

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -66,18 +66,18 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
   if (document.HasParseError())
   {
     alarmMgr.badInput(clientIp, "JSON parse error");
-    eP->oe.fill(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
     ciP->httpStatusCode = SccBadRequest;
-    return eP->render(ciP->uriParamOptions, ciP->uriParam);
+    OrionError oe(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    return oe.toJson();
   }
 
 
   if (!document.IsObject())
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
-    eP->oe.fill(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
     ciP->httpStatusCode = SccBadRequest;
-    return eP->render(ciP->uriParamOptions, ciP->uriParam);
+    OrionError oe(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    return oe.toJson();
   }
 
 
@@ -86,10 +86,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     if (!document.HasMember("id"))
     {
       alarmMgr.badInput(clientIp, "No entity id specified");
-      eP->oe.fill(SccBadRequest, "no entity id specified", "BadRequest");
-      ciP->httpStatusCode = SccBadRequest;;
-
-      return eP->render(ciP->uriParamOptions, ciP->uriParam);
+      ciP->httpStatusCode = SccBadRequest;
+      OrionError oe(SccBadRequest, "no entity id specified", "BadRequest");
+      return oe.toJson();
     }
   }
 
@@ -99,19 +98,17 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     if (document.HasMember("id"))
     {
       alarmMgr.badInput(clientIp, "entity id specified in payload");
-      eP->oe.fill(SccBadRequest, "entity id specified in payload", "BadRequest");
-      ciP->httpStatusCode = SccBadRequest;;
-
-      return eP->render(ciP->uriParamOptions, ciP->uriParam);
+      ciP->httpStatusCode = SccBadRequest;
+      OrionError oe(SccBadRequest, "entity id specified in payload", "BadRequest");
+      return oe.toJson();
     }
 
     if (document.HasMember("type"))
     {
       alarmMgr.badInput(clientIp, "entity type specified in payload");
-      eP->oe.fill(SccBadRequest, "entity type specified in payload", "BadRequest");
-      ciP->httpStatusCode = SccBadRequest;;
-
-      return eP->render(ciP->uriParamOptions, ciP->uriParam);
+      ciP->httpStatusCode = SccBadRequest;
+      OrionError oe(SccBadRequest, "entity type specified in payload", "BadRequest");
+      return oe.toJson();
     }
   }
   else if (document.ObjectEmpty()) 
@@ -122,10 +119,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     // about crashes with small docs and "Empty()" were found on the internet, we opted to use ObjectEmpty
     //
     alarmMgr.badInput(clientIp, "Empty payload");
-    eP->oe.fill(SccBadRequest, "empty payload", "BadRequest");
     ciP->httpStatusCode = SccBadRequest;
-
-    return eP->render(ciP->uriParamOptions, ciP->uriParam);
+    OrionError oe(SccBadRequest, "empty payload", "BadRequest");
+    return oe.toJson();
   }
 
   int membersFound = 0;
@@ -143,10 +139,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         if (type != "String")
         {
           alarmMgr.badInput(clientIp, "invalid JSON type for entity id");
-          eP->oe.fill(SccBadRequest, "invalid JSON type for entity id", "BadRequest");
           ciP->httpStatusCode = SccBadRequest;;
-
-          return eP->render(ciP->uriParamOptions, ciP->uriParam);
+          OrionError oe(SccBadRequest, "invalid input, 'id' as attribute", "BadRequest");
+          return oe.toJson();
         }
 
         eP->id = iter->value.GetString();
@@ -154,10 +149,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       else  // "id" is present in payload for /v2/entities/<eid> - not a valid payload
       {
         alarmMgr.badInput(clientIp, "'id' is not a valid attribute");
-        eP->oe.fill(SccBadRequest, "invalid input, 'id' as attribute", "BadRequest");
         ciP->httpStatusCode = SccBadRequest;;
-
-        return eP->render(ciP->uriParamOptions, ciP->uriParam);
+        OrionError oe(SccBadRequest, "invalid input, 'id' as attribute", "BadRequest");
+        return oe.toJson();
       }
     }
     else if (name == "type")
@@ -165,10 +159,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       if (type != "String")
       {
         alarmMgr.badInput(clientIp, "invalid JSON type for entity type");
-        eP->oe.fill(SccBadRequest, "invalid JSON type for entity type", "BadRequest");
-        ciP->httpStatusCode = SccBadRequest;;
-
-        return eP->render(ciP->uriParamOptions, ciP->uriParam);
+        ciP->httpStatusCode = SccBadRequest;
+        OrionError oe(SccBadRequest, "invalid JSON type for entity type", "BadRequest");
+        return oe.toJson();
       }
 
       eP->type      = iter->value.GetString();
@@ -184,19 +177,19 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       if (r != "OK")
       {
         alarmMgr.badInput(clientIp, "parse error in context attribute");
-        eP->oe.fill(SccBadRequest, r, "BadRequest");
         ciP->httpStatusCode = SccBadRequest;
-
-        return eP->render(ciP->uriParamOptions, ciP->uriParam);
+        OrionError oe(SccBadRequest, r, "BadRequest");
+        return oe.toJson();
       }
     }
   }
 
   if (membersFound == 0)
   {
-    eP->oe.fill(SccBadRequest, "empty payload", "BadRequest");
+    alarmMgr.badInput(clientIp, "empty payload");
     ciP->httpStatusCode = SccBadRequest;
-    return eP->render(ciP->uriParamOptions, ciP->uriParam);
+    OrionError oe(SccBadRequest, "empty payload", "BadRequest");
+    return oe.toJson();
   }
 
   if (eidInURL == false)
@@ -204,10 +197,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     if (eP->id == "")
     {
       alarmMgr.badInput(clientIp, "empty entity id");
-      eP->oe.fill(SccBadRequest, "empty entity id", "BadRequest");
       ciP->httpStatusCode = SccBadRequest;
-
-      return eP->render(ciP->uriParamOptions, ciP->uriParam);
+      OrionError oe(SccBadRequest, "empty entity id", "BadRequest");
+      return oe.toJson();
     }
   }
 

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -140,7 +140,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         {
           alarmMgr.badInput(clientIp, "invalid JSON type for entity id");
           ciP->httpStatusCode = SccBadRequest;;
-          OrionError oe(SccBadRequest, "invalid input, 'id' as attribute", "BadRequest");
+          OrionError oe(SccBadRequest, "invalid JSON type for entity id", "BadRequest");
           return oe.toJson();
         }
 

--- a/src/lib/ngsi/AttributeDomainName.cpp
+++ b/src/lib/ngsi/AttributeDomainName.cpp
@@ -119,7 +119,7 @@ std::string AttributeDomainName::render(const std::string& indent, bool comma)
     return "";
   }
 
-  return valueTag1(indent, "attributeDomainName", string, comma);
+  return valueTag(indent, "attributeDomainName", string, comma);
 }
 
 

--- a/src/lib/ngsi/AttributeExpression.cpp
+++ b/src/lib/ngsi/AttributeExpression.cpp
@@ -117,7 +117,7 @@ std::string AttributeExpression::render(const std::string& indent, bool comma)
     return "";
   }
 
-  return valueTag1(indent, "attributeExpression", string, comma);
+  return valueTag(indent, "attributeExpression", string, comma);
 }
 
 

--- a/src/lib/ngsi/AttributeList.cpp
+++ b/src/lib/ngsi/AttributeList.cpp
@@ -78,7 +78,7 @@ std::string AttributeList::render(const std::string& indent, bool comma)
 
   for (unsigned int ix = 0; ix < attributeV.size(); ++ix)
   {
-    out += valueTag1(indent + "  ", "attribute", attributeV[ix], ix != attributeV.size() - 1, true);
+    out += valueTag(indent + "  ", "attribute", attributeV[ix], ix != attributeV.size() - 1, true);
   }
 
   out += endTag(indent, comma, true);

--- a/src/lib/ngsi/AttributeList.cpp
+++ b/src/lib/ngsi/AttributeList.cpp
@@ -75,7 +75,7 @@ std::string AttributeList::render(const std::string& indent, bool comma)
     return "";
   }
 
-  out += startTag2(indent, key, true, true);
+  out += startTag(indent, key, true, true);
 
   for (unsigned int ix = 0; ix < attributeV.size(); ++ix)
   {

--- a/src/lib/ngsi/AttributeList.cpp
+++ b/src/lib/ngsi/AttributeList.cpp
@@ -68,14 +68,13 @@ void AttributeList::fill(const std::string& commaSeparatedList)
 std::string AttributeList::render(const std::string& indent, bool comma)
 {
   std::string  out = "";
-  std::string  key = "attributes";
 
   if (attributeV.size() == 0)
   {
     return "";
   }
 
-  out += startTag(indent, key, true, true);
+  out += startTag(indent, "attributes", true);
 
   for (unsigned int ix = 0; ix < attributeV.size(); ++ix)
   {

--- a/src/lib/ngsi/ConditionValueList.cpp
+++ b/src/lib/ngsi/ConditionValueList.cpp
@@ -42,14 +42,13 @@
 std::string ConditionValueList::render(const std::string& indent, bool comma)
 {
   std::string  out = "";
-  std::string  tag = "condValueList";
 
   if (vec.size() == 0)
   {
     return "";
   }
 
-  out += startTag(indent, tag, true, true);
+  out += startTag(indent, "condValueList", true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ConditionValueList.cpp
+++ b/src/lib/ngsi/ConditionValueList.cpp
@@ -49,7 +49,7 @@ std::string ConditionValueList::render(const std::string& indent, bool comma)
     return "";
   }
 
-  out += startTag2(indent, tag, true, true);
+  out += startTag(indent, tag, true, true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ConditionValueList.cpp
+++ b/src/lib/ngsi/ConditionValueList.cpp
@@ -52,7 +52,7 @@ std::string ConditionValueList::render(const std::string& indent, bool comma)
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += valueTag2(indent + "  ", "", vec[ix], ix != vec.size() - 1);
+    out += valueTag(indent + "  ", "", vec[ix], ix != vec.size() - 1, false);
   }
 
   out += endTag(indent, comma, true);

--- a/src/lib/ngsi/ConditionValueList.cpp
+++ b/src/lib/ngsi/ConditionValueList.cpp
@@ -52,7 +52,7 @@ std::string ConditionValueList::render(const std::string& indent, bool comma)
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += valueTag(indent + "  ", "", vec[ix], ix != vec.size() - 1, false);
+    out += valueTag(indent + "  ", "", vec[ix], ix != vec.size() - 1, true);
   }
 
   out += endTag(indent, comma, true);

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -498,7 +498,7 @@ std::string ContextAttribute::renderAsJsonObject
   bool         commaAfterType         = !omitValue || commaAfterContextValue;
 
   out += startTag(indent, name, false);
-  out += valueTag1(indent + "  ", "type",         type,  commaAfterType);
+  out += valueTag(indent + "  ", "type",         type,  commaAfterType);
 
   if (compoundValueP == NULL)
   {
@@ -544,7 +544,7 @@ std::string ContextAttribute::renderAsJsonObject
       // renderAsJsonObject is used in v1 only.
       // => we only need to care about stringValue (not boolValue, numberValue nor nullValue)
       //
-      out += valueTag1(indent + "  ", "value",
+      out += valueTag(indent + "  ", "value",
                             (request != RtUpdateContextResponse)? effectiveValue : "",
                             commaAfterContextValue, false, withoutQuotes);
     }
@@ -619,8 +619,8 @@ std::string ContextAttribute::render
   }
 
   out += startTag(indent);
-  out += valueTag1(indent + "  ", "name", name,  true);  // attribute.type is always rendered
-  out += valueTag1(indent + "  ", "type", type,  commaAfterType);
+  out += valueTag(indent + "  ", "name", name,  true);  // attribute.type is always rendered
+  out += valueTag(indent + "  ", "type", type,  commaAfterType);
 
   if (compoundValueP == NULL)
   {
@@ -661,14 +661,17 @@ std::string ContextAttribute::render
         LM_E(("Runtime Error (unknown value type: %d)", valueType));
       }
 
-      out += valueTag2(indent + "  ", "value",
-                              (request != RtUpdateContextResponse)? effectiveValue : "",
-                              commaAfterContextValue, withoutQuotes);
+      out += valueTag(indent + "  ",
+                      "value",
+                      (request != RtUpdateContextResponse)? effectiveValue : "",
+                      commaAfterContextValue,
+                      false,
+                      withoutQuotes);
 
     }
     else if (request == RtUpdateContextResponse)
     {
-      out += valueTag1(indent + "  ", "value", "", commaAfterContextValue);
+      out += valueTag(indent + "  ", "value", "", commaAfterContextValue);
     }
   }
   else

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -498,7 +498,7 @@ std::string ContextAttribute::renderAsJsonObject
   bool         commaAfterContextValue = metadataVector.size() != 0;
   bool         commaAfterType         = !omitValue || commaAfterContextValue;
 
-  out += startTag2(indent, key, false, true);
+  out += startTag(indent, key, false, true);
   out += valueTag1(indent + "  ", "type",         type,  commaAfterType);
 
   if (compoundValueP == NULL)
@@ -559,7 +559,7 @@ std::string ContextAttribute::renderAsJsonObject
       isCompoundVector = true;
     }
 
-    out += startTag2(indent + "  ", "value", isCompoundVector, true);
+    out += startTag(indent + "  ", "value", isCompoundVector, true);
     out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }
@@ -622,7 +622,7 @@ std::string ContextAttribute::render
     return renderAsJsonObject(apiVersion, request, indent, comma, omitValue);
   }
 
-  out += startTag2(indent, key, false, false);
+  out += startTag(indent, key, false, false);
   out += valueTag1(indent + "  ", "name", name,  true);  // attribute.type is always rendered
   out += valueTag1(indent + "  ", "type", type,  commaAfterType);
 
@@ -684,7 +684,7 @@ std::string ContextAttribute::render
       isCompoundVector = true;
     }
 
-    out += startTag2(indent + "  ", "value", isCompoundVector, true);
+    out += startTag(indent + "  ", "value", isCompoundVector, true);
     out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -613,8 +613,6 @@ std::string ContextAttribute::render
   bool         commaAfterContextValue = metadataVector.size() != 0;
   bool         commaAfterType         = valueRendered;
 
-  metadataVector.keyNameSet("metadata");
-
   if (asJsonObject)
   {
     return renderAsJsonObject(apiVersion, request, indent, comma, omitValue);

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -494,11 +494,10 @@ std::string ContextAttribute::renderAsJsonObject
 )
 {
   std::string  out                    = "";
-  std::string  key                    = name;
   bool         commaAfterContextValue = metadataVector.size() != 0;
   bool         commaAfterType         = !omitValue || commaAfterContextValue;
 
-  out += startTag(indent, key, false, true);
+  out += startTag(indent, name, false);
   out += valueTag1(indent + "  ", "type",         type,  commaAfterType);
 
   if (compoundValueP == NULL)
@@ -559,7 +558,7 @@ std::string ContextAttribute::renderAsJsonObject
       isCompoundVector = true;
     }
 
-    out += startTag(indent + "  ", "value", isCompoundVector, true);
+    out += startTag(indent + "  ", "value", isCompoundVector);
     out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }
@@ -610,7 +609,6 @@ std::string ContextAttribute::render
 )
 {
   std::string  out                    = "";
-  std::string  key                    = "attribute";
   bool         valueRendered          = (compoundValueP != NULL) || (omitValue == false) || (request == RtUpdateContextResponse);
   bool         commaAfterContextValue = metadataVector.size() != 0;
   bool         commaAfterType         = valueRendered;
@@ -622,7 +620,7 @@ std::string ContextAttribute::render
     return renderAsJsonObject(apiVersion, request, indent, comma, omitValue);
   }
 
-  out += startTag(indent, key, false, false);
+  out += startTag(indent);
   out += valueTag1(indent + "  ", "name", name,  true);  // attribute.type is always rendered
   out += valueTag1(indent + "  ", "type", type,  commaAfterType);
 
@@ -684,7 +682,7 @@ std::string ContextAttribute::render
       isCompoundVector = true;
     }
 
-    out += startTag(indent + "  ", "value", isCompoundVector, true);
+    out += startTag(indent + "  ", "value", isCompoundVector);
     out += compoundValueP->render(apiVersion, indent + "    ");
     out += endTag(indent + "  ", commaAfterContextValue, isCompoundVector);
   }

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -300,7 +300,6 @@ std::string ContextAttributeVector::render
 )
 {
   std::string out = "";
-  std::string key = "attributes";
 
   if (vec.size() == 0)
   {
@@ -339,7 +338,7 @@ std::string ContextAttributeVector::render
     // 2. Now it's time to render
     // Note that in the case of attribute as name, we have to use a vector, thus using
     // attrsAsName variable as value for isVector parameter
-    out += startTag(indent, key, attrsAsName, true);
+    out += startTag(indent, "attributes", attrsAsName);
     for (unsigned int ix = 0; ix < vec.size(); ++ix)
     {
       if (attrsAsName)
@@ -355,7 +354,7 @@ std::string ContextAttributeVector::render
   }
   else
   {
-    out += startTag(indent, key, true, true);
+    out += startTag(indent, "attributes", true);
     for (unsigned int ix = 0; ix < vec.size(); ++ix)
     {
       if (attrsAsName)

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -339,7 +339,7 @@ std::string ContextAttributeVector::render
     // 2. Now it's time to render
     // Note that in the case of attribute as name, we have to use a vector, thus using
     // attrsAsName variable as value for isVector parameter
-    out += startTag2(indent, key, attrsAsName, true);
+    out += startTag(indent, key, attrsAsName, true);
     for (unsigned int ix = 0; ix < vec.size(); ++ix)
     {
       if (attrsAsName)
@@ -355,7 +355,7 @@ std::string ContextAttributeVector::render
   }
   else
   {
-    out += startTag2(indent, key, true, true);
+    out += startTag(indent, key, true, true);
     for (unsigned int ix = 0; ix < vec.size(); ++ix)
     {
       if (attrsAsName)

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -89,11 +89,11 @@ std::string ContextElement::render(const std::string& apiVersion, bool asJsonObj
 
   if (requestType == UpdateContext)
   {
-    out += startTag2(indent, key, false, false);
+    out += startTag(indent, key, false, false);
   }
   else
   {
-    out += startTag2(indent, key, false, true);
+    out += startTag(indent, key, false, true);
   }
 
   out += entityId.render(indent + "  ", commaAfterEntityId, false);

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -77,7 +77,6 @@ ContextElement::ContextElement(const std::string& id, const std::string& type, c
 std::string ContextElement::render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues)
 {
   std::string  out                              = "";
-  std::string  key                              = "contextElement";
   bool         attributeDomainNameRendered      = attributeDomainName.get() != "";
   bool         contextAttributeVectorRendered   = contextAttributeVector.size() != 0;
   bool         domainMetadataVectorRendered     = domainMetadataVector.size() != 0;
@@ -87,14 +86,7 @@ std::string ContextElement::render(const std::string& apiVersion, bool asJsonObj
   bool         commaAfterAttributeDomainName    = domainMetadataVectorRendered  || contextAttributeVectorRendered;
   bool         commaAfterEntityId               = commaAfterAttributeDomainName || attributeDomainNameRendered;
 
-  if (requestType == UpdateContext)
-  {
-    out += startTag(indent, key, false, false);
-  }
-  else
-  {
-    out += startTag(indent, key, false, true);
-  }
+  out += startTag(indent, requestType != UpdateContext? "contextElement" : "");
 
   out += entityId.render(indent + "  ", commaAfterEntityId, false);
   out += attributeDomainName.render(indent + "  ", commaAfterAttributeDomainName);

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -335,7 +335,7 @@ std::string ContextElementResponse::render
   std::string key = "contextElement";
   std::string out = "";
 
-  out += startTag2(indent, key, false, false);
+  out += startTag(indent, key, false, false);
   out += contextElement.render(apiVersion, asJsonObject, requestType, indent + "  ", true, omitAttributeValues);
   out += statusCode.render(indent + "  ", false);
   out += endTag(indent, comma, false);

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -332,10 +332,9 @@ std::string ContextElementResponse::render
   bool                omitAttributeValues
 )
 {
-  std::string key = "contextElement";
   std::string out = "";
 
-  out += startTag(indent, key, false, false);
+  out += startTag(indent);
   out += contextElement.render(apiVersion, asJsonObject, requestType, indent + "  ", true, omitAttributeValues);
   out += statusCode.render(indent + "  ", false);
   out += endTag(indent, comma, false);

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -50,7 +50,6 @@ std::string ContextElementResponseVector::render
   bool                omitAttributeValues
 )
 {
-  std::string key = "contextResponses";
   std::string out = "";
 
   if (vec.size() == 0)
@@ -58,7 +57,7 @@ std::string ContextElementResponseVector::render
     return "";
   }
 
-  out += startTag(indent, key, true, true);
+  out += startTag(indent, "contextResponses", true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -58,7 +58,7 @@ std::string ContextElementResponseVector::render
     return "";
   }
 
-  out += startTag2(indent, key, true, true);
+  out += startTag(indent, key, true, true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextElementVector.cpp
+++ b/src/lib/ngsi/ContextElementVector.cpp
@@ -66,7 +66,7 @@ std::string ContextElementVector::render
     return "";
   }
 
-  out += startTag2(indent, key, true, true);
+  out += startTag(indent, key, true, true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextElementVector.cpp
+++ b/src/lib/ngsi/ContextElementVector.cpp
@@ -59,14 +59,13 @@ std::string ContextElementVector::render
 )
 {
   std::string  out = "";
-  std::string  key = "contextElements";
 
   if (vec.size() == 0)
   {
     return "";
   }
 
-  out += startTag(indent, key, true, true);
+  out += startTag(indent, "contextElements", true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextRegistration.cpp
+++ b/src/lib/ngsi/ContextRegistration.cpp
@@ -54,7 +54,6 @@ ContextRegistration::ContextRegistration()
 std::string ContextRegistration::render(const std::string& indent, bool comma, bool isInVector)
 {
   std::string out = "";
-  std::string tag = "contextRegistration";
 
   //
   // About JSON commas;
@@ -62,7 +61,8 @@ std::string ContextRegistration::render(const std::string& indent, bool comma, b
   // the problem with the JSON commas disappear. All fields will have 'comma set to true'.
   // All, except providingApplication of course :-)
   //
-  out += startTag(indent, tag, false, isInVector == false);
+
+  out += startTag(indent, !isInVector? "contextRegistration" : "");
   out += entityIdVector.render(indent + "  ", true);
   out += contextRegistrationAttributeVector.render(indent + "  ", true);
   out += registrationMetadataVector.render(indent + "  ", true);

--- a/src/lib/ngsi/ContextRegistration.cpp
+++ b/src/lib/ngsi/ContextRegistration.cpp
@@ -62,7 +62,7 @@ std::string ContextRegistration::render(const std::string& indent, bool comma, b
   // the problem with the JSON commas disappear. All fields will have 'comma set to true'.
   // All, except providingApplication of course :-)
   //
-  out += startTag1(indent, tag, isInVector == false);
+  out += startTag(indent, tag, false, isInVector == false);
   out += entityIdVector.render(indent + "  ", true);
   out += contextRegistrationAttributeVector.render(indent + "  ", true);
   out += registrationMetadataVector.render(indent + "  ", true);

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -69,7 +69,6 @@ ContextRegistrationAttribute::ContextRegistrationAttribute
 */
 std::string ContextRegistrationAttribute::render(const std::string& indent, bool comma)
 {
-  std::string key = "registrationAttribute";
   std::string out = "";
 
   metadataVector.keyNameSet("metadata");
@@ -81,7 +80,7 @@ std::string ContextRegistrationAttribute::render(const std::string& indent, bool
   // The only doubt here is whether isDomain should have the comma or not,
   // that depends on whether the metadataVector is empty or not.
   //
-  out += startTag(indent, key, false, false);
+  out += startTag(indent);
   out += valueTag1(indent + "  ", "name",     name, true);
   out += valueTag1(indent + "  ", "type",     type, true);
   out += valueTag1(indent + "  ", "isDomain", isDomain, metadataVector.size() != 0);

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -81,7 +81,7 @@ std::string ContextRegistrationAttribute::render(const std::string& indent, bool
   // The only doubt here is whether isDomain should have the comma or not,
   // that depends on whether the metadataVector is empty or not.
   //
-  out += startTag2(indent, key, false, false);
+  out += startTag(indent, key, false, false);
   out += valueTag1(indent + "  ", "name",     name, true);
   out += valueTag1(indent + "  ", "type",     type, true);
   out += valueTag1(indent + "  ", "isDomain", isDomain, metadataVector.size() != 0);

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -79,9 +79,9 @@ std::string ContextRegistrationAttribute::render(const std::string& indent, bool
   // that depends on whether the metadataVector is empty or not.
   //
   out += startTag(indent);
-  out += valueTag1(indent + "  ", "name",     name, true);
-  out += valueTag1(indent + "  ", "type",     type, true);
-  out += valueTag1(indent + "  ", "isDomain", isDomain, metadataVector.size() != 0);
+  out += valueTag(indent + "  ", "name",     name, true);
+  out += valueTag(indent + "  ", "type",     type, true);
+  out += valueTag(indent + "  ", "isDomain", isDomain, metadataVector.size() != 0);
   out += metadataVector.render(indent + "  ");
   out += endTag(indent, comma);
 

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -71,8 +71,6 @@ std::string ContextRegistrationAttribute::render(const std::string& indent, bool
 {
   std::string out = "";
 
-  metadataVector.keyNameSet("metadata");
-
   //
   // About JSON commas:
   // The field isDomain is mandatory, so all field before that will

--- a/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
@@ -41,8 +41,6 @@
 */
 std::string ContextRegistrationAttributeVector::render(const std::string& indent, bool comma)
 {
-
-  std::string key = "attributes";
   std::string out = "";
 
   if (vec.size() == 0)
@@ -50,7 +48,7 @@ std::string ContextRegistrationAttributeVector::render(const std::string& indent
     return "";
   }
 
-  out += startTag(indent, key, true, true);
+  out += startTag(indent, "attributes", true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     out += vec[ix]->render(indent + "  ", ix != vec.size() - 1);

--- a/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
@@ -50,7 +50,7 @@ std::string ContextRegistrationAttributeVector::render(const std::string& indent
     return "";
   }
 
-  out += startTag2(indent, key, true, true);
+  out += startTag(indent, key, true, true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     out += vec[ix]->render(indent + "  ", ix != vec.size() - 1);

--- a/src/lib/ngsi/ContextRegistrationResponse.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponse.cpp
@@ -48,11 +48,10 @@ ContextRegistrationResponse::ContextRegistrationResponse()
 */
 std::string ContextRegistrationResponse::render(const std::string& indent, bool comma)
 {
-  std::string  key               = "contextRegistration";
   std::string  out               = "";
   bool         errorCodeRendered = errorCode.code != SccNone;
 
-  out += startTag(indent, key, false, false);
+  out += startTag(indent);
 
   out += contextRegistration.render(indent + "  ", errorCodeRendered, false);
 

--- a/src/lib/ngsi/ContextRegistrationResponse.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponse.cpp
@@ -52,7 +52,7 @@ std::string ContextRegistrationResponse::render(const std::string& indent, bool 
   std::string  out               = "";
   bool         errorCodeRendered = errorCode.code != SccNone;
 
-  out += startTag2(indent, key, false, false);
+  out += startTag(indent, key, false, false);
 
   out += contextRegistration.render(indent + "  ", errorCodeRendered, false);
 

--- a/src/lib/ngsi/ContextRegistrationResponseVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponseVector.cpp
@@ -52,14 +52,13 @@ void ContextRegistrationResponseVector::push_back(ContextRegistrationResponse* i
 std::string ContextRegistrationResponseVector::render(const std::string& indent, bool comma)
 {
   std::string  out = "";
-  std::string  key = "contextRegistrationResponses";
 
   if (vec.size() == 0)
   {
     return "";
   }
 
-  out += startTag(indent, key, true, true);
+  out += startTag(indent, "contextRegistrationResponses", true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextRegistrationResponseVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponseVector.cpp
@@ -59,7 +59,7 @@ std::string ContextRegistrationResponseVector::render(const std::string& indent,
     return "";
   }
 
-  out += startTag2(indent, key, true, true);
+  out += startTag(indent, key, true, true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextRegistrationVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationVector.cpp
@@ -59,7 +59,7 @@ std::string ContextRegistrationVector::render(const std::string& indent, bool co
     return "";
   }
 
-  out += startTag2(indent, key, true, true);
+  out += startTag(indent, key, true, true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextRegistrationVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationVector.cpp
@@ -52,14 +52,13 @@ void ContextRegistrationVector::push_back(ContextRegistration* item)
 std::string ContextRegistrationVector::render(const std::string& indent, bool comma)
 {
   std::string  out = "";
-  std::string  key = "contextRegistrations";
 
   if (vec.size() == 0)
   {
     return "";
   }
 
-  out += startTag(indent, key, true, true);
+  out += startTag(indent, "contextRegistrations", true);
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/Duration.cpp
+++ b/src/lib/ngsi/Duration.cpp
@@ -174,7 +174,7 @@ std::string Duration::render(const std::string& indent, bool comma)
     return "";
   }
 
-  return valueTag1(indent, "duration", string, comma);
+  return valueTag(indent, "duration", string, comma);
 }
 
 

--- a/src/lib/ngsi/EntityIdVector.cpp
+++ b/src/lib/ngsi/EntityIdVector.cpp
@@ -46,14 +46,13 @@
 std::string EntityIdVector::render(const std::string& indent, bool comma)
 {
   std::string out = "";
-  std::string key = "entities";
 
   if (vec.size() == 0)
   {
     return "";
   }
 
-  out += startTag(indent, key, true, true);
+  out += startTag(indent, "entities", true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     out += vec[ix]->render(indent + "  ", ix != vec.size() - 1, true);

--- a/src/lib/ngsi/EntityIdVector.cpp
+++ b/src/lib/ngsi/EntityIdVector.cpp
@@ -53,7 +53,7 @@ std::string EntityIdVector::render(const std::string& indent, bool comma)
     return "";
   }
 
-  out += startTag2(indent, key, true, true);
+  out += startTag(indent, key, true, true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     out += vec[ix]->render(indent + "  ", ix != vec.size() - 1, true);

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -231,12 +231,12 @@ std::string Metadata::render(const std::string& indent, bool comma)
   std::string xValue  = toStringValue();
 
   out += startTag(indent);
-  out += valueTag1(indent + "  ", "name", name, true);
-  out += valueTag1(indent + "  ", "type", type, true);
+  out += valueTag(indent + "  ", "name", name, true);
+  out += valueTag(indent + "  ", "type", type, true);
 
   if (valueType == orion::ValueTypeString)
   {
-    out += valueTag1(indent + "  ", "value", xValue, false);
+    out += valueTag(indent + "  ", "value", xValue, false);
   }
   else if (valueType == orion::ValueTypeNumber)
   {

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -231,7 +231,7 @@ std::string Metadata::render(const std::string& indent, bool comma)
   std::string tag     = "contextMetadata";
   std::string xValue  = toStringValue();
 
-  out += startTag2(indent, tag, false, false);
+  out += startTag(indent, tag, false, false);
   out += valueTag1(indent + "  ", "name", name, true);
   out += valueTag1(indent + "  ", "type", type, true);
 

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -228,10 +228,9 @@ Metadata::Metadata(const std::string& _name, const BSONObj& mdB)
 std::string Metadata::render(const std::string& indent, bool comma)
 {
   std::string out     = "";
-  std::string tag     = "contextMetadata";
   std::string xValue  = toStringValue();
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += valueTag1(indent + "  ", "name", name, true);
   out += valueTag1(indent + "  ", "type", type, true);
 

--- a/src/lib/ngsi/MetadataVector.cpp
+++ b/src/lib/ngsi/MetadataVector.cpp
@@ -39,21 +39,9 @@
 *
 * MetadataVector::MetadataVector -
 */
-MetadataVector::MetadataVector(const std::string& _keyName)
+MetadataVector::MetadataVector(void)
 {
   vec.clear();
-  keyNameSet(_keyName);
-}
-
-
-
-/* ****************************************************************************
-*
-* MetadataVector::keyNameSet -
-*/
-void MetadataVector::keyNameSet(const std::string& _keyName)
-{
-  keyName = _keyName;
 }
 
 
@@ -65,14 +53,13 @@ void MetadataVector::keyNameSet(const std::string& _keyName)
 std::string MetadataVector::render(const std::string& indent, bool comma)
 {
   std::string out = "";
-  std::string key = "metadatas";
 
   if (vec.size() == 0)
   {
     return "";
   }
 
-  out += startTag(indent, key, true);
+  out += startTag(indent, "metadatas", true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     out += vec[ix]->render(indent + "  ", ix != vec.size() - 1);

--- a/src/lib/ngsi/MetadataVector.cpp
+++ b/src/lib/ngsi/MetadataVector.cpp
@@ -72,7 +72,7 @@ std::string MetadataVector::render(const std::string& indent, bool comma)
     return "";
   }
 
-  out += startTag2(indent, key, true);
+  out += startTag(indent, key, true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     out += vec[ix]->render(indent + "  ", ix != vec.size() - 1);

--- a/src/lib/ngsi/MetadataVector.h
+++ b/src/lib/ngsi/MetadataVector.h
@@ -41,11 +41,8 @@ typedef struct MetadataVector
 public:
   std::vector<Metadata*>  vec;
 
-  std::string             keyName;        // Help variable for the 'render' method
+  MetadataVector(void);
 
-  MetadataVector(const std::string& _keyName = "registrationMetadata");
-
-  void            keyNameSet(const std::string& key);
   std::string     render(const std::string& indent, bool comma = false);
   std::string     toJson(bool                             isLastElement,
                          const std::vector<std::string>&  metadataFilter);

--- a/src/lib/ngsi/NotifyCondition.cpp
+++ b/src/lib/ngsi/NotifyCondition.cpp
@@ -74,7 +74,7 @@ std::string NotifyCondition::render(const std::string& indent, bool notLastInVec
   bool commaAfterCondValueList = restrictionRendered;
   bool commaAfterType          = condValueListRendered || restrictionRendered;
 
-  out += startTag2(indent, tag, false, false);
+  out += startTag(indent, tag, false, false);
   out += valueTag1(indent + "  ", "type", type, commaAfterType);
   out += condValueList.render(indent + "  ",   commaAfterCondValueList);
   out += restriction.render(  indent + "  ",   commaAfterRestriction);

--- a/src/lib/ngsi/NotifyCondition.cpp
+++ b/src/lib/ngsi/NotifyCondition.cpp
@@ -74,7 +74,7 @@ std::string NotifyCondition::render(const std::string& indent, bool notLastInVec
   bool commaAfterType          = condValueListRendered || restrictionRendered;
 
   out += startTag(indent);
-  out += valueTag1(indent + "  ", "type", type, commaAfterType);
+  out += valueTag(indent + "  ", "type", type, commaAfterType);
   out += condValueList.render(indent + "  ",   commaAfterCondValueList);
   out += restriction.render(  indent + "  ",   commaAfterRestriction);
   out += endTag(indent);

--- a/src/lib/ngsi/NotifyCondition.cpp
+++ b/src/lib/ngsi/NotifyCondition.cpp
@@ -66,7 +66,6 @@ NotifyCondition::NotifyCondition(NotifyCondition* ncP)
 std::string NotifyCondition::render(const std::string& indent, bool notLastInVector)
 {
   std::string out = "";
-  std::string tag = "notifyCondition";
 
   bool condValueListRendered   = condValueList.size() != 0;
   bool restrictionRendered     = restriction.get() != "";
@@ -74,7 +73,7 @@ std::string NotifyCondition::render(const std::string& indent, bool notLastInVec
   bool commaAfterCondValueList = restrictionRendered;
   bool commaAfterType          = condValueListRendered || restrictionRendered;
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += valueTag1(indent + "  ", "type", type, commaAfterType);
   out += condValueList.render(indent + "  ",   commaAfterCondValueList);
   out += restriction.render(  indent + "  ",   commaAfterRestriction);

--- a/src/lib/ngsi/NotifyConditionVector.cpp
+++ b/src/lib/ngsi/NotifyConditionVector.cpp
@@ -59,7 +59,7 @@ std::string NotifyConditionVector::render(const std::string& indent, bool comma)
     return "";
   }
 
-  out += startTag2(indent, tag, true, true);
+  out += startTag(indent, tag, true, true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     out += vec[ix]->render(indent + "  ", ix != vec.size() - 1);

--- a/src/lib/ngsi/NotifyConditionVector.cpp
+++ b/src/lib/ngsi/NotifyConditionVector.cpp
@@ -52,14 +52,13 @@ NotifyConditionVector::NotifyConditionVector()
 std::string NotifyConditionVector::render(const std::string& indent, bool comma)
 {
   std::string out = "";
-  std::string tag = "notifyConditions";
 
   if (vec.size() == 0)
   {
     return "";
   }
 
-  out += startTag(indent, tag, true, true);
+  out += startTag(indent, "notifyConditions", true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     out += vec[ix]->render(indent + "  ", ix != vec.size() - 1);

--- a/src/lib/ngsi/Originator.cpp
+++ b/src/lib/ngsi/Originator.cpp
@@ -115,7 +115,7 @@ std::string Originator::render(const std::string& indent, bool comma)
     return "";
   }
 
-  return valueTag1(indent, "originator", string, comma);
+  return valueTag(indent, "originator", string, comma);
 }
 
 

--- a/src/lib/ngsi/ProvidingApplication.cpp
+++ b/src/lib/ngsi/ProvidingApplication.cpp
@@ -155,7 +155,7 @@ std::string ProvidingApplication::render(const std::string& indent, bool comma)
     return "";
   }
 
-  return valueTag1(indent, "providingApplication", string, comma);
+  return valueTag(indent, "providingApplication", string, comma);
 }
 
 

--- a/src/lib/ngsi/Reference.cpp
+++ b/src/lib/ngsi/Reference.cpp
@@ -135,7 +135,7 @@ std::string Reference::render(const std::string& indent, bool comma)
     return "";
   }
 
-  return valueTag1(indent, "reference", string, comma);
+  return valueTag(indent, "reference", string, comma);
 }
 
 

--- a/src/lib/ngsi/RegistrationId.cpp
+++ b/src/lib/ngsi/RegistrationId.cpp
@@ -131,7 +131,7 @@ std::string RegistrationId::render(RequestType requestType, const std::string& i
     }
   }
 
-  return valueTag1(indent, "registrationId", string, comma);
+  return valueTag(indent, "registrationId", string, comma);
 }
 
 

--- a/src/lib/ngsi/Restriction.cpp
+++ b/src/lib/ngsi/Restriction.cpp
@@ -104,7 +104,7 @@ std::string Restriction::render(const std::string& indent, int restrictions, boo
     return "";
   }
 
-  out += startTag1(indent, tag);
+  out += startTag(indent, tag, false);
   out += attributeExpression.render(indent + "  ", scopeVectorRendered);
   out += scopeVector.render(indent + "  ", false);
   out += endTag(indent, comma);

--- a/src/lib/ngsi/Restriction.cpp
+++ b/src/lib/ngsi/Restriction.cpp
@@ -104,7 +104,7 @@ std::string Restriction::render(const std::string& indent, int restrictions, boo
     return "";
   }
 
-  out += startTag(indent, tag, false);
+  out += startTag(indent, tag);
   out += attributeExpression.render(indent + "  ", scopeVectorRendered);
   out += scopeVector.render(indent + "  ", false);
   out += endTag(indent, comma);

--- a/src/lib/ngsi/RestrictionString.cpp
+++ b/src/lib/ngsi/RestrictionString.cpp
@@ -115,7 +115,7 @@ std::string RestrictionString::render(const std::string& indent, bool comma)
     return "";
   }
 
-  return valueTag1(indent, "restriction", string, comma);
+  return valueTag(indent, "restriction", string, comma);
 }
 
 

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -389,11 +389,10 @@ int Scope::fill
 std::string Scope::render(const std::string& indent, bool notLastInVector)
 {
   std::string out      = "";
-  std::string tag      = "operationScope";
   const char* tTag     = "type";
   const char* vTag     = "value";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += valueTag1(indent + "  ", tTag, type, true);
   out += valueTag1(indent + "  ", vTag, value);
   out += endTag(indent, notLastInVector);

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -393,7 +393,7 @@ std::string Scope::render(const std::string& indent, bool notLastInVector)
   const char* tTag     = "type";
   const char* vTag     = "value";
 
-  out += startTag2(indent, tag, false, false);
+  out += startTag(indent, tag, false, false);
   out += valueTag1(indent + "  ", tTag, type, true);
   out += valueTag1(indent + "  ", vTag, value);
   out += endTag(indent, notLastInVector);

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -393,8 +393,8 @@ std::string Scope::render(const std::string& indent, bool notLastInVector)
   const char* vTag     = "value";
 
   out += startTag(indent);
-  out += valueTag1(indent + "  ", tTag, type, true);
-  out += valueTag1(indent + "  ", vTag, value);
+  out += valueTag(indent + "  ", tTag, type, true);
+  out += valueTag(indent + "  ", vTag, value);
   out += endTag(indent, notLastInVector);
 
   return out;

--- a/src/lib/ngsi/ScopeVector.cpp
+++ b/src/lib/ngsi/ScopeVector.cpp
@@ -51,7 +51,7 @@ std::string ScopeVector::render(const std::string& indent, bool comma)
     return "";
   }
 
-  out += startTag2(indent, tag, true, true);
+  out += startTag(indent, tag, true, true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
      out += vec[ix]->render(indent + "  ", ix != vec.size() - 1);

--- a/src/lib/ngsi/ScopeVector.cpp
+++ b/src/lib/ngsi/ScopeVector.cpp
@@ -44,14 +44,13 @@
 std::string ScopeVector::render(const std::string& indent, bool comma)
 {
   std::string out = "";
-  std::string tag = "scope";
 
   if (vec.size() == 0)
   {
     return "";
   }
 
-  out += startTag(indent, tag, true, true);
+  out += startTag(indent, "scope", true);
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
      out += vec[ix]->render(indent + "  ", ix != vec.size() - 1);

--- a/src/lib/ngsi/StatusCode.cpp
+++ b/src/lib/ngsi/StatusCode.cpp
@@ -107,7 +107,7 @@ std::string StatusCode::render(const std::string& indent, bool comma, bool showK
     details += " - ZERO code set to 500";
   }
 
-  out += startTag(indent, keyName, false, showKey);
+  out += startTag(indent, showKey? keyName : "");
   out += valueTag(indent + "  ", "code", code, true);
   out += valueTag1(indent + "  ", "reasonPhrase", reasonPhrase, details != "");
 

--- a/src/lib/ngsi/StatusCode.cpp
+++ b/src/lib/ngsi/StatusCode.cpp
@@ -109,11 +109,11 @@ std::string StatusCode::render(const std::string& indent, bool comma, bool showK
 
   out += startTag(indent, showKey? keyName : "");
   out += valueTag(indent + "  ", "code", code, true);
-  out += valueTag1(indent + "  ", "reasonPhrase", reasonPhrase, details != "");
+  out += valueTag(indent + "  ", "reasonPhrase", reasonPhrase, details != "");
 
   if (details != "")
   {
-    out += valueTag1(indent + "  ", "details", details, false);
+    out += valueTag(indent + "  ", "details", details, false);
   }
 
   out += endTag(indent, comma);

--- a/src/lib/ngsi/StatusCode.cpp
+++ b/src/lib/ngsi/StatusCode.cpp
@@ -107,7 +107,7 @@ std::string StatusCode::render(const std::string& indent, bool comma, bool showK
     details += " - ZERO code set to 500";
   }
 
-  out += startTag1(indent, keyName, showKey);
+  out += startTag(indent, keyName, false, showKey);
   out += valueTag(indent + "  ", "code", code, true);
   out += valueTag1(indent + "  ", "reasonPhrase", reasonPhrase, details != "");
 

--- a/src/lib/ngsi/SubscribeError.cpp
+++ b/src/lib/ngsi/SubscribeError.cpp
@@ -51,7 +51,7 @@ std::string SubscribeError::render(RequestType requestType, const std::string& i
   std::string out = "";
   std::string tag = "subscribeError";
 
-  out += startTag1(indent, tag, true);
+  out += startTag(indent, tag, false, true);
 
   // subscriptionId is Mandatory if part of updateContextSubscriptionResponse
   // errorCode is Mandatory so, the JSON comma is always TRUE

--- a/src/lib/ngsi/SubscribeError.cpp
+++ b/src/lib/ngsi/SubscribeError.cpp
@@ -49,9 +49,8 @@ SubscribeError::SubscribeError()
 std::string SubscribeError::render(RequestType requestType, const std::string& indent, bool comma)
 {
   std::string out = "";
-  std::string tag = "subscribeError";
 
-  out += startTag(indent, tag, false, true);
+  out += startTag(indent, "subscribeError", false);
 
   // subscriptionId is Mandatory if part of updateContextSubscriptionResponse
   // errorCode is Mandatory so, the JSON comma is always TRUE

--- a/src/lib/ngsi/SubscribeResponse.cpp
+++ b/src/lib/ngsi/SubscribeResponse.cpp
@@ -51,7 +51,7 @@ std::string SubscribeResponse::render(const std::string& indent, bool comma)
   bool         durationRendered    = !duration.isEmpty();
   bool         throttlingRendered  = !throttling.isEmpty();
 
-  out += startTag1(indent, tag);
+  out += startTag(indent, tag, false);
   out += subscriptionId.render(RtSubscribeResponse, indent + "  ", durationRendered || throttlingRendered);
   out += duration.render(indent + "  ", throttlingRendered);
   out += throttling.render(indent + "  ", false);

--- a/src/lib/ngsi/SubscribeResponse.cpp
+++ b/src/lib/ngsi/SubscribeResponse.cpp
@@ -51,7 +51,7 @@ std::string SubscribeResponse::render(const std::string& indent, bool comma)
   bool         durationRendered    = !duration.isEmpty();
   bool         throttlingRendered  = !throttling.isEmpty();
 
-  out += startTag(indent, tag, false);
+  out += startTag(indent, tag);
   out += subscriptionId.render(RtSubscribeResponse, indent + "  ", durationRendered || throttlingRendered);
   out += duration.render(indent + "  ", throttlingRendered);
   out += throttling.render(indent + "  ", false);

--- a/src/lib/ngsi/SubscriptionId.cpp
+++ b/src/lib/ngsi/SubscriptionId.cpp
@@ -164,7 +164,7 @@ std::string SubscriptionId::render(RequestType container, const std::string& ind
     }
   }
 
-  return valueTag1(indent, "subscriptionId", xString, comma);
+  return valueTag(indent, "subscriptionId", xString, comma);
 }
 
 

--- a/src/lib/ngsi/Throttling.cpp
+++ b/src/lib/ngsi/Throttling.cpp
@@ -139,5 +139,5 @@ std::string Throttling::render(const std::string& indent, bool comma)
     return "";
   }
 
-  return valueTag1(indent, "throttling", string, comma);
+  return valueTag(indent, "throttling", string, comma);
 }

--- a/src/lib/ngsi/UpdateActionType.cpp
+++ b/src/lib/ngsi/UpdateActionType.cpp
@@ -123,7 +123,7 @@ std::string UpdateActionType::render(const std::string& indent, bool comma)
     return "";
   }
 
-  return valueTag1(indent, "updateAction", string, comma);
+  return valueTag(indent, "updateAction", string, comma);
 }
 
 

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -50,7 +50,7 @@ std::string NotifyContextRequest::render(const std::string& apiVersion, bool asJ
   //   The only doubt here if whether originator should end in a comma.
   //   This doubt is taken care of by the variable 'contextElementResponseVectorRendered'
   //
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += subscriptionId.render(NotifyContext, indent + "  ", true);
   out += originator.render(indent  + "  ", contextElementResponseVectorRendered);
   out += contextElementResponseVector.render(apiVersion, asJsonObject, NotifyContext, indent  + "  ", false);

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -41,7 +41,6 @@
 std::string NotifyContextRequest::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out                                  = "";
-  std::string  tag                                  = "notifyContextRequest";
   bool         contextElementResponseVectorRendered = contextElementResponseVector.size() != 0;
 
   //
@@ -50,7 +49,7 @@ std::string NotifyContextRequest::render(const std::string& apiVersion, bool asJ
   //   The only doubt here if whether originator should end in a comma.
   //   This doubt is taken care of by the variable 'contextElementResponseVectorRendered'
   //
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += subscriptionId.render(NotifyContext, indent + "  ", true);
   out += originator.render(indent  + "  ", contextElementResponseVectorRendered);
   out += contextElementResponseVector.render(apiVersion, asJsonObject, NotifyContext, indent  + "  ", false);

--- a/src/lib/ngsi10/NotifyContextResponse.cpp
+++ b/src/lib/ngsi10/NotifyContextResponse.cpp
@@ -65,11 +65,10 @@ NotifyContextResponse::NotifyContextResponse(StatusCode& sc)
 std::string NotifyContextResponse::render(const std::string& indent)
 {
   std::string out = "";
-  std::string tag = "notifyContextResponse";
 
   responseCode.keyNameSet("responseCode");
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += responseCode.render(indent + "  ");
   out += endTag(indent);
 

--- a/src/lib/ngsi10/NotifyContextResponse.cpp
+++ b/src/lib/ngsi10/NotifyContextResponse.cpp
@@ -69,7 +69,7 @@ std::string NotifyContextResponse::render(const std::string& indent)
 
   responseCode.keyNameSet("responseCode");
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += responseCode.render(indent + "  ");
   out += endTag(indent);
 

--- a/src/lib/ngsi10/QueryContextRequest.cpp
+++ b/src/lib/ngsi10/QueryContextRequest.cpp
@@ -103,7 +103,7 @@ std::string QueryContextRequest::render(const std::string& indent)
   bool          commaAfterAttributeList  = restrictionRendered;
   bool          commaAfterEntityIdVector = attributeListRendered || restrictionRendered;
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += entityIdVector.render(indent + "  ", commaAfterEntityIdVector);
   out += attributeList.render( indent + "  ", commaAfterAttributeList);
   out += restriction.render(   indent + "  ", restrictions, false);

--- a/src/lib/ngsi10/QueryContextRequest.cpp
+++ b/src/lib/ngsi10/QueryContextRequest.cpp
@@ -97,13 +97,12 @@ QueryContextRequest::QueryContextRequest(const std::string& _contextProvider, En
 std::string QueryContextRequest::render(const std::string& indent)
 {
   std::string   out                      = "";
-  std::string   tag                      = "queryContextRequest";
   bool          attributeListRendered    = attributeList.size() != 0;
   bool          restrictionRendered      = restrictions != 0;
   bool          commaAfterAttributeList  = restrictionRendered;
   bool          commaAfterEntityIdVector = attributeListRendered || restrictionRendered;
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += entityIdVector.render(indent + "  ", commaAfterEntityIdVector);
   out += attributeList.render( indent + "  ", commaAfterAttributeList);
   out += restriction.render(   indent + "  ", restrictions, false);

--- a/src/lib/ngsi10/QueryContextResponse.cpp
+++ b/src/lib/ngsi10/QueryContextResponse.cpp
@@ -97,7 +97,6 @@ QueryContextResponse::~QueryContextResponse()
 std::string QueryContextResponse::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out               = "";
-  std::string  tag               = "queryContextResponse";
   bool         errorCodeRendered = false;
   
   //
@@ -125,7 +124,7 @@ std::string QueryContextResponse::render(const std::string& apiVersion, bool asJ
   //
   // 02. render 
   //
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   if (contextElementResponseVector.size() > 0)
   {

--- a/src/lib/ngsi10/QueryContextResponse.cpp
+++ b/src/lib/ngsi10/QueryContextResponse.cpp
@@ -125,7 +125,7 @@ std::string QueryContextResponse::render(const std::string& apiVersion, bool asJ
   //
   // 02. render 
   //
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   if (contextElementResponseVector.size() > 0)
   {

--- a/src/lib/ngsi10/SubscribeContextResponse.cpp
+++ b/src/lib/ngsi10/SubscribeContextResponse.cpp
@@ -65,9 +65,8 @@ SubscribeContextResponse::SubscribeContextResponse(StatusCode& errorCode)
 std::string SubscribeContextResponse::render(const std::string& indent)
 {
   std::string out     = "";
-  std::string tag     = "subscribeContextResponse";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   if (subscribeError.errorCode.code == SccNone)
   {

--- a/src/lib/ngsi10/SubscribeContextResponse.cpp
+++ b/src/lib/ngsi10/SubscribeContextResponse.cpp
@@ -67,7 +67,7 @@ std::string SubscribeContextResponse::render(const std::string& indent)
   std::string out     = "";
   std::string tag     = "subscribeContextResponse";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   if (subscribeError.errorCode.code == SccNone)
   {

--- a/src/lib/ngsi10/UnsubscribeContextRequest.cpp
+++ b/src/lib/ngsi10/UnsubscribeContextRequest.cpp
@@ -38,9 +38,8 @@
 std::string UnsubscribeContextRequest::render(const std::string& indent)
 {
   std::string out = "";
-  std::string tag = "unsubscribeContextRequest";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += subscriptionId.render(UnsubscribeContext, indent + "  ");
   out += endTag(indent);
 

--- a/src/lib/ngsi10/UnsubscribeContextRequest.cpp
+++ b/src/lib/ngsi10/UnsubscribeContextRequest.cpp
@@ -40,7 +40,7 @@ std::string UnsubscribeContextRequest::render(const std::string& indent)
   std::string out = "";
   std::string tag = "unsubscribeContextRequest";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += subscriptionId.render(UnsubscribeContext, indent + "  ");
   out += endTag(indent);
 

--- a/src/lib/ngsi10/UnsubscribeContextResponse.cpp
+++ b/src/lib/ngsi10/UnsubscribeContextResponse.cpp
@@ -71,7 +71,7 @@ std::string UnsubscribeContextResponse::render(const std::string& indent)
   std::string out = "";
   std::string tag = "unsubscribeContextResponse";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += subscriptionId.render(RtUnsubscribeContextResponse, indent + "  ", true);
   out += statusCode.render(indent + "  ", false);
   out += endTag(indent);

--- a/src/lib/ngsi10/UnsubscribeContextResponse.cpp
+++ b/src/lib/ngsi10/UnsubscribeContextResponse.cpp
@@ -69,9 +69,8 @@ UnsubscribeContextResponse::~UnsubscribeContextResponse()
 std::string UnsubscribeContextResponse::render(const std::string& indent)
 {
   std::string out = "";
-  std::string tag = "unsubscribeContextResponse";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += subscriptionId.render(RtUnsubscribeContextResponse, indent + "  ", true);
   out += statusCode.render(indent + "  ", false);
   out += endTag(indent);

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -69,12 +69,11 @@ UpdateContextRequest::UpdateContextRequest(const std::string& _contextProvider, 
 std::string UpdateContextRequest::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out = "";
-  std::string  tag = "updateContextRequest";
 
   // JSON commas:
   // Both fields are MANDATORY, so, comma after "contextElementVector"
   //  
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += contextElementVector.render(apiVersion, asJsonObject, UpdateContext, indent + "  ", true);
   out += updateActionType.render(indent + "  ", false);
   out += endTag(indent, false);

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -74,7 +74,7 @@ std::string UpdateContextRequest::render(const std::string& apiVersion, bool asJ
   // JSON commas:
   // Both fields are MANDATORY, so, comma after "contextElementVector"
   //  
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += contextElementVector.render(apiVersion, asJsonObject, UpdateContext, indent + "  ", true);
   out += updateActionType.render(indent + "  ", false);
   out += endTag(indent, false);

--- a/src/lib/ngsi10/UpdateContextResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextResponse.cpp
@@ -85,7 +85,7 @@ std::string UpdateContextResponse::render(const std::string& apiVersion, bool as
   std::string out = "";
   std::string tag = "updateContextResponse";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   if ((errorCode.code != SccNone) && (errorCode.code != SccOk))
   {

--- a/src/lib/ngsi10/UpdateContextResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextResponse.cpp
@@ -83,9 +83,8 @@ UpdateContextResponse::~UpdateContextResponse()
 std::string UpdateContextResponse::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string out = "";
-  std::string tag = "updateContextResponse";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   if ((errorCode.code != SccNone) && (errorCode.code != SccOk))
   {

--- a/src/lib/ngsi10/UpdateContextSubscriptionResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextSubscriptionResponse.cpp
@@ -66,9 +66,8 @@ UpdateContextSubscriptionResponse::~UpdateContextSubscriptionResponse() {
 std::string UpdateContextSubscriptionResponse::render(const std::string& indent)
 {
   std::string out  = "";
-  std::string tag  = "updateContextSubscriptionResponse";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   if (subscribeError.errorCode.code == SccNone)
   {

--- a/src/lib/ngsi10/UpdateContextSubscriptionResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextSubscriptionResponse.cpp
@@ -68,7 +68,7 @@ std::string UpdateContextSubscriptionResponse::render(const std::string& indent)
   std::string out  = "";
   std::string tag  = "updateContextSubscriptionResponse";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   if (subscribeError.errorCode.code == SccNone)
   {

--- a/src/lib/ngsi9/DiscoverContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/DiscoverContextAvailabilityResponse.cpp
@@ -73,14 +73,13 @@ DiscoverContextAvailabilityResponse::DiscoverContextAvailabilityResponse(StatusC
 std::string DiscoverContextAvailabilityResponse::render(const std::string& indent)
 {
   std::string  out = "";
-  std::string  tag = "discoverContextAvailabilityResponse";
 
   //
   // JSON commas:
   // Exactly ONE of responseVector|errorCode is included in the discovery response so,
   // no JSON commas necessary
   //
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   
   if (responseVector.size() > 0)
   {

--- a/src/lib/ngsi9/DiscoverContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/DiscoverContextAvailabilityResponse.cpp
@@ -80,7 +80,7 @@ std::string DiscoverContextAvailabilityResponse::render(const std::string& inden
   // Exactly ONE of responseVector|errorCode is included in the discovery response so,
   // no JSON commas necessary
   //
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   
   if (responseVector.size() > 0)
   {

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
@@ -49,7 +49,6 @@ NotifyContextAvailabilityRequest::NotifyContextAvailabilityRequest()
 std::string NotifyContextAvailabilityRequest::render(const std::string& indent)
 {
   std::string out = "";
-  std::string tag = "notifyContextAvailabilityRequest";
 
   //
   // Note on JSON commas:
@@ -57,7 +56,7 @@ std::string NotifyContextAvailabilityRequest::render(const std::string& indent)
   //  Always comma for subscriptionId.
   //  With an empty contextRegistrationResponseVector there would be no notification
   //
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += subscriptionId.render(NotifyContextAvailability, indent + "  ", true);
   out += contextRegistrationResponseVector.render(indent  + "  ", false);
   out += endTag(indent);

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
@@ -57,7 +57,7 @@ std::string NotifyContextAvailabilityRequest::render(const std::string& indent)
   //  Always comma for subscriptionId.
   //  With an empty contextRegistrationResponseVector there would be no notification
   //
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += subscriptionId.render(NotifyContextAvailability, indent + "  ", true);
   out += contextRegistrationResponseVector.render(indent  + "  ", false);
   out += endTag(indent);

--- a/src/lib/ngsi9/NotifyContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityResponse.cpp
@@ -69,7 +69,7 @@ std::string NotifyContextAvailabilityResponse::render(const std::string& indent)
 
   responseCode.keyNameSet("responseCode");
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += responseCode.render(indent + "  ");
   out += endTag(indent);
 

--- a/src/lib/ngsi9/NotifyContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityResponse.cpp
@@ -65,11 +65,10 @@ NotifyContextAvailabilityResponse::NotifyContextAvailabilityResponse(StatusCode&
 std::string NotifyContextAvailabilityResponse::render(const std::string& indent)
 {
   std::string out = "";
-  std::string tag = "notifyContextAvailabilityResponse";
 
   responseCode.keyNameSet("responseCode");
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += responseCode.render(indent + "  ");
   out += endTag(indent);
 

--- a/src/lib/ngsi9/RegisterContextRequest.cpp
+++ b/src/lib/ngsi9/RegisterContextRequest.cpp
@@ -51,7 +51,7 @@ std::string RegisterContextRequest::render(const std::string& indent)
   bool         commaAfterDuration                  = registrationIdRendered;
   bool         commaAfterContextRegistrationVector = registrationIdRendered || durationRendered;
 
-  out += startTag(indent, "", false, false);
+  out += startTag(indent);
 
   out += contextRegistrationVector.render(      indent + "  ", commaAfterContextRegistrationVector);
   out += duration.render(                       indent + "  ", commaAfterDuration);

--- a/src/lib/ngsi9/RegisterContextRequest.cpp
+++ b/src/lib/ngsi9/RegisterContextRequest.cpp
@@ -51,7 +51,7 @@ std::string RegisterContextRequest::render(const std::string& indent)
   bool         commaAfterDuration                  = registrationIdRendered;
   bool         commaAfterContextRegistrationVector = registrationIdRendered || durationRendered;
 
-  out += startTag2(indent, "", false, false);
+  out += startTag(indent, "", false, false);
 
   out += contextRegistrationVector.render(      indent + "  ", commaAfterContextRegistrationVector);
   out += duration.render(                       indent + "  ", commaAfterDuration);

--- a/src/lib/ngsi9/RegisterContextResponse.cpp
+++ b/src/lib/ngsi9/RegisterContextResponse.cpp
@@ -102,10 +102,9 @@ RegisterContextResponse::RegisterContextResponse(const std::string& _registratio
 std::string RegisterContextResponse::render(const std::string& indent)
 {
   std::string  out = "";
-  std::string  tag = "registerContextResponse";
   bool         errorCodeRendered = (errorCode.code != SccNone) && (errorCode.code != SccOk);
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   if (!errorCodeRendered)
   {

--- a/src/lib/ngsi9/RegisterContextResponse.cpp
+++ b/src/lib/ngsi9/RegisterContextResponse.cpp
@@ -105,7 +105,7 @@ std::string RegisterContextResponse::render(const std::string& indent)
   std::string  tag = "registerContextResponse";
   bool         errorCodeRendered = (errorCode.code != SccNone) && (errorCode.code != SccOk);
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   if (!errorCodeRendered)
   {

--- a/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
@@ -55,14 +55,13 @@ SubscribeContextAvailabilityRequest::SubscribeContextAvailabilityRequest()
 std::string SubscribeContextAvailabilityRequest::render(const std::string& indent)
 {
   std::string out                      = "";
-  std::string tag                      = "subscribeContextAvailabilityRequest";
   std::string indent2                  = indent + "  ";
   bool        commaAfterEntityIdVector = (restrictions > 0) || !duration.isEmpty() || !reference.isEmpty() || (attributeList.size() != 0);
   bool        commaAfterAttributeList  = (restrictions > 0) || !duration.isEmpty() || !reference.isEmpty();
   bool        commaAfterReference      = (restrictions > 0) || !duration.isEmpty();
   bool        commaAfterDuration       = restrictions > 0;
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += entityIdVector.render(indent2, commaAfterEntityIdVector);
   out += attributeList.render(indent2, commaAfterAttributeList);
   out += reference.render(indent2, commaAfterReference);

--- a/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityRequest.cpp
@@ -62,7 +62,7 @@ std::string SubscribeContextAvailabilityRequest::render(const std::string& inden
   bool        commaAfterReference      = (restrictions > 0) || !duration.isEmpty();
   bool        commaAfterDuration       = restrictions > 0;
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += entityIdVector.render(indent2, commaAfterEntityIdVector);
   out += attributeList.render(indent2, commaAfterAttributeList);
   out += reference.render(indent2, commaAfterReference);

--- a/src/lib/ngsi9/SubscribeContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityResponse.cpp
@@ -84,12 +84,11 @@ SubscribeContextAvailabilityResponse::SubscribeContextAvailabilityResponse(const
 */
 std::string SubscribeContextAvailabilityResponse::render(const std::string& indent)
 {
-  std::string  tag                = "subscribeContextAvailabilityResponse";
   std::string  out                = "";
   bool         durationRendered   = !duration.isEmpty();
   bool         errorCodeRendered  = (errorCode.code != SccNone);
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   out += subscriptionId.render(RtSubscribeContextAvailabilityResponse, indent + "  ", durationRendered || errorCodeRendered);
   out += duration.render(indent + "  ", errorCodeRendered);

--- a/src/lib/ngsi9/SubscribeContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityResponse.cpp
@@ -89,7 +89,7 @@ std::string SubscribeContextAvailabilityResponse::render(const std::string& inde
   bool         durationRendered   = !duration.isEmpty();
   bool         errorCodeRendered  = (errorCode.code != SccNone);
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   out += subscriptionId.render(RtSubscribeContextAvailabilityResponse, indent + "  ", durationRendered || errorCodeRendered);
   out += duration.render(indent + "  ", errorCodeRendered);

--- a/src/lib/ngsi9/UnsubscribeContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/UnsubscribeContextAvailabilityResponse.cpp
@@ -77,9 +77,8 @@ UnsubscribeContextAvailabilityResponse::~UnsubscribeContextAvailabilityResponse(
 std::string UnsubscribeContextAvailabilityResponse::render(const std::string& indent)
 {
   std::string out = "";
-  std::string tag = "unsubscribeContextAvailabilityResponse";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   out += subscriptionId.render(RtUnsubscribeContextAvailabilityResponse, indent + "  ", true);  // always json comma - statusCode is mandatory
   out += statusCode.render(indent + "  ");

--- a/src/lib/ngsi9/UnsubscribeContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/UnsubscribeContextAvailabilityResponse.cpp
@@ -79,7 +79,7 @@ std::string UnsubscribeContextAvailabilityResponse::render(const std::string& in
   std::string out = "";
   std::string tag = "unsubscribeContextAvailabilityResponse";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   out += subscriptionId.render(RtUnsubscribeContextAvailabilityResponse, indent + "  ", true);  // always json comma - statusCode is mandatory
   out += statusCode.render(indent + "  ");

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
@@ -52,7 +52,6 @@ UpdateContextAvailabilitySubscriptionRequest::UpdateContextAvailabilitySubscript
 std::string UpdateContextAvailabilitySubscriptionRequest::render(const std::string& indent)
 {  
   std::string   out                      = "";
-  std::string   tag                      = "updateContextAvailabilitySubscriptionRequest";
   bool          subscriptionRendered     = subscriptionId.rendered(UpdateContextAvailabilitySubscription);
   bool          restrictionRendered      = restrictions != 0;
   bool          durationRendered         = duration.get() != "";
@@ -63,7 +62,7 @@ std::string UpdateContextAvailabilitySubscriptionRequest::render(const std::stri
   bool          commaAfterAttributeList  = durationRendered || restrictionRendered || subscriptionRendered;
   bool          commaAfterEntityIdVector = attributeListRendered || durationRendered || restrictionRendered || subscriptionRendered;
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
   out += entityIdVector.render(indent + "  ", commaAfterEntityIdVector);
   out += attributeList.render( indent + "  ", commaAfterAttributeList);
   out += duration.render(      indent + "  ", commaAfterDuration);

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionRequest.cpp
@@ -63,7 +63,7 @@ std::string UpdateContextAvailabilitySubscriptionRequest::render(const std::stri
   bool          commaAfterAttributeList  = durationRendered || restrictionRendered || subscriptionRendered;
   bool          commaAfterEntityIdVector = attributeListRendered || durationRendered || restrictionRendered || subscriptionRendered;
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
   out += entityIdVector.render(indent + "  ", commaAfterEntityIdVector);
   out += attributeList.render( indent + "  ", commaAfterAttributeList);
   out += duration.render(      indent + "  ", commaAfterDuration);

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.cpp
@@ -79,7 +79,7 @@ std::string UpdateContextAvailabilitySubscriptionResponse::render(const std::str
   bool         durationRendered   = !duration.isEmpty();
   bool         errorCodeRendered  = (errorCode.code != SccNone);
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   out += subscriptionId.render(RtUpdateContextAvailabilitySubscriptionResponse, indent + "  ", errorCodeRendered || durationRendered);
   out += duration.render(      indent + "  ", errorCodeRendered);

--- a/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.cpp
+++ b/src/lib/ngsi9/UpdateContextAvailabilitySubscriptionResponse.cpp
@@ -75,11 +75,10 @@ UpdateContextAvailabilitySubscriptionResponse::~UpdateContextAvailabilitySubscri
 std::string UpdateContextAvailabilitySubscriptionResponse::render(const std::string& indent, int counter)
 {
   std::string  out                = "";
-  std::string  tag                = "updateContextAvailabilitySubscriptionResponse";
   bool         durationRendered   = !duration.isEmpty();
   bool         errorCodeRendered  = (errorCode.code != SccNone);
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   out += subscriptionId.render(RtUpdateContextAvailabilitySubscriptionResponse, indent + "  ", errorCodeRendered || durationRendered);
   out += duration.render(      indent + "  ", errorCodeRendered);

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -79,7 +79,6 @@ std::string EntityType::render
 )
 {
   std::string  out = "";
-  std::string  key = "type";
 
   if (typeNameBefore && asJsonOut)
   {
@@ -88,7 +87,7 @@ std::string EntityType::render
   }
   else
   {
-    out += startTag(indent, key, false, false);
+    out += startTag(indent);
 
     if (collapsed || contextAttributeVector.size() == 0)
     {     

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -82,7 +82,7 @@ std::string EntityType::render
 
   if (typeNameBefore && asJsonOut)
   {
-    out += valueTag1(indent  + "  ", "name", type, true);
+    out += valueTag(indent  + "  ", "name", type, true);
     out += contextAttributeVector.render(apiVersion, asJsonObject, EntityTypes, indent + "  ", true, true, true);
   }
   else
@@ -91,11 +91,11 @@ std::string EntityType::render
 
     if (collapsed || contextAttributeVector.size() == 0)
     {
-      out += valueTag1(indent  + "  ", "name", type, false);
+      out += valueTag(indent  + "  ", "name", type, false);
     }
     else
     {
-      out += valueTag1(indent  + "  ", "name", type, true);
+      out += valueTag(indent  + "  ", "name", type, true);
       out += contextAttributeVector.render(apiVersion, asJsonObject, EntityTypes, indent + "  ", false, true, true);
     }
 

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -88,7 +88,7 @@ std::string EntityType::render
   }
   else
   {
-    out += startTag2(indent, key, false, false);
+    out += startTag(indent, key, false, false);
 
     if (collapsed || contextAttributeVector.size() == 0)
     {     

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -52,10 +52,9 @@ std::string EntityTypeResponse::render
   const std::string&  indent
 )
 {
-  std::string out                 = "";
-  std::string tag                 = "entityTypeAttributesResponse";
+  std::string out = "";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   out += entityType.render(apiVersion, asJsonObject, asJsonOut, collapsed, indent + "  ", true, true);
   out += statusCode.render(indent + "  ");

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -55,7 +55,7 @@ std::string EntityTypeResponse::render
   std::string out                 = "";
   std::string tag                 = "entityTypeAttributesResponse";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   out += entityType.render(apiVersion, asJsonObject, asJsonOut, collapsed, indent + "  ", true, true);
   out += statusCode.render(indent + "  ");

--- a/src/lib/orionTypes/EntityTypeVector.cpp
+++ b/src/lib/orionTypes/EntityTypeVector.cpp
@@ -63,11 +63,10 @@ std::string EntityTypeVector::render
 )
 {
   std::string out  = "";
-  std::string key  = "types";
 
   if (vec.size() > 0)
   {
-    out += startTag(indent, key, true, true);
+    out += startTag(indent, "types", true);
 
     for (unsigned int ix = 0; ix < vec.size(); ++ix)
     {

--- a/src/lib/orionTypes/EntityTypeVector.cpp
+++ b/src/lib/orionTypes/EntityTypeVector.cpp
@@ -67,7 +67,7 @@ std::string EntityTypeVector::render
 
   if (vec.size() > 0)
   {
-    out += startTag2(indent, key, true, true);
+    out += startTag(indent, key, true, true);
 
     for (unsigned int ix = 0; ix < vec.size(); ++ix)
     {

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -51,10 +51,9 @@ std::string EntityTypeVectorResponse::render
   const std::string&  indent
 )
 {
-  std::string out                 = "";
-  std::string tag                 = "entityTypesResponse";
+  std::string out  = "";
 
-  out += startTag(indent, tag, false, false);
+  out += startTag(indent);
 
   if (entityTypeVector.size() > 0)
   {

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -54,7 +54,7 @@ std::string EntityTypeVectorResponse::render
   std::string out                 = "";
   std::string tag                 = "entityTypesResponse";
 
-  out += startTag1(indent, tag, false);
+  out += startTag(indent, tag, false, false);
 
   if (entityTypeVector.size() > 0)
   {

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -668,22 +668,22 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
   if (valueType == orion::ValueTypeString)
   {
     LM_T(LmtCompoundValueRender, ("I am a String (%s)", name.c_str()));
-    out = valueTag1(indent, key, stringValue, jsonComma, container->valueType == orion::ValueTypeVector);
+    out = valueTag(indent, key, stringValue, jsonComma, container->valueType == orion::ValueTypeVector);
   }
   else if (valueType == orion::ValueTypeNumber)
   {
     LM_T(LmtCompoundValueRender, ("I am a number (%s)", name.c_str()));
-    out = valueTag1(indent, key, toString(numberValue), jsonComma, container->valueType == orion::ValueTypeVector, true);
+    out = valueTag(indent, key, toString(numberValue), jsonComma, container->valueType == orion::ValueTypeVector, true);
   }
   else if (valueType == orion::ValueTypeBoolean)
   {
     LM_T(LmtCompoundValueRender, ("I am a bool (%s)", name.c_str()));
-    out = valueTag1(indent, key, boolValue? "true" : "false", jsonComma, container->valueType == orion::ValueTypeVector, true);
+    out = valueTag(indent, key, boolValue? "true" : "false", jsonComma, container->valueType == orion::ValueTypeVector, true);
   }
   else if (valueType == orion::ValueTypeNone)
   {
     LM_T(LmtCompoundValueRender, ("I am NULL (%s)", name.c_str()));
-    out = valueTag1(indent, key, "null", jsonComma, container->valueType == orion::ValueTypeVector, true);
+    out = valueTag(indent, key, "null", jsonComma, container->valueType == orion::ValueTypeVector, true);
   }
 
 #if 0

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -732,7 +732,7 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
   else if ((valueType == orion::ValueTypeVector) && (container != this))
   {
     LM_T(LmtCompoundValueRender, ("I am a Vector (%s)", name.c_str()));
-    out += startTag2(indent, key, true, container->valueType == orion::ValueTypeObject);
+    out += startTag(indent, key, true, container->valueType == orion::ValueTypeObject);
     for (uint64_t ix = 0; ix < childV.size(); ++ix)
     {
       out += childV[ix]->render(apiVersion, indent + "  ");
@@ -751,7 +751,7 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
   else if ((valueType == orion::ValueTypeObject) && (container->valueType == orion::ValueTypeVector))
   {
     LM_T(LmtCompoundValueRender, ("I am an Object (%s) and my container is a Vector", name.c_str()));
-    out += startTag2(indent, "", false, false);
+    out += startTag(indent, "", false, false);
     for (uint64_t ix = 0; ix < childV.size(); ++ix)
     {
       out += childV[ix]->render(apiVersion, indent + "  ");
@@ -764,7 +764,7 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
     if (rootP != this)
     {
       LM_T(LmtCompoundValueRender, ("I am an Object (%s) and my container is NOT a Vector", name.c_str()));     
-      out += startTag2(indent, key, false, true);
+      out += startTag(indent, key, false, true);
 
       for (uint64_t ix = 0; ix < childV.size(); ++ix)
       {

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -738,7 +738,7 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
       out += childV[ix]->render(apiVersion, indent + "  ");
     }
 
-    out += endTag(indent, jsonComma, true, true);
+    out += endTag(indent, jsonComma, true);
   }
   else if ((valueType == orion::ValueTypeVector) && (container == this))
   {
@@ -757,7 +757,7 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
       out += childV[ix]->render(apiVersion, indent + "  ");
     }
 
-    out += endTag(indent, jsonComma, false, true);
+    out += endTag(indent, jsonComma, false);
   }
   else if (valueType == orion::ValueTypeObject)
   {
@@ -771,7 +771,7 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
         out += childV[ix]->render(apiVersion, indent + "  ");
       }
 
-      out += endTag(indent, jsonComma, false, true);
+      out += endTag(indent, jsonComma, false);
     }
     else
     {

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -732,7 +732,7 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
   else if ((valueType == orion::ValueTypeVector) && (container != this))
   {
     LM_T(LmtCompoundValueRender, ("I am a Vector (%s)", name.c_str()));
-    out += startTag(indent, key, true, container->valueType == orion::ValueTypeObject);
+    out += startTag(indent, container->valueType == orion::ValueTypeObject ? key : "", true);
     for (uint64_t ix = 0; ix < childV.size(); ++ix)
     {
       out += childV[ix]->render(apiVersion, indent + "  ");
@@ -751,7 +751,7 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
   else if ((valueType == orion::ValueTypeObject) && (container->valueType == orion::ValueTypeVector))
   {
     LM_T(LmtCompoundValueRender, ("I am an Object (%s) and my container is a Vector", name.c_str()));
-    out += startTag(indent, "", false, false);
+    out += startTag(indent);
     for (uint64_t ix = 0; ix < childV.size(); ++ix)
     {
       out += childV[ix]->render(apiVersion, indent + "  ");
@@ -764,7 +764,7 @@ std::string CompoundValueNode::render(const std::string& apiVersion, const std::
     if (rootP != this)
     {
       LM_T(LmtCompoundValueRender, ("I am an Object (%s) and my container is NOT a Vector", name.c_str()));     
-      out += startTag(indent, key, false, true);
+      out += startTag(indent, key);
 
       for (uint64_t ix = 0; ix < childV.size(); ++ix)
       {

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -144,7 +144,7 @@ std::string OrionError::render(void)
   //
   // OrionError is NEVER part of any other payload, so the JSON start/end braces must be added here
   //
-  out += startTag1(indent, tag);
+  out += startTag(indent, tag, false);
   out += valueTag(indent  + "  ", "code",          code,         true);
   out += valueTag1(indent + "  ", "reasonPhrase",  reasonPhrase, details != "");
 

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -145,11 +145,11 @@ std::string OrionError::render(void)
   //
   out += startTag(indent, "orionError", false);
   out += valueTag(indent  + "  ", "code",          code,         true);
-  out += valueTag1(indent + "  ", "reasonPhrase",  reasonPhrase, details != "");
+  out += valueTag(indent + "  ", "reasonPhrase",  reasonPhrase, details != "");
 
   if (details != "")
   {
-    out += valueTag1(indent + "  ", "details",       details);
+    out += valueTag(indent + "  ", "details",       details);
   }
 
   out += endTag(indent);

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -139,12 +139,11 @@ std::string OrionError::render(void)
 {
   std::string  out           = "{\n";
   std::string  indent        = "  ";
-  std::string  tag           = "orionError";
 
   //
   // OrionError is NEVER part of any other payload, so the JSON start/end braces must be added here
   //
-  out += startTag(indent, tag, false);
+  out += startTag(indent, "orionError", false);
   out += valueTag(indent  + "  ", "code",          code,         true);
   out += valueTag1(indent + "  ", "reasonPhrase",  reasonPhrase, details != "");
 

--- a/src/lib/rest/orionLogReply.cpp
+++ b/src/lib/rest/orionLogReply.cpp
@@ -39,7 +39,7 @@ std::string orionLogReply(ConnectionInfo* ciP, const std::string& what, const st
    std::string out = "";
 
    out += '{';
-   out += valueTag1(" ", what, value);
+   out += valueTag(" ", what, value);
    out += '}';
 
    ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutines/versionTreat.cpp
+++ b/src/lib/serviceRoutines/versionTreat.cpp
@@ -95,7 +95,7 @@ std::string versionTreat
   out += valueTag1(indent + "  ", "compile_time",  COMPILE_TIME,    true);
   out += valueTag1(indent + "  ", "compiled_by",   COMPILED_BY,     true);
   out += valueTag1(indent + "  ", "compiled_in",   COMPILED_IN,     false);
-  out += endTag(indent, false, false, true);
+  out += endTag(indent, false, false);
   out += "}\n";
 
   ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutines/versionTreat.cpp
+++ b/src/lib/serviceRoutines/versionTreat.cpp
@@ -88,14 +88,16 @@ std::string versionTreat
   std::string uptime = parsedUptime(getTimer()->getCurrentTime() - startTime);
 #endif
 
-  out += startTag1(indent, tag, true, true);
+  out += "{\n";
+  out += startTag(indent, tag, false, true);
   out += valueTag1(indent + "  ", "version",       versionString,   true);
   out += valueTag1(indent + "  ", "uptime",        uptime,          true);
   out += valueTag1(indent + "  ", "git_hash",      GIT_HASH,        true);
   out += valueTag1(indent + "  ", "compile_time",  COMPILE_TIME,    true);
   out += valueTag1(indent + "  ", "compiled_by",   COMPILED_BY,     true);
   out += valueTag1(indent + "  ", "compiled_in",   COMPILED_IN,     false);
-  out += endTag(indent, false, false, true, true);
+  out += endTag(indent, false, false, true);
+  out += "}\n";
 
   ciP->httpStatusCode = SccOk;
   return out;

--- a/src/lib/serviceRoutines/versionTreat.cpp
+++ b/src/lib/serviceRoutines/versionTreat.cpp
@@ -89,12 +89,12 @@ std::string versionTreat
 
   out += "{\n";
   out += startTag(indent, "orion");
-  out += valueTag1(indent + "  ", "version",       versionString,   true);
-  out += valueTag1(indent + "  ", "uptime",        uptime,          true);
-  out += valueTag1(indent + "  ", "git_hash",      GIT_HASH,        true);
-  out += valueTag1(indent + "  ", "compile_time",  COMPILE_TIME,    true);
-  out += valueTag1(indent + "  ", "compiled_by",   COMPILED_BY,     true);
-  out += valueTag1(indent + "  ", "compiled_in",   COMPILED_IN,     false);
+  out += valueTag(indent + "  ", "version",       versionString,   true);
+  out += valueTag(indent + "  ", "uptime",        uptime,          true);
+  out += valueTag(indent + "  ", "git_hash",      GIT_HASH,        true);
+  out += valueTag(indent + "  ", "compile_time",  COMPILE_TIME,    true);
+  out += valueTag(indent + "  ", "compiled_by",   COMPILED_BY,     true);
+  out += valueTag(indent + "  ", "compiled_in",   COMPILED_IN,     false);
   out += endTag(indent, false, false);
   out += "}\n";
 

--- a/src/lib/serviceRoutines/versionTreat.cpp
+++ b/src/lib/serviceRoutines/versionTreat.cpp
@@ -79,7 +79,6 @@ std::string versionTreat
 )
 {
   std::string out     = "";
-  std::string tag     = "orion";
   std::string indent  = "";
 
 #ifdef UNIT_TEST
@@ -89,7 +88,7 @@ std::string versionTreat
 #endif
 
   out += "{\n";
-  out += startTag(indent, tag, false, true);
+  out += startTag(indent, "orion");
   out += valueTag1(indent + "  ", "version",       versionString,   true);
   out += valueTag1(indent + "  ", "uptime",        uptime,          true);
   out += valueTag1(indent + "  ", "git_hash",      GIT_HASH,        true);

--- a/test/functionalTest/cases/0000_ngsi10_compound_values/compound_empty_keys_and_vector_values.test
+++ b/test/functionalTest/cases/0000_ngsi10_compound_values/compound_empty_keys_and_vector_values.test
@@ -1,0 +1,99 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Create and query compound with empty keys and vector values
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+# 01. Create and query compound with empty keys and vector values
+# 02. Get entity
+
+echo "01. Create and query compound with empty keys and vector values"
+echo "==============================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "type": "compound",
+    "value": {
+       "": "foo",
+       "v": [ "", "bar", "" ]
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Get entity"
+echo "=============="
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create and query compound with empty keys and vector values
+===============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Get entity
+==============
+HTTP/1.1 200 OK
+Content-Length: 96
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "compound",
+        "value": {
+            "": "foo",
+            "v": [
+                "",
+                "bar",
+                ""
+            ]
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/unittests/common/commonTag_test.cpp
+++ b/test/unittests/common/commonTag_test.cpp
@@ -37,28 +37,16 @@ TEST(commonTag, startTag)
 {
    std::string      tag    = "TAG";
    std::string      indent = "  ";
-   std::string      json   = "  {\n";
-   std::string      json2  = "  \"TAG\" : {\n";
    std::string      out;
 
-   out = startTag(indent, tag, false, false);
-   EXPECT_EQ(json, out);
-
-   out = startTag(indent, tag, false, true);
-   EXPECT_EQ(json2, out);
-
-   out = startTag(indent, tag, false, true);
+   out = startTag(indent, tag, false);
    EXPECT_EQ("  \"TAG\" : {\n", out);
 
-   out = startTag(indent, tag, true, true);
+   out = startTag(indent, tag, true);
    EXPECT_EQ("  \"TAG\" : [\n", out);
 
-   out = startTag(indent, tag, false, false);
+   out = startTag(indent);
    EXPECT_EQ("  {\n", out);
-
-   out = startTag(indent, tag, true, false);
-   EXPECT_EQ("  [\n", out);
-
 }
 
 

--- a/test/unittests/common/commonTag_test.cpp
+++ b/test/unittests/common/commonTag_test.cpp
@@ -83,21 +83,21 @@ TEST(commonTag, valueTag)
    std::string      stringJsonNoComma       = "  \"TAG\" : \"8\"\n";
    std::string      out;
 
-   out = valueTag1(indent, tag, value);
+   out = valueTag(indent, tag, value);
    EXPECT_EQ(jsonNoComma, out);
 
-   out = valueTag1(indent, tag, value, true);
+   out = valueTag(indent, tag, value, true);
    EXPECT_EQ(jsonComma, out);   
 
-   out = valueTag1(indent, tag, value);
+   out = valueTag(indent, tag, value);
    EXPECT_EQ(jsonNoComma, out);   
 
    out = valueTag(indent, tag, 8, false);
    EXPECT_EQ(integerJsonNoComma, out);
 
-   out = valueTag2(indent, tag, "8", true);
+   out = valueTag(indent, tag, "8", true, false);
    EXPECT_EQ(stringJsonComma, out);
 
-   out = valueTag2(indent, tag, "8", false);
+   out = valueTag(indent, tag, "8", false, false);
    EXPECT_EQ(stringJsonNoComma, out);
 }

--- a/test/unittests/common/commonTag_test.cpp
+++ b/test/unittests/common/commonTag_test.cpp
@@ -41,22 +41,22 @@ TEST(commonTag, startTag)
    std::string      json2  = "  \"TAG\" : {\n";
    std::string      out;
 
-   out = startTag1(indent, tag, false);
+   out = startTag(indent, tag, false, false);
    EXPECT_EQ(json, out);
 
-   out = startTag1(indent, tag, true);
+   out = startTag(indent, tag, false, true);
    EXPECT_EQ(json2, out);
 
-   out = startTag2(indent, tag, false, true);
+   out = startTag(indent, tag, false, true);
    EXPECT_EQ("  \"TAG\" : {\n", out);
 
-   out = startTag2(indent, tag, true, true);
+   out = startTag(indent, tag, true, true);
    EXPECT_EQ("  \"TAG\" : [\n", out);
 
-   out = startTag2(indent, tag, false, false);
+   out = startTag(indent, tag, false, false);
    EXPECT_EQ("  {\n", out);
 
-   out = startTag2(indent, tag, true, false);
+   out = startTag(indent, tag, true, false);
    EXPECT_EQ("  [\n", out);
 
 }

--- a/test/unittests/ngsi/MetadataVector_test.cpp
+++ b/test/unittests/ngsi/MetadataVector_test.cpp
@@ -49,8 +49,6 @@ TEST(MetadataVector, render)
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
-  mV.keyNameSet("metadata");
-
   mV.push_back(&m2); 
   out = mV.render("");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";

--- a/test/unittests/ngsi/MetadataVector_test.cpp
+++ b/test/unittests/ngsi/MetadataVector_test.cpp
@@ -36,7 +36,7 @@ TEST(MetadataVector, render)
 {
   Metadata        m("Name", "Type", "Value");
   Metadata        m2("Name2", "Type2", "Value2");
-  MetadataVector  mV("registrationMetadata");
+  MetadataVector  mV;
   const char*     outfile1 = "ngsi.metadataVector.render1.middle.json";
   const char*     outfile2 = "ngsi.metadataVector.render3.middle.json";
   std::string     out;


### PR DESCRIPTION
This PR includes several simplifications:

* Unify startTag() and startTag1() methods into only one
* Unify valueTag(), valueTag1() and valueTag2() into only one
* Simplifying argument in suviving startTag() and valueTag() and also in endTag()
* Remove unneeded tag/key management (a leftover that makes more sense in the times of XML)

*Edit*: again, important to note: this PR doesn't touch any .test, so 100% regresion is kept with this refactor.