### PR TITLE
Error string extraction

### DIFF
--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -103,7 +103,7 @@ void Attribute::fill(QueryContextResponse* qcrsP, std::string attrName)
 {
   if (qcrsP->errorCode.code == SccContextElementNotFound)
   {
-    oe.fill(SccContextElementNotFound, "The requested entity has not been found. Check type and id", "NotFound");
+    oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ENTITY, ERROR_NOT_FOUND);
   }
   else if (qcrsP->errorCode.code != SccOk)
   {
@@ -117,7 +117,7 @@ void Attribute::fill(QueryContextResponse* qcrsP, std::string attrName)
     //
     // If there are more than one entity, we return an error
     //
-    oe.fill(SccConflict, MORE_MATCHING_ENT, "TooManyResults");
+    oe.fill(SccConflict, ERROR_DESC_TOO_MANY_ENTITIES, ERROR_TOO_MANY);
   }
   else
   {
@@ -134,7 +134,7 @@ void Attribute::fill(QueryContextResponse* qcrsP, std::string attrName)
 
     if (pcontextAttribute == NULL)
     {
-      oe.fill(SccContextElementNotFound, "The entity does not have such an attribute", "NotFound");
+      oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ATTRIBUTE, ERROR_NOT_FOUND);
     }
   }
 }

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -286,7 +286,7 @@ void Entity::fill(QueryContextResponse* qcrsP)
 
   if (qcrsP->errorCode.code == SccContextElementNotFound)
   {
-    oe.fill(SccContextElementNotFound, "The requested entity has not been found. Check type and id", "NotFound");
+    oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ENTITY, ERROR_NOT_FOUND);
   }
   else if (qcrsP->errorCode.code != SccOk)
   {
@@ -300,7 +300,7 @@ void Entity::fill(QueryContextResponse* qcrsP)
       //
       // If there are more than one entity, we return an error
       //
-      oe.fill(SccConflict, MORE_MATCHING_ENT, "TooManyResults");
+      oe.fill(SccConflict, ERROR_DESC_TOO_MANY_ENTITIES, ERROR_TOO_MANY);
   }
   else
   {

--- a/src/lib/common/errorMessages.h
+++ b/src/lib/common/errorMessages.h
@@ -37,13 +37,35 @@
 #define STR2(x) #x
 #define STR(x)  STR2(x)
 
+/* FIXME P5: the current set of defines in this file doesn't cover all the possible cases we have in the code.
+ * The unhardwiring work should continue, specially with regards to BadRequest errors (we have *a lot* of them
+ * in the code.
+ *
+ * In addition, by the moment we are using this constants only for error payloads, but maybe they should be
+ * also used for alarm error mensajes, e.g. alarmMgr.badInput(clientIp, ERROR_DESC_PARSE) instead of
+ * alarmMgr.badInput(clientIp, "JSON parse error").
+ */
 
+#define ERROR_PARSE                               "ParseError"
+#define ERROR_DESC_PARSE                          "Errors found in incoming JSON buffer"
 
-#define MORE_MATCHING_ENT   "More than one matching entity. Please refine your query"
-#define INVAL_CHAR_URI      "invalid character in URI"
-#define EMPTY_ENTITY_ID     "entity id length: 0, min length supported: "      STR(MIN_ID_LEN)
-#define EMPTY_ATTR_NAME     "attribute name length: 0, min length supported: " STR(MIN_ID_LEN)
-#define EMPTY_ENTITY_TYPE   "entity type length: 0, min length supported: "    STR(MIN_ID_LEN)
-#define BAD_VERB            "method not allowed"
+#define ERROR_BAD_REQUEST                         "BadRequest"
+#define ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI   "invalid character in URI"
+#define ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID    "entity id length: 0, min length supported: "      STR(MIN_ID_LEN)
+#define ERROR_DESC_BAD_REQUEST_EMPTY_ATTR_NAME    "attribute name length: 0, min length supported: " STR(MIN_ID_LEN)
+#define ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_TYPE  "entity type length: 0, min length supported: "    STR(MIN_ID_LEN)
+#define ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD      "empty payload"
+
+#define ERROR_NOT_FOUND                           "NotFound"
+#define ERROR_DESC_NOT_FOUND_ENTITY               "The requested entity has not been found. Check type and id"
+#define ERROR_DESC_NOT_FOUND_ENTITY_TYPE          "Entity type not found"
+#define ERROR_DESC_NOT_FOUND_CONTEXT_ELEMENT      "No context element found"
+#define ERROR_DESC_NOT_FOUND_ATTRIBUTE            "The entity does not have such an attribute"
+#define ERROR_DESC_NOT_FOUND_SUBSCRIPTION         "The requested subscription has not been found. Check id"
+
+#define ERROR_TOO_MANY                            "TooManyResults"
+#define ERROR_DESC_TOO_MANY_ENTITIES              "More than one matching entity. Please refine your query"
+
+#define ERROR_DESC_BAD_VERB                       "method not allowed"
 
 #endif // SRC_LIB_COMMON_ERRORMESSAGES_H

--- a/src/lib/jsonParseV2/parseAttributeValue.cpp
+++ b/src/lib/jsonParseV2/parseAttributeValue.cpp
@@ -24,6 +24,7 @@
 */
 #include "rapidjson/document.h"
 
+#include "common/errorMessages.h"
 #include "alarmMgr/alarmMgr.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/OrionError.h"
@@ -49,7 +50,7 @@ std::string parseAttributeValue(ConnectionInfo* ciP, ContextAttribute* caP)
   if (document.HasParseError())
   {
     alarmMgr.badInput(clientIp, "JSON parse error");
-    oe.fill(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
     ciP->httpStatusCode = SccBadRequest;;
     return oe.toJson();
   }

--- a/src/lib/jsonParseV2/parseBatchQuery.cpp
+++ b/src/lib/jsonParseV2/parseBatchQuery.cpp
@@ -24,6 +24,7 @@
 */
 #include "rapidjson/document.h"
 
+#include "common/errorMessages.h"
 #include "alarmMgr/alarmMgr.h"
 #include "rest/ConnectionInfo.h"
 #include "ngsi/ParseData.h"
@@ -51,7 +52,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
   if (document.HasParseError())
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
-    oe.fill(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
     ciP->httpStatusCode = SccBadRequest;
 
     return oe.toJson();
@@ -60,7 +61,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
   if (!document.IsObject())
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
-    oe.fill(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
     ciP->httpStatusCode = SccBadRequest;
 
     return oe.toJson();
@@ -68,7 +69,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
   else if (document.ObjectEmpty())
   {
     alarmMgr.badInput(clientIp, "Empty JSON payload");
-    oe.fill(SccBadRequest, "empty payload", "BadRequest");
+    oe.fill(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = SccBadRequest;
 
     return oe.toJson();

--- a/src/lib/jsonParseV2/parseBatchUpdate.cpp
+++ b/src/lib/jsonParseV2/parseBatchUpdate.cpp
@@ -24,6 +24,7 @@
 */
 #include "rapidjson/document.h"
 
+#include "common/errorMessages.h"
 #include "alarmMgr/alarmMgr.h"
 #include "rest/ConnectionInfo.h"
 #include "ngsi/ParseData.h"
@@ -51,7 +52,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
   if (document.HasParseError())
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
-    oe.fill(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
     ciP->httpStatusCode = SccBadRequest;
 
     return oe.toJson();
@@ -60,7 +61,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
   if (!document.IsObject())
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
-    oe.fill(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
     ciP->httpStatusCode = SccBadRequest;
 
     return oe.toJson();
@@ -68,7 +69,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
   else if (document.ObjectEmpty())
   {
     alarmMgr.badInput(clientIp, "Empty JSON payload");
-    oe.fill(SccBadRequest, "empty payload", "BadRequest");
+    oe.fill(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = SccBadRequest;
 
     return oe.toJson();

--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -26,6 +26,7 @@
 
 #include "logMsg/logMsg.h"
 
+#include "common/errorMessages.h"
 #include "ngsi/ContextAttribute.h"
 #include "parse/CompoundValueNode.h"
 #include "parse/forbiddenChars.h"
@@ -303,7 +304,7 @@ std::string parseContextAttribute(ConnectionInfo* ciP, ContextAttribute* caP)
 
   if (document.HasParseError())
   {
-    OrionError oe(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
 
     alarmMgr.badInput(clientIp, "JSON parse error");
     ciP->httpStatusCode = SccBadRequest;
@@ -314,7 +315,7 @@ std::string parseContextAttribute(ConnectionInfo* ciP, ContextAttribute* caP)
 
   if (!document.IsObject())
   {
-    OrionError oe(SccBadRequest, "Error parsing incoming JSON buffer", ERROR_STRING_PARSERROR);
+    OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
 
     alarmMgr.badInput(clientIp, "JSON Parse Error");
     ciP->httpStatusCode = SccBadRequest;

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -25,6 +25,7 @@
 #include "rapidjson/document.h"
 
 #include "common/globals.h"
+#include "common/errorMessages.h"
 #include "rest/ConnectionInfo.h"
 #include "ngsi/ParseData.h"
 #include "ngsi/Request.h"
@@ -67,7 +68,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
   {
     alarmMgr.badInput(clientIp, "JSON parse error");
     ciP->httpStatusCode = SccBadRequest;
-    OrionError oe(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
     return oe.toJson();
   }
 
@@ -76,7 +77,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
     ciP->httpStatusCode = SccBadRequest;
-    OrionError oe(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
     return oe.toJson();
   }
 
@@ -87,7 +88,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     {
       alarmMgr.badInput(clientIp, "No entity id specified");
       ciP->httpStatusCode = SccBadRequest;
-      OrionError oe(SccBadRequest, "no entity id specified", "BadRequest");
+      OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID, ERROR_BAD_REQUEST);
       return oe.toJson();
     }
   }
@@ -120,7 +121,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     //
     alarmMgr.badInput(clientIp, "Empty payload");
     ciP->httpStatusCode = SccBadRequest;
-    OrionError oe(SccBadRequest, "empty payload", "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD, ERROR_BAD_REQUEST);
     return oe.toJson();
   }
 
@@ -188,7 +189,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
   {
     alarmMgr.badInput(clientIp, "empty payload");
     ciP->httpStatusCode = SccBadRequest;
-    OrionError oe(SccBadRequest, "empty payload", "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD, ERROR_BAD_REQUEST);
     return oe.toJson();
   }
 
@@ -198,7 +199,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     {
       alarmMgr.badInput(clientIp, "empty entity id");
       ciP->httpStatusCode = SccBadRequest;
-      OrionError oe(SccBadRequest, "empty entity id", "BadRequest");
+      OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID, ERROR_BAD_REQUEST);
       return oe.toJson();
     }
   }

--- a/src/lib/jsonParseV2/parseSubscription.cpp
+++ b/src/lib/jsonParseV2/parseSubscription.cpp
@@ -29,6 +29,7 @@
 
 #include "alarmMgr/alarmMgr.h"
 #include "common/globals.h"
+#include "common/errorMessages.h"
 #include "common/RenderFormat.h"
 #include "common/string.h"
 #include "rest/ConnectionInfo.h"
@@ -70,7 +71,7 @@ std::string parseSubscription(ConnectionInfo* ciP, SubscriptionUpdate* subsP, bo
 
   if (document.HasParseError())
   {
-    OrionError oe(SccBadRequest, "Errors found in incoming JSON buffer", ERROR_STRING_PARSERROR);
+    OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
     alarmMgr.badInput(clientIp, "JSON parse error");
     ciP->httpStatusCode = SccBadRequest;
     return oe.toJson();
@@ -78,7 +79,7 @@ std::string parseSubscription(ConnectionInfo* ciP, SubscriptionUpdate* subsP, bo
 
   if (!document.IsObject())
   {
-    OrionError oe(SccBadRequest, "Error parsing incoming JSON buffer", ERROR_STRING_PARSERROR);
+    OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
     alarmMgr.badInput(clientIp, "JSON parse error");
     ciP->httpStatusCode = SccBadRequest;
     return oe.toJson();
@@ -91,7 +92,7 @@ std::string parseSubscription(ConnectionInfo* ciP, SubscriptionUpdate* subsP, bo
     // research was made and "ObjectEmpty" was found. As the broker stopped crashing and complaints
     // about crashes with small docs and "Empty()" were found on the internet, we opted to use ObjectEmpty
     //
-    return badInput(ciP, "empty payload");
+    return badInput(ciP, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD);
   }
 
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -2430,7 +2430,7 @@ static bool updateContextAttributeItem
                             " - entity: [" + eP->toString() + "]" +
                             " - offending attribute: " + targetAttr->getName();
       cerP->statusCode.fill(SccInvalidParameter, details);
-      oe->fill(SccContextElementNotFound, "The entity does not have such an attribute", "NotFound");
+      oe->fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ATTRIBUTE, ERROR_NOT_FOUND);
 
       /* Although 'ca' has been already pushed into cerP, the pointer is still valid, of course */
       ca->found = false;
@@ -2585,7 +2585,7 @@ static bool deleteContextAttributeItem
                           " - offending attribute: " + targetAttr->getName() +
                           " - attribute not found";
     cerP->statusCode.fill(SccInvalidParameter, details);
-    oe->fill(SccContextElementNotFound, "Attribute not found", "NotFound");
+    oe->fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ATTRIBUTE, ERROR_NOT_FOUND);
 
     alarmMgr.badInput(clientIp, "attribute to be deleted is not found");
     ca->found = false;
@@ -3554,8 +3554,8 @@ void processContextElement
     // This is the case of POST /v2/entities/<id>, in order to check that entity previously exist
     if ((entitiesNumber == 0) && (ngsiv2Flavour == NGSIV2_FLAVOUR_ONAPPEND))
     {
-      buildGeneralErrorResponse(ceP, NULL, responseP, SccContextElementNotFound, "The requested entity has not been found. Check type and id");
-      responseP->oe.fill(SccContextElementNotFound, "The requested entity has not been found. Check type and id", "NotFound");
+      buildGeneralErrorResponse(ceP, NULL, responseP, SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ENTITY);
+      responseP->oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ENTITY, ERROR_NOT_FOUND);
       return;
     }
 
@@ -3564,8 +3564,8 @@ void processContextElement
     // thinking too much about it, but NGSIv1 behaviour has to be preserved to keep backward compatibility)
     if (entitiesNumber > 1)
     {
-      buildGeneralErrorResponse(ceP, NULL, responseP, SccConflict, MORE_MATCHING_ENT);
-      responseP->oe.fill(SccConflict, MORE_MATCHING_ENT, "TooManyResults");
+      buildGeneralErrorResponse(ceP, NULL, responseP, SccConflict, ERROR_DESC_TOO_MANY_ENTITIES);
+      responseP->oe.fill(SccConflict, ERROR_DESC_TOO_MANY_ENTITIES, ERROR_TOO_MANY);
       return;
     }
   }
@@ -3698,11 +3698,11 @@ void processContextElement
 
         if (apiVersion == "v1")
         {
-          responseP->oe.fill(SccContextElementNotFound, "No context element found", "NotFound");
+          responseP->oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_CONTEXT_ELEMENT, ERROR_NOT_FOUND);
         }
         else
         {
-          responseP->oe.fill(SccContextElementNotFound, "The requested entity has not been found. Check type and id", "NotFound");
+          responseP->oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ENTITY, ERROR_NOT_FOUND);
         }
       }
     }
@@ -3710,7 +3710,7 @@ void processContextElement
     {
       cerP->statusCode.fill(SccContextElementNotFound);
 
-      responseP->oe.fill(SccContextElementNotFound, "The requested entity has not been found. Check type and id", "NotFound");
+      responseP->oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ENTITY, ERROR_NOT_FOUND);
       responseP->contextElementResponseVector.push_back(cerP);
     }
     else   /* APPEND or APPEND_STRICT */

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -32,6 +32,7 @@
 #include "common/sem.h"
 #include "common/statistics.h"
 #include "common/idCheck.h"
+#include "common/errorMessages.h"
 #include "mongoBackend/mongoGetSubscriptions.h"
 #include "mongoBackend/MongoGlobal.h"
 #include "mongoBackend/connectionOperations.h"
@@ -375,7 +376,7 @@ void mongoGetSubscription
     releaseMongoConnection(connection);
     LM_T(LmtMongo, ("subscription not found: '%s'", idSub.c_str()));
     reqSemGive(__FUNCTION__, "Mongo Get Subscription", reqSemTaken);
-    *oe = OrionError(SccContextElementNotFound, "subscriptionId does not correspond to an active subscription", "NotFound");
+    *oe = OrionError(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_SUBSCRIPTION, ERROR_NOT_FOUND);
     return;
   }
   releaseMongoConnection(connection);

--- a/src/lib/mongoBackend/mongoUnsubscribeContext.cpp
+++ b/src/lib/mongoBackend/mongoUnsubscribeContext.cpp
@@ -28,6 +28,7 @@
 #include "logMsg/traceLevels.h"
 
 #include "common/sem.h"
+#include "common/errorMessages.h"
 #include "alarmMgr/alarmMgr.h"
 
 #include "mongoBackend/MongoGlobal.h"
@@ -61,7 +62,7 @@ HttpStatusCode mongoUnsubscribeContext(UnsubscribeContextRequest* requestP, Unsu
     {
         reqSemGive(__FUNCTION__, "ngsi10 unsubscribe request (no subscriptions found)", reqSemTaken);
         responseP->statusCode.fill(SccContextElementNotFound);
-        responseP->oe.fill(SccContextElementNotFound, "The requested subscription has not been found. Check id", "NotFound");
+        responseP->oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_SUBSCRIPTION, ERROR_NOT_FOUND);
         alarmMgr.badInput(clientIp, "no subscriptionId");
         return SccOk;
     }
@@ -77,7 +78,7 @@ HttpStatusCode mongoUnsubscribeContext(UnsubscribeContextRequest* requestP, Unsu
       {
         // FIXME: Doubt - invalid OID format?  Or, just a subscription that was not found?
         std::string details = std::string("invalid OID format: '") + requestP->subscriptionId.get() + "'";
-        responseP->oe.fill(SccContextElementNotFound, "The requested subscription has not been found. Check id", "NotFound");
+        responseP->oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_SUBSCRIPTION, ERROR_NOT_FOUND);
         alarmMgr.badInput(clientIp, details);
       }
       else // SccReceiverInternalError
@@ -100,7 +101,7 @@ HttpStatusCode mongoUnsubscribeContext(UnsubscribeContextRequest* requestP, Unsu
     {
        reqSemGive(__FUNCTION__, "ngsi10 unsubscribe request (no subscriptions found)", reqSemTaken);
        responseP->statusCode.fill(SccContextElementNotFound, std::string("subscriptionId: /") + requestP->subscriptionId.get() + "/");
-       responseP->oe.fill(SccContextElementNotFound, "The requested subscription has not been found. Check id", "NotFound");
+       responseP->oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_SUBSCRIPTION, ERROR_NOT_FOUND);
        return SccOk;
     }
 

--- a/src/lib/rest/HttpStatusCode.h
+++ b/src/lib/rest/HttpStatusCode.h
@@ -28,8 +28,6 @@
 * Author: developer
 */
 
-#define ERROR_STRING_PARSERROR  "ParseError"
-
 /* ****************************************************************************
 *
 * HttpStatusCode - 

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -390,7 +390,7 @@ static bool compErrorDetect
 
       if (entityId == "")
       {
-        details = EMPTY_ENTITY_ID;
+        details = ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID;
       }
     }
     else if ((components == 5) && (compV[3] == "attrs"))  // URL: /v2/entities/<entity-id>/attrs/<attr-name>
@@ -400,11 +400,11 @@ static bool compErrorDetect
 
       if (entityId == "")
       {
-        details = EMPTY_ENTITY_ID;
+        details = ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID;
       }
       else if (attrName == "")
       {
-        details = EMPTY_ATTR_NAME;
+        details = ERROR_DESC_BAD_REQUEST_EMPTY_ATTR_NAME;
       }
     }
     else if ((components == 6) && (compV[3] == "attrs") && (compV[5] == "value")) // URL: /v2/entities/<entity-id>/attrs/<attr-name>/value
@@ -414,11 +414,11 @@ static bool compErrorDetect
 
       if (entityId == "")
       {
-        details = EMPTY_ENTITY_ID;
+        details = ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID;
       }
       else if (attrName == "")
       {
-        details = EMPTY_ATTR_NAME;
+        details = ERROR_DESC_BAD_REQUEST_EMPTY_ATTR_NAME;
       }
     }
   }

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -39,6 +39,7 @@
 #include "common/string.h"
 #include "common/wsStrip.h"
 #include "common/globals.h"
+#include "common/errorMessages.h"
 #include "common/defaultValues.h"
 #include "common/clockFunctions.h"
 #include "common/statistics.h"
@@ -879,7 +880,7 @@ bool urlCheck(ConnectionInfo* ciP, const std::string& url)
 {
   if (forbiddenChars(url.c_str()) == true)
   {
-    OrionError error(SccBadRequest, "invalid character in URI");
+    OrionError error(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI);
     ciP->httpStatusCode = error.code;
     ciP->answer         = error.smartRender(ciP->apiVersion);
     return false;

--- a/src/lib/serviceRoutines/badVerbAllFive.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFive.cpp
@@ -51,7 +51,7 @@ std::string badVerbAllFive
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("POST, GET, PUT, DELETE, PATCH");

--- a/src/lib/serviceRoutines/badVerbAllFour.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFour.cpp
@@ -51,7 +51,7 @@ std::string badVerbAllFour
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("POST, GET, PUT, DELETE");

--- a/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbGetDeleteOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("GET, DELETE");

--- a/src/lib/serviceRoutines/badVerbGetOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbGetOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("GET");

--- a/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbGetPostDeleteOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("GET, POST, DELETE");

--- a/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbGetPostOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method+ "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("POST, GET");

--- a/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbGetPutDeleteOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("GET, PUT, DELETE");

--- a/src/lib/serviceRoutines/badVerbPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPostOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbPostOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("POST");

--- a/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbPutDeleteOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("PUT, DELETE");

--- a/src/lib/serviceRoutines/badVerbPutOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbPutOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("PUT");

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -31,6 +31,7 @@
 #include "common/string.h"
 #include "common/defaultValues.h"
 #include "common/globals.h"
+#include "common/errorMessages.h"
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -693,11 +694,11 @@ std::string postUpdateContext
       // If all CER result in error, then it isn't a partial update, but a regular NotFound
       if (ciP->apiVersion == "v1")
       {
-        parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, "No context element found", "NotFound");
+        parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_CONTEXT_ELEMENT, ERROR_NOT_FOUND);
       }
       else
       {
-        parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, "The requested entity has not been found. Check type and id", "NotFound");
+        parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ENTITY, ERROR_NOT_FOUND);
       }
     }
     else if (fails > 0)

--- a/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
@@ -52,7 +52,7 @@ std::string badVerbAllNotDelete
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("GET, PATCH, POST, PUT");

--- a/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbGetDeletePatchOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("GET, DELETE, PATCH");

--- a/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
@@ -51,7 +51,7 @@ std::string badVerbGetPutOnly
 )
 {
   std::string  details = std::string("bad verb for url '") + ciP->url + "', method '" + ciP->method + "'";
-  OrionError   oe(SccBadVerb, BAD_VERB);
+  OrionError   oe(SccBadVerb, ERROR_DESC_BAD_VERB);
 
   ciP->httpHeader.push_back("Allow");
   ciP->httpHeaderValue.push_back("GET, PUT");

--- a/src/lib/serviceRoutinesV2/deleteEntity.cpp
+++ b/src/lib/serviceRoutinesV2/deleteEntity.cpp
@@ -68,7 +68,7 @@ std::string deleteEntity
 
   if (forbiddenIdChars(ciP->apiVersion, compV[2].c_str() , NULL))
   {
-    OrionError oe(SccBadRequest, INVAL_CHAR_URI, "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = oe.code;
     return oe.toJson();
   }

--- a/src/lib/serviceRoutinesV2/getEntity.cpp
+++ b/src/lib/serviceRoutinesV2/getEntity.cpp
@@ -71,14 +71,14 @@ std::string getEntity
 
    if (entityId == "")
    {
-     OrionError oe(SccBadRequest, EMPTY_ENTITY_ID, "BadRequest");
+     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID, ERROR_BAD_REQUEST);
      ciP->httpStatusCode = oe.code;
      return oe.toJson();
    }
 
    if (forbiddenIdChars(ciP->apiVersion, entityId.c_str(), NULL))
    {
-     OrionError oe(SccBadRequest, INVAL_CHAR_URI, "BadRequest");
+     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
      ciP->httpStatusCode = oe.code;
      return oe.toJson();
    }

--- a/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
@@ -68,7 +68,7 @@ std::string getEntityAttribute
 
   if (forbiddenIdChars(ciP->apiVersion, compV[2].c_str() , NULL) || (forbiddenIdChars(ciP->apiVersion, compV[4].c_str() , NULL)))
   {
-    OrionError oe(SccBadRequest, INVAL_CHAR_URI, "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = oe.code;
     return oe.toJson();
   }
@@ -95,11 +95,11 @@ std::string getEntityAttribute
                                          ciP->uriParam[URI_PARAM_METADATA],
                                          EntityAttributeResponse));
 
-  if (attribute.oe.reasonPhrase == "TooManyResults")
+  if (attribute.oe.reasonPhrase == ERROR_TOO_MANY)
   {
     ciP->httpStatusCode = SccConflict;
   }
-  else if (attribute.oe.reasonPhrase == "NotFound")
+  else if (attribute.oe.reasonPhrase == ERROR_NOT_FOUND)
   {
     ciP->httpStatusCode = SccContextElementNotFound; // Attribute to be precise!
   }

--- a/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
@@ -70,7 +70,7 @@ std::string getEntityAttributeValue
 
   if (forbiddenIdChars(ciP->apiVersion, compV[2].c_str() , NULL) || (forbiddenIdChars(ciP->apiVersion, compV[4].c_str() , NULL)))
   {
-    OrionError oe(SccBadRequest, INVAL_CHAR_URI, "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = oe.code;
     return oe.toJson();
   }

--- a/src/lib/serviceRoutinesV2/getEntityType.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityType.cpp
@@ -66,7 +66,7 @@ std::string getEntityType
 
   if (entityTypeName == "")
   {
-    OrionError oe(SccBadRequest, EMPTY_ENTITY_TYPE, "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_TYPE, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = oe.code;
     return oe.toJson();
   }
@@ -75,7 +75,7 @@ std::string getEntityType
 
   if (response.entityType.count == 0)
   {
-    OrionError oe(SccContextElementNotFound, "Entity type not found", "NotFound");
+    OrionError oe(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ENTITY_TYPE, ERROR_NOT_FOUND);
     TIMED_RENDER(answer = oe.toJson());
     ciP->httpStatusCode = oe.code;
   }

--- a/src/lib/serviceRoutinesV2/patchEntity.cpp
+++ b/src/lib/serviceRoutinesV2/patchEntity.cpp
@@ -73,7 +73,7 @@ std::string patchEntity
 
   if (forbiddenIdChars(ciP->apiVersion, eP->id.c_str() , NULL))
   {
-    OrionError oe(SccBadRequest, "invalid character in URI", "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = oe.code;
     return oe.toJson();
   }

--- a/src/lib/serviceRoutinesV2/postEntity.cpp
+++ b/src/lib/serviceRoutinesV2/postEntity.cpp
@@ -71,7 +71,7 @@ std::string postEntity
 
   if (forbiddenIdChars(ciP->apiVersion, compV[2].c_str() , NULL))
   {
-    OrionError oe(SccBadRequest, INVAL_CHAR_URI, "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = oe.code;
     return oe.toJson();
   }

--- a/src/lib/serviceRoutinesV2/putEntity.cpp
+++ b/src/lib/serviceRoutinesV2/putEntity.cpp
@@ -72,7 +72,7 @@ std::string putEntity
 
   if (forbiddenIdChars(ciP->apiVersion, compV[2].c_str() , NULL))
   {
-    OrionError oe(SccBadRequest, INVAL_CHAR_URI, "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = oe.code;
     return oe.toJson();
   }

--- a/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
@@ -69,7 +69,7 @@ std::string putEntityAttribute
 
   if (forbiddenIdChars(ciP->apiVersion, entityId.c_str() , NULL) || (forbiddenIdChars(ciP->apiVersion, attributeName.c_str() , NULL)))
   {
-    OrionError oe(SccBadRequest, INVAL_CHAR_URI, "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = oe.code;
     return oe.toJson();
   }

--- a/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
@@ -67,7 +67,7 @@ std::string putEntityAttributeValue
 
   if (forbiddenIdChars(ciP->apiVersion, entityId.c_str() , NULL) || forbiddenIdChars(ciP->apiVersion, attributeName.c_str() , NULL))
   {
-    OrionError oe(SccBadRequest, INVAL_CHAR_URI, "BadRequest");
+    OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
     ciP->httpStatusCode = oe.code;
     return oe.toJson();
   }

--- a/test/functionalTest/cases/0970_create_entity/errors_at_creation.test
+++ b/test/functionalTest/cases/0970_create_entity/errors_at_creation.test
@@ -151,13 +151,13 @@ echo
 01. POST /v2/entities without Entity::id
 ========================================
 HTTP/1.1 400 Bad Request
-Content-Length: 61
+Content-Length: 83
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "no entity id specified", 
+    "description": "entity id length: 0, min length supported: 1", 
     "error": "BadRequest"
 }
 
@@ -165,13 +165,13 @@ Date: REGEX(.*)
 02. POST /v2/entities with empty Entity::id
 ===========================================
 HTTP/1.1 400 Bad Request
-Content-Length: 54
+Content-Length: 83
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "empty entity id", 
+    "description": "entity id length: 0, min length supported: 1",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/0993_DELETE_v2_entity_attr/delete_not_exist_attr.test
+++ b/test/functionalTest/cases/0993_DELETE_v2_entity_attr/delete_not_exist_attr.test
@@ -103,13 +103,13 @@ Date: REGEX(.*)
 03. DELETE /v2/entities/E1/attrs/none
 =====================================
 HTTP/1.1 404 Not Found
-Content-Length: 56
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "Attribute not found",
+    "description": "The entity does not have such an attribute",
     "error": "NotFound"
 }
 

--- a/test/functionalTest/cases/1259_new_json_for_v2/putPostPatch_v2_entities_eid_with_error.test
+++ b/test/functionalTest/cases/1259_new_json_for_v2/putPostPatch_v2_entities_eid_with_error.test
@@ -237,13 +237,13 @@ Date: REGEX(.*)
 08. POST /v2/entities without id in payload
 ===========================================
 HTTP/1.1 400 Bad Request
-Content-Length: 61
+Content-Length: 83
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "no entity id specified",
+    "description": "entity id length: 0, min length supported: 1",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1305_all_tests_empty_payload/all_tests_empty_payload.test
+++ b/test/functionalTest/cases/1305_all_tests_empty_payload/all_tests_empty_payload.test
@@ -182,13 +182,13 @@ Date: REGEX(.*)
 02. POST /v2/entities (empty payload)
 =====================================
 HTTP/1.1 400 Bad Request
-Content-Length: 61
+Content-Length: 83
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "no entity id specified",
+    "description": "entity id length: 0, min length supported: 1",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1316_create_subscription/post_subs_errors.test
+++ b/test/functionalTest/cases/1316_create_subscription/post_subs_errors.test
@@ -289,13 +289,13 @@ Date: REGEX(.*)
 04. POST /v2/subscriptions (not an object)
 ==========================================
 HTTP/1.1 400 Bad Request
-Content-Length: 73
+Content-Length: 75
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "Error parsing incoming JSON buffer",
+    "description": "Errors found in incoming JSON buffer",
     "error": "ParseError"
 }
 

--- a/test/functionalTest/cases/1552_invalid_sub_id/invalid_sub_id.test
+++ b/test/functionalTest/cases/1552_invalid_sub_id/invalid_sub_id.test
@@ -66,13 +66,13 @@ Date: REGEX(.*)
 02. Ask to see a subscription that doesn't exist
 ================================================
 HTTP/1.1 404 Not Found
-Content-Length: 97
+Content-Length: 92
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "subscriptionId does not correspond to an active subscription",
+    "description": "The requested subscription has not been found. Check id",
     "error": "NotFound"
 }
 

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -9981,7 +9981,7 @@ TEST(mongoUpdateContextRequest, tooManyEntitiesNGSIv2)
   ASSERT_EQ(0, RES_CER(0).contextAttributeVector.size());
   EXPECT_EQ(SccConflict, RES_CER_STATUS(0).code);
   EXPECT_EQ("Too Many Results", RES_CER_STATUS(0).reasonPhrase);
-  EXPECT_EQ(MORE_MATCHING_ENT, RES_CER_STATUS(0).details);
+  EXPECT_EQ(ERROR_DESC_TOO_MANY_ENTITIES, RES_CER_STATUS(0).details);
 
   /* Check that every involved collection at MongoDB is as expected */
   /* Note we are using EXPECT_STREQ() for some cases, as Mongo Driver returns const char*, not string


### PR DESCRIPTION
Note that as cited in the code itself (https://github.com/telefonicaid/fiware-orion/compare/hardening/error_string?expand=1#diff-c2640173c861df9babf636b17a6b3755R40) this PR doesn't do an exhaustive extraction. However, it puts some order in some existing and quite common error situations, as you can see in the .test modifications (only in error description texts).