### PR TITLE
apiVersion from std::string to int

### DIFF
--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -40,7 +40,7 @@
 */
 std::string Attribute::render
 (
-  int                 apiVersion,          // in parameter (pass-through)
+  ApiVersion          apiVersion,          // in parameter (pass-through)
   bool                acceptedTextPlain,   // in parameter (pass-through)
   bool                acceptedJson,        // in parameter (pass-through)
   MimeType            outFormatSelection,  // in parameter (pass-through)

--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -40,7 +40,7 @@
 */
 std::string Attribute::render
 (
-  const std::string&  apiVersion,          // in parameter (pass-through)
+  int                 apiVersion,          // in parameter (pass-through)
   bool                acceptedTextPlain,   // in parameter (pass-through)
   bool                acceptedJson,        // in parameter (pass-through)
   MimeType            outFormatSelection,  // in parameter (pass-through)

--- a/src/lib/apiTypesV2/Attribute.h
+++ b/src/lib/apiTypesV2/Attribute.h
@@ -46,7 +46,7 @@ public:
   OrionError         oe;                    // Optional - mandatory if not 200-OK
 
   Attribute(): pcontextAttribute(0) {}
-  std::string  render(const std::string&  apiVersion,
+  std::string  render(int                 apiVersion,
                       bool                acceptedTextPlain,
                       bool                acceptedJson,
                       MimeType            outFormatSelection,

--- a/src/lib/apiTypesV2/Attribute.h
+++ b/src/lib/apiTypesV2/Attribute.h
@@ -46,7 +46,7 @@ public:
   OrionError         oe;                    // Optional - mandatory if not 200-OK
 
   Attribute(): pcontextAttribute(0) {}
-  std::string  render(int                 apiVersion,
+  std::string  render(ApiVersion          apiVersion,
                       bool                acceptedTextPlain,
                       bool                acceptedJson,
                       MimeType            outFormatSelection,

--- a/src/lib/apiTypesV2/Entities.cpp
+++ b/src/lib/apiTypesV2/Entities.cpp
@@ -78,7 +78,7 @@ std::string Entities::render
 *   The 'check' method is normally only used to check that incoming payload is correct.
 *   For now (at least), the Entities type is only used as outgoing payload ...
 */
-std::string Entities::check(int apiVersion, RequestType requestType)
+std::string Entities::check(ApiVersion apiVersion, RequestType requestType)
 {
   return vec.check(apiVersion, requestType);
 }

--- a/src/lib/apiTypesV2/Entities.cpp
+++ b/src/lib/apiTypesV2/Entities.cpp
@@ -78,7 +78,7 @@ std::string Entities::render
 *   The 'check' method is normally only used to check that incoming payload is correct.
 *   For now (at least), the Entities type is only used as outgoing payload ...
 */
-std::string Entities::check(const std::string& apiVersion, RequestType requestType)
+std::string Entities::check(int apiVersion, RequestType requestType)
 {
   return vec.check(apiVersion, requestType);
 }

--- a/src/lib/apiTypesV2/Entities.h
+++ b/src/lib/apiTypesV2/Entities.h
@@ -49,7 +49,7 @@ public:
 
   std::string  render(std::map<std::string, bool>&         uriParamOptions,
                       std::map<std::string, std::string>&  uriParam);
-  std::string  check(const std::string& apiVersion, RequestType requestType);
+  std::string  check(int apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);
   void         fill(QueryContextResponse* qcrsP);

--- a/src/lib/apiTypesV2/Entities.h
+++ b/src/lib/apiTypesV2/Entities.h
@@ -49,7 +49,7 @@ public:
 
   std::string  render(std::map<std::string, bool>&         uriParamOptions,
                       std::map<std::string, std::string>&  uriParam);
-  std::string  check(int apiVersion, RequestType requestType);
+  std::string  check(ApiVersion apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);
   void         fill(QueryContextResponse* qcrsP);

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -175,12 +175,12 @@ std::string Entity::render
 *
 * Entity::check - 
 */
-std::string Entity::check(int apiVersion, RequestType requestType)
+std::string Entity::check(ApiVersion apiVersion, RequestType requestType)
 {
   ssize_t len;
   char errorMsg[128];
 
-  if (((apiVersion == 2) && (len = strlen(id.c_str())) < MIN_ID_LEN) && (requestType != EntityRequest))
+  if (((apiVersion == V2) && (len = strlen(id.c_str())) < MIN_ID_LEN) && (requestType != EntityRequest))
   {
     snprintf(errorMsg, sizeof errorMsg, "entity id length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
@@ -212,7 +212,7 @@ std::string Entity::check(int apiVersion, RequestType requestType)
     return std::string(errorMsg);
   }
 
-  if ((apiVersion == 2) && ((len = strlen(type.c_str())) < MIN_ID_LEN) && (requestType != BatchQueryRequest))
+  if ((apiVersion == V2) && ((len = strlen(type.c_str())) < MIN_ID_LEN) && (requestType != BatchQueryRequest))
   {
     snprintf(errorMsg, sizeof errorMsg, "entity type length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -175,12 +175,12 @@ std::string Entity::render
 *
 * Entity::check - 
 */
-std::string Entity::check(const std::string& apiVersion, RequestType requestType)
+std::string Entity::check(int apiVersion, RequestType requestType)
 {
   ssize_t len;
   char errorMsg[128];
 
-  if (((apiVersion == "v2") && (len = strlen(id.c_str())) < MIN_ID_LEN) && (requestType != EntityRequest))
+  if (((apiVersion == 2) && (len = strlen(id.c_str())) < MIN_ID_LEN) && (requestType != EntityRequest))
   {
     snprintf(errorMsg, sizeof errorMsg, "entity id length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
@@ -212,7 +212,7 @@ std::string Entity::check(const std::string& apiVersion, RequestType requestType
     return std::string(errorMsg);
   }
 
-  if ((apiVersion == "v2") && ((len = strlen(type.c_str())) < MIN_ID_LEN) && (requestType != BatchQueryRequest))
+  if ((apiVersion == 2) && ((len = strlen(type.c_str())) < MIN_ID_LEN) && (requestType != BatchQueryRequest))
   {
     snprintf(errorMsg, sizeof errorMsg, "entity type length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);

--- a/src/lib/apiTypesV2/Entity.h
+++ b/src/lib/apiTypesV2/Entity.h
@@ -60,7 +60,7 @@ public:
   std::string  render(std::map<std::string, bool>&         uriParamOptions,
                       std::map<std::string, std::string>&  uriParam,
                       bool                                 comma = false);
-  std::string  check(int apiVersion, RequestType requestType);
+  std::string  check(ApiVersion apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);
   void         fill(const std::string&       id,

--- a/src/lib/apiTypesV2/Entity.h
+++ b/src/lib/apiTypesV2/Entity.h
@@ -60,7 +60,7 @@ public:
   std::string  render(std::map<std::string, bool>&         uriParamOptions,
                       std::map<std::string, std::string>&  uriParam,
                       bool                                 comma = false);
-  std::string  check(const std::string& apiVersion, RequestType requestType);
+  std::string  check(int apiVersion, RequestType requestType);
   void         present(const std::string& indent);
   void         release(void);
   void         fill(const std::string&       id,

--- a/src/lib/apiTypesV2/EntityVector.cpp
+++ b/src/lib/apiTypesV2/EntityVector.cpp
@@ -73,7 +73,7 @@ std::string EntityVector::render
 *
 * EntityVector::check -
 */
-std::string EntityVector::check(const std::string& apiVersion, RequestType requestType)
+std::string EntityVector::check(int apiVersion, RequestType requestType)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/apiTypesV2/EntityVector.cpp
+++ b/src/lib/apiTypesV2/EntityVector.cpp
@@ -73,7 +73,7 @@ std::string EntityVector::render
 *
 * EntityVector::check -
 */
-std::string EntityVector::check(int apiVersion, RequestType requestType)
+std::string EntityVector::check(ApiVersion apiVersion, RequestType requestType)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/apiTypesV2/EntityVector.h
+++ b/src/lib/apiTypesV2/EntityVector.h
@@ -42,7 +42,7 @@ typedef struct EntityVector
 
   std::string   render(std::map<std::string, bool>&         uriParamOptions,
                        std::map<std::string, std::string>&  uriParam);
-  std::string   check(const std::string& apiVersion, RequestType requestType);
+  std::string   check(int apiVersion, RequestType requestType);
   void          present(const std::string& indent);
   void          push_back(Entity* item);
   unsigned int  size(void);

--- a/src/lib/apiTypesV2/EntityVector.h
+++ b/src/lib/apiTypesV2/EntityVector.h
@@ -42,7 +42,7 @@ typedef struct EntityVector
 
   std::string   render(std::map<std::string, bool>&         uriParamOptions,
                        std::map<std::string, std::string>&  uriParam);
-  std::string   check(int apiVersion, RequestType requestType);
+  std::string   check(ApiVersion apiVersion, RequestType requestType);
   void          present(const std::string& indent);
   void          push_back(Entity* item);
   unsigned int  size(void);

--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -151,6 +151,20 @@ typedef enum Ngsiv2Flavour
 
 
 /* ****************************************************************************
+*
+*  NGSI API version -
+*/
+typedef enum ApiVersion
+{
+  NO_VERSION  = -1,
+  ADMIN_API   = 0,
+  V1          = 1,
+  V2          = 2
+} ApiVersion;
+
+
+
+/* ****************************************************************************
  * Future date to represent permanent subscriptions.
  * High enough to make the subscription "permanent" but leaving room for
  * some (sloppy) increments, without causing overflow and accidental subscription

--- a/src/lib/convenience/AppendContextElementRequest.cpp
+++ b/src/lib/convenience/AppendContextElementRequest.cpp
@@ -49,7 +49,7 @@ AppendContextElementRequest::AppendContextElementRequest()
 *
 * render - 
 */
-std::string AppendContextElementRequest::render(int apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
+std::string AppendContextElementRequest::render(ApiVersion apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
 {
   std::string out = "";
 
@@ -85,7 +85,7 @@ std::string AppendContextElementRequest::render(int apiVersion, bool asJsonObjec
 */
 std::string AppendContextElementRequest::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   std::string         indent,

--- a/src/lib/convenience/AppendContextElementRequest.cpp
+++ b/src/lib/convenience/AppendContextElementRequest.cpp
@@ -49,7 +49,7 @@ AppendContextElementRequest::AppendContextElementRequest()
 *
 * render - 
 */
-std::string AppendContextElementRequest::render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
+std::string AppendContextElementRequest::render(int apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
 {
   std::string out = "";
 
@@ -85,12 +85,11 @@ std::string AppendContextElementRequest::render(const std::string& apiVersion, b
 */
 std::string AppendContextElementRequest::check
 (
-  const std::string& apiVersion,
-  bool               asJsonObject,
-  RequestType        requestType,
-  std::string        indent,
-  std::string        predetectedError,     // Predetected Error, normally during parsing
-  int                counter
+  int                 apiVersion,
+  bool                asJsonObject,
+  RequestType         requestType,
+  std::string         indent,
+  const std::string&  predetectedError     // Predetected Error, normally during parsing
 )
 {
   AppendContextElementResponse  response;

--- a/src/lib/convenience/AppendContextElementRequest.h
+++ b/src/lib/convenience/AppendContextElementRequest.h
@@ -56,10 +56,10 @@ typedef struct AppendContextElementRequest
 
   AppendContextElementRequest();
 
-  std::string  render(int apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
+  std::string  render(ApiVersion apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
   void         present(std::string indent);
   void         release();
-  std::string  check(int                 apiVersion,
+  std::string  check(ApiVersion          apiVersion,
                      bool                asJsonObject,
                      RequestType         requestType,
                      std::string         indent,

--- a/src/lib/convenience/AppendContextElementRequest.h
+++ b/src/lib/convenience/AppendContextElementRequest.h
@@ -56,15 +56,14 @@ typedef struct AppendContextElementRequest
 
   AppendContextElementRequest();
 
-  std::string  render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
+  std::string  render(int apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
   void         present(std::string indent);
   void         release();
-  std::string  check(const std::string&  apiVersion,
+  std::string  check(int                 apiVersion,
                      bool                asJsonObject,
                      RequestType         requestType,
                      std::string         indent,
-                     std::string         predetectedError,
-                     int                 counter);
+                     const std::string&  predetectedError);
 } AppendContextElementRequest;
 
 #endif  // SRC_LIB_CONVENIENCE_APPENDCONTEXTELEMENTREQUEST_H_

--- a/src/lib/convenience/AppendContextElementResponse.cpp
+++ b/src/lib/convenience/AppendContextElementResponse.cpp
@@ -54,10 +54,10 @@ AppendContextElementResponse::AppendContextElementResponse() : errorCode("errorC
 */
 std::string AppendContextElementResponse::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
-  const std::string& indent)
+  const std::string&  indent)
 {
   std::string out = "";
 
@@ -90,12 +90,11 @@ std::string AppendContextElementResponse::render
 */
 std::string AppendContextElementResponse::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   std::string         indent,
-  std::string         predetectedError,
-  int                 counter
+  const std::string&  predetectedError
 )
 {
   std::string res;
@@ -104,7 +103,7 @@ std::string AppendContextElementResponse::check
   {
     errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = contextAttributeResponseVector.check(apiVersion, asJsonObject, requestType, indent, "", counter)) != "OK")
+  else if ((res = contextAttributeResponseVector.check(apiVersion, asJsonObject, requestType, indent, "")) != "OK")
   {
     errorCode.fill(SccBadRequest, res);
   }

--- a/src/lib/convenience/AppendContextElementResponse.cpp
+++ b/src/lib/convenience/AppendContextElementResponse.cpp
@@ -54,7 +54,7 @@ AppendContextElementResponse::AppendContextElementResponse() : errorCode("errorC
 */
 std::string AppendContextElementResponse::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent)
@@ -90,7 +90,7 @@ std::string AppendContextElementResponse::render
 */
 std::string AppendContextElementResponse::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   std::string         indent,

--- a/src/lib/convenience/AppendContextElementResponse.h
+++ b/src/lib/convenience/AppendContextElementResponse.h
@@ -71,13 +71,13 @@ typedef struct AppendContextElementResponse
 
   AppendContextElementResponse();
 
-  std::string  render(int                 apiVersion,
+  std::string  render(ApiVersion          apiVersion,
                       bool                asJsonObject,
                       RequestType         requestType,
                       const std::string&  indent);
   void         present(void);
   void         release(void);
-  std::string  check(int                 apiVersion,
+  std::string  check(ApiVersion          apiVersion,
                      bool                asJsonObject,
                      RequestType         requestType,
                      std::string         indent,

--- a/src/lib/convenience/AppendContextElementResponse.h
+++ b/src/lib/convenience/AppendContextElementResponse.h
@@ -71,18 +71,17 @@ typedef struct AppendContextElementResponse
 
   AppendContextElementResponse();
 
-  std::string  render(const std::string&  apiVersion,
+  std::string  render(int                 apiVersion,
                       bool                asJsonObject,
                       RequestType         requestType,
                       const std::string&  indent);
   void         present(void);
   void         release(void);
-  std::string  check(const std::string&  apiVersion,
+  std::string  check(int                 apiVersion,
                      bool                asJsonObject,
                      RequestType         requestType,
                      std::string         indent,
-                     std::string         predetectedError,
-                     int                 counter);
+                     const std::string&  predetectedError);
   void         fill(UpdateContextResponse* ucrsP, const std::string& entityId = "", const std::string& entityType = "");
 } AppendContextElementResponse;
 

--- a/src/lib/convenience/ContextAttributeResponse.cpp
+++ b/src/lib/convenience/ContextAttributeResponse.cpp
@@ -44,7 +44,7 @@
 */
 std::string ContextAttributeResponse::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         request,
   const std::string&  indent
@@ -68,12 +68,11 @@ std::string ContextAttributeResponse::render
 */
 std::string ContextAttributeResponse::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   std::string         indent,
-  std::string         predetectedError,
-  int                 counter
+  const std::string&  predetectedError
 )
 {
   std::string  res;

--- a/src/lib/convenience/ContextAttributeResponse.cpp
+++ b/src/lib/convenience/ContextAttributeResponse.cpp
@@ -44,7 +44,7 @@
 */
 std::string ContextAttributeResponse::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         request,
   const std::string&  indent
@@ -68,7 +68,7 @@ std::string ContextAttributeResponse::render
 */
 std::string ContextAttributeResponse::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   std::string         indent,

--- a/src/lib/convenience/ContextAttributeResponse.h
+++ b/src/lib/convenience/ContextAttributeResponse.h
@@ -51,13 +51,13 @@ typedef struct ContextAttributeResponse
   ContextAttributeVector     contextAttributeVector;     // Mandatory
   StatusCode                 statusCode;                 // Mandatory
 
-  std::string render(int                 apiVersion,
+  std::string render(ApiVersion          apiVersion,
                      bool                asJsonObject,
                      RequestType         request,
                      const std::string&  indent);
   void        present(std::string indent);
   void        release(void);
-  std::string check(int                 apiVersion,
+  std::string check(ApiVersion          apiVersion,
                     bool                asJsonObject,
                     RequestType         requestType,
                     std::string         indent,

--- a/src/lib/convenience/ContextAttributeResponse.h
+++ b/src/lib/convenience/ContextAttributeResponse.h
@@ -51,18 +51,17 @@ typedef struct ContextAttributeResponse
   ContextAttributeVector     contextAttributeVector;     // Mandatory
   StatusCode                 statusCode;                 // Mandatory
 
-  std::string render(const std::string&  apiVersion,
+  std::string render(int                 apiVersion,
                      bool                asJsonObject,
                      RequestType         request,
                      const std::string&  indent);
   void        present(std::string indent);
   void        release(void);
-  std::string check(const std::string&  apiVersion,
+  std::string check(int                 apiVersion,
                     bool                asJsonObject,
                     RequestType         requestType,
                     std::string         indent,
-                    std::string         predetectedError,
-                    int                 counter);
+                    const std::string&  predetectedError);
   void        fill(ContextAttributeVector* _cavP, const StatusCode& _statusCode);
   void        fill(QueryContextResponse*  qcrP,
                    const std::string&     entityId,

--- a/src/lib/convenience/ContextAttributeResponseVector.cpp
+++ b/src/lib/convenience/ContextAttributeResponseVector.cpp
@@ -40,7 +40,7 @@
 */
 std::string ContextAttributeResponseVector::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         request,
   const std::string&  indent)
@@ -71,7 +71,7 @@ std::string ContextAttributeResponseVector::render
 */
 std::string ContextAttributeResponseVector::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         request,
   std::string         indent,

--- a/src/lib/convenience/ContextAttributeResponseVector.cpp
+++ b/src/lib/convenience/ContextAttributeResponseVector.cpp
@@ -40,7 +40,7 @@
 */
 std::string ContextAttributeResponseVector::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         request,
   const std::string&  indent)
@@ -71,19 +71,18 @@ std::string ContextAttributeResponseVector::render
 */
 std::string ContextAttributeResponseVector::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         request,
   std::string         indent,
-  std::string         predetectedError,
-  int                 counter
+  const std::string&  predetectedError
 )
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     std::string res;
 
-    if ((res = vec[ix]->check(apiVersion, asJsonObject, request, indent, predetectedError, counter)) != "OK")
+    if ((res = vec[ix]->check(apiVersion, asJsonObject, request, indent, predetectedError)) != "OK")
     {
       return res;
     }

--- a/src/lib/convenience/ContextAttributeResponseVector.h
+++ b/src/lib/convenience/ContextAttributeResponseVector.h
@@ -41,7 +41,7 @@ typedef struct ContextAttributeResponseVector
 {
   std::vector<ContextAttributeResponse*>  vec;
 
-  std::string                render(int                 apiVersion,
+  std::string                render(ApiVersion          apiVersion,
                                     bool                asJsonObject,
                                     RequestType         request,
                                     const std::string&  indent);
@@ -49,7 +49,7 @@ typedef struct ContextAttributeResponseVector
   void                       push_back(ContextAttributeResponse* item);
   unsigned int               size(void);
   void                       release(void);
-  std::string                check(int                 apiVersion,
+  std::string                check(ApiVersion          apiVersion,
                                    bool                asJsonObject,
                                    RequestType         requestType,
                                    std::string         indent,

--- a/src/lib/convenience/ContextAttributeResponseVector.h
+++ b/src/lib/convenience/ContextAttributeResponseVector.h
@@ -41,7 +41,7 @@ typedef struct ContextAttributeResponseVector
 {
   std::vector<ContextAttributeResponse*>  vec;
 
-  std::string                render(const std::string&  apiVersion,
+  std::string                render(int                 apiVersion,
                                     bool                asJsonObject,
                                     RequestType         request,
                                     const std::string&  indent);
@@ -49,12 +49,11 @@ typedef struct ContextAttributeResponseVector
   void                       push_back(ContextAttributeResponse* item);
   unsigned int               size(void);
   void                       release(void);
-  std::string                check(const std::string&  apiVersion,
+  std::string                check(int                 apiVersion,
                                    bool                asJsonObject,
                                    RequestType         requestType,
                                    std::string         indent,
-                                   std::string         predetectedError,
-                                   int                 counter);
+                                   const std::string&  predetectedError);
   void                       fill(ContextAttributeVector* cavP, const StatusCode& statusCode);
 
   ContextAttributeResponse*  operator[](unsigned int ix) const;

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -86,11 +86,10 @@ std::string RegisterProviderRequest::render(std::string indent)
 */
 std::string RegisterProviderRequest::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         requestType,
   std::string         indent,
-  std::string         predetectedError,
-  int                 counter
+  const std::string&  predetectedError
 )
 {
   DiscoverContextAvailabilityResponse  response;

--- a/src/lib/convenience/RegisterProviderRequest.cpp
+++ b/src/lib/convenience/RegisterProviderRequest.cpp
@@ -86,7 +86,7 @@ std::string RegisterProviderRequest::render(std::string indent)
 */
 std::string RegisterProviderRequest::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         requestType,
   std::string         indent,
   const std::string&  predetectedError

--- a/src/lib/convenience/RegisterProviderRequest.h
+++ b/src/lib/convenience/RegisterProviderRequest.h
@@ -49,7 +49,7 @@ typedef struct RegisterProviderRequest
   RegisterProviderRequest();
 
   std::string  render(std::string indent);
-  std::string  check(const std::string& apiVersion, RequestType requestType, std::string indent, std::string preError, int counter);
+  std::string  check(int apiVersion, RequestType requestType, std::string indent, const std::string& preError);
   void         present(std::string indent);
   void         release();
 } RegisterProviderRequest;

--- a/src/lib/convenience/RegisterProviderRequest.h
+++ b/src/lib/convenience/RegisterProviderRequest.h
@@ -49,7 +49,7 @@ typedef struct RegisterProviderRequest
   RegisterProviderRequest();
 
   std::string  render(std::string indent);
-  std::string  check(int apiVersion, RequestType requestType, std::string indent, const std::string& preError);
+  std::string  check(ApiVersion apiVersion, RequestType requestType, std::string indent, const std::string& preError);
   void         present(std::string indent);
   void         release();
 } RegisterProviderRequest;

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -53,7 +53,7 @@ UpdateContextAttributeRequest::UpdateContextAttributeRequest()
 *
 * render - 
 */
-std::string UpdateContextAttributeRequest::render(const std::string& apiVersion, std::string indent)
+std::string UpdateContextAttributeRequest::render(int apiVersion, std::string indent)
 {
   std::string out = "";
   std::string indent2 = indent + "  ";
@@ -94,11 +94,9 @@ std::string UpdateContextAttributeRequest::render(const std::string& apiVersion,
 */
 std::string UpdateContextAttributeRequest::check
 (
-  const std::string&  apiVersion,
-  RequestType         requestType,
+  int                 apiVersion,
   std::string         indent,
-  std::string         predetectedError,
-  int                 counter
+  const std::string&  predetectedError
 )
 {
   StatusCode       response;

--- a/src/lib/convenience/UpdateContextAttributeRequest.cpp
+++ b/src/lib/convenience/UpdateContextAttributeRequest.cpp
@@ -53,7 +53,7 @@ UpdateContextAttributeRequest::UpdateContextAttributeRequest()
 *
 * render - 
 */
-std::string UpdateContextAttributeRequest::render(int apiVersion, std::string indent)
+std::string UpdateContextAttributeRequest::render(ApiVersion apiVersion, std::string indent)
 {
   std::string out = "";
   std::string indent2 = indent + "  ";
@@ -94,7 +94,7 @@ std::string UpdateContextAttributeRequest::render(int apiVersion, std::string in
 */
 std::string UpdateContextAttributeRequest::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   std::string         indent,
   const std::string&  predetectedError
 )

--- a/src/lib/convenience/UpdateContextAttributeRequest.h
+++ b/src/lib/convenience/UpdateContextAttributeRequest.h
@@ -49,8 +49,8 @@ typedef struct UpdateContextAttributeRequest
   orion::CompoundValueNode*  compoundValueP;
 
   UpdateContextAttributeRequest();
-  std::string  render(int apiVersion, std::string indent);
-  std::string  check(int apiVersion, std::string indent, const std::string& preError);
+  std::string  render(ApiVersion apiVersion, std::string indent);
+  std::string  check(ApiVersion apiVersion, std::string indent, const std::string& preError);
   void         present(std::string indent);
   void         release();
 } UpdateContextAttributeRequest;

--- a/src/lib/convenience/UpdateContextAttributeRequest.h
+++ b/src/lib/convenience/UpdateContextAttributeRequest.h
@@ -49,8 +49,8 @@ typedef struct UpdateContextAttributeRequest
   orion::CompoundValueNode*  compoundValueP;
 
   UpdateContextAttributeRequest();
-  std::string  render(const std::string& apiVersion, std::string indent);
-  std::string  check(const std::string& apiVersion, RequestType requestType, std::string indent, std::string preError, int counter);
+  std::string  render(int apiVersion, std::string indent);
+  std::string  check(int apiVersion, std::string indent, const std::string& preError);
   void         present(std::string indent);
   void         release();
 } UpdateContextAttributeRequest;

--- a/src/lib/convenience/UpdateContextElementRequest.cpp
+++ b/src/lib/convenience/UpdateContextElementRequest.cpp
@@ -39,7 +39,7 @@
 *
 * render - 
 */
-std::string UpdateContextElementRequest::render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
+std::string UpdateContextElementRequest::render(int apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
 {
   std::string out = "";
 
@@ -69,12 +69,11 @@ std::string UpdateContextElementRequest::render(const std::string& apiVersion, b
 */
 std::string UpdateContextElementRequest::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   std::string         indent,
-  std::string         predetectedError,     // Predetected Error, normally during parsing
-  int                 counter
+  const std::string&  predetectedError     // Predetected Error, normally during parsing
 )
 {
   UpdateContextElementResponse  response;

--- a/src/lib/convenience/UpdateContextElementRequest.cpp
+++ b/src/lib/convenience/UpdateContextElementRequest.cpp
@@ -39,7 +39,7 @@
 *
 * render - 
 */
-std::string UpdateContextElementRequest::render(int apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
+std::string UpdateContextElementRequest::render(ApiVersion apiVersion, bool asJsonObject, RequestType requestType, std::string indent)
 {
   std::string out = "";
 
@@ -69,7 +69,7 @@ std::string UpdateContextElementRequest::render(int apiVersion, bool asJsonObjec
 */
 std::string UpdateContextElementRequest::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   std::string         indent,

--- a/src/lib/convenience/UpdateContextElementRequest.h
+++ b/src/lib/convenience/UpdateContextElementRequest.h
@@ -44,15 +44,14 @@ typedef struct UpdateContextElementRequest
   ContextAttributeVector     contextAttributeVector;     // Optional
   MetadataVector             domainMetadataVector;       // Optional
 
-  std::string  render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
+  std::string  render(int apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
   void         present(std::string indent);
   void         release(void);
-  std::string  check(const std::string&  apiVersion,
+  std::string  check(int                 apiVersion,
                      bool                asJsonObject,
                      RequestType         requestType,
                      std::string         indent,
-                     std::string         predetectedError,
-                     int                 counter);
+                     const std::string&  predetectedError);
 } UpdateContextElementRequest;
 
 #endif  // SRC_LIB_CONVENIENCE_UPDATECONTEXTELEMENTREQUEST_H_

--- a/src/lib/convenience/UpdateContextElementRequest.h
+++ b/src/lib/convenience/UpdateContextElementRequest.h
@@ -44,10 +44,10 @@ typedef struct UpdateContextElementRequest
   ContextAttributeVector     contextAttributeVector;     // Optional
   MetadataVector             domainMetadataVector;       // Optional
 
-  std::string  render(int apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
+  std::string  render(ApiVersion apiVersion, bool asJsonObject, RequestType requestType, std::string indent);
   void         present(std::string indent);
   void         release(void);
-  std::string  check(int                 apiVersion,
+  std::string  check(ApiVersion          apiVersion,
                      bool                asJsonObject,
                      RequestType         requestType,
                      std::string         indent,

--- a/src/lib/convenience/UpdateContextElementResponse.cpp
+++ b/src/lib/convenience/UpdateContextElementResponse.cpp
@@ -52,7 +52,7 @@ UpdateContextElementResponse::UpdateContextElementResponse()
 */
 std::string UpdateContextElementResponse::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent
@@ -84,7 +84,7 @@ std::string UpdateContextElementResponse::render
 */
 std::string UpdateContextElementResponse::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,

--- a/src/lib/convenience/UpdateContextElementResponse.cpp
+++ b/src/lib/convenience/UpdateContextElementResponse.cpp
@@ -52,7 +52,7 @@ UpdateContextElementResponse::UpdateContextElementResponse()
 */
 std::string UpdateContextElementResponse::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent
@@ -84,12 +84,11 @@ std::string UpdateContextElementResponse::render
 */
 std::string UpdateContextElementResponse::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
-  const std::string&  predetectedError,  // Predetected Error, normally during parsing
-  int                 counter
+  const std::string&  predetectedError  // Predetected Error, normally during parsing
 )
 {
   std::string res;
@@ -98,7 +97,7 @@ std::string UpdateContextElementResponse::check
   {
     errorCode.fill(SccBadRequest, predetectedError);
   }
-  else if ((res = contextAttributeResponseVector.check(apiVersion, asJsonObject, requestType, indent, "", counter)) != "OK")
+  else if ((res = contextAttributeResponseVector.check(apiVersion, asJsonObject, requestType, indent, "")) != "OK")
   {
     errorCode.fill(SccBadRequest, res);
   }

--- a/src/lib/convenience/UpdateContextElementResponse.h
+++ b/src/lib/convenience/UpdateContextElementResponse.h
@@ -58,13 +58,13 @@ typedef struct UpdateContextElementResponse
 
   UpdateContextElementResponse();
 
-  std::string  render(int                 apiVersion,
+  std::string  render(ApiVersion          apiVersion,
                       bool                asJsonObject,
                       RequestType         requestType,
                       const std::string&  indent);
   void         present(const std::string&  indent);
   void         release();
-  std::string  check(int                 apiVersion,
+  std::string  check(ApiVersion          apiVersion,
                      bool                asJsonObject,
                      RequestType         requestType,
                      const std::string&  indent,

--- a/src/lib/convenience/UpdateContextElementResponse.h
+++ b/src/lib/convenience/UpdateContextElementResponse.h
@@ -58,18 +58,17 @@ typedef struct UpdateContextElementResponse
 
   UpdateContextElementResponse();
 
-  std::string  render(const std::string&  apiVersion,
+  std::string  render(int                 apiVersion,
                       bool                asJsonObject,
                       RequestType         requestType,
-                      const std::string&   indent);
-  void         present(const std::string& indent);
+                      const std::string&  indent);
+  void         present(const std::string&  indent);
   void         release();
-  std::string  check(const std::string&  apiVersion,
+  std::string  check(int                 apiVersion,
                      bool                asJsonObject,
                      RequestType         requestType,
                      const std::string&  indent,
-                     const std::string&  predetectedError,
-                     int                 counter);
+                     const std::string&  predetectedError);
   void         fill(UpdateContextResponse* ucrsP);
 } UpdateContextElementResponse;
 

--- a/src/lib/jsonParse/jsonAppendContextElementRequest.cpp
+++ b/src/lib/jsonParse/jsonAppendContextElementRequest.cpp
@@ -329,9 +329,8 @@ void jsonAcerRelease(ParseData* reqData)
 */
 std::string jsonAcerCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->acer.res.check(ciP->apiVersion,
-                                 ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                 AppendContextElement, "", reqData->errorString, 0);
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+  return reqData->acer.res.check(ciP->apiVersion, asJsonObject, AppendContextElement, "", reqData->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonQueryContextRequest.cpp
+++ b/src/lib/jsonParse/jsonQueryContextRequest.cpp
@@ -768,8 +768,8 @@ void jsonQcrRelease(ParseData* reqDataP)
 */
 std::string jsonQcrCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->qcr.res.check(ciP->apiVersion,
-                                 ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, "", reqDataP->errorString);
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+  return reqDataP->qcr.res.check(ciP->apiVersion, asJsonObject, "", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonQueryContextResponse.cpp
+++ b/src/lib/jsonParse/jsonQueryContextResponse.cpp
@@ -445,7 +445,8 @@ void jsonQcrsRelease(ParseData* reqDataP)
 */
 std::string jsonQcrsCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->qcrs.res.check(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, "", reqDataP->errorString);
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+  return reqDataP->qcrs.res.check(ciP->apiVersion,asJsonObject, "", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonRegisterProviderRequest.cpp
+++ b/src/lib/jsonParse/jsonRegisterProviderRequest.cpp
@@ -185,7 +185,7 @@ void jsonRprRelease(ParseData* reqData)
 */
 std::string jsonRprCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->rpr.res.check(ciP->apiVersion, ContextEntitiesByEntityId, "", reqData->errorString, 0);
+  return reqData->rpr.res.check(ciP->apiVersion, ContextEntitiesByEntityId, "", reqData->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextAttributeRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextAttributeRequest.cpp
@@ -166,7 +166,7 @@ void jsonUpcarRelease(ParseData* reqData)
 */
 std::string jsonUpcarCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->upcar.res.check(ciP->apiVersion, UpdateContextAttribute, "", reqData->errorString, 0);
+  return reqData->upcar.res.check(ciP->apiVersion, "", reqData->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextElementRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextElementRequest.cpp
@@ -216,9 +216,8 @@ void jsonUcerRelease(ParseData* reqData)
 */
 std::string jsonUcerCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->ucer.res.check(ciP->apiVersion,
-                                 ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                 UpdateContextElement, "", reqData->errorString, 0);
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+  return reqData->ucer.res.check(ciP->apiVersion, asJsonObject, UpdateContextElement, "", reqData->errorString);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextRequest.cpp
@@ -385,9 +385,8 @@ void jsonUpcrRelease(ParseData* reqDataP)
 */
 std::string jsonUpcrCheck(ParseData* reqData, ConnectionInfo* ciP)
 {
-  return reqData->upcr.res.check(ciP->apiVersion,
-                                 ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON,
-                                 "", reqData->errorString, 0);
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+  return reqData->upcr.res.check(ciP->apiVersion, asJsonObject, "", reqData->errorString, 0);
 }
 
 

--- a/src/lib/jsonParse/jsonUpdateContextResponse.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextResponse.cpp
@@ -444,7 +444,8 @@ void jsonUpcrsRelease(ParseData* reqDataP)
 */
 std::string jsonUpcrsCheck(ParseData* reqDataP, ConnectionInfo* ciP)
 {
-  return reqDataP->upcrs.res.check(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, "", reqDataP->errorString);
+  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+  return reqDataP->upcrs.res.check(ciP->apiVersion, asJsonObject, "", reqDataP->errorString);
 }
 
 

--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -256,7 +256,7 @@ std::string parseContextAttribute(ConnectionInfo* ciP, const Value::ConstMemberI
     }
 
     // Attribute has a regular structure, in which 'value' is mandatory (except in v2)
-    if (iter->value.HasMember("value") || ciP->apiVersion == 2)
+    if (iter->value.HasMember("value") || ciP->apiVersion == V2)
     {
       std::string r = parseContextAttributeObject(iter->value, caP, &compoundVector);
       if (r != "OK")

--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -256,7 +256,7 @@ std::string parseContextAttribute(ConnectionInfo* ciP, const Value::ConstMemberI
     }
 
     // Attribute has a regular structure, in which 'value' is mandatory (except in v2)
-    if (iter->value.HasMember("value") || ciP->apiVersion == "v2")
+    if (iter->value.HasMember("value") || ciP->apiVersion == 2)
     {
       std::string r = parseContextAttributeObject(iter->value, caP, &compoundVector);
       if (r != "OK")

--- a/src/lib/jsonParseV2/parseScope.cpp
+++ b/src/lib/jsonParseV2/parseScope.cpp
@@ -139,7 +139,7 @@ std::string parseScopeValueLocation(Value::ConstMemberIterator valueP, Scope* sc
   }
 
   std::string result;
-  scopeP->fill(2, geometryS, coordsS, georelS, &result);
+  scopeP->fill(V2, geometryS, coordsS, georelS, &result);
   return result;
 }
 

--- a/src/lib/jsonParseV2/parseScope.cpp
+++ b/src/lib/jsonParseV2/parseScope.cpp
@@ -139,7 +139,7 @@ std::string parseScopeValueLocation(Value::ConstMemberIterator valueP, Scope* sc
   }
 
   std::string result;
-  scopeP->fill("v2", geometryS, coordsS, georelS, &result);
+  scopeP->fill(2, geometryS, coordsS, georelS, &result);
   return result;
 }
 

--- a/src/lib/jsonParseV2/parseSubscription.cpp
+++ b/src/lib/jsonParseV2/parseSubscription.cpp
@@ -851,7 +851,7 @@ static std::string parseNotifyConditionVector(ConnectionInfo* ciP, ngsiv2::Subsc
     {
       Scope*       scopeP = new Scope(SCOPE_TYPE_LOCATION, "");
       std::string  err;
-      if (scopeP->fill(2, subExpr.geometry, subExpr.coords, subExpr.georel, &err) != 0)
+      if (scopeP->fill(V2, subExpr.geometry, subExpr.coords, subExpr.georel, &err) != 0)
       {
         delete scopeP;
         return badInput(ciP, "error parsing geo-query fields: " + err);

--- a/src/lib/jsonParseV2/parseSubscription.cpp
+++ b/src/lib/jsonParseV2/parseSubscription.cpp
@@ -851,7 +851,7 @@ static std::string parseNotifyConditionVector(ConnectionInfo* ciP, ngsiv2::Subsc
     {
       Scope*       scopeP = new Scope(SCOPE_TYPE_LOCATION, "");
       std::string  err;
-      if (scopeP->fill("v2", subExpr.geometry, subExpr.coords, subExpr.georel, &err) != 0)
+      if (scopeP->fill(2, subExpr.geometry, subExpr.coords, subExpr.georel, &err) != 0)
       {
         delete scopeP;
         return badInput(ciP, "error parsing geo-query fields: " + err);

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -285,10 +285,10 @@ static bool equalMetadata(BSONObj& md1, BSONObj& md2)
 * Check that the attribute doesn't have any value
 *
 */
-bool attributeValueAbsent(ContextAttribute* caP, const string& apiVersion)
+bool attributeValueAbsent(ContextAttribute* caP, int apiVersion)
 {
   /* In v2, absent attribute means "null", which has diferent semantics */
-  return ((caP->valueType == ValueTypeNone) && (apiVersion == "v1"));
+  return ((caP->valueType == ValueTypeNone) && (apiVersion == 1));
 }
 
 /* ****************************************************************************
@@ -311,7 +311,7 @@ bool attributeTypeAbsent(ContextAttribute* caP)
 *
 * changedAttr -
 */
-bool attrValueChanges(BSONObj& attr, ContextAttribute* caP, std::string apiVersion)
+bool attrValueChanges(BSONObj& attr, ContextAttribute* caP, int apiVersion)
 {
   /* Not finding the attribute field at MongoDB is considered as an implicit "" */
   if (!attr.hasField(ENT_ATTRS_VALUE))
@@ -321,7 +321,7 @@ bool attrValueChanges(BSONObj& attr, ContextAttribute* caP, std::string apiVersi
 
   /* No value in the request means that the value stays as it was before, so it is not
    * a change */
-  if (caP->valueType == ValueTypeNone && apiVersion !="v2")
+  if (caP->valueType == ValueTypeNone && apiVersion !=2)
   {
     return false;
   }
@@ -470,7 +470,7 @@ void appendMetadata(BSONObjBuilder* mdBuilder, BSONArrayBuilder* mdNamesBuilder,
 * request (caP), and merged them producing the mergedAttr output. The function returns
 * true if it was an actual update, false otherwise.
 */
-static bool mergeAttrInfo(BSONObj& attr, ContextAttribute* caP, BSONObj* mergedAttr, const std::string& apiVersion)
+static bool mergeAttrInfo(BSONObj& attr, ContextAttribute* caP, BSONObj* mergedAttr, int apiVersion)
 {
   BSONObjBuilder ab;
 
@@ -543,7 +543,7 @@ static bool mergeAttrInfo(BSONObj& attr, ContextAttribute* caP, BSONObj* mergedA
       continue;
     }
 
-    appendMetadata(&mdBuilder, &mdNamesBuilder, mdP, apiVersion == "v2");
+    appendMetadata(&mdBuilder, &mdNamesBuilder, mdP, apiVersion == 2);
   }
 
 
@@ -566,7 +566,7 @@ static bool mergeAttrInfo(BSONObj& attr, ContextAttribute* caP, BSONObj* mergedA
 
       mdSize++;
 
-      if (apiVersion != "v2" || caP->onlyValue)
+      if (apiVersion != 2 || caP->onlyValue)
       {
         if (!hasMetadata(dbDotDecode(md.name), md.type, caP))
         {
@@ -708,7 +708,7 @@ static bool updateAttribute
   ContextAttribute*   caP,
   bool&               actualUpdate,
   bool                isReplace,
-  const string&       apiVersion
+  int                 apiVersion
 )
 {
   actualUpdate = false;
@@ -727,7 +727,7 @@ static bool updateAttribute
 
     int now = getCurrentTime();
 
-    if (!caP->typeGiven && (apiVersion == "v2"))
+    if (!caP->typeGiven && (apiVersion == 2))
     {
       std::string attrType;
 
@@ -754,7 +754,7 @@ static bool updateAttribute
     /* Custom metadata */
     BSONObj    md;
     BSONArray  mdNames;
-    if (contextAttributeCustomMetadataToBson(&md, &mdNames, caP, apiVersion == "v2"));
+    if (contextAttributeCustomMetadataToBson(&md, &mdNames, caP, apiVersion == 2));
     {
       newAttr.append(ENT_ATTRS_MD, md);
     }
@@ -806,7 +806,7 @@ static bool appendAttribute
   BSONArrayBuilder*   toPush,
   ContextAttribute*   caP,
   bool&               actualUpdate,
-  const std::string&  apiVersion
+  int                 apiVersion
 )
 {
   std::string effectiveName = dbDotEncode(caP->name);
@@ -830,7 +830,7 @@ static bool appendAttribute
   caP->valueBson(ab);
 
   /* 2. Type */
-  if ((apiVersion == "v2") && !caP->typeGiven)
+  if ((apiVersion == 2) && !caP->typeGiven)
   {
     std::string attrType;
 
@@ -854,7 +854,7 @@ static bool appendAttribute
   BSONObj   md;
   BSONArray mdNames;
 
-  if (contextAttributeCustomMetadataToBson(&md, &mdNames, caP, apiVersion == "v2"))
+  if (contextAttributeCustomMetadataToBson(&md, &mdNames, caP, apiVersion == 2))
   {
       ab.append(ENT_ATTRS_MD, md);
   }
@@ -1968,7 +1968,7 @@ static bool processSubscriptions
       Scope        geoScope;
       std::string  filterErr;
 
-      if (geoScope.fill("v2", tSubP->expression.geometry, tSubP->expression.coords, tSubP->expression.georel, &filterErr) != 0)
+      if (geoScope.fill(2, tSubP->expression.geometry, tSubP->expression.coords, tSubP->expression.georel, &filterErr) != 0)
       {
         // This has been already checked at subscription creation/update parsing time. Thus, the code cannot reach
         // this part.
@@ -2404,7 +2404,7 @@ static bool updateContextAttributeItem
   std::string*              currentLocAttrName,
   BSONObjBuilder*           geoJson,
   bool                      isReplace,
-  const std::string&        apiVersion,
+  int                       apiVersion,
   OrionError*               oe
 )
 {
@@ -2451,7 +2451,7 @@ static bool updateContextAttributeItem
     return false;
   }
 
-  updateAttrInNotifyCer(notifyCerP, targetAttr, apiVersion == "v2", NGSI_MD_ACTIONTYPE_UPDATE);
+  updateAttrInNotifyCer(notifyCerP, targetAttr, apiVersion == 2, NGSI_MD_ACTIONTYPE_UPDATE);
 
   return true;
 }
@@ -2476,7 +2476,7 @@ static bool appendContextAttributeItem
   bool&                     entityModified,
   std::string*              currentLocAttrName,
   BSONObjBuilder*           geoJson,
-  const std::string&        apiVersion,
+  int                       apiVersion,
   OrionError*               oe
 )
 {
@@ -2521,7 +2521,7 @@ static bool appendContextAttributeItem
   // to be called after the location processing logic (as this logic may need the compoundValueP
 
   std::string actionType = (actualAppend == true)? NGSI_MD_ACTIONTYPE_APPEND : NGSI_MD_ACTIONTYPE_UPDATE;
-  updateAttrInNotifyCer(notifyCerP, targetAttr, apiVersion == "v2", actionType);
+  updateAttrInNotifyCer(notifyCerP, targetAttr, apiVersion == 2, actionType);
 
   return true;
 }
@@ -2543,7 +2543,7 @@ static bool deleteContextAttributeItem
   bool&                                 entityModified,
   std::string*                          currentLocAttrName,
   std::map<std::string, unsigned int>*  deletedAttributesCounter,
-  const std::string&                    apiVersion,
+  int                                   apiVersion,
   OrionError*                           oe
 )
 {
@@ -2620,7 +2620,7 @@ static bool processContextAttributeVector
   BSONObjBuilder*                            geoJson,
   std::string                                tenant,
   const std::vector<std::string>&            servicePathV,
-  const std::string&                         apiVersion,
+  int                                        apiVersion,
   OrionError*                                oe
 )
 {
@@ -2796,7 +2796,7 @@ static bool createEntity
   std::string*                     errDetail,
   std::string                      tenant,
   const std::vector<std::string>&  servicePathV,
-  const std::string&               apiVersion,
+  int                              apiVersion,
   OrionError*                      oe
 )
 {
@@ -2835,7 +2835,7 @@ static bool createEntity
     std::string     attrId = attrsV[ix]->getId();
     BSONObjBuilder  bsonAttr;
 
-    if (!attrsV[ix]->typeGiven && (apiVersion == "v2"))
+    if (!attrsV[ix]->typeGiven && (apiVersion == 2))
     {
       std::string attrType;
 
@@ -2874,7 +2874,7 @@ static bool createEntity
     /* Custom metadata */
     BSONObj   md;
     BSONArray mdNames;
-    if (contextAttributeCustomMetadataToBson(&md, &mdNames, attrsV[ix], apiVersion == "v2"))
+    if (contextAttributeCustomMetadataToBson(&md, &mdNames, attrsV[ix], apiVersion == 2))
     {
       bsonAttr.append(ENT_ATTRS_MD, md);
     }
@@ -2890,7 +2890,7 @@ static bool createEntity
 
   if (eP->type == "")
   {
-    if (apiVersion == "v2")
+    if (apiVersion == 2)
     {
       // NGSIv2 uses default entity type
       bsonId.append(ENT_ENTITY_TYPE, DEFAULT_ENTITY_TYPE);
@@ -3091,7 +3091,7 @@ static void updateEntity
   UpdateContextResponse*          responseP,
   bool*                           attributeAlreadyExistsError,
   std::string*                    attributeAlreadyExistsList,
-  const std::string&              apiVersion,
+  int                             apiVersion,
   const std::string&              fiwareCorrelator
 )
 {
@@ -3381,7 +3381,7 @@ static bool contextElementPreconditionsCheck
   ContextElement*         ceP,
   UpdateContextResponse*  responseP,
   const std::string&      action,
-  const std::string&      apiVersion
+  int                     apiVersion
 )
 {
   /* Getting the entity in the request (helpful in other places) */
@@ -3420,7 +3420,7 @@ static bool contextElementPreconditionsCheck
   if (((strcasecmp(action.c_str(), "update") == 0) ||
       (strcasecmp(action.c_str(), "append") == 0) ||
       (strcasecmp(action.c_str(), "append_strict") == 0) ||
-       (strcasecmp(action.c_str(), "replace") == 0)) && (apiVersion == "v1"))
+       (strcasecmp(action.c_str(), "replace") == 0)) && (apiVersion == 1))
   {
 
     // FIXME: Careful, in V2, this check is not wanted ...
@@ -3486,7 +3486,7 @@ void processContextElement
   std::map<std::string, std::string>&  uriParams,   // FIXME P7: we need this to implement "restriction-based" filters
   const std::string&                   xauthToken,
   const std::string&                   fiwareCorrelator,
-  const std::string&                   apiVersion,
+  int                                  apiVersion,
   Ngsiv2Flavour                        ngsiv2Flavour
 )
 {
@@ -3531,7 +3531,7 @@ void processContextElement
   auto_ptr<DBClientCursor> cursor;
 
   // Several checkings related with NGSIv2
-  if (apiVersion == "v2")
+  if (apiVersion == 2)
   {
     unsigned long long entitiesNumber;
     std::string        err;
@@ -3696,7 +3696,7 @@ void processContextElement
       {
         cerP->statusCode.fill(SccContextElementNotFound);
 
-        if (apiVersion == "v1")
+        if (apiVersion == 1)
         {
           responseP->oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_CONTEXT_ELEMENT, ERROR_NOT_FOUND);
         }
@@ -3757,7 +3757,7 @@ void processContextElement
         // Build CER used for notifying (if needed). Service Path vector shouldn't have more than
         // one item, so it should be safe to get item 0
         //
-        ContextElementResponse* notifyCerP = new ContextElementResponse(ceP, apiVersion == "v2");
+        ContextElementResponse* notifyCerP = new ContextElementResponse(ceP, apiVersion == 2);
 
         // Set action type
         setActionType(notifyCerP, NGSI_MD_ACTIONTYPE_APPEND);

--- a/src/lib/mongoBackend/MongoCommonUpdate.h
+++ b/src/lib/mongoBackend/MongoCommonUpdate.h
@@ -44,7 +44,7 @@ extern void processContextElement(ContextElement*                      ceP,
                                   std::map<std::string, std::string>&  uriParams,   // FIXME P7: we need this to implement "restriction-based" filters
                                   const std::string&                   xauthToken,
                                   const std::string&                   fiwareCorrelator,
-                                  const std::string&                   apiVersion       = "v1",
+                                  int                                  apiVersion       = 1,
                                   Ngsiv2Flavour                        ngsiV2Flavour    = NGSIV2_NO_FLAVOUR);
 
 #endif

--- a/src/lib/mongoBackend/MongoCommonUpdate.h
+++ b/src/lib/mongoBackend/MongoCommonUpdate.h
@@ -44,7 +44,7 @@ extern void processContextElement(ContextElement*                      ceP,
                                   std::map<std::string, std::string>&  uriParams,   // FIXME P7: we need this to implement "restriction-based" filters
                                   const std::string&                   xauthToken,
                                   const std::string&                   fiwareCorrelator,
-                                  int                                  apiVersion       = 1,
+                                  ApiVersion                           apiVersion       = V1,
                                   Ngsiv2Flavour                        ngsiV2Flavour    = NGSIV2_NO_FLAVOUR);
 
 #endif

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1075,7 +1075,7 @@ bool entitiesQuery
   long long*                       countP,
   bool*                            badInputP,
   const std::string&               sortOrderList,
-  int                              apiVersion
+  ApiVersion                       apiVersion
 )
 {
   /* Query structure is as follows

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1075,7 +1075,7 @@ bool entitiesQuery
   long long*                       countP,
   bool*                            badInputP,
   const std::string&               sortOrderList,
-  const std::string&               apiVersion
+  int                              apiVersion
 )
 {
   /* Query structure is as follows
@@ -1138,7 +1138,7 @@ bool entitiesQuery
 
     if (scopeP->type.find(SCOPE_FILTER) == 0)
     {
-      // FIXME P5: NGSI "v1" filter, probably to be removed in the future
+      // FIXME P5: NGSIv1 filter, probably to be removed in the future
       addFilterScope(scopeP, filters);
     }
     else if (scopeP->type == FIWARE_LOCATION || scopeP->type == FIWARE_LOCATION_DEPRECATED || scopeP->type == FIWARE_LOCATION_V2)

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -290,7 +290,7 @@ extern bool entitiesQuery
   long long*                       countP         = NULL,
   bool*                            badInputP      = NULL,
   const std::string&               sortOrderList  = "",
-  const std::string&               apiVersion     = "v1"
+  int                              apiVersion     = 1
 );
 
 /* ****************************************************************************

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -290,7 +290,7 @@ extern bool entitiesQuery
   long long*                       countP         = NULL,
   bool*                            badInputP      = NULL,
   const std::string&               sortOrderList  = "",
-  int                              apiVersion     = 1
+  ApiVersion                       apiVersion     = V1
 );
 
 /* ****************************************************************************

--- a/src/lib/mongoBackend/location.cpp
+++ b/src/lib/mongoBackend/location.cpp
@@ -103,7 +103,7 @@ static bool getGeoJson
   const ContextAttribute*  caP,
   BSONObjBuilder*          geoJson,
   std::string*             errDetail,
-  int                      apiVersion
+  ApiVersion               apiVersion
 )
 {
   double               aLat;
@@ -112,7 +112,7 @@ static bool getGeoJson
   std::vector<double>  coordLong;
   BSONArrayBuilder     ba;
 
-  if ((apiVersion == 1) || (caP->type == GEO_POINT))
+  if ((apiVersion == V1) || (caP->type == GEO_POINT))
   {
     if (!string2coords(caP->stringValue, aLat, aLong))
     {
@@ -259,7 +259,7 @@ bool processLocationAtEntityCreation
   std::string*                   locAttr,
   BSONObjBuilder*                geoJson,
   std::string*                   errDetail,
-  int                            apiVersion,
+  ApiVersion                     apiVersion,
   OrionError*                    oe
 )
 {
@@ -314,7 +314,7 @@ bool processLocationAtUpdateAttribute
   const ContextAttribute*        targetAttr,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  int                            apiVersion,
+  ApiVersion                     apiVersion,
   OrionError*                    oe
 )
 {
@@ -381,7 +381,7 @@ bool processLocationAtUpdateAttribute
    * The behaviour is differenet depending on NGSI version */
   else if (*currentLocAttrName == targetAttr->name)
   {
-    if (apiVersion == 1)
+    if (apiVersion == V1)
     {
       /* In this case, no-location means that the target attribute doesn't have the "location" metadata. In order
        * to mantain backwards compabitibility, this is interpreted as a location update */
@@ -414,7 +414,7 @@ bool processLocationAtAppendAttribute
   bool                           actualAppend,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  int                            apiVersion,
+  ApiVersion                     apiVersion,
   OrionError*                    oe
 )
 {

--- a/src/lib/mongoBackend/location.cpp
+++ b/src/lib/mongoBackend/location.cpp
@@ -103,7 +103,7 @@ static bool getGeoJson
   const ContextAttribute*  caP,
   BSONObjBuilder*          geoJson,
   std::string*             errDetail,
-  const std::string        apiVersion
+  int                      apiVersion
 )
 {
   double               aLat;
@@ -112,7 +112,7 @@ static bool getGeoJson
   std::vector<double>  coordLong;
   BSONArrayBuilder     ba;
 
-  if ((apiVersion == "v1") || (caP->type == GEO_POINT))
+  if ((apiVersion == 1) || (caP->type == GEO_POINT))
   {
     if (!string2coords(caP->stringValue, aLat, aLong))
     {
@@ -259,7 +259,7 @@ bool processLocationAtEntityCreation
   std::string*                   locAttr,
   BSONObjBuilder*                geoJson,
   std::string*                   errDetail,
-  const std::string&             apiVersion,
+  int                            apiVersion,
   OrionError*                    oe
 )
 {
@@ -314,7 +314,7 @@ bool processLocationAtUpdateAttribute
   const ContextAttribute*        targetAttr,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  const std::string&             apiVersion,
+  int                            apiVersion,
   OrionError*                    oe
 )
 {
@@ -381,7 +381,7 @@ bool processLocationAtUpdateAttribute
    * The behaviour is differenet depending on NGSI version */
   else if (*currentLocAttrName == targetAttr->name)
   {
-    if (apiVersion == "v1")
+    if (apiVersion == 1)
     {
       /* In this case, no-location means that the target attribute doesn't have the "location" metadata. In order
        * to mantain backwards compabitibility, this is interpreted as a location update */
@@ -414,7 +414,7 @@ bool processLocationAtAppendAttribute
   bool                           actualAppend,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  const std::string&             apiVersion,
+  int                            apiVersion,
   OrionError*                    oe
 )
 {

--- a/src/lib/mongoBackend/location.h
+++ b/src/lib/mongoBackend/location.h
@@ -43,7 +43,7 @@ extern bool processLocationAtEntityCreation
   std::string*                   locAttr,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  const std::string&             apiVersion,
+  int                            apiVersion,
   OrionError*                    oe
 );
 
@@ -58,7 +58,7 @@ extern bool processLocationAtUpdateAttribute
   const ContextAttribute*        targetAttr,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  const std::string&             apiVersion,
+  int                            apiVersion,
   OrionError*                    oe
 );
 
@@ -74,7 +74,7 @@ extern bool processLocationAtAppendAttribute
   bool                           actualAppend,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  const std::string&             apiVersion,
+  int                            apiVersion,
   OrionError*                    oe
 );
 

--- a/src/lib/mongoBackend/location.h
+++ b/src/lib/mongoBackend/location.h
@@ -43,7 +43,7 @@ extern bool processLocationAtEntityCreation
   std::string*                   locAttr,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  int                            apiVersion,
+  ApiVersion                     apiVersion,
   OrionError*                    oe
 );
 
@@ -58,7 +58,7 @@ extern bool processLocationAtUpdateAttribute
   const ContextAttribute*        targetAttr,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  int                            apiVersion,
+  ApiVersion                     apiVersion,
   OrionError*                    oe
 );
 
@@ -74,7 +74,7 @@ extern bool processLocationAtAppendAttribute
   bool                           actualAppend,
   mongo::BSONObjBuilder*         geoJson,
   std::string*                   errDetail,
-  int                            apiVersion,
+  ApiVersion                     apiVersion,
   OrionError*                    oe
 );
 

--- a/src/lib/mongoBackend/mongoQueryContext.cpp
+++ b/src/lib/mongoBackend/mongoQueryContext.cpp
@@ -280,7 +280,7 @@ HttpStatusCode mongoQueryContext
   std::map<std::string, std::string>&  uriParams,
   std::map<std::string, bool>&         options,
   long long*                           countP,
-  const std::string&                   apiVersion
+  int                                  apiVersion
 )
 {
     int         offset         = atoi(uriParams[URI_PARAM_PAGINATION_OFFSET].c_str());

--- a/src/lib/mongoBackend/mongoQueryContext.cpp
+++ b/src/lib/mongoBackend/mongoQueryContext.cpp
@@ -280,7 +280,7 @@ HttpStatusCode mongoQueryContext
   std::map<std::string, std::string>&  uriParams,
   std::map<std::string, bool>&         options,
   long long*                           countP,
-  int                                  apiVersion
+  ApiVersion                           apiVersion
 )
 {
     int         offset         = atoi(uriParams[URI_PARAM_PAGINATION_OFFSET].c_str());

--- a/src/lib/mongoBackend/mongoQueryContext.h
+++ b/src/lib/mongoBackend/mongoQueryContext.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <map>
 
+#include "common/globals.h"
 #include "ngsi10/QueryContextRequest.h"
 #include "ngsi10/QueryContextResponse.h"
 #include "rest/StringFilter.h"
@@ -47,7 +48,7 @@ extern HttpStatusCode mongoQueryContext
   std::map<std::string, std::string>&   uriParams,
   std::map<std::string, bool>&          options,
   long long*                            countP        = NULL,
-  int                                   apiVersion    = 1
+  ApiVersion                            apiVersion    = V1
 );
 
 #endif

--- a/src/lib/mongoBackend/mongoQueryContext.h
+++ b/src/lib/mongoBackend/mongoQueryContext.h
@@ -47,7 +47,7 @@ extern HttpStatusCode mongoQueryContext
   std::map<std::string, std::string>&   uriParams,
   std::map<std::string, bool>&          options,
   long long*                            countP        = NULL,
-  const std::string&                    apiVersion    = "v1"
+  int                                   apiVersion    = 1
 );
 
 #endif

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -277,7 +277,7 @@ HttpStatusCode mongoEntityTypes
   const std::string&                   tenant,
   const std::vector<std::string>&      servicePathV,
   std::map<std::string, std::string>&  uriParams,
-  const std::string&                   apiVersion,
+  int                                  apiVersion,
   unsigned int*                        totalTypesP,
   bool                                 noAttrDetail
 )
@@ -447,7 +447,7 @@ HttpStatusCode mongoEntityTypes
             entityType->contextAttributeVector.push_back(ca);
 
             // For backward compability, NGSIv1 only accepts one element
-            if (apiVersion == "v1")
+            if (apiVersion == 1)
             {
               break;
             }
@@ -525,7 +525,7 @@ HttpStatusCode mongoAttributesForEntityType
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams,
   bool                                  noAttrDetail,
-  const std::string&                    apiVersion
+  int                                   apiVersion
 )
 {  
   unsigned int   offset         = atoi(uriParams[URI_PARAM_PAGINATION_OFFSET].c_str());
@@ -534,7 +534,7 @@ HttpStatusCode mongoAttributesForEntityType
   bool           count          = false;
 
   // Count only makes sense for this operation in the case of NGSIv1
-  if (apiVersion == "v1")
+  if (apiVersion == 1)
   {
     std::string    detailsString  = uriParams[URI_PARAM_PAGINATION_DETAILS];
     count = (strcasecmp("on", detailsString.c_str()) == 0)? true : false;
@@ -631,7 +631,7 @@ HttpStatusCode mongoAttributesForEntityType
         responseP->entityType.contextAttributeVector.push_back(ca);
 
         // For backward compability, NGSIv1 only accepts one element
-        if (apiVersion == "v1")
+        if (apiVersion == 1)
         {
           break;
         }

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -277,7 +277,7 @@ HttpStatusCode mongoEntityTypes
   const std::string&                   tenant,
   const std::vector<std::string>&      servicePathV,
   std::map<std::string, std::string>&  uriParams,
-  int                                  apiVersion,
+  ApiVersion                           apiVersion,
   unsigned int*                        totalTypesP,
   bool                                 noAttrDetail
 )
@@ -447,7 +447,7 @@ HttpStatusCode mongoEntityTypes
             entityType->contextAttributeVector.push_back(ca);
 
             // For backward compability, NGSIv1 only accepts one element
-            if (apiVersion == 1)
+            if (apiVersion == V1)
             {
               break;
             }
@@ -525,7 +525,7 @@ HttpStatusCode mongoAttributesForEntityType
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams,
   bool                                  noAttrDetail,
-  int                                   apiVersion
+  ApiVersion                            apiVersion
 )
 {  
   unsigned int   offset         = atoi(uriParams[URI_PARAM_PAGINATION_OFFSET].c_str());
@@ -534,7 +534,7 @@ HttpStatusCode mongoAttributesForEntityType
   bool           count          = false;
 
   // Count only makes sense for this operation in the case of NGSIv1
-  if (apiVersion == 1)
+  if (apiVersion == V1)
   {
     std::string    detailsString  = uriParams[URI_PARAM_PAGINATION_DETAILS];
     count = (strcasecmp("on", detailsString.c_str()) == 0)? true : false;
@@ -631,7 +631,7 @@ HttpStatusCode mongoAttributesForEntityType
         responseP->entityType.contextAttributeVector.push_back(ca);
 
         // For backward compability, NGSIv1 only accepts one element
-        if (apiVersion == 1)
+        if (apiVersion == V1)
         {
           break;
         }

--- a/src/lib/mongoBackend/mongoQueryTypes.h
+++ b/src/lib/mongoBackend/mongoQueryTypes.h
@@ -58,7 +58,7 @@ extern HttpStatusCode mongoEntityTypes
   const std::string&                   tenant,
   const std::vector<std::string>&      servicePathV,
   std::map<std::string, std::string>&  uriParams,
-  int                                  apiVersion,
+  ApiVersion                           apiVersion,
   unsigned int*                        totalTypesP,
   bool                                 noAttrDetail
 );
@@ -92,7 +92,7 @@ extern HttpStatusCode mongoAttributesForEntityType
   const std::vector<std::string>&      servicePathV,
   std::map<std::string, std::string>&  uriParams,
   bool                                 noAttrDetail,
-  int                                  apiVersion
+  ApiVersion                           apiVersion
 );
 
 #endif

--- a/src/lib/mongoBackend/mongoQueryTypes.h
+++ b/src/lib/mongoBackend/mongoQueryTypes.h
@@ -58,7 +58,7 @@ extern HttpStatusCode mongoEntityTypes
   const std::string&                   tenant,
   const std::vector<std::string>&      servicePathV,
   std::map<std::string, std::string>&  uriParams,
-  const std::string&                   apiVersion,
+  int                                  apiVersion,
   unsigned int*                        totalTypesP,
   bool                                 noAttrDetail
 );
@@ -92,7 +92,7 @@ extern HttpStatusCode mongoAttributesForEntityType
   const std::vector<std::string>&      servicePathV,
   std::map<std::string, std::string>&  uriParams,
   bool                                 noAttrDetail,
-  const std::string&                   apiVersion
+  int                                  apiVersion
 );
 
 #endif

--- a/src/lib/mongoBackend/mongoUpdateContext.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContext.cpp
@@ -57,7 +57,7 @@ HttpStatusCode mongoUpdateContext
   std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
   const std::string&                    xauthToken,
   const std::string&                    fiwareCorrelator,
-  int                                   apiVersion,
+  ApiVersion                            apiVersion,
   Ngsiv2Flavour                         ngsiv2Flavour
 )
 {

--- a/src/lib/mongoBackend/mongoUpdateContext.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContext.cpp
@@ -57,7 +57,7 @@ HttpStatusCode mongoUpdateContext
   std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
   const std::string&                    xauthToken,
   const std::string&                    fiwareCorrelator,
-  const std::string&                    apiVersion,
+  int                                   apiVersion,
   Ngsiv2Flavour                         ngsiv2Flavour
 )
 {

--- a/src/lib/mongoBackend/mongoUpdateContext.h
+++ b/src/lib/mongoBackend/mongoUpdateContext.h
@@ -47,7 +47,7 @@ extern HttpStatusCode mongoUpdateContext
   std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
   const std::string&                    xauthToken,
   const std::string&                    fiwareCorrelator = "no correlator",
-  int                                   apiVersion       = 1,
+  ApiVersion                            apiVersion       = V1,
   Ngsiv2Flavour                         ngsiv2Flavour    = NGSIV2_NO_FLAVOUR
 );
 

--- a/src/lib/mongoBackend/mongoUpdateContext.h
+++ b/src/lib/mongoBackend/mongoUpdateContext.h
@@ -47,7 +47,7 @@ extern HttpStatusCode mongoUpdateContext
   std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
   const std::string&                    xauthToken,
   const std::string&                    fiwareCorrelator = "no correlator",
-  const std::string&                    apiVersion       = "v1",
+  int                                   apiVersion       = 1,
   Ngsiv2Flavour                         ngsiv2Flavour    = NGSIV2_NO_FLAVOUR
 );
 

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -447,9 +447,9 @@ std::string ContextAttribute::getId(void) const
 *
 * ContextAttribute::getLocation() -
 */
-std::string ContextAttribute::getLocation(const std::string& apiVersion) const
+std::string ContextAttribute::getLocation(int apiVersion) const
 {
-  if (apiVersion == "v1")
+  if (apiVersion == 1)
   {
     // Deprecated way, but still supported
     for (unsigned int ix = 0; ix < metadataVector.size(); ++ix)
@@ -486,7 +486,7 @@ std::string ContextAttribute::getLocation(const std::string& apiVersion) const
 */
 std::string ContextAttribute::renderAsJsonObject
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         request,
   const std::string&  indent,
   bool                comma,
@@ -600,7 +600,7 @@ std::string ContextAttribute::renderAsNameString(const std::string& indent, bool
 */
 std::string ContextAttribute::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         request,
   const std::string&  indent,
@@ -858,12 +858,12 @@ std::string ContextAttribute::toJson
 */
 std::string ContextAttribute::toJsonAsValue
 (
-  const std::string&  apiVersion,          // in parameter
-  bool                acceptedTextPlain,   // in parameter
-  bool                acceptedJson,        // in parameter
-  MimeType            outFormatSelection,  // in parameter
-  MimeType*           outMimeTypeP,        // out parameter
-  HttpStatusCode*     scP                  // out parameter
+  int              apiVersion,          // in parameter
+  bool             acceptedTextPlain,   // in parameter
+  bool             acceptedJson,        // in parameter
+  MimeType         outFormatSelection,  // in parameter
+  MimeType*        outMimeTypeP,        // out parameter
+  HttpStatusCode*  scP                  // out parameter
 )
 {
   std::string  out;
@@ -879,7 +879,7 @@ std::string ContextAttribute::toJsonAsValue
       switch (valueType)
       {
       case orion::ValueTypeString:
-        if (apiVersion == "v2")
+        if (apiVersion == 2)
         { 
           out = '"' + stringValue + '"';
         }
@@ -956,12 +956,12 @@ std::string ContextAttribute::toJsonAsValue
 *
 * ContextAttribute::check - 
 */
-std::string ContextAttribute::check(const std::string& apiVersion, RequestType requestType)
+std::string ContextAttribute::check(int apiVersion, RequestType requestType)
 {
   size_t len;
   char errorMsg[128];
 
-  if (((apiVersion == "v2") && (len = strlen(name.c_str())) < MIN_ID_LEN) && (requestType != EntityAttributeValueRequest))
+  if (((apiVersion == 2) && (len = strlen(name.c_str())) < MIN_ID_LEN) && (requestType != EntityAttributeValueRequest))
   {
     snprintf(errorMsg, sizeof errorMsg, "attribute name length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
@@ -994,7 +994,7 @@ std::string ContextAttribute::check(const std::string& apiVersion, RequestType r
   }
 
 
-  if (apiVersion == "v2" && (requestType != EntityAttributeValueRequest) && (len = strlen(type.c_str())) < MIN_ID_LEN)
+  if (apiVersion == 2 && (requestType != EntityAttributeValueRequest) && (len = strlen(type.c_str())) < MIN_ID_LEN)
   {
     snprintf(errorMsg, sizeof errorMsg, "attribute type length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -447,9 +447,9 @@ std::string ContextAttribute::getId(void) const
 *
 * ContextAttribute::getLocation() -
 */
-std::string ContextAttribute::getLocation(int apiVersion) const
+std::string ContextAttribute::getLocation(ApiVersion apiVersion) const
 {
-  if (apiVersion == 1)
+  if (apiVersion == V1)
   {
     // Deprecated way, but still supported
     for (unsigned int ix = 0; ix < metadataVector.size(); ++ix)
@@ -486,7 +486,7 @@ std::string ContextAttribute::getLocation(int apiVersion) const
 */
 std::string ContextAttribute::renderAsJsonObject
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         request,
   const std::string&  indent,
   bool                comma,
@@ -600,7 +600,7 @@ std::string ContextAttribute::renderAsNameString(const std::string& indent, bool
 */
 std::string ContextAttribute::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         request,
   const std::string&  indent,
@@ -858,7 +858,7 @@ std::string ContextAttribute::toJson
 */
 std::string ContextAttribute::toJsonAsValue
 (
-  int              apiVersion,          // in parameter
+  ApiVersion       apiVersion,          // in parameter
   bool             acceptedTextPlain,   // in parameter
   bool             acceptedJson,        // in parameter
   MimeType         outFormatSelection,  // in parameter
@@ -879,7 +879,7 @@ std::string ContextAttribute::toJsonAsValue
       switch (valueType)
       {
       case orion::ValueTypeString:
-        if (apiVersion == 2)
+        if (apiVersion == V2)
         { 
           out = '"' + stringValue + '"';
         }
@@ -956,12 +956,12 @@ std::string ContextAttribute::toJsonAsValue
 *
 * ContextAttribute::check - 
 */
-std::string ContextAttribute::check(int apiVersion, RequestType requestType)
+std::string ContextAttribute::check(ApiVersion apiVersion, RequestType requestType)
 {
   size_t len;
   char errorMsg[128];
 
-  if (((apiVersion == 2) && (len = strlen(name.c_str())) < MIN_ID_LEN) && (requestType != EntityAttributeValueRequest))
+  if (((apiVersion == V2) && (len = strlen(name.c_str())) < MIN_ID_LEN) && (requestType != EntityAttributeValueRequest))
   {
     snprintf(errorMsg, sizeof errorMsg, "attribute name length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
@@ -994,7 +994,7 @@ std::string ContextAttribute::check(int apiVersion, RequestType requestType)
   }
 
 
-  if (apiVersion == 2 && (requestType != EntityAttributeValueRequest) && (len = strlen(type.c_str())) < MIN_ID_LEN)
+  if (apiVersion == V2 && (requestType != EntityAttributeValueRequest) && (len = strlen(type.c_str())) < MIN_ID_LEN)
   {
     snprintf(errorMsg, sizeof errorMsg, "attribute type length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "common/RenderFormat.h"
+#include "common/globals.h"
 #include "orionTypes/OrionValueType.h"
 #include "ngsi/MetadataVector.h"
 #include "ngsi/Request.h"
@@ -89,21 +90,21 @@ public:
 
   /* Grabbers for metadata to which CB gives a special semantic */
   std::string  getId() const;
-  std::string  getLocation(int apiVersion = 1) const;
+  std::string  getLocation(ApiVersion apiVersion = V1) const;
 
-  std::string  render(int                 apiVersion,
+  std::string  render(ApiVersion          apiVersion,
                       bool                asJsonObject,
                       RequestType         request,
                       const std::string&  indent,
                       bool                comma = false,
                       bool                omitValue = false);
-  std::string  renderAsJsonObject(int apiVersion, RequestType request, const std::string& indent, bool comma, bool omitValue = false);
+  std::string  renderAsJsonObject(ApiVersion apiVersion, RequestType request, const std::string& indent, bool comma, bool omitValue = false);
   std::string  renderAsNameString(const std::string& indent, bool comma = false);
   std::string  toJson(bool                             isLastElement,
                       RenderFormat                     renderFormat,
                       const std::vector<std::string>&  metadataFilter,
                       RequestType                      requestType = NoRequest);
-  std::string  toJsonAsValue(int              apiVersion,
+  std::string  toJsonAsValue(ApiVersion       apiVersion,
                              bool             acceptedTextPlain,
                              bool             acceptedJson,
                              MimeType         outFormatSelection,
@@ -119,7 +120,7 @@ public:
   /* Helper method to be use in some places wher '%s' is needed */
   std::string  getValue(void) const;
 
-  std::string  check(int apiVersion, RequestType requestType);
+  std::string  check(ApiVersion apiVersion, RequestType requestType);
   ContextAttribute* clone();
   bool              compoundItemExists(const std::string& compoundPath, orion::CompoundValueNode** compoundItemPP = NULL);
 

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -89,26 +89,26 @@ public:
 
   /* Grabbers for metadata to which CB gives a special semantic */
   std::string  getId() const;
-  std::string  getLocation(const std::string& apiValue ="v1") const;
+  std::string  getLocation(int apiVersion = 1) const;
 
-  std::string  render(const std::string&  apiVersion,
+  std::string  render(int                 apiVersion,
                       bool                asJsonObject,
                       RequestType         request,
                       const std::string&  indent,
                       bool                comma = false,
                       bool                omitValue = false);
-  std::string  renderAsJsonObject(const std::string& apiVersion, RequestType request, const std::string& indent, bool comma, bool omitValue = false);
+  std::string  renderAsJsonObject(int apiVersion, RequestType request, const std::string& indent, bool comma, bool omitValue = false);
   std::string  renderAsNameString(const std::string& indent, bool comma = false);
   std::string  toJson(bool                             isLastElement,
                       RenderFormat                     renderFormat,
                       const std::vector<std::string>&  metadataFilter,
                       RequestType                      requestType = NoRequest);
-  std::string  toJsonAsValue(const std::string&  apiVersion,
-                             bool                acceptedTextPlain,
-                             bool                acceptedJson,
-                             MimeType            outFormatSelection,
-                             MimeType*           outMimeTypeP,
-                             HttpStatusCode*     scP);
+  std::string  toJsonAsValue(int              apiVersion,
+                             bool             acceptedTextPlain,
+                             bool             acceptedJson,
+                             MimeType         outFormatSelection,
+                             MimeType*        outMimeTypeP,
+                             HttpStatusCode*  scP);
   void         present(const std::string& indent, int ix);
   void         release(void);
   std::string  getName(void);
@@ -119,7 +119,7 @@ public:
   /* Helper method to be use in some places wher '%s' is needed */
   std::string  getValue(void) const;
 
-  std::string  check(const std::string& apiVersion, RequestType requestType);
+  std::string  check(int apiVersion, RequestType requestType);
   ContextAttribute* clone();
   bool              compoundItemExists(const std::string& compoundPath, orion::CompoundValueNode** compoundItemPP = NULL);
 

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -290,7 +290,7 @@ std::string ContextAttributeVector::toJson
 */
 std::string ContextAttributeVector::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         request,
   const std::string&  indent,
@@ -378,7 +378,7 @@ std::string ContextAttributeVector::render
 *
 * ContextAttributeVector::check - 
 */
-std::string ContextAttributeVector::check(const std::string& apiVersion, RequestType requestType)
+std::string ContextAttributeVector::check(int apiVersion, RequestType requestType)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -290,7 +290,7 @@ std::string ContextAttributeVector::toJson
 */
 std::string ContextAttributeVector::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         request,
   const std::string&  indent,
@@ -378,7 +378,7 @@ std::string ContextAttributeVector::render
 *
 * ContextAttributeVector::check - 
 */
-std::string ContextAttributeVector::check(int apiVersion, RequestType requestType)
+std::string ContextAttributeVector::check(ApiVersion apiVersion, RequestType requestType)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextAttributeVector.h
+++ b/src/lib/ngsi/ContextAttributeVector.h
@@ -55,9 +55,9 @@ typedef struct ContextAttributeVector
   ContextAttribute*  operator[](unsigned int ix) const;
 
 
-  std::string        check(const std::string& apiVersion, RequestType requestType);
+  std::string        check(int apiVersion, RequestType requestType);
 
-  std::string        render(const std::string&  apiVersion,
+  std::string        render(int                 apiVersion,
                             bool                asJsonObject,
                             RequestType         requestType,
                             const std::string&  indent,

--- a/src/lib/ngsi/ContextAttributeVector.h
+++ b/src/lib/ngsi/ContextAttributeVector.h
@@ -55,9 +55,9 @@ typedef struct ContextAttributeVector
   ContextAttribute*  operator[](unsigned int ix) const;
 
 
-  std::string        check(int apiVersion, RequestType requestType);
+  std::string        check(ApiVersion apiVersion, RequestType requestType);
 
-  std::string        render(int                 apiVersion,
+  std::string        render(ApiVersion          apiVersion,
                             bool                asJsonObject,
                             RequestType         requestType,
                             const std::string&  indent,

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -74,7 +74,7 @@ ContextElement::ContextElement(const std::string& id, const std::string& type, c
 *
 * ContextElement::render - 
 */
-std::string ContextElement::render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues)
+std::string ContextElement::render(int apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues)
 {
   std::string  out                              = "";
   bool         attributeDomainNameRendered      = attributeDomainName.get() != "";
@@ -160,7 +160,7 @@ ContextAttribute* ContextElement::getAttribute(const std::string& attrName)
 */
 std::string ContextElement::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -74,7 +74,7 @@ ContextElement::ContextElement(const std::string& id, const std::string& type, c
 *
 * ContextElement::render - 
 */
-std::string ContextElement::render(int apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues)
+std::string ContextElement::render(ApiVersion apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues)
 {
   std::string  out                              = "";
   bool         attributeDomainNameRendered      = attributeDomainName.get() != "";
@@ -160,7 +160,7 @@ ContextAttribute* ContextElement::getAttribute(const std::string& attrName)
 */
 std::string ContextElement::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElement.h
+++ b/src/lib/ngsi/ContextElement.h
@@ -53,7 +53,7 @@ typedef struct ContextElement
   ContextElement(const std::string& id, const std::string& type, const std::string& isPattern);
   ContextElement(EntityId* eP);
 
-  std::string  render(const std::string& apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues = false);
+  std::string  render(int apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues = false);
   std::string  toJson(RenderFormat                     renderFormat,
                       const std::vector<std::string>&  attrsFilter,
                       const std::vector<std::string>&  metadataFilter,
@@ -65,7 +65,7 @@ typedef struct ContextElement
 
   ContextAttribute* getAttribute(const std::string& attrName);
 
-  std::string  check(const std::string&  apiVersion,
+  std::string  check(int                 apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElement.h
+++ b/src/lib/ngsi/ContextElement.h
@@ -53,7 +53,7 @@ typedef struct ContextElement
   ContextElement(const std::string& id, const std::string& type, const std::string& isPattern);
   ContextElement(EntityId* eP);
 
-  std::string  render(int apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues = false);
+  std::string  render(ApiVersion apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma, bool omitAttributeValues = false);
   std::string  toJson(RenderFormat                     renderFormat,
                       const std::vector<std::string>&  attrsFilter,
                       const std::vector<std::string>&  metadataFilter,
@@ -65,7 +65,7 @@ typedef struct ContextElement
 
   ContextAttribute* getAttribute(const std::string& attrName);
 
-  std::string  check(int                 apiVersion,
+  std::string  check(ApiVersion          apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -134,7 +134,7 @@ ContextElementResponse::ContextElementResponse
   const mongo::BSONObj&  entityDoc,
   const AttributeList&   attrL,
   bool                   includeEmpty,
-  int                    apiVersion
+  ApiVersion             apiVersion
 )
 {
   prune = false;
@@ -250,7 +250,7 @@ ContextElementResponse::ContextElementResponse
       caP->metadataVector.push_back(md);
     }
 
-    if (apiVersion == 1)
+    if (apiVersion == V1)
     {
       /* Setting location metadata (if found) */
       if ((locAttr == ca.name) && (ca.type != GEO_POINT))
@@ -324,7 +324,7 @@ ContextElementResponse::ContextElementResponse(ContextElement* ceP, bool useDefa
 */
 std::string ContextElementResponse::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
@@ -383,7 +383,7 @@ void ContextElementResponse::release(void)
 */
 std::string ContextElementResponse::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -134,7 +134,7 @@ ContextElementResponse::ContextElementResponse
   const mongo::BSONObj&  entityDoc,
   const AttributeList&   attrL,
   bool                   includeEmpty,
-  const std::string&     apiVersion
+  int                    apiVersion
 )
 {
   prune = false;
@@ -250,7 +250,7 @@ ContextElementResponse::ContextElementResponse
       caP->metadataVector.push_back(md);
     }
 
-    if (apiVersion == "v1")
+    if (apiVersion == 1)
     {
       /* Setting location metadata (if found) */
       if ((locAttr == ca.name) && (ca.type != GEO_POINT))
@@ -324,7 +324,7 @@ ContextElementResponse::ContextElementResponse(ContextElement* ceP, bool useDefa
 */
 std::string ContextElementResponse::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
@@ -383,7 +383,7 @@ void ContextElementResponse::release(void)
 */
 std::string ContextElementResponse::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponse.h
+++ b/src/lib/ngsi/ContextElementResponse.h
@@ -61,10 +61,10 @@ typedef struct ContextElementResponse
   ContextElementResponse(const mongo::BSONObj&  entityDoc,
                          const AttributeList&   attrL,
                          bool                   includeEmpty = true,
-                         const std::string&     apiVersion   = "v1");
+                         int                    apiVersion   = 1);
   ContextElementResponse(ContextElement* ceP, bool useDefaultType = false);
 
-  std::string  render(const std::string&  apiVersion,
+  std::string  render(int                 apiVersion,
                       bool                asJsonObject,
                       RequestType         requestType,
                       const std::string&  indent,
@@ -77,7 +77,7 @@ typedef struct ContextElementResponse
   void         present(const std::string& indent, int ix);
   void         release(void);
 
-  std::string  check(const std::string&  apiVersion,
+  std::string  check(int                 apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponse.h
+++ b/src/lib/ngsi/ContextElementResponse.h
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "common/RenderFormat.h"
+#include "common/globals.h"
 #include "ngsi/ContextElement.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi/AttributeList.h"
@@ -61,10 +62,10 @@ typedef struct ContextElementResponse
   ContextElementResponse(const mongo::BSONObj&  entityDoc,
                          const AttributeList&   attrL,
                          bool                   includeEmpty = true,
-                         int                    apiVersion   = 1);
+                         ApiVersion             apiVersion   = V1);
   ContextElementResponse(ContextElement* ceP, bool useDefaultType = false);
 
-  std::string  render(int                 apiVersion,
+  std::string  render(ApiVersion          apiVersion,
                       bool                asJsonObject,
                       RequestType         requestType,
                       const std::string&  indent,
@@ -77,7 +78,7 @@ typedef struct ContextElementResponse
   void         present(const std::string& indent, int ix);
   void         release(void);
 
-  std::string  check(int                 apiVersion,
+  std::string  check(ApiVersion          apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -42,7 +42,7 @@
 */
 std::string ContextElementResponseVector::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
@@ -108,7 +108,7 @@ std::string ContextElementResponseVector::toJson
 */
 std::string ContextElementResponseVector::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -42,7 +42,7 @@
 */
 std::string ContextElementResponseVector::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
@@ -108,7 +108,7 @@ std::string ContextElementResponseVector::toJson
 */
 std::string ContextElementResponseVector::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponseVector.h
+++ b/src/lib/ngsi/ContextElementResponseVector.h
@@ -41,7 +41,7 @@ typedef struct ContextElementResponseVector
 {
   std::vector<ContextElementResponse*>  vec;
 
-  std::string              render(int                 apiVersion,
+  std::string              render(ApiVersion          apiVersion,
                                   bool                asJsonObject,
                                   RequestType         requestType,
                                   const std::string&  indent,
@@ -61,7 +61,7 @@ typedef struct ContextElementResponseVector
   ContextElementResponse*  operator[] (unsigned int ix) const;
   
 
-  std::string              check(int                 apiVersion,
+  std::string              check(ApiVersion          apiVersion,
                                  RequestType         requestType,
                                  const std::string&  indent,
                                  const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementResponseVector.h
+++ b/src/lib/ngsi/ContextElementResponseVector.h
@@ -41,7 +41,7 @@ typedef struct ContextElementResponseVector
 {
   std::vector<ContextElementResponse*>  vec;
 
-  std::string              render(const std::string&  apiVersion,
+  std::string              render(int                 apiVersion,
                                   bool                asJsonObject,
                                   RequestType         requestType,
                                   const std::string&  indent,
@@ -61,7 +61,7 @@ typedef struct ContextElementResponseVector
   ContextElementResponse*  operator[] (unsigned int ix) const;
   
 
-  std::string              check(const std::string&  apiVersion,
+  std::string              check(int                 apiVersion,
                                  RequestType         requestType,
                                  const std::string&  indent,
                                  const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementVector.cpp
+++ b/src/lib/ngsi/ContextElementVector.cpp
@@ -51,7 +51,7 @@ void ContextElementVector::push_back(ContextElement* item)
 */
 std::string ContextElementVector::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
@@ -143,7 +143,7 @@ unsigned int ContextElementVector::size(void)
 */
 std::string ContextElementVector::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementVector.cpp
+++ b/src/lib/ngsi/ContextElementVector.cpp
@@ -51,7 +51,7 @@ void ContextElementVector::push_back(ContextElement* item)
 */
 std::string ContextElementVector::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   RequestType         requestType,
   const std::string&  indent,
@@ -143,7 +143,7 @@ unsigned int ContextElementVector::size(void)
 */
 std::string ContextElementVector::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementVector.h
+++ b/src/lib/ngsi/ContextElementVector.h
@@ -42,13 +42,13 @@ typedef struct ContextElementVector
 
   void             push_back(ContextElement* item);
   unsigned int     size(void);
-  std::string      render(const std::string&  apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma);
+  std::string      render(int apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma);
   void             present(const std::string& indent);
   void             release(void);
   ContextElement*  lookup(EntityId* eP);
   ContextElement*  operator[](unsigned int ix) const;
 
-  std::string      check(const std::string&  apiVersion,
+  std::string      check(int                 apiVersion,
                          RequestType         requestType,
                          const std::string&  indent,
                          const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextElementVector.h
+++ b/src/lib/ngsi/ContextElementVector.h
@@ -42,13 +42,13 @@ typedef struct ContextElementVector
 
   void             push_back(ContextElement* item);
   unsigned int     size(void);
-  std::string      render(int apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma);
+  std::string      render(ApiVersion apiVersion, bool asJsonObject, RequestType requestType, const std::string& indent, bool comma);
   void             present(const std::string& indent);
   void             release(void);
   ContextElement*  lookup(EntityId* eP);
   ContextElement*  operator[](unsigned int ix) const;
 
-  std::string      check(int                 apiVersion,
+  std::string      check(ApiVersion          apiVersion,
                          RequestType         requestType,
                          const std::string&  indent,
                          const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistration.cpp
+++ b/src/lib/ngsi/ContextRegistration.cpp
@@ -80,7 +80,7 @@ std::string ContextRegistration::render(const std::string& indent, bool comma, b
 */
 std::string ContextRegistration::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistration.cpp
+++ b/src/lib/ngsi/ContextRegistration.cpp
@@ -80,7 +80,7 @@ std::string ContextRegistration::render(const std::string& indent, bool comma, b
 */
 std::string ContextRegistration::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,
@@ -94,7 +94,7 @@ std::string ContextRegistration::check
     return res;
   }
 
-  if ((res = contextRegistrationAttributeVector.check(apiVersion, requestType, indent, predetectedError, counter)) != "OK")
+  if ((res = contextRegistrationAttributeVector.check(apiVersion)) != "OK")
   {
     return res;
   }

--- a/src/lib/ngsi/ContextRegistration.h
+++ b/src/lib/ngsi/ContextRegistration.h
@@ -53,7 +53,7 @@ typedef struct ContextRegistration
   void         present(const std::string& indent, int ix);
   void         release();
 
-  std::string  check(const std::string&  apiVersion,
+  std::string  check(int                 apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistration.h
+++ b/src/lib/ngsi/ContextRegistration.h
@@ -53,7 +53,7 @@ typedef struct ContextRegistration
   void         present(const std::string& indent, int ix);
   void         release();
 
-  std::string  check(int                 apiVersion,
+  std::string  check(ApiVersion          apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -94,11 +94,7 @@ std::string ContextRegistrationAttribute::render(const std::string& indent, bool
 *
 * ContextRegistrationAttribute::check -
 */
-std::string ContextRegistrationAttribute::check
-(
-  const std::string&  apiVersion,
-  const std::string&  indent
-)
+std::string ContextRegistrationAttribute::check(int apiVersion)
 {
 
   if (name == "")

--- a/src/lib/ngsi/ContextRegistrationAttribute.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttribute.cpp
@@ -94,7 +94,7 @@ std::string ContextRegistrationAttribute::render(const std::string& indent, bool
 *
 * ContextRegistrationAttribute::check -
 */
-std::string ContextRegistrationAttribute::check(int apiVersion)
+std::string ContextRegistrationAttribute::check(ApiVersion apiVersion)
 {
 
   if (name == "")

--- a/src/lib/ngsi/ContextRegistrationAttribute.h
+++ b/src/lib/ngsi/ContextRegistrationAttribute.h
@@ -50,8 +50,7 @@ typedef struct ContextRegistrationAttribute
   void            present(int ix, const std::string& indent);
   void            release(void);
 
-  std::string     check(const std::string&  apiVersion,
-                        const std::string&  indent);
+  std::string     check(int apiVersion);
 } ContextRegistrationAttribute;
 
 #endif  // SRC_LIB_NGSI_CONTEXTREGISTRATIONATTRIBUTE_H_

--- a/src/lib/ngsi/ContextRegistrationAttribute.h
+++ b/src/lib/ngsi/ContextRegistrationAttribute.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include "common/globals.h"
+
 #include "ngsi/MetadataVector.h"
 #include "ngsi/Request.h"
 
@@ -50,7 +52,7 @@ typedef struct ContextRegistrationAttribute
   void            present(int ix, const std::string& indent);
   void            release(void);
 
-  std::string     check(int apiVersion);
+  std::string     check(ApiVersion apiVersion);
 } ContextRegistrationAttribute;
 
 #endif  // SRC_LIB_NGSI_CONTEXTREGISTRATIONATTRIBUTE_H_

--- a/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
@@ -64,7 +64,7 @@ std::string ContextRegistrationAttributeVector::render(const std::string& indent
 *
 * ContextRegistrationAttributeVector::check -
 */
-std::string ContextRegistrationAttributeVector::check(int apiVersion)
+std::string ContextRegistrationAttributeVector::check(ApiVersion apiVersion)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationAttributeVector.cpp
@@ -64,20 +64,13 @@ std::string ContextRegistrationAttributeVector::render(const std::string& indent
 *
 * ContextRegistrationAttributeVector::check -
 */
-std::string ContextRegistrationAttributeVector::check
-(
-  const std::string&  apiVersion,
-  RequestType         requestType,
-  const std::string&  indent,
-  const std::string&  predetectedError,
-  int                 counter
-)
+std::string ContextRegistrationAttributeVector::check(int apiVersion)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     std::string res;
 
-    if ((res = vec[ix]->check(apiVersion, indent)) != "OK")
+    if ((res = vec[ix]->check(apiVersion)) != "OK")
     {
       return res;
     }

--- a/src/lib/ngsi/ContextRegistrationAttributeVector.h
+++ b/src/lib/ngsi/ContextRegistrationAttributeVector.h
@@ -46,11 +46,7 @@ typedef struct ContextRegistrationAttributeVector
   unsigned int                     size(void);
   void                             release();
 
-  std::string                      check(const std::string&  apiVersion,
-                                         RequestType         requestType,
-                                         const std::string&  indent,
-                                         const std::string&  predetectedError,
-                                         int                 counter);
+  std::string                      check(int apiVersion);
 
   ContextRegistrationAttribute*  operator[](unsigned int ix) const;
 

--- a/src/lib/ngsi/ContextRegistrationAttributeVector.h
+++ b/src/lib/ngsi/ContextRegistrationAttributeVector.h
@@ -46,7 +46,7 @@ typedef struct ContextRegistrationAttributeVector
   unsigned int                     size(void);
   void                             release();
 
-  std::string                      check(int apiVersion);
+  std::string                      check(ApiVersion apiVersion);
 
   ContextRegistrationAttribute*  operator[](unsigned int ix) const;
 

--- a/src/lib/ngsi/ContextRegistrationResponse.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponse.cpp
@@ -73,7 +73,7 @@ std::string ContextRegistrationResponse::render(const std::string& indent, bool 
 */
 std::string ContextRegistrationResponse::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationResponse.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponse.cpp
@@ -73,7 +73,7 @@ std::string ContextRegistrationResponse::render(const std::string& indent, bool 
 */
 std::string ContextRegistrationResponse::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationResponse.h
+++ b/src/lib/ngsi/ContextRegistrationResponse.h
@@ -48,7 +48,7 @@ typedef struct ContextRegistrationResponse
   void         present(const std::string& indent);
   void         release(void);
 
-  std::string  check(const std::string&  apiVersion,
+  std::string  check(int                 apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationResponse.h
+++ b/src/lib/ngsi/ContextRegistrationResponse.h
@@ -48,7 +48,7 @@ typedef struct ContextRegistrationResponse
   void         present(const std::string& indent);
   void         release(void);
 
-  std::string  check(int                 apiVersion,
+  std::string  check(ApiVersion          apiVersion,
                      RequestType         requestType,
                      const std::string&  indent,
                      const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationResponseVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponseVector.cpp
@@ -137,7 +137,7 @@ unsigned int ContextRegistrationResponseVector::size(void)
 */
 std::string ContextRegistrationResponseVector::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationResponseVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationResponseVector.cpp
@@ -137,7 +137,7 @@ unsigned int ContextRegistrationResponseVector::size(void)
 */
 std::string ContextRegistrationResponseVector::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         requestType,
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationResponseVector.h
+++ b/src/lib/ngsi/ContextRegistrationResponseVector.h
@@ -49,7 +49,7 @@ typedef struct ContextRegistrationResponseVector
   ContextRegistrationResponse*  operator[](unsigned int ix) const;
 
 
-  std::string                   check(const std::string&  apiVersion,
+  std::string                   check(int                 apiVersion,
                                       RequestType         requestType,
                                       const std::string&  indent,
                                       const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationResponseVector.h
+++ b/src/lib/ngsi/ContextRegistrationResponseVector.h
@@ -49,7 +49,7 @@ typedef struct ContextRegistrationResponseVector
   ContextRegistrationResponse*  operator[](unsigned int ix) const;
 
 
-  std::string                   check(int                 apiVersion,
+  std::string                   check(ApiVersion          apiVersion,
                                       RequestType         requestType,
                                       const std::string&  indent,
                                       const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationVector.cpp
@@ -138,7 +138,7 @@ unsigned int ContextRegistrationVector::size(void)
 */
 std::string ContextRegistrationVector::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   RequestType         requestType, 
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationVector.cpp
+++ b/src/lib/ngsi/ContextRegistrationVector.cpp
@@ -138,7 +138,7 @@ unsigned int ContextRegistrationVector::size(void)
 */
 std::string ContextRegistrationVector::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   RequestType         requestType, 
   const std::string&  indent,
   const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationVector.h
+++ b/src/lib/ngsi/ContextRegistrationVector.h
@@ -46,7 +46,7 @@ typedef struct ContextRegistrationVector
   void                  present(const std::string& indent);
   void                  release(void);
 
-  std::string           check(const std::string&  apiVersion,
+  std::string           check(int                 apiVersion,
                               RequestType         requestType,
                               const std::string&  indent,
                               const std::string&  predetectedError,

--- a/src/lib/ngsi/ContextRegistrationVector.h
+++ b/src/lib/ngsi/ContextRegistrationVector.h
@@ -46,7 +46,7 @@ typedef struct ContextRegistrationVector
   void                  present(const std::string& indent);
   void                  release(void);
 
-  std::string           check(int                 apiVersion,
+  std::string           check(ApiVersion          apiVersion,
                               RequestType         requestType,
                               const std::string&  indent,
                               const std::string&  predetectedError,

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -289,12 +289,12 @@ std::string Metadata::render(const std::string& indent, bool comma)
 *
 * Metadata::check -
 */
-std::string Metadata::check(int apiVersion)
+std::string Metadata::check(ApiVersion apiVersion)
 {
   size_t len;
   char   errorMsg[128];
 
-  if (apiVersion == 2 && (len = strlen(name.c_str())) < MIN_ID_LEN)
+  if (apiVersion == V2 && (len = strlen(name.c_str())) < MIN_ID_LEN)
   {
     snprintf(errorMsg, sizeof errorMsg, "metadata name length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
@@ -328,7 +328,7 @@ std::string Metadata::check(int apiVersion)
   }
 
 
-  if (apiVersion == 2 && (len = strlen(type.c_str())) < MIN_ID_LEN)
+  if (apiVersion == V2 && (len = strlen(type.c_str())) < MIN_ID_LEN)
   {
     snprintf(errorMsg, sizeof errorMsg, "metadata type length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -289,12 +289,12 @@ std::string Metadata::render(const std::string& indent, bool comma)
 *
 * Metadata::check -
 */
-std::string Metadata::check(const std::string& apiVersion)
+std::string Metadata::check(int apiVersion)
 {
   size_t len;
   char   errorMsg[128];
 
-  if (apiVersion == "v2" && (len = strlen(name.c_str())) < MIN_ID_LEN)
+  if (apiVersion == 2 && (len = strlen(name.c_str())) < MIN_ID_LEN)
   {
     snprintf(errorMsg, sizeof errorMsg, "metadata name length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);
@@ -328,7 +328,7 @@ std::string Metadata::check(const std::string& apiVersion)
   }
 
 
-  if (apiVersion == "v2" && (len = strlen(type.c_str())) < MIN_ID_LEN)
+  if (apiVersion == 2 && (len = strlen(type.c_str())) < MIN_ID_LEN)
   {
     snprintf(errorMsg, sizeof errorMsg, "metadata type length: %zd, min length supported: %d", len, MIN_ID_LEN);
     alarmMgr.badInput(clientIp, errorMsg);

--- a/src/lib/ngsi/Metadata.h
+++ b/src/lib/ngsi/Metadata.h
@@ -95,7 +95,7 @@ typedef struct Metadata
   std::string  toStringValue(void) const;
   bool         compoundItemExists(const std::string& compoundPath, orion::CompoundValueNode** compoundItemPP = NULL);
 
-  std::string  check(const std::string& apiVersion);
+  std::string  check(int apiVersion);
 } Metadata;
 
 #endif  // SRC_LIB_NGSI_METADATA_H_

--- a/src/lib/ngsi/Metadata.h
+++ b/src/lib/ngsi/Metadata.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include "common/globals.h"
+
 #include "mongo/client/dbclient.h"
 
 #include "orionTypes/OrionValueType.h"
@@ -95,7 +97,7 @@ typedef struct Metadata
   std::string  toStringValue(void) const;
   bool         compoundItemExists(const std::string& compoundPath, orion::CompoundValueNode** compoundItemPP = NULL);
 
-  std::string  check(int apiVersion);
+  std::string  check(ApiVersion apiVersion);
 } Metadata;
 
 #endif  // SRC_LIB_NGSI_METADATA_H_

--- a/src/lib/ngsi/MetadataVector.cpp
+++ b/src/lib/ngsi/MetadataVector.cpp
@@ -163,7 +163,7 @@ std::string MetadataVector::toJson(bool isLastElement, const std::vector<std::st
 *
 * MetadataVector::check -
 */
-std::string MetadataVector::check(const std::string& apiVersion)
+std::string MetadataVector::check(int apiVersion)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/MetadataVector.cpp
+++ b/src/lib/ngsi/MetadataVector.cpp
@@ -163,7 +163,7 @@ std::string MetadataVector::toJson(bool isLastElement, const std::vector<std::st
 *
 * MetadataVector::check -
 */
-std::string MetadataVector::check(int apiVersion)
+std::string MetadataVector::check(ApiVersion apiVersion)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/MetadataVector.h
+++ b/src/lib/ngsi/MetadataVector.h
@@ -46,7 +46,7 @@ public:
   std::string     render(const std::string& indent, bool comma = false);
   std::string     toJson(bool                             isLastElement,
                          const std::vector<std::string>&  metadataFilter);
-  std::string     check(const std::string& apiVersion);
+  std::string     check(int apiVersion);
 
   void            present(const std::string& metadataType, const std::string& indent);
   void            push_back(Metadata* item);

--- a/src/lib/ngsi/MetadataVector.h
+++ b/src/lib/ngsi/MetadataVector.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include "common/globals.h"
+
 #include "ngsi/Metadata.h"
 
 
@@ -46,7 +48,7 @@ public:
   std::string     render(const std::string& indent, bool comma = false);
   std::string     toJson(bool                             isLastElement,
                          const std::vector<std::string>&  metadataFilter);
-  std::string     check(int apiVersion);
+  std::string     check(ApiVersion apiVersion);
 
   void            present(const std::string& metadataType, const std::string& indent);
   void            push_back(Metadata* item);

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -100,7 +100,7 @@ static void pointVectorRelease(const std::vector<orion::Point*>& pointV)
 */
 int Scope::fill
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   const std::string&  geometryString,
   const std::string&  coordsString,
   const std::string&  georelString,
@@ -112,7 +112,7 @@ int Scope::fill
   int                         points;
   std::vector<orion::Point*>  pointV;
 
-  type = (apiVersion == 1)? FIWARE_LOCATION : FIWARE_LOCATION_V2;
+  type = (apiVersion == V1)? FIWARE_LOCATION : FIWARE_LOCATION_V2;
 
   //
   // parse geometry
@@ -232,7 +232,7 @@ int Scope::fill
 
   if (geometry.areaType == "circle")
   {
-    if (apiVersion == 2)
+    if (apiVersion == V2)
     {
       *errorStringP = "circle geometry is not supported by Orion API v2";
       pointVectorRelease(pointV);
@@ -263,14 +263,14 @@ int Scope::fill
   {
     areaType = orion::PolygonType;
     
-    if ((apiVersion == 1) && (pointV.size() < 3))
+    if ((apiVersion == V1) && (pointV.size() < 3))
     {
       *errorStringP = "Too few coordinates for polygon";
       pointVectorRelease(pointV);
       pointV.clear();
       return -1;
     }
-    else if ((apiVersion == 2) && (pointV.size() < 4))
+    else if ((apiVersion == V2) && (pointV.size() < 4))
     {
       *errorStringP = "Too few coordinates for polygon";
       pointVectorRelease(pointV);
@@ -281,7 +281,7 @@ int Scope::fill
     //
     // If v2, first and last point must be identical
     //
-    if ((apiVersion == 2) && (pointV[0]->equals(pointV[pointV.size() - 1]) == false))
+    if ((apiVersion == V2) && (pointV[0]->equals(pointV[pointV.size() - 1]) == false))
     {
       *errorStringP = "First and last point in polygon not the same";
       pointVectorRelease(pointV);

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -100,7 +100,7 @@ static void pointVectorRelease(const std::vector<orion::Point*>& pointV)
 */
 int Scope::fill
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   const std::string&  geometryString,
   const std::string&  coordsString,
   const std::string&  georelString,
@@ -112,7 +112,7 @@ int Scope::fill
   int                         points;
   std::vector<orion::Point*>  pointV;
 
-  type = (apiVersion == "v1")? FIWARE_LOCATION : FIWARE_LOCATION_V2;
+  type = (apiVersion == 1)? FIWARE_LOCATION : FIWARE_LOCATION_V2;
 
   //
   // parse geometry
@@ -232,7 +232,7 @@ int Scope::fill
 
   if (geometry.areaType == "circle")
   {
-    if (apiVersion == "v2")
+    if (apiVersion == 2)
     {
       *errorStringP = "circle geometry is not supported by Orion API v2";
       pointVectorRelease(pointV);
@@ -263,14 +263,14 @@ int Scope::fill
   {
     areaType = orion::PolygonType;
     
-    if ((apiVersion == "v1") && (pointV.size() < 3))
+    if ((apiVersion == 1) && (pointV.size() < 3))
     {
       *errorStringP = "Too few coordinates for polygon";
       pointVectorRelease(pointV);
       pointV.clear();
       return -1;
     }
-    else if ((apiVersion == "v2") && (pointV.size() < 4))
+    else if ((apiVersion == 2) && (pointV.size() < 4))
     {
       *errorStringP = "Too few coordinates for polygon";
       pointVectorRelease(pointV);
@@ -281,7 +281,7 @@ int Scope::fill
     //
     // If v2, first and last point must be identical
     //
-    if ((apiVersion == "v2") && (pointV[0]->equals(pointV[pointV.size() - 1]) == false))
+    if ((apiVersion == 2) && (pointV[0]->equals(pointV[pointV.size() - 1]) == false))
     {
       *errorStringP = "First and last point in polygon not the same";
       pointVectorRelease(pointV);

--- a/src/lib/ngsi/Scope.h
+++ b/src/lib/ngsi/Scope.h
@@ -76,7 +76,7 @@ typedef struct Scope
   Scope();
   Scope(const std::string& _type, const std::string& _value,  const std::string& _oper = "");
 
-  int          fill(int                 apiVersion,
+  int          fill(ApiVersion          apiVersion,
                     const std::string&  geometry,
                     const std::string&  coords,
                     const std::string&  georelString,

--- a/src/lib/ngsi/Scope.h
+++ b/src/lib/ngsi/Scope.h
@@ -76,7 +76,7 @@ typedef struct Scope
   Scope();
   Scope(const std::string& _type, const std::string& _value,  const std::string& _oper = "");
 
-  int          fill(const std::string&  apiVersion,
+  int          fill(int                 apiVersion,
                     const std::string&  geometry,
                     const std::string&  coords,
                     const std::string&  georelString,

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -38,7 +38,7 @@
 *
 * NotifyContextRequest::render -
 */
-std::string NotifyContextRequest::render(int apiVersion, bool asJsonObject, const std::string& indent)
+std::string NotifyContextRequest::render(ApiVersion apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out                                  = "";
   bool         contextElementResponseVectorRendered = contextElementResponseVector.size() != 0;
@@ -101,7 +101,7 @@ std::string NotifyContextRequest::toJson
 *
 * NotifyContextRequest::check
 */
-std::string NotifyContextRequest::check(int apiVersion, const std::string& indent, const std::string& predetectedError)
+std::string NotifyContextRequest::check(ApiVersion apiVersion, const std::string& indent, const std::string& predetectedError)
 {
   std::string            res;
   NotifyContextResponse  response;

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -38,7 +38,7 @@
 *
 * NotifyContextRequest::render -
 */
-std::string NotifyContextRequest::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
+std::string NotifyContextRequest::render(int apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out                                  = "";
   bool         contextElementResponseVectorRendered = contextElementResponseVector.size() != 0;
@@ -101,7 +101,7 @@ std::string NotifyContextRequest::toJson
 *
 * NotifyContextRequest::check
 */
-std::string NotifyContextRequest::check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError)
+std::string NotifyContextRequest::check(int apiVersion, const std::string& indent, const std::string& predetectedError)
 {
   std::string            res;
   NotifyContextResponse  response;

--- a/src/lib/ngsi10/NotifyContextRequest.h
+++ b/src/lib/ngsi10/NotifyContextRequest.h
@@ -45,12 +45,12 @@ typedef struct NotifyContextRequest
   Originator                    originator;                    // Mandatory
   ContextElementResponseVector  contextElementResponseVector;  // Optional
 
-  std::string   render(int apiVersion, bool asJsonObject, const std::string& indent);
+  std::string   render(ApiVersion apiVersion, bool asJsonObject, const std::string& indent);
   std::string   toJson(RenderFormat                     renderFormat,
                        const std::vector<std::string>&  attrsFilter,
                        const std::vector<std::string>&  metadataFilter,
                        bool                             blacklist = false);
-  std::string   check(int apiVersion, const std::string& indent, const std::string& predetectedError);
+  std::string   check(ApiVersion apiVersion, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   NotifyContextRequest* clone(void);

--- a/src/lib/ngsi10/NotifyContextRequest.h
+++ b/src/lib/ngsi10/NotifyContextRequest.h
@@ -45,12 +45,12 @@ typedef struct NotifyContextRequest
   Originator                    originator;                    // Mandatory
   ContextElementResponseVector  contextElementResponseVector;  // Optional
 
-  std::string   render(const std::string& apiVersion, bool asJsonObject, const std::string& indent);
+  std::string   render(int apiVersion, bool asJsonObject, const std::string& indent);
   std::string   toJson(RenderFormat                     renderFormat,
                        const std::vector<std::string>&  attrsFilter,
                        const std::vector<std::string>&  metadataFilter,
                        bool                             blacklist = false);
-  std::string   check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError);
+  std::string   check(int apiVersion, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   NotifyContextRequest* clone(void);

--- a/src/lib/ngsi10/QueryContextRequest.cpp
+++ b/src/lib/ngsi10/QueryContextRequest.cpp
@@ -117,7 +117,7 @@ std::string QueryContextRequest::render(const std::string& indent)
 *
 * QueryContextRequest::check - 
 */
-std::string QueryContextRequest::check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
+std::string QueryContextRequest::check(ApiVersion apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
 {
   std::string           res;
   QueryContextResponse  response;

--- a/src/lib/ngsi10/QueryContextRequest.cpp
+++ b/src/lib/ngsi10/QueryContextRequest.cpp
@@ -117,7 +117,7 @@ std::string QueryContextRequest::render(const std::string& indent)
 *
 * QueryContextRequest::check - 
 */
-std::string QueryContextRequest::check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
+std::string QueryContextRequest::check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
 {
   std::string           res;
   QueryContextResponse  response;

--- a/src/lib/ngsi10/QueryContextRequest.h
+++ b/src/lib/ngsi10/QueryContextRequest.h
@@ -62,7 +62,7 @@ typedef struct QueryContextRequest
   QueryContextRequest(const std::string& _contextProvider, EntityId* eP, const AttributeList& attributeList);
 
   std::string   render(const std::string& indent);
-  std::string   check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
+  std::string   check(ApiVersion apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   void          fill(const std::string& entityId, const std::string& entityType, const std::string& attributeName);

--- a/src/lib/ngsi10/QueryContextRequest.h
+++ b/src/lib/ngsi10/QueryContextRequest.h
@@ -62,7 +62,7 @@ typedef struct QueryContextRequest
   QueryContextRequest(const std::string& _contextProvider, EntityId* eP, const AttributeList& attributeList);
 
   std::string   render(const std::string& indent);
-  std::string   check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
+  std::string   check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   void          fill(const std::string& entityId, const std::string& entityType, const std::string& attributeName);

--- a/src/lib/ngsi10/QueryContextResponse.cpp
+++ b/src/lib/ngsi10/QueryContextResponse.cpp
@@ -94,7 +94,7 @@ QueryContextResponse::~QueryContextResponse()
 *
 * QueryContextResponse::render - 
 */
-std::string QueryContextResponse::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
+std::string QueryContextResponse::render(int apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out               = "";
   bool         errorCodeRendered = false;
@@ -161,7 +161,7 @@ std::string QueryContextResponse::render(const std::string& apiVersion, bool asJ
 *
 * QueryContextResponse::check -
 */
-std::string QueryContextResponse::check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
+std::string QueryContextResponse::check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
 {
   std::string  res;
 

--- a/src/lib/ngsi10/QueryContextResponse.cpp
+++ b/src/lib/ngsi10/QueryContextResponse.cpp
@@ -94,7 +94,7 @@ QueryContextResponse::~QueryContextResponse()
 *
 * QueryContextResponse::render - 
 */
-std::string QueryContextResponse::render(int apiVersion, bool asJsonObject, const std::string& indent)
+std::string QueryContextResponse::render(ApiVersion apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out               = "";
   bool         errorCodeRendered = false;
@@ -161,7 +161,7 @@ std::string QueryContextResponse::render(int apiVersion, bool asJsonObject, cons
 *
 * QueryContextResponse::check -
 */
-std::string QueryContextResponse::check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
+std::string QueryContextResponse::check(ApiVersion apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError)
 {
   std::string  res;
 

--- a/src/lib/ngsi10/QueryContextResponse.h
+++ b/src/lib/ngsi10/QueryContextResponse.h
@@ -52,8 +52,8 @@ typedef struct QueryContextResponse
   QueryContextResponse(StatusCode& _errorCode);
   ~QueryContextResponse();
 
-  std::string            render(int apiVersion, bool asJsonObject, const std::string& indent);
-  std::string            check(int apiVersion, bool asJsonObject, const std::string&  indent, const std::string&  predetectedError);
+  std::string            render(ApiVersion apiVersion, bool asJsonObject, const std::string& indent);
+  std::string            check(ApiVersion apiVersion, bool asJsonObject, const std::string&  indent, const std::string&  predetectedError);
   void                   present(const std::string& indent, const std::string& caller);
   void                   release(void);  
   void                   fill(QueryContextResponse* qcrsP);

--- a/src/lib/ngsi10/QueryContextResponse.h
+++ b/src/lib/ngsi10/QueryContextResponse.h
@@ -52,8 +52,8 @@ typedef struct QueryContextResponse
   QueryContextResponse(StatusCode& _errorCode);
   ~QueryContextResponse();
 
-  std::string            render(const std::string& apiVersion, bool asJsonObject, const std::string& indent);
-  std::string            check(const std::string& apiVersion, bool asJsonObject, const std::string&  indent, const std::string&  predetectedError);
+  std::string            render(int apiVersion, bool asJsonObject, const std::string& indent);
+  std::string            check(int apiVersion, bool asJsonObject, const std::string&  indent, const std::string&  predetectedError);
   void                   present(const std::string& indent, const std::string& caller);
   void                   release(void);  
   void                   fill(QueryContextResponse* qcrsP);

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -66,7 +66,7 @@ UpdateContextRequest::UpdateContextRequest(const std::string& _contextProvider, 
 *
 * UpdateContextRequest::render - 
 */
-std::string UpdateContextRequest::render(int apiVersion, bool asJsonObject, const std::string& indent)
+std::string UpdateContextRequest::render(ApiVersion apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out = "";
 
@@ -87,7 +87,7 @@ std::string UpdateContextRequest::render(int apiVersion, bool asJsonObject, cons
 *
 * UpdateContextRequest::check - 
 */
-std::string UpdateContextRequest::check(int apiVersion, bool asJsonObject,  const std::string& indent, const std::string& predetectedError, int counter)
+std::string UpdateContextRequest::check(ApiVersion apiVersion, bool asJsonObject,  const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string            res;
   UpdateContextResponse  response;

--- a/src/lib/ngsi10/UpdateContextRequest.cpp
+++ b/src/lib/ngsi10/UpdateContextRequest.cpp
@@ -66,7 +66,7 @@ UpdateContextRequest::UpdateContextRequest(const std::string& _contextProvider, 
 *
 * UpdateContextRequest::render - 
 */
-std::string UpdateContextRequest::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
+std::string UpdateContextRequest::render(int apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string  out = "";
 
@@ -87,7 +87,7 @@ std::string UpdateContextRequest::render(const std::string& apiVersion, bool asJ
 *
 * UpdateContextRequest::check - 
 */
-std::string UpdateContextRequest::check(const std::string& apiVersion, bool asJsonObject,  const std::string& indent, const std::string& predetectedError, int counter)
+std::string UpdateContextRequest::check(int apiVersion, bool asJsonObject,  const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string            res;
   UpdateContextResponse  response;

--- a/src/lib/ngsi10/UpdateContextRequest.h
+++ b/src/lib/ngsi10/UpdateContextRequest.h
@@ -59,8 +59,8 @@ typedef struct UpdateContextRequest
   UpdateContextRequest();
   UpdateContextRequest(const std::string& _contextProvider, EntityId* eP);
 
-  std::string        render(const std::string& apiVersion, bool asJsonObject, const std::string& indent);
-  std::string        check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string        render(int apiVersion, bool asJsonObject, const std::string& indent);
+  std::string        check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError, int counter);
   void               release(void);
   ContextAttribute*  attributeLookup(EntityId* eP, const std::string& attributeName);
 

--- a/src/lib/ngsi10/UpdateContextRequest.h
+++ b/src/lib/ngsi10/UpdateContextRequest.h
@@ -59,8 +59,8 @@ typedef struct UpdateContextRequest
   UpdateContextRequest();
   UpdateContextRequest(const std::string& _contextProvider, EntityId* eP);
 
-  std::string        render(int apiVersion, bool asJsonObject, const std::string& indent);
-  std::string        check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string        render(ApiVersion apiVersion, bool asJsonObject, const std::string& indent);
+  std::string        check(ApiVersion apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError, int counter);
   void               release(void);
   ContextAttribute*  attributeLookup(EntityId* eP, const std::string& attributeName);
 

--- a/src/lib/ngsi10/UpdateContextResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextResponse.cpp
@@ -80,7 +80,7 @@ UpdateContextResponse::~UpdateContextResponse()
 *
 * UpdateContextResponse::render - 
 */
-std::string UpdateContextResponse::render(int apiVersion, bool asJsonObject, const std::string& indent)
+std::string UpdateContextResponse::render(ApiVersion apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string out = "";
 
@@ -116,7 +116,7 @@ std::string UpdateContextResponse::render(int apiVersion, bool asJsonObject, con
 */
 std::string UpdateContextResponse::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   const std::string&  indent,
   const std::string&  predetectedError

--- a/src/lib/ngsi10/UpdateContextResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextResponse.cpp
@@ -80,7 +80,7 @@ UpdateContextResponse::~UpdateContextResponse()
 *
 * UpdateContextResponse::render - 
 */
-std::string UpdateContextResponse::render(const std::string& apiVersion, bool asJsonObject, const std::string& indent)
+std::string UpdateContextResponse::render(int apiVersion, bool asJsonObject, const std::string& indent)
 {
   std::string out = "";
 
@@ -116,7 +116,7 @@ std::string UpdateContextResponse::render(const std::string& apiVersion, bool as
 */
 std::string UpdateContextResponse::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   const std::string&  indent,
   const std::string&  predetectedError

--- a/src/lib/ngsi10/UpdateContextResponse.h
+++ b/src/lib/ngsi10/UpdateContextResponse.h
@@ -50,8 +50,8 @@ typedef struct UpdateContextResponse
   UpdateContextResponse(StatusCode& _errorCode);
   ~UpdateContextResponse();
 
-  std::string   render(int apiVersion, bool asJsonObject, const std::string& indent);
-  std::string   check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
+  std::string   render(ApiVersion apiVersion, bool asJsonObject, const std::string& indent);
+  std::string   check(ApiVersion apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   void          fill(UpdateContextResponse* upcrsP);

--- a/src/lib/ngsi10/UpdateContextResponse.h
+++ b/src/lib/ngsi10/UpdateContextResponse.h
@@ -50,8 +50,8 @@ typedef struct UpdateContextResponse
   UpdateContextResponse(StatusCode& _errorCode);
   ~UpdateContextResponse();
 
-  std::string   render(const std::string& apiVersion, bool asJsonObject, const std::string& indent);
-  std::string   check(const std::string& apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
+  std::string   render(int apiVersion, bool asJsonObject, const std::string& indent);
+  std::string   check(int apiVersion, bool asJsonObject, const std::string& indent, const std::string& predetectedError);
   void          present(const std::string& indent);
   void          release(void);
   void          fill(UpdateContextResponse* upcrsP);

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
@@ -70,7 +70,7 @@ std::string NotifyContextAvailabilityRequest::render(const std::string& indent)
 *
 * NotifyContextAvailabilityRequest::check - 
 */
-std::string NotifyContextAvailabilityRequest::check(int apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
+std::string NotifyContextAvailabilityRequest::check(ApiVersion apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string                        res;
   NotifyContextAvailabilityResponse  response;

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.cpp
@@ -70,7 +70,7 @@ std::string NotifyContextAvailabilityRequest::render(const std::string& indent)
 *
 * NotifyContextAvailabilityRequest::check - 
 */
-std::string NotifyContextAvailabilityRequest::check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
+std::string NotifyContextAvailabilityRequest::check(int apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
 {
   std::string                        res;
   NotifyContextAvailabilityResponse  response;

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.h
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.h
@@ -44,7 +44,7 @@ typedef struct NotifyContextAvailabilityRequest
   NotifyContextAvailabilityRequest();
 
   std::string   render(const std::string& indent);
-  std::string   check(int apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string   check(ApiVersion apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
   void          present(const std::string& indent);
   void          release(void);
 } NotifyContextAvailabilityRequest;

--- a/src/lib/ngsi9/NotifyContextAvailabilityRequest.h
+++ b/src/lib/ngsi9/NotifyContextAvailabilityRequest.h
@@ -44,7 +44,7 @@ typedef struct NotifyContextAvailabilityRequest
   NotifyContextAvailabilityRequest();
 
   std::string   render(const std::string& indent);
-  std::string   check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string   check(int apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
   void          present(const std::string& indent);
   void          release(void);
 } NotifyContextAvailabilityRequest;

--- a/src/lib/ngsi9/RegisterContextRequest.cpp
+++ b/src/lib/ngsi9/RegisterContextRequest.cpp
@@ -68,7 +68,7 @@ std::string RegisterContextRequest::render(const std::string& indent)
 *
 * RegisterContextRequest::check - 
 */
-std::string RegisterContextRequest::check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
+std::string RegisterContextRequest::check(int apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
 {
   RegisterContextResponse  response(this);
   std::string              res;

--- a/src/lib/ngsi9/RegisterContextRequest.cpp
+++ b/src/lib/ngsi9/RegisterContextRequest.cpp
@@ -68,7 +68,7 @@ std::string RegisterContextRequest::render(const std::string& indent)
 *
 * RegisterContextRequest::check - 
 */
-std::string RegisterContextRequest::check(int apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
+std::string RegisterContextRequest::check(ApiVersion apiVersion, const std::string& indent, const std::string& predetectedError, int counter)
 {
   RegisterContextResponse  response(this);
   std::string              res;

--- a/src/lib/ngsi9/RegisterContextRequest.h
+++ b/src/lib/ngsi9/RegisterContextRequest.h
@@ -48,7 +48,7 @@ typedef struct RegisterContextRequest
   std::string                servicePath;                // Not part of payload, just an internal field
 
   std::string   render(const std::string& indent);
-  std::string   check(const std::string& apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string   check(int apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
   void          present(void);
   void          release(void);
   void          fill(RegisterProviderRequest& rpr, const std::string& entityId, const std::string& entityType, const std::string& attributeName);

--- a/src/lib/ngsi9/RegisterContextRequest.h
+++ b/src/lib/ngsi9/RegisterContextRequest.h
@@ -48,7 +48,7 @@ typedef struct RegisterContextRequest
   std::string                servicePath;                // Not part of payload, just an internal field
 
   std::string   render(const std::string& indent);
-  std::string   check(int apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
+  std::string   check(ApiVersion apiVersion, const std::string& indent, const std::string& predetectedError, int counter);
   void          present(void);
   void          release(void);
   void          fill(RegisterProviderRequest& rpr, const std::string& entityId, const std::string& entityType, const std::string& attributeName);

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -69,7 +69,7 @@ EntityType::EntityType(std::string _type): type(_type), count(0)
 */
 std::string EntityType::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,
@@ -111,7 +111,7 @@ std::string EntityType::render
 *
 * EntityType::check -
 */
-std::string EntityType::check(const std::string& apiVersion, const std::string&  predetectedError)
+std::string EntityType::check(int apiVersion, const std::string&  predetectedError)
 {
   if (predetectedError != "")
   {

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -69,7 +69,7 @@ EntityType::EntityType(std::string _type): type(_type), count(0)
 */
 std::string EntityType::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,
@@ -111,7 +111,7 @@ std::string EntityType::render
 *
 * EntityType::check -
 */
-std::string EntityType::check(int apiVersion, const std::string&  predetectedError)
+std::string EntityType::check(ApiVersion apiVersion, const std::string&  predetectedError)
 {
   if (predetectedError != "")
   {

--- a/src/lib/orionTypes/EntityType.h
+++ b/src/lib/orionTypes/EntityType.h
@@ -45,14 +45,14 @@ class EntityType
   EntityType();
   explicit EntityType(std::string _type);
 
-  std::string   check(const std::string& apiVersion, const std::string& predetectedError);
-  std::string   render(const std::string&  apiVersion,
+  std::string   check(int apiVersion, const std::string& predetectedError);
+  std::string   render(int                 apiVersion,
                        bool                asJsonObject,
                        bool                asJsonOut,
                        bool                collapsed,
                        const std::string&  indent,
                        bool                comma = false,
-                       bool typeNameBefore = false);
+                       bool                typeNameBefore = false);
   void          present(const std::string& indent);
   void          release(void);
   std::string   toJson(bool includeType = false);

--- a/src/lib/orionTypes/EntityType.h
+++ b/src/lib/orionTypes/EntityType.h
@@ -45,8 +45,8 @@ class EntityType
   EntityType();
   explicit EntityType(std::string _type);
 
-  std::string   check(int apiVersion, const std::string& predetectedError);
-  std::string   render(int                 apiVersion,
+  std::string   check(ApiVersion apiVersion, const std::string& predetectedError);
+  std::string   render(ApiVersion          apiVersion,
                        bool                asJsonObject,
                        bool                asJsonOut,
                        bool                collapsed,

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -45,7 +45,7 @@
 */
 std::string EntityTypeResponse::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,
@@ -72,11 +72,10 @@ std::string EntityTypeResponse::render
 */
 std::string EntityTypeResponse::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
-  bool                collapsed,
-  const std::string&  indent,
+  bool                collapsed,  
   const std::string&  predetectedError
 )
 {

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -45,7 +45,7 @@
 */
 std::string EntityTypeResponse::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,
@@ -72,7 +72,7 @@ std::string EntityTypeResponse::render
 */
 std::string EntityTypeResponse::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,  

--- a/src/lib/orionTypes/EntityTypeResponse.h
+++ b/src/lib/orionTypes/EntityTypeResponse.h
@@ -44,17 +44,17 @@ class EntityTypeResponse
   EntityType    entityType;
   StatusCode    statusCode;
 
-  std::string   render(const std::string&  apiVersion,
+  std::string   render(int                 apiVersion,
                        bool                asJsonObject,
                        bool                asJsonOut,
                        bool                collapsed,
                        const std::string&  indent);
   std::string   toJson(void);
-  std::string   check(const std::string&  apiVersion,
+  std::string   check(int                 apiVersion,
                       bool                asJsonObject,
                       bool                asJsonOut,
                       bool                collapsed,
-                      const std::string&  indent, const std::string& predetectedError);
+                      const std::string&  predetectedError);
   void          present(const std::string& indent);
   void          release(void);
 };

--- a/src/lib/orionTypes/EntityTypeResponse.h
+++ b/src/lib/orionTypes/EntityTypeResponse.h
@@ -44,13 +44,13 @@ class EntityTypeResponse
   EntityType    entityType;
   StatusCode    statusCode;
 
-  std::string   render(int                 apiVersion,
+  std::string   render(ApiVersion          apiVersion,
                        bool                asJsonObject,
                        bool                asJsonOut,
                        bool                collapsed,
                        const std::string&  indent);
   std::string   toJson(void);
-  std::string   check(int                 apiVersion,
+  std::string   check(ApiVersion          apiVersion,
                       bool                asJsonObject,
                       bool                asJsonOut,
                       bool                collapsed,

--- a/src/lib/orionTypes/EntityTypeVector.cpp
+++ b/src/lib/orionTypes/EntityTypeVector.cpp
@@ -54,7 +54,7 @@ EntityTypeVector::EntityTypeVector()
 */
 std::string EntityTypeVector::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,
@@ -84,7 +84,7 @@ std::string EntityTypeVector::render
 *
 * EntityTypeVector::check -
 */
-std::string EntityTypeVector::check(int apiVersion, const std::string& predetectedError)
+std::string EntityTypeVector::check(ApiVersion apiVersion, const std::string& predetectedError)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/orionTypes/EntityTypeVector.cpp
+++ b/src/lib/orionTypes/EntityTypeVector.cpp
@@ -54,7 +54,7 @@ EntityTypeVector::EntityTypeVector()
 */
 std::string EntityTypeVector::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,
@@ -84,7 +84,7 @@ std::string EntityTypeVector::render
 *
 * EntityTypeVector::check -
 */
-std::string EntityTypeVector::check(const std::string&  apiVersion, const std::string&  predetectedError)
+std::string EntityTypeVector::check(int apiVersion, const std::string& predetectedError)
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/orionTypes/EntityTypeVector.h
+++ b/src/lib/orionTypes/EntityTypeVector.h
@@ -47,8 +47,8 @@ class EntityTypeVector
   void          push_back(EntityType* item);
   unsigned int  size(void);
   void          release(void);
-  std::string   check(int apiVersion, const std::string& predetectedError);
-  std::string   render(int                 apiVersion,
+  std::string   check(ApiVersion apiVersion, const std::string& predetectedError);
+  std::string   render(ApiVersion          apiVersion,
                        bool                asJsonObject,
                        bool                asJsonOut,
                        bool                collapsed,

--- a/src/lib/orionTypes/EntityTypeVector.h
+++ b/src/lib/orionTypes/EntityTypeVector.h
@@ -47,8 +47,8 @@ class EntityTypeVector
   void          push_back(EntityType* item);
   unsigned int  size(void);
   void          release(void);
-  std::string   check(const std::string& apiVersion, const std::string& predetectedError);
-  std::string   render(const std::string&  apiVersion,
+  std::string   check(int apiVersion, const std::string& predetectedError);
+  std::string   render(int                 apiVersion,
                        bool                asJsonObject,
                        bool                asJsonOut,
                        bool                collapsed,

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -44,7 +44,7 @@
 */
 std::string EntityTypeVectorResponse::render
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,
@@ -75,7 +75,7 @@ std::string EntityTypeVectorResponse::render
 */
 std::string EntityTypeVectorResponse::check
 (
-  int                 apiVersion,
+  ApiVersion          apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -44,7 +44,7 @@
 */
 std::string EntityTypeVectorResponse::render
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,
@@ -75,7 +75,7 @@ std::string EntityTypeVectorResponse::render
 */
 std::string EntityTypeVectorResponse::check
 (
-  const std::string&  apiVersion,
+  int                 apiVersion,
   bool                asJsonObject,
   bool                asJsonOut,
   bool                collapsed,

--- a/src/lib/orionTypes/EntityTypeVectorResponse.h
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.h
@@ -44,12 +44,12 @@ class EntityTypeVectorResponse
   EntityTypeVector  entityTypeVector;
   StatusCode        statusCode;
 
-  std::string       render(const std::string&  apiVersion,
+  std::string       render(int                 apiVersion,
                            bool                asJsonObject,
                            bool                asJsonOut,
                            bool                collapsed,
                            const std::string&  indent);
-  std::string       check(const std::string&  apiVersion,
+  std::string       check(int                 apiVersion,
                           bool                asJsonObject,
                           bool                asJsonOut,
                           bool                collapsed,

--- a/src/lib/orionTypes/EntityTypeVectorResponse.h
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.h
@@ -44,12 +44,12 @@ class EntityTypeVectorResponse
   EntityTypeVector  entityTypeVector;
   StatusCode        statusCode;
 
-  std::string       render(int                 apiVersion,
+  std::string       render(ApiVersion          apiVersion,
                            bool                asJsonObject,
                            bool                asJsonOut,
                            bool                collapsed,
                            const std::string&  indent);
-  std::string       check(int                 apiVersion,
+  std::string       check(ApiVersion          apiVersion,
                           bool                asJsonObject,
                           bool                asJsonOut,
                           bool                collapsed,

--- a/src/lib/orionTypes/QueryContextResponseVector.cpp
+++ b/src/lib/orionTypes/QueryContextResponseVector.cpp
@@ -123,7 +123,7 @@ void QueryContextResponseVector::present(void)
 *
 * QueryContextResponseVector::render - 
 */
-std::string QueryContextResponseVector::render(int apiVersion, bool asJsonObject, bool details, const std::string& detailsString)
+std::string QueryContextResponseVector::render(ApiVersion apiVersion, bool asJsonObject, bool details, const std::string& detailsString)
 {
   QueryContextResponse* responseP = new QueryContextResponse();
   std::string           answer;

--- a/src/lib/orionTypes/QueryContextResponseVector.cpp
+++ b/src/lib/orionTypes/QueryContextResponseVector.cpp
@@ -123,7 +123,7 @@ void QueryContextResponseVector::present(void)
 *
 * QueryContextResponseVector::render - 
 */
-std::string QueryContextResponseVector::render(const std::string& apiVersion, bool asJsonObject, bool details, const std::string& detailsString)
+std::string QueryContextResponseVector::render(int apiVersion, bool asJsonObject, bool details, const std::string& detailsString)
 {
   QueryContextResponse* responseP = new QueryContextResponse();
   std::string           answer;

--- a/src/lib/orionTypes/QueryContextResponseVector.h
+++ b/src/lib/orionTypes/QueryContextResponseVector.h
@@ -44,7 +44,7 @@ typedef struct QueryContextResponseVector
   void                   push_back(QueryContextResponse* item);
   void                   release(void);
   void                   present(void);
-  std::string            render(int apiVersion, bool asJsonObject, bool details, const std::string& detailsString);
+  std::string            render(ApiVersion apiVersion, bool asJsonObject, bool details, const std::string& detailsString);
   void                   populate(QueryContextResponse* responseP);
 
   QueryContextResponse*  operator[](unsigned int ix) const;

--- a/src/lib/orionTypes/QueryContextResponseVector.h
+++ b/src/lib/orionTypes/QueryContextResponseVector.h
@@ -44,7 +44,7 @@ typedef struct QueryContextResponseVector
   void                   push_back(QueryContextResponse* item);
   void                   release(void);
   void                   present(void);
-  std::string            render(const std::string& apiVersion, bool asJsonObject, bool details, const std::string& detailsString);
+  std::string            render(int apiVersion, bool asJsonObject, bool details, const std::string& detailsString);
   void                   populate(QueryContextResponse* responseP);
 
   QueryContextResponse*  operator[](unsigned int ix) const;

--- a/src/lib/orionTypes/areas.cpp
+++ b/src/lib/orionTypes/areas.cpp
@@ -585,7 +585,7 @@ Geometry::Geometry(): areaType(""), radius(-1), external(false)
 *
 * Geometry::parse - 
 */
-int Geometry::parse(int apiVersion, const char* in, std::string* errorString)
+int Geometry::parse(ApiVersion apiVersion, const char* in, std::string* errorString)
 {
   std::vector<std::string> items;
 
@@ -597,7 +597,7 @@ int Geometry::parse(int apiVersion, const char* in, std::string* errorString)
 
   for (unsigned int ix = 0; ix < items.size(); ++ix)
   {
-    if ((apiVersion == 1) && ((items[ix] == "polygon") || (items[ix] == "circle")))
+    if ((apiVersion == V1) && ((items[ix] == "polygon") || (items[ix] == "circle")))
     {
       if (areaType != "")
       {
@@ -606,7 +606,7 @@ int Geometry::parse(int apiVersion, const char* in, std::string* errorString)
       }
       areaType = items[ix];
     }
-    else if ((apiVersion == 2) && ((items[ix] == "point") || (items[ix] == "line") || (items[ix] == "box") || (items[ix] == "polygon")))
+    else if ((apiVersion == V2) && ((items[ix] == "point") || (items[ix] == "line") || (items[ix] == "box") || (items[ix] == "polygon")))
     {
       if (areaType != "")
       {

--- a/src/lib/orionTypes/areas.cpp
+++ b/src/lib/orionTypes/areas.cpp
@@ -585,7 +585,7 @@ Geometry::Geometry(): areaType(""), radius(-1), external(false)
 *
 * Geometry::parse - 
 */
-int Geometry::parse(const std::string& apiVersion, const char* in, std::string* errorString)
+int Geometry::parse(int apiVersion, const char* in, std::string* errorString)
 {
   std::vector<std::string> items;
 
@@ -597,7 +597,7 @@ int Geometry::parse(const std::string& apiVersion, const char* in, std::string* 
 
   for (unsigned int ix = 0; ix < items.size(); ++ix)
   {
-    if ((apiVersion == "v1") && ((items[ix] == "polygon") || (items[ix] == "circle")))
+    if ((apiVersion == 1) && ((items[ix] == "polygon") || (items[ix] == "circle")))
     {
       if (areaType != "")
       {
@@ -606,7 +606,7 @@ int Geometry::parse(const std::string& apiVersion, const char* in, std::string* 
       }
       areaType = items[ix];
     }
-    else if ((apiVersion == "v2") && ((items[ix] == "point") || (items[ix] == "line") || (items[ix] == "box") || (items[ix] == "polygon")))
+    else if ((apiVersion == 2) && ((items[ix] == "point") || (items[ix] == "line") || (items[ix] == "box") || (items[ix] == "polygon")))
     {
       if (areaType != "")
       {

--- a/src/lib/orionTypes/areas.h
+++ b/src/lib/orionTypes/areas.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <vector>
 
-
+#include "common/globals.h"
 
 namespace orion
 {
@@ -189,7 +189,7 @@ class Geometry
 {
 public:
   Geometry();
-  int          parse(int apiVersion, const char* in, std::string* errorString);
+  int          parse(ApiVersion apiVersion, const char* in, std::string* errorString);
 
   std::string  areaType;
   float        radius;

--- a/src/lib/orionTypes/areas.h
+++ b/src/lib/orionTypes/areas.h
@@ -189,7 +189,7 @@ class Geometry
 {
 public:
   Geometry();
-  int          parse(const std::string& apiVersion, const char* in, std::string* errorString);
+  int          parse(int apiVersion, const char* in, std::string* errorString);
 
   std::string  areaType;
   float        radius;

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -654,13 +654,13 @@ std::string CompoundValueNode::check(void)
 *
 * render -
 */
-std::string CompoundValueNode::render(int apiVersion, const std::string& indent)
+std::string CompoundValueNode::render(ApiVersion apiVersion, const std::string& indent)
 {
   std::string  out       = "";
   bool         jsonComma = siblingNo < (int) container->childV.size() - 1;
   std::string  key       = (container->valueType == orion::ValueTypeVector)? "item" : name;
 
-  if (apiVersion == 2)
+  if (apiVersion == V2)
   {
     return toJson(true); // FIXME P8: The info on comma-after-or-not is not available here ...
   }

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -654,13 +654,13 @@ std::string CompoundValueNode::check(void)
 *
 * render -
 */
-std::string CompoundValueNode::render(const std::string& apiVersion, const std::string& indent)
+std::string CompoundValueNode::render(int apiVersion, const std::string& indent)
 {
   std::string  out       = "";
   bool         jsonComma = siblingNo < (int) container->childV.size() - 1;
   std::string  key       = (container->valueType == orion::ValueTypeVector)? "item" : name;
 
-  if (apiVersion == "v2")
+  if (apiVersion == 2)
   {
     return toJson(true); // FIXME P8: The info on comma-after-or-not is not available here ...
   }

--- a/src/lib/parse/CompoundValueNode.h
+++ b/src/lib/parse/CompoundValueNode.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include "common/globals.h"
+
 #include "orionTypes/OrionValueType.h"
 
 
@@ -158,7 +160,7 @@ class CompoundValueNode
   CompoundValueNode*  add(const orion::ValueType _type, const std::string& _name, bool _value);
   std::string         check(void);
   std::string         finish(void);
-  std::string         render(int apiVersion, const std::string& indent);
+  std::string         render(ApiVersion apiVersion, const std::string& indent);
   std::string         toJson(bool isLastElement, bool comma = true);
 
   void                shortShow(const std::string& indent);

--- a/src/lib/parse/CompoundValueNode.h
+++ b/src/lib/parse/CompoundValueNode.h
@@ -158,7 +158,7 @@ class CompoundValueNode
   CompoundValueNode*  add(const orion::ValueType _type, const std::string& _name, bool _value);
   std::string         check(void);
   std::string         finish(void);
-  std::string         render(const std::string& apiVersion, const std::string& indent);
+  std::string         render(int apiVersion, const std::string& indent);
   std::string         toJson(bool isLastElement, bool comma = true);
 
   void                shortShow(const std::string& indent);

--- a/src/lib/parse/forbiddenChars.cpp
+++ b/src/lib/parse/forbiddenChars.cpp
@@ -91,9 +91,9 @@ bool forbiddenChars(const char* s, const char* exceptions)
 *
 * forbiddenIdChars -
 */
-bool forbiddenIdChars(const std::string& api, const char* s, const char* exceptions)
+bool forbiddenIdChars(int api, const char* s, const char* exceptions)
 {
-  if (api == "v1" && !checkIdv1)
+  if (api == 1 && !checkIdv1)
   {
     return forbiddenChars(s, exceptions);  // old behavior
   }

--- a/src/lib/parse/forbiddenChars.h
+++ b/src/lib/parse/forbiddenChars.h
@@ -38,7 +38,7 @@ extern bool forbiddenChars(const char* s, const char* exceptions = NULL);
 *
 * forbiddenIdChars -
 */
-extern bool forbiddenIdChars(const std::string& api, const char* s, const char* exceptions = NULL);
+extern bool forbiddenIdChars(int api, const char* s, const char* exceptions = NULL);
 
 /* ****************************************************************************
 *

--- a/src/lib/parseArgs/parseTest.cpp
+++ b/src/lib/parseArgs/parseTest.cpp
@@ -104,7 +104,7 @@ PaArgument paArgs[] =
   { "-f1",      &f1,     "F",      PaFloat,  PaOpt, _i 3.1,   0,       100,     "float"               },
   { "-d1",      &d1,     "D",      PaDouble, PaOpt, _i 3.3,   0,       100,     "double"              },
   { "--lmTest", &lmTest, "",       PaBool,   PaOpt, FALSE,    FALSE,   TRUE,    "test logMsg"         },
-  { NULL,       &v2,     "V2",     PaInt,    PaOpt, 19,       PaNL,    1000,    "env var 2"           },
+  { NULL,       &v2,     2,     PaInt,    PaOpt, 19,       PaNL,    1000,    "env var 2"           },
 
   PA_END_OF_ARGS
 };

--- a/src/lib/parseArgs/parseTest.cpp
+++ b/src/lib/parseArgs/parseTest.cpp
@@ -104,7 +104,7 @@ PaArgument paArgs[] =
   { "-f1",      &f1,     "F",      PaFloat,  PaOpt, _i 3.1,   0,       100,     "float"               },
   { "-d1",      &d1,     "D",      PaDouble, PaOpt, _i 3.3,   0,       100,     "double"              },
   { "--lmTest", &lmTest, "",       PaBool,   PaOpt, FALSE,    FALSE,   TRUE,    "test logMsg"         },
-  { NULL,       &v2,     2,     PaInt,    PaOpt, 19,       PaNL,    1000,    "env var 2"           },
+  { NULL,       &v2,     "v2",     PaInt,    PaOpt, 19,       PaNL,    1000,    "env var 2"           },
 
   PA_END_OF_ARGS
 };

--- a/src/lib/rest/ConnectionInfo.h
+++ b/src/lib/rest/ConnectionInfo.h
@@ -65,7 +65,7 @@ public:
     parseDataP             (NULL),
     port                   (0),
     ip                     (""),
-    apiVersion             (1),
+    apiVersion             (V1),
     inCompoundValue        (false),
     compoundValueP         (NULL),
     compoundValueRoot      (NULL),
@@ -87,7 +87,7 @@ public:
     parseDataP             (NULL),
     port                   (0),
     ip                     (""),
-    apiVersion             (1),
+    apiVersion             (V1),
     inCompoundValue        (false),
     compoundValueP         (NULL),
     compoundValueRoot      (NULL),
@@ -112,7 +112,7 @@ public:
     parseDataP             (NULL),
     port                   (0),
     ip                     (""),
-    apiVersion             (1),
+    apiVersion             (V1),
     inCompoundValue        (false),
     compoundValueP         (NULL),
     compoundValueRoot      (NULL),
@@ -159,7 +159,7 @@ public:
   ParseData*                 parseDataP;
   unsigned short             port;
   std::string                ip;
-  int                        apiVersion;
+  ApiVersion                 apiVersion;
   RequestType                requestType;
   std::string                acceptHeaderError;
 

--- a/src/lib/rest/ConnectionInfo.h
+++ b/src/lib/rest/ConnectionInfo.h
@@ -65,7 +65,7 @@ public:
     parseDataP             (NULL),
     port                   (0),
     ip                     (""),
-    apiVersion             ("v1"),
+    apiVersion             (1),
     inCompoundValue        (false),
     compoundValueP         (NULL),
     compoundValueRoot      (NULL),
@@ -87,7 +87,7 @@ public:
     parseDataP             (NULL),
     port                   (0),
     ip                     (""),
-    apiVersion             ("v1"),
+    apiVersion             (1),
     inCompoundValue        (false),
     compoundValueP         (NULL),
     compoundValueRoot      (NULL),
@@ -112,7 +112,7 @@ public:
     parseDataP             (NULL),
     port                   (0),
     ip                     (""),
-    apiVersion             ("v1"),
+    apiVersion             (1),
     inCompoundValue        (false),
     compoundValueP         (NULL),
     compoundValueRoot      (NULL),
@@ -159,7 +159,7 @@ public:
   ParseData*                 parseDataP;
   unsigned short             port;
   std::string                ip;
-  std::string                apiVersion;
+  int                        apiVersion;
   RequestType                requestType;
   std::string                acceptHeaderError;
 

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -88,9 +88,9 @@ void OrionError::fill(HttpStatusCode _code, const std::string& _details, const s
 *
 * OrionError::smartRender -
 */
-std::string OrionError::smartRender(int apiVersion)
+std::string OrionError::smartRender(ApiVersion apiVersion)
 {
-  if (apiVersion == 1 || apiVersion == -1)
+  if (apiVersion == V1 || apiVersion == -1)
   {
     return render();
   }
@@ -107,9 +107,9 @@ std::string OrionError::smartRender(int apiVersion)
 *
 * OrionError::setStatusCodeAndSmartRender -
 */
-std::string OrionError::setStatusCodeAndSmartRender(int apiVersion, HttpStatusCode* scP)
+std::string OrionError::setStatusCodeAndSmartRender(ApiVersion apiVersion, HttpStatusCode* scP)
 {
-  if (apiVersion == 2)
+  if (apiVersion == V2)
   {
     *scP = code;
   }

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -90,7 +90,7 @@ void OrionError::fill(HttpStatusCode _code, const std::string& _details, const s
 */
 std::string OrionError::smartRender(ApiVersion apiVersion)
 {
-  if (apiVersion == V1 || apiVersion == -1)
+  if (apiVersion == V1 || apiVersion == NO_VERSION)
   {
     return render();
   }

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -88,13 +88,13 @@ void OrionError::fill(HttpStatusCode _code, const std::string& _details, const s
 *
 * OrionError::smartRender -
 */
-std::string OrionError::smartRender(const std::string& apiVersion)
+std::string OrionError::smartRender(int apiVersion)
 {
-  if (apiVersion == "v1")
+  if (apiVersion == 1 || apiVersion == -1)
   {
     return render();
   }
-  else // v2
+  else // admin or v2
   {
     shrinkReasonPhrase();
     return toJson();
@@ -107,9 +107,9 @@ std::string OrionError::smartRender(const std::string& apiVersion)
 *
 * OrionError::setStatusCodeAndSmartRender -
 */
-std::string OrionError::setStatusCodeAndSmartRender(const std::string& apiVersion, HttpStatusCode* scP)
+std::string OrionError::setStatusCodeAndSmartRender(int apiVersion, HttpStatusCode* scP)
 {
-  if (apiVersion == "v2")
+  if (apiVersion == 2)
   {
     *scP = code;
   }
@@ -144,7 +144,7 @@ std::string OrionError::render(void)
   // OrionError is NEVER part of any other payload, so the JSON start/end braces must be added here
   //
   out += startTag(indent, "orionError", false);
-  out += valueTag(indent  + "  ", "code",          code,         true);
+  out += valueTag(indent + "  ", "code",          code,         true);
   out += valueTag(indent + "  ", "reasonPhrase",  reasonPhrase, details != "");
 
   if (details != "")

--- a/src/lib/rest/OrionError.h
+++ b/src/lib/rest/OrionError.h
@@ -47,8 +47,8 @@ public:
   OrionError(StatusCode& statusCode);
   OrionError(HttpStatusCode _code, const std::string& _details = "", const std::string& _reasonPhrase = "");
 
-  std::string  smartRender(const std::string& apiVersion);
-  std::string  setStatusCodeAndSmartRender(const std::string& apiVersion, HttpStatusCode* scP);
+  std::string  smartRender(int apiVersion);
+  std::string  setStatusCodeAndSmartRender(int apiVersion, HttpStatusCode* scP);
   std::string  toJson(void);
   std::string  render(void);
   void         fill(HttpStatusCode _code, const std::string& _details,  const std::string& _reasonPhrase = "");

--- a/src/lib/rest/OrionError.h
+++ b/src/lib/rest/OrionError.h
@@ -27,6 +27,8 @@
 */
 #include <string>
 
+#include "common/globals.h"
+
 #include "ngsi/StatusCode.h"
 #include "rest/HttpStatusCode.h"
 
@@ -47,8 +49,8 @@ public:
   OrionError(StatusCode& statusCode);
   OrionError(HttpStatusCode _code, const std::string& _details = "", const std::string& _reasonPhrase = "");
 
-  std::string  smartRender(int apiVersion);
-  std::string  setStatusCodeAndSmartRender(int apiVersion, HttpStatusCode* scP);
+  std::string  smartRender(ApiVersion apiVersion);
+  std::string  setStatusCodeAndSmartRender(ApiVersion apiVersion, HttpStatusCode* scP);
   std::string  toJson(void);
   std::string  render(void);
   void         fill(HttpStatusCode _code, const std::string& _details,  const std::string& _reasonPhrase = "");

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -488,19 +488,6 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
     }
   }
 
-
-  //
-  // Detect API version
-  // FIXME PR: we have a method for this...
-  //
-  int apiVersion = 1;
-
-  if ((compV.size() != 0) && strcasecmp(compV[0].c_str(), "v2") == 0)
-  {
-    apiVersion = 2;
-  }
-
-
   //
   // Lookup the requested service
   //
@@ -525,7 +512,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
         continue;
       }
 
-      if (apiVersion == 1)
+      if (ciP->apiVersion == 1)
       {
         if (strcasecmp(serviceV[ix].compV[compNo].c_str(), compV[compNo].c_str()) != 0)
         {

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -439,15 +439,6 @@ static bool compErrorDetect
 *
 * restService - 
 *
-* NGSIv1 uses a case-insensitive URI PATH, while NGSIv2 is case-sensitive, so
-* before we can start to compare the URI PATH with the vector of supported services,
-* we need to know if it's v1 or v2.
-*
-* This is very easy, we just look at the first component of the URI PATH, and
-* if it is 2 or 2, then case-sensitive checks are used.
-*
-* Note that for NGSIv2 to be 'turned on', the URI PATH must start with exactly /v2.
-* If it starts with /V2, the request will not be considered a NGSIv2 request.
 */
 std::string restService(ConnectionInfo* ciP, RestService* serviceV)
 {

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -112,7 +112,7 @@ std::string payloadParse
 
   if (ciP->inMimeType == JSON)
   {
-    if (ciP->apiVersion == 2)
+    if (ciP->apiVersion == V2)
     {
       result = jsonRequestTreat(ciP, parseDataP, service->request, jsonReleaseP, compV);
     }
@@ -375,7 +375,7 @@ static bool compCheck(int components, const std::vector<std::string>& compV)
 */
 static bool compErrorDetect
 (
-  int                              apiVersion,
+  ApiVersion                       apiVersion,
   int                              components,
   const std::vector<std::string>&  compV,
   OrionError*                      oeP
@@ -383,7 +383,7 @@ static bool compErrorDetect
 {
   std::string  details; 
 
-  if ((apiVersion == 2) && (compV[1] == "entities"))
+  if ((apiVersion == V2) && (compV[1] == "entities"))
   {
     if ((components == 4) && (compV[3] == "attrs"))  // URL: /v2/entities/<entity-id>/attrs
     {
@@ -503,7 +503,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
         continue;
       }
 
-      if (ciP->apiVersion == 1)
+      if (ciP->apiVersion == V1)
       {
         if (strcasecmp(serviceV[ix].compV[compNo].c_str(), compV[compNo].c_str()) != 0)
         {
@@ -546,7 +546,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
           jsonReqP->release(&parseData);
         }
 
-        if (ciP->apiVersion == 2)
+        if (ciP->apiVersion == V2)
         {
           delayedRelease(&jsonRelease);
         }
@@ -587,7 +587,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
         jsonReqP->release(&parseData);
       }
 
-      if (ciP->apiVersion == 2)
+      if (ciP->apiVersion == V2)
       {
         delayedRelease(&jsonRelease);
       }
@@ -622,7 +622,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
       jsonReqP->release(&parseData);
     }
 
-    if (ciP->apiVersion == 2)
+    if (ciP->apiVersion == V2)
     {
       delayedRelease(&jsonRelease);
     }

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -112,7 +112,7 @@ std::string payloadParse
 
   if (ciP->inMimeType == JSON)
   {
-    if (compV[0] == "v2")
+    if (ciP->apiVersion == 2)
     {
       result = jsonRequestTreat(ciP, parseDataP, service->request, jsonReleaseP, compV);
     }
@@ -375,6 +375,7 @@ static bool compCheck(int components, const std::vector<std::string>& compV)
 */
 static bool compErrorDetect
 (
+  int                              apiVersion,
   int                              components,
   const std::vector<std::string>&  compV,
   OrionError*                      oeP
@@ -382,7 +383,7 @@ static bool compErrorDetect
 {
   std::string  details; 
 
-  if ((compV[0] == "v2") && (compV[1] == "entities"))
+  if ((apiVersion == 2) && (compV[1] == "entities"))
   {
     if ((components == 4) && (compV[3] == "attrs"))  // URL: /v2/entities/<entity-id>/attrs
     {
@@ -443,7 +444,7 @@ static bool compErrorDetect
 * we need to know if it's v1 or v2.
 *
 * This is very easy, we just look at the first component of the URI PATH, and
-* if it is "v2" or "V2", then case-sensitive checks are used.
+* if it is 2 or 2, then case-sensitive checks are used.
 *
 * Note that for NGSIv2 to be 'turned on', the URI PATH must start with exactly /v2.
 * If it starts with /V2, the request will not be considered a NGSIv2 request.
@@ -478,7 +479,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
   {
     OrionError oe;
 
-    if (compErrorDetect(components, compV, &oe))
+    if (compErrorDetect(ciP->apiVersion, components, compV, &oe))
     {
       alarmMgr.badInput(clientIp, oe.details);
       ciP->httpStatusCode = SccBadRequest;
@@ -490,12 +491,13 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
 
   //
   // Detect API version
+  // FIXME PR: we have a method for this...
   //
-  std::string apiVersion = "v1";
+  int apiVersion = 1;
 
   if ((compV.size() != 0) && strcasecmp(compV[0].c_str(), "v2") == 0)
   {
-    apiVersion = "v2";
+    apiVersion = 2;
   }
 
 
@@ -523,7 +525,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
         continue;
       }
 
-      if (apiVersion == "v1")
+      if (apiVersion == 1)
       {
         if (strcasecmp(serviceV[ix].compV[compNo].c_str(), compV[compNo].c_str()) != 0)
         {
@@ -566,7 +568,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
           jsonReqP->release(&parseData);
         }
 
-        if (ciP->apiVersion == "v2")
+        if (ciP->apiVersion == 2)
         {
           delayedRelease(&jsonRelease);
         }
@@ -607,7 +609,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
         jsonReqP->release(&parseData);
       }
 
-      if (ciP->apiVersion == "v2")
+      if (ciP->apiVersion == 2)
       {
         delayedRelease(&jsonRelease);
       }
@@ -642,7 +644,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
       jsonReqP->release(&parseData);
     }
 
-    if (ciP->apiVersion == "v2")
+    if (ciP->apiVersion == 2)
     {
       delayedRelease(&jsonRelease);
     }

--- a/src/lib/rest/StringFilter.cpp
+++ b/src/lib/rest/StringFilter.cpp
@@ -43,27 +43,6 @@ using namespace mongo;
 
 
 
-// FIXME PR: Temporary debug function
-const char* opName(StringFilterOp op)
-{
-  switch (op)
-  {
-  case SfopExists:              return "Exists";
-  case SfopNotExists:           return "NotExists";
-  case SfopEquals:              return "Equals";
-  case SfopDiffers:             return "Differs";
-  case SfopGreaterThan:         return "GreaterThan";
-  case SfopGreaterThanOrEqual:  return "GreaterThanOrEqual";
-  case SfopLessThan:            return "LessThan";
-  case SfopLessThanOrEqual:     return "LessThanOrEqual";
-  case SfopMatchPattern:        return "MatchPattern";
-  }
-
-  return "InvalidOperator";
-}
-
-
-
 /* ****************************************************************************
 *
 * StringFilterItem::StringFilterItem -

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -905,13 +905,12 @@ bool urlCheck(ConnectionInfo* ciP, const std::string& url)
 * apiVersionGet - 
 *
 * This function returns the version of the API for the incoming message,
-* based on the URL.
+* based on the URL according to:
 *
-* /v2    -> 2
-* /v1    -> 1
-* /admin -> 0
-*
-* Otherwise, -1 is returned, corresponding to invalid path cases.
+*  2: for URLs in the /v2 path
+*  1: for URLs in the /v1 or with an equivalence (e.g. /ngi10, /log, etc.)
+*  0: admin operations without /v1 alias
+* -1: others (invalid paths)
 *
 */
 static int apiVersionGet(const char* path)
@@ -926,8 +925,17 @@ static int apiVersionGet(const char* path)
   {
     return 1;
   }
+  if ((strncasecmp("/ngsi9",      path, strlen("/ngsi9"))      == 0)  ||
+      (strncasecmp("/ngsi10",     path, strlen("/ngsi10"))     == 0)  ||
+      (strncasecmp("/log",        path, strlen("/log"))        == 0)  ||
+      (strncasecmp("/cache",      path, strlen("/cache"))      == 0)  ||
+      (strncasecmp("/statistics", path, strlen("/statistics")) == 0))
+  {
+    return 1;
+  }
 
-  if (strncmp("/admin", path, strlen("/admin")) == 0)
+  if ((strncmp("/admin",   path, strlen("/admin"))   == 0) ||
+      (strncmp("/version", path, strlen("/version")) == 0))
   {
     return 0;
   }

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -116,7 +116,7 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
       ciP->httpStatusCode = error.code;
       ciP->answer         = error.smartRender(ciP->apiVersion);
     }
-    else if (ciP->apiVersion == 0)   // admin
+    else if (ciP->apiVersion == ADMIN_API)
     {
       ciP->httpStatusCode = SccBadRequest;
       ciP->answer         = "{" + JSON_STR("error") + ":" + JSON_STR(errorString) + "}";

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -110,7 +110,7 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
   {
     std::string  errorString = std::string("Empty right-hand-side for URI param /") + ckey + "/";
 
-    if (ciP->apiVersion == 2)
+    if (ciP->apiVersion == V2)
     {
       OrionError error(SccBadRequest, errorString);
       ciP->httpStatusCode = error.code;
@@ -843,7 +843,7 @@ static int contentTypeCheck(ConnectionInfo* ciP)
   }
 
   // Case 3
-  if ((ciP->apiVersion == 1) && (ciP->httpHeaders.contentType != "application/json"))
+  if ((ciP->apiVersion == V1) && (ciP->httpHeaders.contentType != "application/json"))
   {
     std::string details = std::string("not supported content type: ") + ciP->httpHeaders.contentType;
     ciP->httpStatusCode = SccUnsupportedMediaType;
@@ -854,7 +854,7 @@ static int contentTypeCheck(ConnectionInfo* ciP)
 
 
   // Case 4
-  if ((ciP->apiVersion == 2) && (ciP->httpHeaders.contentType != "application/json") && (ciP->httpHeaders.contentType != "text/plain"))
+  if ((ciP->apiVersion == V2) && (ciP->httpHeaders.contentType != "application/json") && (ciP->httpHeaders.contentType != "text/plain"))
   {
     std::string details = std::string("not supported content type: ") + ciP->httpHeaders.contentType;
     ciP->httpStatusCode = SccUnsupportedMediaType;
@@ -907,23 +907,23 @@ bool urlCheck(ConnectionInfo* ciP, const std::string& url)
 * This function returns the version of the API for the incoming message,
 * based on the URL according to:
 *
-*  2: for URLs in the /v2 path
-*  1: for URLs in the /v1 or with an equivalence (e.g. /ngi10, /log, etc.)
-*  0: admin operations without /v1 alias
-* -1: others (invalid paths)
+*  V2:         for URLs in the /v2 path
+*  V1:         for URLs in the /v1 or with an equivalence (e.g. /ngi10, /log, etc.)
+*  ADMIN_API:  admin operations without /v1 alias
+*  NO_VERSION: others (invalid paths)
 *
 */
-static int apiVersionGet(const char* path)
+static ApiVersion apiVersionGet(const char* path)
 {
   if ((path[1] == 'v') && (path[2] == '2'))
   {
-    return 2;
+    return V2;
   }
 
   // Different from v2, v1 is case-insensitive (see case/2057 test)
   if (((path[1] == 'v') || (path[1] == 'V')) && (path[2] == '1'))
   {
-    return 1;
+    return V1;
   }
   if ((strncasecmp("/ngsi9",      path, strlen("/ngsi9"))      == 0)  ||
       (strncasecmp("/ngsi10",     path, strlen("/ngsi10"))     == 0)  ||
@@ -931,16 +931,16 @@ static int apiVersionGet(const char* path)
       (strncasecmp("/cache",      path, strlen("/cache"))      == 0)  ||
       (strncasecmp("/statistics", path, strlen("/statistics")) == 0))
   {
-    return 1;
+    return V1;
   }
 
   if ((strncmp("/admin",   path, strlen("/admin"))   == 0) ||
       (strncmp("/version", path, strlen("/version")) == 0))
   {
-    return 0;
+    return ADMIN_API;
   }
 
-  return -1;
+  return NO_VERSION;
 }
 
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -116,8 +116,6 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
       ciP->httpStatusCode = error.code;
       ciP->answer         = error.smartRender(ciP->apiVersion);
     }
-    // FIXME PR
-    //else if (ciP->apiVersion == "admin")
     else if (ciP->apiVersion == 0)   // admin
     {
       ciP->httpStatusCode = SccBadRequest;
@@ -913,7 +911,7 @@ bool urlCheck(ConnectionInfo* ciP, const std::string& url)
 * /v1    -> 1
 * /admin -> 0
 *
-* Otherwise, -1 is returned, corresponding to wrong path cases.
+* Otherwise, -1 is returned, corresponding to invalid path cases.
 *
 */
 static int apiVersionGet(const char* path)
@@ -923,7 +921,8 @@ static int apiVersionGet(const char* path)
     return 2;
   }
 
-  if ((path[1] == 'v') && (path[2] == '1'))
+  // Different from v2, v1 is case-insensitive (see case/2057 test)
+  if (((path[1] == 'v') || (path[1] == 'V')) && (path[2] == '1'))
   {
     return 1;
   }
@@ -934,16 +933,6 @@ static int apiVersionGet(const char* path)
   }
 
   return -1;
-
-#if 0
-  // FIXME PR
-  if (strcmp(path, "/admin/log") == 0)
-  {
-    return 0;
-  }
-
-  return 1;
-#endif
 }
 
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -110,13 +110,15 @@ static int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
   {
     std::string  errorString = std::string("Empty right-hand-side for URI param /") + ckey + "/";
 
-    if (ciP->apiVersion == "v2")
+    if (ciP->apiVersion == 2)
     {
       OrionError error(SccBadRequest, errorString);
       ciP->httpStatusCode = error.code;
       ciP->answer         = error.smartRender(ciP->apiVersion);
     }
-    else if (ciP->apiVersion == "admin")
+    // FIXME PR
+    //else if (ciP->apiVersion == "admin")
+    else if (ciP->apiVersion == 0)   // admin
     {
       ciP->httpStatusCode = SccBadRequest;
       ciP->answer         = "{" + JSON_STR("error") + ":" + JSON_STR(errorString) + "}";
@@ -843,7 +845,7 @@ static int contentTypeCheck(ConnectionInfo* ciP)
   }
 
   // Case 3
-  if ((ciP->apiVersion == "v1") && (ciP->httpHeaders.contentType != "application/json"))
+  if ((ciP->apiVersion == 1) && (ciP->httpHeaders.contentType != "application/json"))
   {
     std::string details = std::string("not supported content type: ") + ciP->httpHeaders.contentType;
     ciP->httpStatusCode = SccUnsupportedMediaType;
@@ -854,7 +856,7 @@ static int contentTypeCheck(ConnectionInfo* ciP)
 
 
   // Case 4
-  if ((ciP->apiVersion == "v2") && (ciP->httpHeaders.contentType != "application/json") && (ciP->httpHeaders.contentType != "text/plain"))
+  if ((ciP->apiVersion == 2) && (ciP->httpHeaders.contentType != "application/json") && (ciP->httpHeaders.contentType != "text/plain"))
   {
     std::string details = std::string("not supported content type: ") + ciP->httpHeaders.contentType;
     ciP->httpStatusCode = SccUnsupportedMediaType;
@@ -906,32 +908,42 @@ bool urlCheck(ConnectionInfo* ciP, const std::string& url)
 *
 * This function returns the version of the API for the incoming message,
 * based on the URL.
-* If the URL starts with "/v2" then the request is considered API version 2.
 *
-* Otherwise, API version 1.
+* /v2    -> 2
+* /v1    -> 1
+* /admin -> 0
 *
-* Except ...
-* The new request to change the log level (not trace level), uses the
-* URL /admin/log, which DOES NOT start with '/v2', but as some render methods
-* depend on the apiVersion and we prefer the 'new render' from v2 for this
-* operation (see OrionError::render), we consider internally /admin/log to be part of v2.
+* Otherwise, -1 is returned, corresponding to wrong path cases.
 *
-* FIXME P2: instead of looking at apiVersion for rendering, perhaps we need
-*           some other algorithm, considering 'admin' requests as well ...
 */
-static std::string apiVersionGet(const char* path)
+static int apiVersionGet(const char* path)
 {
   if ((path[1] == 'v') && (path[2] == '2'))
   {
-    return "v2";
+    return 2;
   }
 
+  if ((path[1] == 'v') && (path[2] == '1'))
+  {
+    return 1;
+  }
+
+  if (strncmp("/admin", path, strlen("/admin")) == 0)
+  {
+    return 0;
+  }
+
+  return -1;
+
+#if 0
+  // FIXME PR
   if (strcmp(path, "/admin/log") == 0)
   {
-    return "admin";
+    return 0;
   }
 
-  return "v1";
+  return 1;
+#endif
 }
 
 

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -212,7 +212,8 @@ std::string restErrorReplyGet(ConnectionInfo* ciP, const std::string& indent, co
    else if (tag == "queryContextResponse")
    {
       QueryContextResponse qcr(errorCode);
-      reply =  qcr.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, indent);
+      bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+      reply =  qcr.render(ciP->apiVersion, asJsonObject, indent);
    }
    else if (tag == "subscribeContextResponse")
    {
@@ -232,7 +233,8 @@ std::string restErrorReplyGet(ConnectionInfo* ciP, const std::string& indent, co
    else if (tag == "updateContextResponse")
    {
       UpdateContextResponse ucr(errorCode);
-      reply = ucr.render(ciP->apiVersion, ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON, indent);
+      bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+      reply = ucr.render(ciP->apiVersion, asJsonObject, indent);
    }
    else if (tag == "notifyContextResponse")
    {

--- a/src/lib/serviceRoutines/badVerbAllFive.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFive.cpp
@@ -59,5 +59,5 @@ std::string badVerbAllFive
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbAllFive.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFive.cpp
@@ -59,5 +59,5 @@ std::string badVerbAllFive
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbAllFive.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFive.cpp
@@ -59,5 +59,5 @@ std::string badVerbAllFive
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbAllFour.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFour.cpp
@@ -59,5 +59,5 @@ std::string badVerbAllFour
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbAllFour.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFour.cpp
@@ -59,5 +59,5 @@ std::string badVerbAllFour
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbAllFour.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFour.cpp
@@ -59,5 +59,5 @@ std::string badVerbAllFour
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetDeleteOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetDeleteOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetDeleteOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPostDeleteOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPostDeleteOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPostDeleteOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPostOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPostOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPostOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPutDeleteOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPutDeleteOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPutDeleteOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPostOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbPostOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPostOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbPostOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPostOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbPostOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
@@ -57,5 +57,5 @@ std::string badVerbPutDeleteOnly
   ciP->httpHeaderValue.push_back("PUT, DELETE");
   ciP->httpStatusCode = SccBadVerb;
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
@@ -57,5 +57,5 @@ std::string badVerbPutDeleteOnly
   ciP->httpHeaderValue.push_back("PUT, DELETE");
   ciP->httpStatusCode = SccBadVerb;
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
@@ -57,5 +57,5 @@ std::string badVerbPutDeleteOnly
   ciP->httpHeaderValue.push_back("PUT, DELETE");
   ciP->httpStatusCode = SccBadVerb;
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPutOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbPutOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPutOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbPutOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPutOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbPutOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutines/deleteAvailabilitySubscriptionConvOp.cpp
+++ b/src/lib/serviceRoutines/deleteAvailabilitySubscriptionConvOp.cpp
@@ -53,7 +53,7 @@ std::string deleteAvailabilitySubscriptionConvOp
   ParseData*                 parseDataP
 )
 {
-  std::string  subscriptionId = (compV[0] == "v1")? compV[3] : compV[2];
+  std::string  subscriptionId = (ciP->apiVersion == 1)? compV[3] : compV[2];
 
   parseDataP->ucar.res.fill(subscriptionId);
 

--- a/src/lib/serviceRoutines/deleteAvailabilitySubscriptionConvOp.cpp
+++ b/src/lib/serviceRoutines/deleteAvailabilitySubscriptionConvOp.cpp
@@ -53,7 +53,7 @@ std::string deleteAvailabilitySubscriptionConvOp
   ParseData*                 parseDataP
 )
 {
-  std::string  subscriptionId = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string  subscriptionId = (compV.size() == 4)? compV[3] : compV[2];
 
   parseDataP->ucar.res.fill(subscriptionId);
 

--- a/src/lib/serviceRoutines/deleteAvailabilitySubscriptionConvOp.cpp
+++ b/src/lib/serviceRoutines/deleteAvailabilitySubscriptionConvOp.cpp
@@ -53,7 +53,7 @@ std::string deleteAvailabilitySubscriptionConvOp
   ParseData*                 parseDataP
 )
 {
-  std::string  subscriptionId = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string  subscriptionId = (ciP->apiVersion == V1)? compV[3] : compV[2];
 
   parseDataP->ucar.res.fill(subscriptionId);
 

--- a/src/lib/serviceRoutines/getContextEntitiesByEntityId.cpp
+++ b/src/lib/serviceRoutines/getContextEntitiesByEntityId.cpp
@@ -64,7 +64,7 @@ std::string getContextEntitiesByEntityId
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string  entityId = (ciP->apiVersion == V1)? compV[3] : compV[2];
   std::string  answer;
 
   //

--- a/src/lib/serviceRoutines/getContextEntitiesByEntityId.cpp
+++ b/src/lib/serviceRoutines/getContextEntitiesByEntityId.cpp
@@ -64,7 +64,7 @@ std::string getContextEntitiesByEntityId
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId = (compV[0] == "v1")? compV[3] : compV[2];
+  std::string  entityId = (ciP->apiVersion == 1)? compV[3] : compV[2];
   std::string  answer;
 
   //

--- a/src/lib/serviceRoutines/getContextEntitiesByEntityId.cpp
+++ b/src/lib/serviceRoutines/getContextEntitiesByEntityId.cpp
@@ -64,7 +64,7 @@ std::string getContextEntitiesByEntityId
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string  entityId = (compV.size() == 4)? compV[3] : compV[2];
   std::string  answer;
 
   //

--- a/src/lib/serviceRoutines/getContextEntityAttributes.cpp
+++ b/src/lib/serviceRoutines/getContextEntityAttributes.cpp
@@ -56,7 +56,7 @@ std::string getContextEntityAttributes
   ParseData*                 parseDataP
 )
 {
-  std::string   entityId = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string   entityId = (ciP->apiVersion == V1)? compV[3] : compV[2];
   std::string   answer;
 
   //

--- a/src/lib/serviceRoutines/getContextEntityAttributes.cpp
+++ b/src/lib/serviceRoutines/getContextEntityAttributes.cpp
@@ -56,7 +56,7 @@ std::string getContextEntityAttributes
   ParseData*                 parseDataP
 )
 {
-  std::string   entityId = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string   entityId = (compV.size() == 5)? compV[3] : compV[2];
   std::string   answer;
 
   //

--- a/src/lib/serviceRoutines/getContextEntityAttributes.cpp
+++ b/src/lib/serviceRoutines/getContextEntityAttributes.cpp
@@ -56,7 +56,7 @@ std::string getContextEntityAttributes
   ParseData*                 parseDataP
 )
 {
-  std::string   entityId = (compV[0] == "v1")? compV[3] : compV[2];
+  std::string   entityId = (ciP->apiVersion == 1)? compV[3] : compV[2];
   std::string   answer;
 
   //

--- a/src/lib/serviceRoutines/getContextEntityTypeAttribute.cpp
+++ b/src/lib/serviceRoutines/getContextEntityTypeAttribute.cpp
@@ -56,8 +56,8 @@ std::string getContextEntityTypeAttribute
   ParseData*                 parseDataP
 )
 {
-  std::string  entityType     = (ciP->apiVersion == 1)? compV[3] : compV[2];
-  std::string  attributeName  = (ciP->apiVersion == 1)? compV[5] : compV[4];
+  std::string  entityType     = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string  attributeName  = (ciP->apiVersion == V1)? compV[5] : compV[4];
   std::string  answer;
 
   LM_T(LmtConvenience,

--- a/src/lib/serviceRoutines/getContextEntityTypeAttribute.cpp
+++ b/src/lib/serviceRoutines/getContextEntityTypeAttribute.cpp
@@ -56,8 +56,8 @@ std::string getContextEntityTypeAttribute
   ParseData*                 parseDataP
 )
 {
-  std::string  entityType     = (ciP->apiVersion == V1)? compV[3] : compV[2];
-  std::string  attributeName  = (ciP->apiVersion == V1)? compV[5] : compV[4];
+  std::string  entityType     = (compV.size() == 6)? compV[3] : compV[2];
+  std::string  attributeName  = (compV.size() == 6)? compV[5] : compV[4];
   std::string  answer;
 
   LM_T(LmtConvenience,

--- a/src/lib/serviceRoutines/getContextEntityTypeAttribute.cpp
+++ b/src/lib/serviceRoutines/getContextEntityTypeAttribute.cpp
@@ -56,8 +56,8 @@ std::string getContextEntityTypeAttribute
   ParseData*                 parseDataP
 )
 {
-  std::string  entityType     = (compV[0] == "v1")? compV[3] : compV[2];
-  std::string  attributeName  = (compV[0] == "v1")? compV[5] : compV[4];
+  std::string  entityType     = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string  attributeName  = (ciP->apiVersion == 1)? compV[5] : compV[4];
   std::string  answer;
 
   LM_T(LmtConvenience,

--- a/src/lib/serviceRoutines/getContextEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getContextEntityTypes.cpp
@@ -56,7 +56,7 @@ std::string getContextEntityTypes
   ParseData*                 parseDataP
 )
 {
-  std::string  typeName     = (compV[0] == "v1")? compV[3] : compV[2];
+  std::string  typeName     = (ciP->apiVersion == 1)? compV[3] : compV[2];
   std::string  answer;
 
   //

--- a/src/lib/serviceRoutines/getContextEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getContextEntityTypes.cpp
@@ -39,8 +39,10 @@
 *
 * getContextEntityTypes -
 *
-* POST /v1/registry/contextEntityTypes/{entityId::type}
-* POST /ngsi9/contextEntityTypes/{entityId::type}
+* GET /v1/registry/contextEntityTypes/{entityId::type}
+* GET /v1/registry/contextEntityTypes/{entityId::type}/attributes
+* GET /ngsi9/contextEntityTypes/{entityId::type}
+* GET /ngsi9/contextEntityTypes/{entityId::type}/attributes
 *
 * Payload In:  None
 * Payload Out: DiscoverContextAvailabilityResponse
@@ -56,7 +58,9 @@ std::string getContextEntityTypes
   ParseData*                 parseDataP
 )
 {
-  std::string  typeName     = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  // Other similar functions use a condition based on compV.size(), but in this
+  // case is ambiguous so we use compV[0]
+  std::string  typeName     = (compV[0] == "v1")? compV[3] : compV[2];
   std::string  answer;
 
   //

--- a/src/lib/serviceRoutines/getContextEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getContextEntityTypes.cpp
@@ -56,7 +56,7 @@ std::string getContextEntityTypes
   ParseData*                 parseDataP
 )
 {
-  std::string  typeName     = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string  typeName     = (ciP->apiVersion == V1)? compV[3] : compV[2];
   std::string  answer;
 
   //

--- a/src/lib/serviceRoutines/getEntityByIdAttributeByName.cpp
+++ b/src/lib/serviceRoutines/getEntityByIdAttributeByName.cpp
@@ -53,8 +53,8 @@ std::string getEntityByIdAttributeByName
   ParseData*                 parseDataP
 )
 {
-  std::string                          entityId      = (ciP->apiVersion == V1)? compV[3] : compV[2];
-  std::string                          attributeName = (ciP->apiVersion == V1)? compV[5] : compV[4];
+  std::string                          entityId      = (compV.size() == 6)? compV[3] : compV[2];
+  std::string                          attributeName = (compV.size() == 6)? compV[5] : compV[4];
   std::string                          answer;
 
   //

--- a/src/lib/serviceRoutines/getEntityByIdAttributeByName.cpp
+++ b/src/lib/serviceRoutines/getEntityByIdAttributeByName.cpp
@@ -53,8 +53,8 @@ std::string getEntityByIdAttributeByName
   ParseData*                 parseDataP
 )
 {
-  std::string                          entityId      = (compV[0] == "v1")? compV[3] : compV[2];
-  std::string                          attributeName = (compV[0] == "v1")? compV[5] : compV[4];
+  std::string                          entityId      = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string                          attributeName = (ciP->apiVersion == 1)? compV[5] : compV[4];
   std::string                          answer;
 
   //

--- a/src/lib/serviceRoutines/getEntityByIdAttributeByName.cpp
+++ b/src/lib/serviceRoutines/getEntityByIdAttributeByName.cpp
@@ -53,8 +53,8 @@ std::string getEntityByIdAttributeByName
   ParseData*                 parseDataP
 )
 {
-  std::string                          entityId      = (ciP->apiVersion == 1)? compV[3] : compV[2];
-  std::string                          attributeName = (ciP->apiVersion == 1)? compV[5] : compV[4];
+  std::string                          entityId      = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string                          attributeName = (ciP->apiVersion == V1)? compV[5] : compV[4];
   std::string                          answer;
 
   //

--- a/src/lib/serviceRoutines/postContextEntitiesByEntityId.cpp
+++ b/src/lib/serviceRoutines/postContextEntitiesByEntityId.cpp
@@ -56,7 +56,7 @@ std::string postContextEntitiesByEntityId
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string  entityId = (ciP->apiVersion == V1)? compV[3] : compV[2];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, entityId, "", "");

--- a/src/lib/serviceRoutines/postContextEntitiesByEntityId.cpp
+++ b/src/lib/serviceRoutines/postContextEntitiesByEntityId.cpp
@@ -56,7 +56,7 @@ std::string postContextEntitiesByEntityId
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId = (compV[0] == "v1")? compV[3] : compV[2];
+  std::string  entityId = (ciP->apiVersion == 1)? compV[3] : compV[2];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, entityId, "", "");

--- a/src/lib/serviceRoutines/postContextEntitiesByEntityId.cpp
+++ b/src/lib/serviceRoutines/postContextEntitiesByEntityId.cpp
@@ -56,7 +56,7 @@ std::string postContextEntitiesByEntityId
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string  entityId = (compV.size() == 4)? compV[3] : compV[2];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, entityId, "", "");

--- a/src/lib/serviceRoutines/postContextEntityAttributes.cpp
+++ b/src/lib/serviceRoutines/postContextEntityAttributes.cpp
@@ -56,7 +56,7 @@ std::string postContextEntityAttributes
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId = (compV[0] == "v1")? compV[3] : compV[2];
+  std::string  entityId = (ciP->apiVersion == 1)? compV[3] : compV[2];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, entityId, "", "");

--- a/src/lib/serviceRoutines/postContextEntityAttributes.cpp
+++ b/src/lib/serviceRoutines/postContextEntityAttributes.cpp
@@ -56,7 +56,7 @@ std::string postContextEntityAttributes
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string  entityId = (compV.size() == 5)? compV[3] : compV[2];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, entityId, "", "");

--- a/src/lib/serviceRoutines/postContextEntityAttributes.cpp
+++ b/src/lib/serviceRoutines/postContextEntityAttributes.cpp
@@ -56,7 +56,7 @@ std::string postContextEntityAttributes
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string  entityId = (ciP->apiVersion == V1)? compV[3] : compV[2];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, entityId, "", "");

--- a/src/lib/serviceRoutines/postContextEntityTypeAttribute.cpp
+++ b/src/lib/serviceRoutines/postContextEntityTypeAttribute.cpp
@@ -56,8 +56,8 @@ std::string postContextEntityTypeAttribute
   ParseData*                 parseDataP
 )
 {
-  std::string  entityIdType   = (compV[0] == "v1")? compV[3] : compV[2];
-  std::string  attributeName  = (compV[0] == "v1")? compV[5] : compV[4];
+  std::string  entityIdType   = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string  attributeName  = (ciP->apiVersion == 1)? compV[5] : compV[4];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, "", entityIdType, attributeName);

--- a/src/lib/serviceRoutines/postContextEntityTypeAttribute.cpp
+++ b/src/lib/serviceRoutines/postContextEntityTypeAttribute.cpp
@@ -56,8 +56,8 @@ std::string postContextEntityTypeAttribute
   ParseData*                 parseDataP
 )
 {
-  std::string  entityIdType   = (ciP->apiVersion == 1)? compV[3] : compV[2];
-  std::string  attributeName  = (ciP->apiVersion == 1)? compV[5] : compV[4];
+  std::string  entityIdType   = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string  attributeName  = (ciP->apiVersion == V1)? compV[5] : compV[4];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, "", entityIdType, attributeName);

--- a/src/lib/serviceRoutines/postContextEntityTypeAttribute.cpp
+++ b/src/lib/serviceRoutines/postContextEntityTypeAttribute.cpp
@@ -56,8 +56,8 @@ std::string postContextEntityTypeAttribute
   ParseData*                 parseDataP
 )
 {
-  std::string  entityIdType   = (ciP->apiVersion == V1)? compV[3] : compV[2];
-  std::string  attributeName  = (ciP->apiVersion == V1)? compV[5] : compV[4];
+  std::string  entityIdType   = (compV.size() == 6)? compV[3] : compV[2];
+  std::string  attributeName  = (compV.size() == 6)? compV[5] : compV[4];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, "", entityIdType, attributeName);

--- a/src/lib/serviceRoutines/postContextEntityTypes.cpp
+++ b/src/lib/serviceRoutines/postContextEntityTypes.cpp
@@ -57,7 +57,7 @@ std::string postContextEntityTypes
   ParseData*                 parseDataP
 )
 {
-  std::string  entityType    = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string  entityType    = (ciP->apiVersion == V1)? compV[3] : compV[2];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, "", entityType, "");

--- a/src/lib/serviceRoutines/postContextEntityTypes.cpp
+++ b/src/lib/serviceRoutines/postContextEntityTypes.cpp
@@ -41,7 +41,9 @@
 * postContextEntityTypes -
 *
 * POST /v1/registry/contextEntityTypes/{entityType}
+* POST /v1/registry/contextEntityTypes/{entityType}/attributes
 * POST /ngsi9/contextEntityTypes/{entityType}
+* POST /ngsi9/contextEntityTypes/{entityType}/attributes
 *
 * Payload In:  RegisterProviderRequest
 * Payload Out: RegisterContextResponse
@@ -57,7 +59,9 @@ std::string postContextEntityTypes
   ParseData*                 parseDataP
 )
 {
-  std::string  entityType    = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  // Other similar functions use a condition based on compV.size(), but in this
+  // case is ambiguous so we use compV[0]
+  std::string  entityType    = (compV[0] == "v1")? compV[3] : compV[2];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, "", entityType, "");

--- a/src/lib/serviceRoutines/postContextEntityTypes.cpp
+++ b/src/lib/serviceRoutines/postContextEntityTypes.cpp
@@ -57,7 +57,7 @@ std::string postContextEntityTypes
   ParseData*                 parseDataP
 )
 {
-  std::string  entityType    = (compV[0] == "v1")? compV[3] : compV[2];
+  std::string  entityType    = (ciP->apiVersion == 1)? compV[3] : compV[2];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, "", entityType, "");

--- a/src/lib/serviceRoutines/postEntityByIdAttributeByName.cpp
+++ b/src/lib/serviceRoutines/postEntityByIdAttributeByName.cpp
@@ -56,8 +56,8 @@ std::string postEntityByIdAttributeByName
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId      = (compV[0] == "v1")? compV[3] : compV[2];
-  std::string  attributeName = (compV[0] == "v1")? compV[5] : compV[4];
+  std::string  entityId      = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string  attributeName = (ciP->apiVersion == 1)? compV[5] : compV[4];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, entityId, "", attributeName);

--- a/src/lib/serviceRoutines/postEntityByIdAttributeByName.cpp
+++ b/src/lib/serviceRoutines/postEntityByIdAttributeByName.cpp
@@ -56,8 +56,8 @@ std::string postEntityByIdAttributeByName
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId      = (ciP->apiVersion == 1)? compV[3] : compV[2];
-  std::string  attributeName = (ciP->apiVersion == 1)? compV[5] : compV[4];
+  std::string  entityId      = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string  attributeName = (ciP->apiVersion == V1)? compV[5] : compV[4];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, entityId, "", attributeName);

--- a/src/lib/serviceRoutines/postEntityByIdAttributeByName.cpp
+++ b/src/lib/serviceRoutines/postEntityByIdAttributeByName.cpp
@@ -56,8 +56,8 @@ std::string postEntityByIdAttributeByName
   ParseData*                 parseDataP
 )
 {
-  std::string  entityId      = (ciP->apiVersion == V1)? compV[3] : compV[2];
-  std::string  attributeName = (ciP->apiVersion == V1)? compV[5] : compV[4];
+  std::string  entityId      = (compV.size() == 6)? compV[3] : compV[2];
+  std::string  attributeName = (compV.size() == 6)? compV[5] : compV[4];
   std::string  answer;
 
   parseDataP->rcr.res.fill(parseDataP->rpr.res, entityId, "", attributeName);

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -298,11 +298,11 @@ std::string postQueryContext
   // In API version 2, this has changed completely. Here, the total count of local entities is returned
   // if the URI parameter 'count' is set to 'true', and it is returned in the HTTP header Fiware-Total-Count.
   //
-  if ((ciP->apiVersion == 2) && (ciP->uriParamOptions["count"]))
+  if ((ciP->apiVersion == V2) && (ciP->uriParamOptions["count"]))
   {
     countP = &count;
   }
-  else if ((ciP->apiVersion == 1) && (ciP->uriParam["details"] == "on"))
+  else if ((ciP->apiVersion == V1) && (ciP->uriParam["details"] == "on"))
   {
     countP = &count;
   }
@@ -337,7 +337,7 @@ std::string postQueryContext
   //
   // If API version 2, add count, if asked for, in HTTP header Fiware-Total-Count
   //
-  if ((ciP->apiVersion == 2) && (countP != NULL))
+  if ((ciP->apiVersion == V2) && (countP != NULL))
   {
     char cV[32];
 

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -298,11 +298,11 @@ std::string postQueryContext
   // In API version 2, this has changed completely. Here, the total count of local entities is returned
   // if the URI parameter 'count' is set to 'true', and it is returned in the HTTP header Fiware-Total-Count.
   //
-  if ((ciP->apiVersion == "v2") && (ciP->uriParamOptions["count"]))
+  if ((ciP->apiVersion == 2) && (ciP->uriParamOptions["count"]))
   {
     countP = &count;
   }
-  else if ((ciP->apiVersion == "v1") && (ciP->uriParam["details"] == "on"))
+  else if ((ciP->apiVersion == 1) && (ciP->uriParam["details"] == "on"))
   {
     countP = &count;
   }
@@ -337,7 +337,7 @@ std::string postQueryContext
   //
   // If API version 2, add count, if asked for, in HTTP header Fiware-Total-Count
   //
-  if ((ciP->apiVersion == "v2") && (countP != NULL))
+  if ((ciP->apiVersion == 2) && (countP != NULL))
   {
     char cV[32];
 

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -658,7 +658,7 @@ std::string postUpdateContext
   // Note this is a slight break in the separation of concerns among the different layers (i.e.
   // serviceRoutine/ logic should work in a "NGSIv1 isolated context"). However, it seems to be
   // a smart way of dealing with partial update situations
-  if (ciP->apiVersion == 2)
+  if (ciP->apiVersion == V2)
   {
     // Adjust OrionError response in the case of partial updates. This may happen in CPr forwarding
     // scenarios. Note that mongoBackend logic "splits" successfull updates and failing updates in
@@ -695,7 +695,7 @@ std::string postUpdateContext
     if (fails == response.contextElementResponseVector.size())
     {
       // If all CER result in error, then it isn't a partial update, but a regular NotFound
-      if (ciP->apiVersion == 1)
+      if (ciP->apiVersion == V1)
       {
         parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_CONTEXT_ELEMENT, ERROR_NOT_FOUND);
       }

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -658,7 +658,7 @@ std::string postUpdateContext
   // Note this is a slight break in the separation of concerns among the different layers (i.e.
   // serviceRoutine/ logic should work in a "NGSIv1 isolated context"). However, it seems to be
   // a smart way of dealing with partial update situations
-  if (ciP->apiVersion == "v2")
+  if (ciP->apiVersion == 2)
   {
     // Adjust OrionError response in the case of partial updates. This may happen in CPr forwarding
     // scenarios. Note that mongoBackend logic "splits" successfull updates and failing updates in
@@ -695,7 +695,7 @@ std::string postUpdateContext
     if (fails == response.contextElementResponseVector.size())
     {
       // If all CER result in error, then it isn't a partial update, but a regular NotFound
-      if (ciP->apiVersion == "v1")
+      if (ciP->apiVersion == 1)
       {
         parseDataP->upcrs.res.oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_CONTEXT_ELEMENT, ERROR_NOT_FOUND);
       }

--- a/src/lib/serviceRoutines/putAvailabilitySubscriptionConvOp.cpp
+++ b/src/lib/serviceRoutines/putAvailabilitySubscriptionConvOp.cpp
@@ -57,7 +57,7 @@ std::string putAvailabilitySubscriptionConvOp
   ParseData*                 parseDataP
 )
 {
-  std::string                                    subscriptionId  = (ciP->apiVersion == V1)? compV[3] : compV[2];
+  std::string                                    subscriptionId  = (compV.size() == 4)? compV[3] : compV[2];
   UpdateContextAvailabilitySubscriptionRequest*  ucasP           = &parseDataP->ucas.res;
 
   if (subscriptionId != ucasP->subscriptionId.get())

--- a/src/lib/serviceRoutines/putAvailabilitySubscriptionConvOp.cpp
+++ b/src/lib/serviceRoutines/putAvailabilitySubscriptionConvOp.cpp
@@ -57,7 +57,7 @@ std::string putAvailabilitySubscriptionConvOp
   ParseData*                 parseDataP
 )
 {
-  std::string                                    subscriptionId  = (compV[0] == "v1")? compV[3] : compV[2];
+  std::string                                    subscriptionId  = (ciP->apiVersion == 1)? compV[3] : compV[2];
   UpdateContextAvailabilitySubscriptionRequest*  ucasP           = &parseDataP->ucas.res;
 
   if (subscriptionId != ucasP->subscriptionId.get())

--- a/src/lib/serviceRoutines/putAvailabilitySubscriptionConvOp.cpp
+++ b/src/lib/serviceRoutines/putAvailabilitySubscriptionConvOp.cpp
@@ -57,7 +57,7 @@ std::string putAvailabilitySubscriptionConvOp
   ParseData*                 parseDataP
 )
 {
-  std::string                                    subscriptionId  = (ciP->apiVersion == 1)? compV[3] : compV[2];
+  std::string                                    subscriptionId  = (ciP->apiVersion == V1)? compV[3] : compV[2];
   UpdateContextAvailabilitySubscriptionRequest*  ucasP           = &parseDataP->ucas.res;
 
   if (subscriptionId != ucasP->subscriptionId.get())

--- a/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
@@ -60,6 +60,6 @@ std::string badVerbAllNotDelete
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }
 

--- a/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
@@ -60,6 +60,6 @@ std::string badVerbAllNotDelete
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }
 

--- a/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
@@ -60,6 +60,6 @@ std::string badVerbAllNotDelete
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }
 

--- a/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetDeletePatchOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetDeletePatchOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetDeletePatchOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPutOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == "v1")? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPutOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == NO_VERSION)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
@@ -59,5 +59,5 @@ std::string badVerbGetPutOnly
 
   alarmMgr.badInput(clientIp, details);
 
-  return (ciP->apiVersion == 1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
+  return (ciP->apiVersion == V1 || ciP->apiVersion == -1)? "" :  oe.smartRender(ciP->apiVersion);
 }

--- a/test/unittests/apiTypesV2/Entities_test.cpp
+++ b/test/unittests/apiTypesV2/Entities_test.cpp
@@ -78,8 +78,8 @@ TEST(Entities, check)
   Entities ens2;
   ens2.vec.push_back(enP);
 
-  EXPECT_EQ("OK", ens1.check(1, EntitiesRequest));
-  EXPECT_EQ("No Entity ID", ens2.check(1, EntitiesRequest));
+  EXPECT_EQ("OK", ens1.check(V1, EntitiesRequest));
+  EXPECT_EQ("No Entity ID", ens2.check(V1, EntitiesRequest));
 
   utExit();
 }

--- a/test/unittests/apiTypesV2/Entities_test.cpp
+++ b/test/unittests/apiTypesV2/Entities_test.cpp
@@ -78,8 +78,8 @@ TEST(Entities, check)
   Entities ens2;
   ens2.vec.push_back(enP);
 
-  EXPECT_EQ("OK", ens1.check("v1", EntitiesRequest));
-  EXPECT_EQ("No Entity ID", ens2.check("v1", EntitiesRequest));
+  EXPECT_EQ("OK", ens1.check(1, EntitiesRequest));
+  EXPECT_EQ("No Entity ID", ens2.check(1, EntitiesRequest));
 
   utExit();
 }

--- a/test/unittests/apiTypesV2/EntityVector_test.cpp
+++ b/test/unittests/apiTypesV2/EntityVector_test.cpp
@@ -77,8 +77,8 @@ TEST(EntityVector, check)
   EntityVector enV2;
   enV2.push_back(enP);
 
-  EXPECT_EQ("OK", enV1.check(1, EntitiesRequest));
-  EXPECT_EQ("No Entity ID", enV2.check(1, EntitiesRequest));
+  EXPECT_EQ("OK", enV1.check(V1, EntitiesRequest));
+  EXPECT_EQ("No Entity ID", enV2.check(V1, EntitiesRequest));
 
   utExit();
 }

--- a/test/unittests/apiTypesV2/EntityVector_test.cpp
+++ b/test/unittests/apiTypesV2/EntityVector_test.cpp
@@ -77,8 +77,8 @@ TEST(EntityVector, check)
   EntityVector enV2;
   enV2.push_back(enP);
 
-  EXPECT_EQ("OK", enV1.check("v1", EntitiesRequest));
-  EXPECT_EQ("No Entity ID", enV2.check("v1", EntitiesRequest));
+  EXPECT_EQ("OK", enV1.check(1, EntitiesRequest));
+  EXPECT_EQ("No Entity ID", enV2.check(1, EntitiesRequest));
 
   utExit();
 }

--- a/test/unittests/apiTypesV2/Entity_test.cpp
+++ b/test/unittests/apiTypesV2/Entity_test.cpp
@@ -65,21 +65,21 @@ TEST(Entity, check)
   ContextAttribute* caP = new ContextAttribute("A", "T", "val");
   enP->attributeVector.push_back(caP);
 
-  EXPECT_EQ("OK", enP->check(1, EntitiesRequest));
+  EXPECT_EQ("OK", enP->check(V1, EntitiesRequest));
 
   enP->id = "";
-  EXPECT_EQ("No Entity ID", enP->check(1, EntitiesRequest));
+  EXPECT_EQ("No Entity ID", enP->check(V1, EntitiesRequest));
 
   enP->id = "E<1>";
-  EXPECT_EQ("Invalid characters in entity id", enP->check(1, EntitiesRequest));
+  EXPECT_EQ("Invalid characters in entity id", enP->check(V1, EntitiesRequest));
   enP->id = "E";
 
   enP->type = "T<1>";
-  EXPECT_EQ("Invalid characters in entity type", enP->check(1, EntitiesRequest));
+  EXPECT_EQ("Invalid characters in entity type", enP->check(V1, EntitiesRequest));
   enP->type = "T";
 
   enP->isPattern = "<false>";
-  EXPECT_EQ("Invalid characters in entity isPattern", enP->check(1, EntitiesRequest));
+  EXPECT_EQ("Invalid characters in entity isPattern", enP->check(V1, EntitiesRequest));
 
   utExit();
 }

--- a/test/unittests/apiTypesV2/Entity_test.cpp
+++ b/test/unittests/apiTypesV2/Entity_test.cpp
@@ -65,21 +65,21 @@ TEST(Entity, check)
   ContextAttribute* caP = new ContextAttribute("A", "T", "val");
   enP->attributeVector.push_back(caP);
 
-  EXPECT_EQ("OK", enP->check("v1", EntitiesRequest));
+  EXPECT_EQ("OK", enP->check(1, EntitiesRequest));
 
   enP->id = "";
-  EXPECT_EQ("No Entity ID", enP->check("v1", EntitiesRequest));
+  EXPECT_EQ("No Entity ID", enP->check(1, EntitiesRequest));
 
   enP->id = "E<1>";
-  EXPECT_EQ("Invalid characters in entity id", enP->check("v1", EntitiesRequest));
+  EXPECT_EQ("Invalid characters in entity id", enP->check(1, EntitiesRequest));
   enP->id = "E";
 
   enP->type = "T<1>";
-  EXPECT_EQ("Invalid characters in entity type", enP->check("v1", EntitiesRequest));
+  EXPECT_EQ("Invalid characters in entity type", enP->check(1, EntitiesRequest));
   enP->type = "T";
 
   enP->isPattern = "<false>";
-  EXPECT_EQ("Invalid characters in entity isPattern", enP->check("v1", EntitiesRequest));
+  EXPECT_EQ("Invalid characters in entity isPattern", enP->check(1, EntitiesRequest));
 
   utExit();
 }

--- a/test/unittests/convenience/AppendContextElementRequest_test.cpp
+++ b/test/unittests/convenience/AppendContextElementRequest_test.cpp
@@ -52,7 +52,7 @@ TEST(AppendContextElementRequest, render_json)
    acer.attributeDomainName.set("ADN");
    acer.contextAttributeVector.push_back(&ca);
    
-   out = acer.render("v1", false, UpdateContext, "");
+   out = acer.render(1, false, UpdateContext, "");
 
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
@@ -83,13 +83,13 @@ TEST(AppendContextElementRequest, check_json)
    acer.domainMetadataVector.push_back(&md);
 
    // 1. ok
-   out = acer.check("v1", false, AppendContextElement, "", "", 0);
+   out = acer.check(1, false, AppendContextElement, "", "");
    EXPECT_STREQ("OK", out.c_str());
 
 
    // 2. Predetected error 
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
-   out = acer.check("v1", false, AppendContextElement, "", "Error is predetected", 0);
+   out = acer.check(1, false, AppendContextElement, "", "Error is predetected");
    EXPECT_STREQ(expectedBuf, out.c_str());
    
 
@@ -97,7 +97,7 @@ TEST(AppendContextElementRequest, check_json)
    ContextAttribute  ca2("", "caType", "121");
 
    acer.contextAttributeVector.push_back(&ca2);
-   out = acer.check("v1", false, AppendContextElement, "", "", 0);
+   out = acer.check(1, false, AppendContextElement, "", "");
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";   
    EXPECT_STREQ(expectedBuf, out.c_str());
    ca2.name = "ca2Name";
@@ -107,7 +107,7 @@ TEST(AppendContextElementRequest, check_json)
    Metadata  md2("", "mdType", "122");
 
    acer.domainMetadataVector.push_back(&md2);
-   out = acer.check("v1", false, AppendContextElement, "", "", 0);
+   out = acer.check(1, false, AppendContextElement, "", "");
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile3)) << "Error getting test data from '" << outfile3 << "'";   
    EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/AppendContextElementRequest_test.cpp
+++ b/test/unittests/convenience/AppendContextElementRequest_test.cpp
@@ -52,7 +52,7 @@ TEST(AppendContextElementRequest, render_json)
    acer.attributeDomainName.set("ADN");
    acer.contextAttributeVector.push_back(&ca);
    
-   out = acer.render(1, false, UpdateContext, "");
+   out = acer.render(V1, false, UpdateContext, "");
 
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
@@ -83,13 +83,13 @@ TEST(AppendContextElementRequest, check_json)
    acer.domainMetadataVector.push_back(&md);
 
    // 1. ok
-   out = acer.check(1, false, AppendContextElement, "", "");
+   out = acer.check(V1, false, AppendContextElement, "", "");
    EXPECT_STREQ("OK", out.c_str());
 
 
    // 2. Predetected error 
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
-   out = acer.check(1, false, AppendContextElement, "", "Error is predetected");
+   out = acer.check(V1, false, AppendContextElement, "", "Error is predetected");
    EXPECT_STREQ(expectedBuf, out.c_str());
    
 
@@ -97,7 +97,7 @@ TEST(AppendContextElementRequest, check_json)
    ContextAttribute  ca2("", "caType", "121");
 
    acer.contextAttributeVector.push_back(&ca2);
-   out = acer.check(1, false, AppendContextElement, "", "");
+   out = acer.check(V1, false, AppendContextElement, "", "");
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";   
    EXPECT_STREQ(expectedBuf, out.c_str());
    ca2.name = "ca2Name";
@@ -107,7 +107,7 @@ TEST(AppendContextElementRequest, check_json)
    Metadata  md2("", "mdType", "122");
 
    acer.domainMetadataVector.push_back(&md2);
-   out = acer.check(1, false, AppendContextElement, "", "");
+   out = acer.check(V1, false, AppendContextElement, "", "");
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile3)) << "Error getting test data from '" << outfile3 << "'";   
    EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/AppendContextElementResponse_test.cpp
+++ b/test/unittests/convenience/AppendContextElementResponse_test.cpp
@@ -50,13 +50,13 @@ TEST(AppendContextElementResponse, render_json)
   utInit();
 
   // 1. empty acer
-  out = acer.render("v1", false, AppendContextElement, "");
+  out = acer.render(1, false, AppendContextElement, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. errorCode 'active'
   acer.errorCode.fill(SccBadRequest, "very bad request");
-  out = acer.render("v1", false, AppendContextElement, "");
+  out = acer.render(1, false, AppendContextElement, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -81,20 +81,20 @@ TEST(AppendContextElementResponse, check_json)
   utInit();
 
   // 1. predetected error
-  out = acer.check("v1", false, IndividualContextEntity, "", "PRE ERR", 0);
+  out = acer.check(1, false, IndividualContextEntity, "", "PRE ERR");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. bad contextAttributeResponseVector
   car.contextAttributeVector.push_back(&ca);
   acer.contextAttributeResponseVector.push_back(&car);
-  out = acer.check("v1", false, IndividualContextEntity, "", "", 0);
+  out = acer.check(1, false, IndividualContextEntity, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 3. OK
   ca.name = "NAME";
-  out = acer.check("v1", false, IndividualContextEntity, "", "", 0);
+  out = acer.check(1, false, IndividualContextEntity, "", "");
   EXPECT_EQ("OK", out);
 
   utExit();

--- a/test/unittests/convenience/AppendContextElementResponse_test.cpp
+++ b/test/unittests/convenience/AppendContextElementResponse_test.cpp
@@ -50,13 +50,13 @@ TEST(AppendContextElementResponse, render_json)
   utInit();
 
   // 1. empty acer
-  out = acer.render(1, false, AppendContextElement, "");
+  out = acer.render(V1, false, AppendContextElement, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. errorCode 'active'
   acer.errorCode.fill(SccBadRequest, "very bad request");
-  out = acer.render(1, false, AppendContextElement, "");
+  out = acer.render(V1, false, AppendContextElement, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -81,20 +81,20 @@ TEST(AppendContextElementResponse, check_json)
   utInit();
 
   // 1. predetected error
-  out = acer.check(1, false, IndividualContextEntity, "", "PRE ERR");
+  out = acer.check(V1, false, IndividualContextEntity, "", "PRE ERR");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. bad contextAttributeResponseVector
   car.contextAttributeVector.push_back(&ca);
   acer.contextAttributeResponseVector.push_back(&car);
-  out = acer.check(1, false, IndividualContextEntity, "", "");
+  out = acer.check(V1, false, IndividualContextEntity, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 3. OK
   ca.name = "NAME";
-  out = acer.check(1, false, IndividualContextEntity, "", "");
+  out = acer.check(V1, false, IndividualContextEntity, "", "");
   EXPECT_EQ("OK", out);
 
   utExit();

--- a/test/unittests/convenience/ContextAttributeResponseVector_test.cpp
+++ b/test/unittests/convenience/ContextAttributeResponseVector_test.cpp
@@ -51,14 +51,14 @@ TEST(ContextAttributeResponseVector, render_json)
 
   // 1. empty vector
   car.statusCode.fill(SccBadRequest, "Empty Vector");
-  out = carV.render("v1", false, ContextEntityAttributes, "");
+  out = carV.render(1, false, ContextEntityAttributes, "");
   EXPECT_STREQ("", out.c_str());
 
   // 2. normal case
   car.contextAttributeVector.push_back(&ca);
   carV.push_back(&car);
 
-  out = carV.render("v1", false, ContextEntityAttributes, "");
+  out = carV.render(1, false, ContextEntityAttributes, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 }
@@ -81,11 +81,11 @@ TEST(ContextAttributeResponseVector, check_json)
   // 1. ok
   car.contextAttributeVector.push_back(&ca);
   carV.push_back(&car);
-  out = carV.check("v1", false, UpdateContextAttribute, "", "", 0);
+  out = carV.check(1, false, UpdateContextAttribute, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
   // 2. Predetected Error
-  out = carV.check("v1", false, UpdateContextAttribute, "", "PRE ERROR", 0);
+  out = carV.check(1, false, UpdateContextAttribute, "", "PRE ERROR");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -93,7 +93,7 @@ TEST(ContextAttributeResponseVector, check_json)
   ContextAttribute  ca2("", "caType", "caValue");
 
   car.contextAttributeVector.push_back(&ca2);
-  out = carV.check("v1", false, UpdateContextAttribute, "", "", 0);
+  out = carV.check(1, false, UpdateContextAttribute, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 }

--- a/test/unittests/convenience/ContextAttributeResponseVector_test.cpp
+++ b/test/unittests/convenience/ContextAttributeResponseVector_test.cpp
@@ -51,14 +51,14 @@ TEST(ContextAttributeResponseVector, render_json)
 
   // 1. empty vector
   car.statusCode.fill(SccBadRequest, "Empty Vector");
-  out = carV.render(1, false, ContextEntityAttributes, "");
+  out = carV.render(V1, false, ContextEntityAttributes, "");
   EXPECT_STREQ("", out.c_str());
 
   // 2. normal case
   car.contextAttributeVector.push_back(&ca);
   carV.push_back(&car);
 
-  out = carV.render(1, false, ContextEntityAttributes, "");
+  out = carV.render(V1, false, ContextEntityAttributes, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 }
@@ -81,11 +81,11 @@ TEST(ContextAttributeResponseVector, check_json)
   // 1. ok
   car.contextAttributeVector.push_back(&ca);
   carV.push_back(&car);
-  out = carV.check(1, false, UpdateContextAttribute, "", "");
+  out = carV.check(V1, false, UpdateContextAttribute, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
   // 2. Predetected Error
-  out = carV.check(1, false, UpdateContextAttribute, "", "PRE ERROR");
+  out = carV.check(V1, false, UpdateContextAttribute, "", "PRE ERROR");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -93,7 +93,7 @@ TEST(ContextAttributeResponseVector, check_json)
   ContextAttribute  ca2("", "caType", "caValue");
 
   car.contextAttributeVector.push_back(&ca2);
-  out = carV.check(1, false, UpdateContextAttribute, "", "");
+  out = carV.check(V1, false, UpdateContextAttribute, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 }

--- a/test/unittests/convenience/ContextAttributeResponse_test.cpp
+++ b/test/unittests/convenience/ContextAttributeResponse_test.cpp
@@ -50,7 +50,7 @@ TEST(ContextAttributeResponse, render_json)
   car.contextAttributeVector.push_back(&ca);
   car.statusCode.fill(SccOk, "OK"); 
 
-  out = car.render(1, false, ContextEntityAttributes, "");
+  out = car.render(V1, false, ContextEntityAttributes, "");
 
   utExit();
 }
@@ -75,12 +75,12 @@ TEST(ContextAttributeResponse, check_json)
   car.contextAttributeVector.push_back(&ca);
   car.statusCode.fill(SccOk, "OK"); 
 
-  out = car.check(1, false, UpdateContextAttribute, "", "");
+  out = car.check(V1, false, UpdateContextAttribute, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
 
   // 2. predetectedError
-  out = car.check(1, false, UpdateContextAttribute, "", "PRE Error");
+  out = car.check(V1, false, UpdateContextAttribute, "", "PRE Error");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -90,7 +90,7 @@ TEST(ContextAttributeResponse, check_json)
   car.contextAttributeVector.push_back(&ca2);
   
   LM_M(("car.contextAttributeVector.size: %d - calling ContextAttributeResponse::check", car.contextAttributeVector.size()));
-  out = car.check(1, false, UpdateContextAttribute, "", "");
+  out = car.check(V1, false, UpdateContextAttribute, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/ContextAttributeResponse_test.cpp
+++ b/test/unittests/convenience/ContextAttributeResponse_test.cpp
@@ -50,7 +50,7 @@ TEST(ContextAttributeResponse, render_json)
   car.contextAttributeVector.push_back(&ca);
   car.statusCode.fill(SccOk, "OK"); 
 
-  out = car.render("v1", false, ContextEntityAttributes, "");
+  out = car.render(1, false, ContextEntityAttributes, "");
 
   utExit();
 }
@@ -75,12 +75,12 @@ TEST(ContextAttributeResponse, check_json)
   car.contextAttributeVector.push_back(&ca);
   car.statusCode.fill(SccOk, "OK"); 
 
-  out = car.check("v1", false, UpdateContextAttribute, "", "", 0);
+  out = car.check(1, false, UpdateContextAttribute, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
 
   // 2. predetectedError
-  out = car.check("v1", false, UpdateContextAttribute, "", "PRE Error", 0);
+  out = car.check(1, false, UpdateContextAttribute, "", "PRE Error");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -90,7 +90,7 @@ TEST(ContextAttributeResponse, check_json)
   car.contextAttributeVector.push_back(&ca2);
   
   LM_M(("car.contextAttributeVector.size: %d - calling ContextAttributeResponse::check", car.contextAttributeVector.size()));
-  out = car.check("v1", false, UpdateContextAttribute, "", "", 0);
+  out = car.check(1, false, UpdateContextAttribute, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/Convenience_test.cpp
+++ b/test/unittests/convenience/Convenience_test.cpp
@@ -91,19 +91,19 @@ TEST(Convenience, shortPath)
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
 
-  ci1.apiVersion = 1;
+  ci1.apiVersion = V1;
   out = restService(&ci1, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
-  ci2.apiVersion = 1;
+  ci2.apiVersion = V1;
   out = restService(&ci2, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
-  ci3.apiVersion = 1;
+  ci3.apiVersion = V1;
   out = restService(&ci3, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
-  ci4.apiVersion = 1;
+  ci4.apiVersion = V1;
   out = restService(&ci4, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -127,7 +127,7 @@ TEST(Convenience, badPathNgsi9)
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
 
-  ci.apiVersion = 1;
+  ci.apiVersion = V1;
   out = restService(&ci, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -150,7 +150,7 @@ TEST(Convenience, badPathNgsi10)
   utInit();
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
-  ci.apiVersion = 1;
+  ci.apiVersion = V1;
   out = restService(&ci, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/Convenience_test.cpp
+++ b/test/unittests/convenience/Convenience_test.cpp
@@ -91,19 +91,19 @@ TEST(Convenience, shortPath)
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
 
-  ci1.apiVersion = "v1";
+  ci1.apiVersion = 1;
   out = restService(&ci1, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
-  ci2.apiVersion = "v1";
+  ci2.apiVersion = 1;
   out = restService(&ci2, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
-  ci3.apiVersion = "v1";
+  ci3.apiVersion = 1;
   out = restService(&ci3, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
-  ci4.apiVersion = "v1";
+  ci4.apiVersion = 1;
   out = restService(&ci4, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -127,7 +127,7 @@ TEST(Convenience, badPathNgsi9)
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
 
-  ci.apiVersion = "v1";
+  ci.apiVersion = 1;
   out = restService(&ci, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -150,7 +150,7 @@ TEST(Convenience, badPathNgsi10)
   utInit();
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
-  ci.apiVersion = "v1";
+  ci.apiVersion = 1;
   out = restService(&ci, restServiceV);
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/RegisterProviderRequest_test.cpp
+++ b/test/unittests/convenience/RegisterProviderRequest_test.cpp
@@ -73,14 +73,14 @@ TEST(RegisterProviderRequest, json_ok)
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile2)) << "Error getting test data from '" << outFile2 << "'";
 
   reqData.rpr.res.metadataVector[0]->name = "";
-  checked = reqData.rpr.res.check(1, DiscoverContextAvailability, "", "");
+  checked = reqData.rpr.res.check(V1, DiscoverContextAvailability, "", "");
   EXPECT_STREQ(expectedBuf, checked.c_str());
 
 
   // 3. sending a 'predetected error' to the check function
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile3)) << "Error getting test data from '" << outFile3 << "'";
 
-  checked   = reqData.rpr.res.check(1, DiscoverContextAvailability, "", "forced predetectedError");
+  checked   = reqData.rpr.res.check(V1, DiscoverContextAvailability, "", "forced predetectedError");
   EXPECT_STREQ(expectedBuf, checked.c_str());
 
   // Just for coverage

--- a/test/unittests/convenience/RegisterProviderRequest_test.cpp
+++ b/test/unittests/convenience/RegisterProviderRequest_test.cpp
@@ -73,14 +73,14 @@ TEST(RegisterProviderRequest, json_ok)
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile2)) << "Error getting test data from '" << outFile2 << "'";
 
   reqData.rpr.res.metadataVector[0]->name = "";
-  checked = reqData.rpr.res.check("v1", DiscoverContextAvailability, "", "", 0);
+  checked = reqData.rpr.res.check(1, DiscoverContextAvailability, "", "");
   EXPECT_STREQ(expectedBuf, checked.c_str());
 
 
   // 3. sending a 'predetected error' to the check function
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile3)) << "Error getting test data from '" << outFile3 << "'";
 
-  checked   = reqData.rpr.res.check("v1", DiscoverContextAvailability, "", "forced predetectedError", 0);
+  checked   = reqData.rpr.res.check(1, DiscoverContextAvailability, "", "forced predetectedError");
   EXPECT_STREQ(expectedBuf, checked.c_str());
 
   // Just for coverage

--- a/test/unittests/convenience/UpdateContextAttributeRequest_test.cpp
+++ b/test/unittests/convenience/UpdateContextAttributeRequest_test.cpp
@@ -51,7 +51,7 @@ TEST(UpdateContextAttributeRequest, render_json)
   ucar.contextValue = "Context Value";
 
   ucar.metadataVector.push_back(&mdata);
-  out = ucar.render(1, "");
+  out = ucar.render(V1, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();
@@ -78,23 +78,23 @@ TEST(UpdateContextAttributeRequest, check_json)
 
   // 1. predetectedError
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
-  out = ucar.check(1, "", "PRE Error");
+  out = ucar.check(V1, "", "PRE Error");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   
   // 2. empty contextValue
-  out = ucar.check(1, "", "");
+  out = ucar.check(V1, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
   // 3. OK
   ucar.contextValue = "CValue";
-  out = ucar.check(1, "", "");
+  out = ucar.check(V1, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
   // 4. bad metadata
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   ucar.metadataVector.push_back(&mdata2);
-  out = ucar.check(1, "", "");
+  out = ucar.check(V1, "", "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/convenience/UpdateContextAttributeRequest_test.cpp
+++ b/test/unittests/convenience/UpdateContextAttributeRequest_test.cpp
@@ -51,7 +51,7 @@ TEST(UpdateContextAttributeRequest, render_json)
   ucar.contextValue = "Context Value";
 
   ucar.metadataVector.push_back(&mdata);
-  out = ucar.render("v1", "");
+  out = ucar.render(1, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();
@@ -78,23 +78,23 @@ TEST(UpdateContextAttributeRequest, check_json)
 
   // 1. predetectedError
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
-  out = ucar.check("v1", UpdateContextAttribute, "", "PRE Error", 0);
+  out = ucar.check(1, "", "PRE Error");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   
   // 2. empty contextValue
-  out = ucar.check("v1", UpdateContextAttribute, "", "", 0);
+  out = ucar.check(1, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
   // 3. OK
   ucar.contextValue = "CValue";
-  out = ucar.check("v1", UpdateContextAttribute, "", "", 0);
+  out = ucar.check(1, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
   // 4. bad metadata
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   ucar.metadataVector.push_back(&mdata2);
-  out = ucar.check("v1", UpdateContextAttribute, "", "", 0);
+  out = ucar.check(1, "", "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/convenience/UpdateContextElementRequest_test.cpp
+++ b/test/unittests/convenience/UpdateContextElementRequest_test.cpp
@@ -54,7 +54,7 @@ TEST(UpdateContextElementRequest, render_json)
   ucer.attributeDomainName.set("ADN");
   ucer.contextAttributeVector.push_back(&ca);
 
-  out = ucer.render(1, false, UpdateContext, "");
+  out = ucer.render(V1, false, UpdateContext, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();
@@ -80,12 +80,12 @@ TEST(UpdateContextElementRequest, check_json)
 
   // 1. predetectedError
   ucer.contextAttributeVector.push_back(&ca);
-  out = ucer.check(1, false, UpdateContextElement, "", "PRE Error");
+  out = ucer.check(V1, false, UpdateContextElement, "", "PRE Error");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. ok
-  out = ucer.check(1, false, UpdateContextElement, "", "");
+  out = ucer.check(V1, false, UpdateContextElement, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
   // 3. bad attributeDomainName
@@ -95,7 +95,7 @@ TEST(UpdateContextElementRequest, check_json)
   // 4. bad contextAttributeVector
   ContextAttribute                ca2("", "caType", "caValue");
   ucer.contextAttributeVector.push_back(&ca2);
-  out = ucer.check(1, false, UpdateContextElement, "", "");
+  out = ucer.check(V1, false, UpdateContextElement, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/UpdateContextElementRequest_test.cpp
+++ b/test/unittests/convenience/UpdateContextElementRequest_test.cpp
@@ -54,7 +54,7 @@ TEST(UpdateContextElementRequest, render_json)
   ucer.attributeDomainName.set("ADN");
   ucer.contextAttributeVector.push_back(&ca);
 
-  out = ucer.render("v1", false, UpdateContext, "");
+  out = ucer.render(1, false, UpdateContext, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();
@@ -80,12 +80,12 @@ TEST(UpdateContextElementRequest, check_json)
 
   // 1. predetectedError
   ucer.contextAttributeVector.push_back(&ca);
-  out = ucer.check("v1", false, UpdateContextElement, "", "PRE Error", 0);
+  out = ucer.check(1, false, UpdateContextElement, "", "PRE Error");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. ok
-  out = ucer.check("v1", false, UpdateContextElement, "", "", 0);
+  out = ucer.check(1, false, UpdateContextElement, "", "");
   EXPECT_STREQ("OK", out.c_str());
 
   // 3. bad attributeDomainName
@@ -95,7 +95,7 @@ TEST(UpdateContextElementRequest, check_json)
   // 4. bad contextAttributeVector
   ContextAttribute                ca2("", "caType", "caValue");
   ucer.contextAttributeVector.push_back(&ca2);
-  out = ucer.check("v1", false, UpdateContextElement, "", "", 0);
+  out = ucer.check(1, false, UpdateContextElement, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/convenience/UpdateContextElementResponse_test.cpp
+++ b/test/unittests/convenience/UpdateContextElementResponse_test.cpp
@@ -52,7 +52,7 @@ TEST(UpdateContextElementResponse, render_json)
   car.contextAttributeVector.push_back(&ca);
   car.statusCode.fill(SccOk, "details");
 
-  out = ucer.render(1, false, UpdateContext, "");
+  out = ucer.render(V1, false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 }
@@ -73,19 +73,19 @@ TEST(UpdateContextElementResponse, check_json)
   const char*                   outfile2 = "ngsi10.updateContextElementResponse.check2.valid.json";
 
   // 1. predetected error
-  out = ucer.check(1, false, IndividualContextEntity, "", "PRE ERR");
+  out = ucer.check(V1, false, IndividualContextEntity, "", "PRE ERR");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. bad contextAttributeResponseVector
   car.contextAttributeVector.push_back(&ca);
   ucer.contextAttributeResponseVector.push_back(&car);
-  out = ucer.check(1, false, IndividualContextEntity, "", "");
+  out = ucer.check(V1, false, IndividualContextEntity, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 3. OK
   ca.name = "NAME";
-  out = ucer.check(1, false, IndividualContextEntity, "", "");
+  out = ucer.check(V1, false, IndividualContextEntity, "", "");
   EXPECT_EQ("OK", out);
 }

--- a/test/unittests/convenience/UpdateContextElementResponse_test.cpp
+++ b/test/unittests/convenience/UpdateContextElementResponse_test.cpp
@@ -52,7 +52,7 @@ TEST(UpdateContextElementResponse, render_json)
   car.contextAttributeVector.push_back(&ca);
   car.statusCode.fill(SccOk, "details");
 
-  out = ucer.render("v1", false, UpdateContext, "");
+  out = ucer.render(1, false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 }
@@ -73,19 +73,19 @@ TEST(UpdateContextElementResponse, check_json)
   const char*                   outfile2 = "ngsi10.updateContextElementResponse.check2.valid.json";
 
   // 1. predetected error
-  out = ucer.check("v1", false, IndividualContextEntity, "", "PRE ERR", 0);
+  out = ucer.check(1, false, IndividualContextEntity, "", "PRE ERR");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 2. bad contextAttributeResponseVector
   car.contextAttributeVector.push_back(&ca);
   ucer.contextAttributeResponseVector.push_back(&car);
-  out = ucer.check("v1", false, IndividualContextEntity, "", "", 0);
+  out = ucer.check(1, false, IndividualContextEntity, "", "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile2)) << "Error getting test data from '" << outfile2 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 3. OK
   ca.name = "NAME";
-  out = ucer.check("v1", false, IndividualContextEntity, "", "", 0);
+  out = ucer.check(1, false, IndividualContextEntity, "", "");
   EXPECT_EQ("OK", out);
 }

--- a/test/unittests/jsonParse/jsonRequest_test.cpp
+++ b/test/unittests/jsonParse/jsonRequest_test.cpp
@@ -48,7 +48,7 @@ TEST(jsonRequest, jsonTreat)
    utInit();
 
    ci.outMimeType  = JSON;
-   ci.apiVersion   = "v1";
+   ci.apiVersion   = 1;
    out  = jsonTreat("non-empty content", &ci, &parseData, InvalidRequest, "", NULL);
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());

--- a/test/unittests/jsonParse/jsonRequest_test.cpp
+++ b/test/unittests/jsonParse/jsonRequest_test.cpp
@@ -48,7 +48,7 @@ TEST(jsonRequest, jsonTreat)
    utInit();
 
    ci.outMimeType  = JSON;
-   ci.apiVersion   = 1;
+   ci.apiVersion   = V1;
    out  = jsonTreat("non-empty content", &ci, &parseData, InvalidRequest, "", NULL);
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());

--- a/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
@@ -201,7 +201,7 @@ TEST(mongoQueryTypes, queryAllType)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -319,7 +319,7 @@ TEST(mongoQueryTypes, queryAllPaginationDetails)
     /* Invoke the function in mongoBackend library */
     /* Using default offset/limit */
     unsigned int totalTypes = 0;  // enables count details
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, &totalTypes, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, &totalTypes, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -436,7 +436,7 @@ TEST(mongoQueryTypes, queryAllPaginationAll)
 
     /* Invoke the function in mongoBackend library */
     /* Using default offset/limit */
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -553,7 +553,7 @@ TEST(mongoQueryTypes, queryAllPaginationOnlyFirst)
 
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_LIMIT] = "1";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -626,7 +626,7 @@ TEST(mongoQueryTypes, queryAllPaginationOnlySecond)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "1";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "1";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -678,7 +678,7 @@ TEST(mongoQueryTypes, queryAllPaginationRange)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "1";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "2";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -756,7 +756,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExisting)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "7";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -788,7 +788,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingOverlap)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "2";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "4";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -848,7 +848,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingDetails)
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "7";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
     unsigned int totalTypes                = 0;  // enables count details
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, &totalTypes, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, &totalTypes, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -885,7 +885,7 @@ TEST(mongoQueryTypes, queryAllDbException)
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
+  ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms); 
@@ -929,7 +929,7 @@ TEST(mongoQueryTypes, queryAllGenericException)
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
+  ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -967,7 +967,7 @@ TEST(mongoQueryTypes, queryGivenTypeBasic)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1035,7 +1035,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationDetails)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "on";
     /* Using default offset/limit */
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1103,7 +1103,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationAll)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     /* Using default offset/limit */
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1171,7 +1171,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationOnlyFirst)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_LIMIT] = "1";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1211,7 +1211,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationOnlySecond)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "1";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "1";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1252,7 +1252,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationRange)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "2";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1307,7 +1307,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExisting)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "7";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1340,7 +1340,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingOverlap)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "3";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1388,7 +1388,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingDetails)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "on";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "7";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1425,7 +1425,7 @@ TEST(mongoQueryTypes, queryGivenTypeDbException)
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+  ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -1469,7 +1469,7 @@ TEST(mongoQueryTypes, queryGivenTypeGenericException)
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
+  ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);

--- a/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
@@ -201,7 +201,7 @@ TEST(mongoQueryTypes, queryAllType)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -319,7 +319,7 @@ TEST(mongoQueryTypes, queryAllPaginationDetails)
     /* Invoke the function in mongoBackend library */
     /* Using default offset/limit */
     unsigned int totalTypes = 0;  // enables count details
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", &totalTypes, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, &totalTypes, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -436,7 +436,7 @@ TEST(mongoQueryTypes, queryAllPaginationAll)
 
     /* Invoke the function in mongoBackend library */
     /* Using default offset/limit */
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -553,7 +553,7 @@ TEST(mongoQueryTypes, queryAllPaginationOnlyFirst)
 
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_LIMIT] = "1";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -626,7 +626,7 @@ TEST(mongoQueryTypes, queryAllPaginationOnlySecond)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "1";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "1";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -678,7 +678,7 @@ TEST(mongoQueryTypes, queryAllPaginationRange)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "1";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "2";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -756,7 +756,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExisting)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "7";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -788,7 +788,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingOverlap)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "2";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "4";
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", NULL, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -848,7 +848,7 @@ TEST(mongoQueryTypes, queryAllPaginationNonExistingDetails)
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "7";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
     unsigned int totalTypes                = 0;  // enables count details
-    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", &totalTypes, false);
+    ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, &totalTypes, false);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -885,7 +885,7 @@ TEST(mongoQueryTypes, queryAllDbException)
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", NULL, false);
+  ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms); 
@@ -929,7 +929,7 @@ TEST(mongoQueryTypes, queryAllGenericException)
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, "v1", NULL, false);
+  ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, 1, NULL, false);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -967,7 +967,7 @@ TEST(mongoQueryTypes, queryGivenTypeBasic)
     prepareDatabase();
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1035,7 +1035,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationDetails)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "on";
     /* Using default offset/limit */
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1103,7 +1103,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationAll)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     /* Using default offset/limit */
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1171,7 +1171,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationOnlyFirst)
     /* Invoke the function in mongoBackend library */
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_LIMIT] = "1";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1211,7 +1211,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationOnlySecond)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "1";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "1";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1252,7 +1252,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationRange)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "2";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1307,7 +1307,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExisting)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "7";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1340,7 +1340,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingOverlap)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "3";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1388,7 +1388,7 @@ TEST(mongoQueryTypes, queryGivenTypePaginationNonExistingDetails)
     uriParams[URI_PARAM_PAGINATION_DETAILS]  = "on";
     uriParams[URI_PARAM_PAGINATION_OFFSET] = "7";
     uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
-    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+    ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1425,7 +1425,7 @@ TEST(mongoQueryTypes, queryGivenTypeDbException)
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+  ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -1469,7 +1469,7 @@ TEST(mongoQueryTypes, queryGivenTypeGenericException)
   setMongoConnectionForUnitTest(connectionMock);
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, "v1");
+  ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, 1);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -9095,7 +9095,7 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", "v2");
+    ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", 2);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -9963,8 +9963,8 @@ TEST(mongoUpdateContextRequest, tooManyEntitiesNGSIv2)
   req.contextElementVector.push_back(&ce);
   req.updateActionType.set("UPDATE");
 
-  /* Invoke the function in mongoBackend library (note the "v2" to activate NGSIv2 special behaviours) */
-  ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", "v2");
+  /* Invoke the function in mongoBackend library (note the 2 to activate NGSIv2 special behaviours) */
+  ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", 2);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -10113,8 +10113,8 @@ TEST(mongoUpdateContextRequest, onlyOneEntityNGSIv2)
   req.contextElementVector.push_back(&ce);
   req.updateActionType.set("UPDATE");
 
-  /* Invoke the function in mongoBackend library (note the "v2" to activate NGSIv2 special behaviours) */
-  ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", "v2");
+  /* Invoke the function in mongoBackend library (note the 2 to activate NGSIv2 special behaviours) */
+  ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", 2);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -9095,7 +9095,7 @@ TEST(mongoUpdateContextRequest, updateNativeTypes)
     req.updateActionType.set("UPDATE");
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", 2);
+    ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", V2);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -9964,7 +9964,7 @@ TEST(mongoUpdateContextRequest, tooManyEntitiesNGSIv2)
   req.updateActionType.set("UPDATE");
 
   /* Invoke the function in mongoBackend library (note the 2 to activate NGSIv2 special behaviours) */
-  ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", 2);
+  ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", V2);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -10114,7 +10114,7 @@ TEST(mongoUpdateContextRequest, onlyOneEntityNGSIv2)
   req.updateActionType.set("UPDATE");
 
   /* Invoke the function in mongoBackend library (note the 2 to activate NGSIv2 special behaviours) */
-  ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", 2);
+  ms = mongoUpdateContext(&req, &res, "", servicePathVector, uriParams, "", "no correlator", V2);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);

--- a/test/unittests/ngsi/ContextAttributeVector_test.cpp
+++ b/test/unittests/ngsi/ContextAttributeVector_test.cpp
@@ -43,7 +43,7 @@ TEST(ContextAttributeVector, render)
 
   utInit();
 
-  out = cav.render("v1", false, UpdateContextAttribute, "");
+  out = cav.render(1, false, UpdateContextAttribute, "");
   EXPECT_STREQ("", out.c_str());
 
   // Just to exercise the code ...

--- a/test/unittests/ngsi/ContextAttributeVector_test.cpp
+++ b/test/unittests/ngsi/ContextAttributeVector_test.cpp
@@ -43,7 +43,7 @@ TEST(ContextAttributeVector, render)
 
   utInit();
 
-  out = cav.render(1, false, UpdateContextAttribute, "");
+  out = cav.render(V1, false, UpdateContextAttribute, "");
   EXPECT_STREQ("", out.c_str());
 
   // Just to exercise the code ...

--- a/test/unittests/ngsi/ContextAttribute_test.cpp
+++ b/test/unittests/ngsi/ContextAttribute_test.cpp
@@ -43,17 +43,17 @@ TEST(ContextAttribute, checkOne)
   utInit();
 
   ca.name = "";
-  res     = ca.check(1, RegisterContext);
+  res     = ca.check(V1, RegisterContext);
   EXPECT_TRUE(res == "missing attribute name");
 
   ca.name  = "Algo, lo que sea!";
   ca.stringValue = ""; // FIXME P10: automacit value -> stringValue change, please review to check if it is safe
 
-  res     = ca.check(1, RegisterContext);
+  res     = ca.check(V1, RegisterContext);
   EXPECT_TRUE(res == "OK");
   
   ca.stringValue = "Algun valor cualquiera"; // FIXME P10: automacit value -> stringValue change, please review to check if it is safe
-  res     = ca.check(1, RegisterContext);
+  res     = ca.check(V1, RegisterContext);
   EXPECT_TRUE(res == "OK");
 
   utExit();
@@ -82,7 +82,7 @@ TEST(ContextAttribute, checkVector)
   caVector.push_back(&ca0);
   caVector.push_back(&ca1);
 
-  res     = caVector.check(1, RegisterContext);
+  res     = caVector.check(V1, RegisterContext);
   EXPECT_TRUE(res == "OK");
 
   utExit();
@@ -102,7 +102,7 @@ TEST(ContextAttribute, render)
 
   utInit();
 
-  out = ca.render(1, false, UpdateContext, "");
+  out = ca.render(V1, false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/ngsi/ContextAttribute_test.cpp
+++ b/test/unittests/ngsi/ContextAttribute_test.cpp
@@ -43,17 +43,17 @@ TEST(ContextAttribute, checkOne)
   utInit();
 
   ca.name = "";
-  res     = ca.check("v1", RegisterContext);
+  res     = ca.check(1, RegisterContext);
   EXPECT_TRUE(res == "missing attribute name");
 
   ca.name  = "Algo, lo que sea!";
   ca.stringValue = ""; // FIXME P10: automacit value -> stringValue change, please review to check if it is safe
 
-  res     = ca.check("v1", RegisterContext);
+  res     = ca.check(1, RegisterContext);
   EXPECT_TRUE(res == "OK");
   
   ca.stringValue = "Algun valor cualquiera"; // FIXME P10: automacit value -> stringValue change, please review to check if it is safe
-  res     = ca.check("v1", RegisterContext);
+  res     = ca.check(1, RegisterContext);
   EXPECT_TRUE(res == "OK");
 
   utExit();
@@ -82,7 +82,7 @@ TEST(ContextAttribute, checkVector)
   caVector.push_back(&ca0);
   caVector.push_back(&ca1);
 
-  res     = caVector.check("v1", RegisterContext);
+  res     = caVector.check(1, RegisterContext);
   EXPECT_TRUE(res == "OK");
 
   utExit();
@@ -102,7 +102,7 @@ TEST(ContextAttribute, render)
 
   utInit();
 
-  out = ca.render("v1", false, UpdateContext, "");
+  out = ca.render(1, false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/ngsi/ContextElementResponseVector_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponseVector_test.cpp
@@ -43,7 +43,7 @@ TEST(ContextElementResponseVector, check)
 
   utInit();
 
-  out = cerv.check(1, UpdateContext, "", "", 0);
+  out = cerv.check(V1, UpdateContext, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   cer.contextElement.entityId.id         = "ID";
@@ -52,7 +52,7 @@ TEST(ContextElementResponseVector, check)
   cer.statusCode.fill(SccOk, "details");
 
   cerv.push_back(&cer);
-  out = cerv.check(1, UpdateContext, "", "", 0);
+  out = cerv.check(V1, UpdateContext, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   utExit();
@@ -73,7 +73,7 @@ TEST(ContextElementResponseVector, render)
 
   utInit();
 
-  out = cerv.render(1, false, UpdateContextElement, "");
+  out = cerv.render(V1, false, UpdateContextElement, "");
   EXPECT_STREQ("", out.c_str());
 
   cer.contextElement.entityId.id         = "ID";

--- a/test/unittests/ngsi/ContextElementResponseVector_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponseVector_test.cpp
@@ -43,7 +43,7 @@ TEST(ContextElementResponseVector, check)
 
   utInit();
 
-  out = cerv.check("v1", UpdateContext, "", "", 0);
+  out = cerv.check(1, UpdateContext, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   cer.contextElement.entityId.id         = "ID";
@@ -52,7 +52,7 @@ TEST(ContextElementResponseVector, check)
   cer.statusCode.fill(SccOk, "details");
 
   cerv.push_back(&cer);
-  out = cerv.check("v1", UpdateContext, "", "", 0);
+  out = cerv.check(1, UpdateContext, "", "", 0);
   EXPECT_STREQ("OK", out.c_str());
 
   utExit();
@@ -73,7 +73,7 @@ TEST(ContextElementResponseVector, render)
 
   utInit();
 
-  out = cerv.render("v1", false, UpdateContextElement, "");
+  out = cerv.render(1, false, UpdateContextElement, "");
   EXPECT_STREQ("", out.c_str());
 
   cer.contextElement.entityId.id         = "ID";

--- a/test/unittests/ngsi/ContextElementResponse_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponse_test.cpp
@@ -42,18 +42,18 @@ TEST(ContextElementResponse, check)
    
    utInit();
 
-   out = cer.check(1, UpdateContext, "", "", 0);
+   out = cer.check(V1, UpdateContext, "", "", 0);
    EXPECT_STREQ("empty entityId:id", out.c_str());
 
    cer.contextElement.entityId.id         = "ID";
    cer.contextElement.entityId.type       = "Type";
    cer.contextElement.entityId.isPattern  = "false";
 
-   out = cer.check(1, UpdateContext, "", "", 0);
+   out = cer.check(V1, UpdateContext, "", "", 0);
    EXPECT_STREQ("no code", out.c_str());
 
    cer.statusCode.fill(SccOk, "details");
-   out = cer.check(1, UpdateContext, "", "", 0);
+   out = cer.check(V1, UpdateContext, "", "", 0);
    EXPECT_STREQ("OK", out.c_str());
 
    utExit();
@@ -79,7 +79,7 @@ TEST(ContextElementResponse, render)
 
    cer.statusCode.fill(SccOk, "details");
 
-   out = cer.render(1, false, UpdateContextElement, "");
+   out = cer.render(V1, false, UpdateContextElement, "");
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/ngsi/ContextElementResponse_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponse_test.cpp
@@ -42,18 +42,18 @@ TEST(ContextElementResponse, check)
    
    utInit();
 
-   out = cer.check("v1", UpdateContext, "", "", 0);
+   out = cer.check(1, UpdateContext, "", "", 0);
    EXPECT_STREQ("empty entityId:id", out.c_str());
 
    cer.contextElement.entityId.id         = "ID";
    cer.contextElement.entityId.type       = "Type";
    cer.contextElement.entityId.isPattern  = "false";
 
-   out = cer.check("v1", UpdateContext, "", "", 0);
+   out = cer.check(1, UpdateContext, "", "", 0);
    EXPECT_STREQ("no code", out.c_str());
 
    cer.statusCode.fill(SccOk, "details");
-   out = cer.check("v1", UpdateContext, "", "", 0);
+   out = cer.check(1, UpdateContext, "", "", 0);
    EXPECT_STREQ("OK", out.c_str());
 
    utExit();
@@ -79,7 +79,7 @@ TEST(ContextElementResponse, render)
 
    cer.statusCode.fill(SccOk, "details");
 
-   out = cer.render("v1", false, UpdateContextElement, "");
+   out = cer.render(1, false, UpdateContextElement, "");
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/ngsi/ContextElementVector_test.cpp
+++ b/test/unittests/ngsi/ContextElementVector_test.cpp
@@ -43,13 +43,13 @@ TEST(ContextElementVector, render)
   std::string           rendered;
   ContextElementVector  ceV;
 
-  rendered = ceV.render(1, false, UpdateContextElement, "", false);
+  rendered = ceV.render(V1, false, UpdateContextElement, "", false);
   EXPECT_STREQ("", rendered.c_str());
 
   ceP->entityId = eId;
   ceV.push_back(ceP);
 
-  rendered = ceV.render(1, false, UpdateContextElement, "", false);
+  rendered = ceV.render(V1, false, UpdateContextElement, "", false);
 
   ceV.release();
 }

--- a/test/unittests/ngsi/ContextElementVector_test.cpp
+++ b/test/unittests/ngsi/ContextElementVector_test.cpp
@@ -43,13 +43,13 @@ TEST(ContextElementVector, render)
   std::string           rendered;
   ContextElementVector  ceV;
 
-  rendered = ceV.render("v1", false, UpdateContextElement, "", false);
+  rendered = ceV.render(1, false, UpdateContextElement, "", false);
   EXPECT_STREQ("", rendered.c_str());
 
   ceP->entityId = eId;
   ceV.push_back(ceP);
 
-  rendered = ceV.render("v1", false, UpdateContextElement, "", false);
+  rendered = ceV.render(1, false, UpdateContextElement, "", false);
 
   ceV.release();
 }

--- a/test/unittests/ngsi/ContextElement_test.cpp
+++ b/test/unittests/ngsi/ContextElement_test.cpp
@@ -42,42 +42,42 @@ TEST(ContextElement, check)
   utInit();
 
   ce.entityId.id = "";
-  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "empty entityId:id");
+  EXPECT_EQ(ce.check(V1, UpdateContext, "", "", 0), "empty entityId:id");
 
   ce.entityId.id = "id";
-  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "OK");
+  EXPECT_EQ(ce.check(V1, UpdateContext, "", "", 0), "OK");
 
   ContextAttribute a;
   a.name  = "";
   a.stringValue = "V";
   ce.contextAttributeVector.push_back(&a);
-  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "missing attribute name");
+  EXPECT_EQ(ce.check(V1, UpdateContext, "", "", 0), "missing attribute name");
   a.name = "name";
   
   Metadata m;
   m.name  = "";
   m.stringValue = "V";
   ce.domainMetadataVector.push_back(&m);
-  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "missing metadata name");
+  EXPECT_EQ(ce.check(V1, UpdateContext, "", "", 0), "missing metadata name");
   m.name = "NAME";
-  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "OK");
+  EXPECT_EQ(ce.check(V1, UpdateContext, "", "", 0), "OK");
 
   ContextElement ce2;
   ce2.entityId.id = "id";
 
   ContextElementVector ceVector;
 
-  EXPECT_EQ(ceVector.check(1, UpdateContext, "", "", 0), "No context elements");
+  EXPECT_EQ(ceVector.check(V1, UpdateContext, "", "", 0), "No context elements");
 
   ceVector.push_back(&ce);
   ceVector.push_back(&ce2);
-  EXPECT_EQ(ceVector.check(1, UpdateContext, "", "", 0), "OK");
+  EXPECT_EQ(ceVector.check(V1, UpdateContext, "", "", 0), "OK");
 
   // render
   const char*     outfile1 = "ngsi.contextelement.check.middle.json";
   std::string     out;
 
-  out = ce2.render(1, false, UpdateContextElement, "", false);
+  out = ce2.render(V1, false, UpdateContextElement, "", false);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -86,7 +86,7 @@ TEST(ContextElement, check)
   ce2.present("", 1);
 
   m.name  = "";
-  EXPECT_EQ("missing metadata name", ceVector.check(1, UpdateContext, "", "", 0));
+  EXPECT_EQ("missing metadata name", ceVector.check(V1, UpdateContext, "", "", 0));
 
   utExit();
 }

--- a/test/unittests/ngsi/ContextElement_test.cpp
+++ b/test/unittests/ngsi/ContextElement_test.cpp
@@ -42,42 +42,42 @@ TEST(ContextElement, check)
   utInit();
 
   ce.entityId.id = "";
-  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "empty entityId:id");
+  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "empty entityId:id");
 
   ce.entityId.id = "id";
-  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "OK");
+  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "OK");
 
   ContextAttribute a;
   a.name  = "";
   a.stringValue = "V";
   ce.contextAttributeVector.push_back(&a);
-  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "missing attribute name");
+  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "missing attribute name");
   a.name = "name";
   
   Metadata m;
   m.name  = "";
   m.stringValue = "V";
   ce.domainMetadataVector.push_back(&m);
-  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "missing metadata name");
+  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "missing metadata name");
   m.name = "NAME";
-  EXPECT_EQ(ce.check("v1", UpdateContext, "", "", 0), "OK");
+  EXPECT_EQ(ce.check(1, UpdateContext, "", "", 0), "OK");
 
   ContextElement ce2;
   ce2.entityId.id = "id";
 
   ContextElementVector ceVector;
 
-  EXPECT_EQ(ceVector.check("v1", UpdateContext, "", "", 0), "No context elements");
+  EXPECT_EQ(ceVector.check(1, UpdateContext, "", "", 0), "No context elements");
 
   ceVector.push_back(&ce);
   ceVector.push_back(&ce2);
-  EXPECT_EQ(ceVector.check("v1", UpdateContext, "", "", 0), "OK");
+  EXPECT_EQ(ceVector.check(1, UpdateContext, "", "", 0), "OK");
 
   // render
   const char*     outfile1 = "ngsi.contextelement.check.middle.json";
   std::string     out;
 
-  out = ce2.render("v1", false, UpdateContextElement, "", false);
+  out = ce2.render(1, false, UpdateContextElement, "", false);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 
@@ -86,7 +86,7 @@ TEST(ContextElement, check)
   ce2.present("", 1);
 
   m.name  = "";
-  EXPECT_EQ("missing metadata name", ceVector.check("v1", UpdateContext, "", "", 0));
+  EXPECT_EQ("missing metadata name", ceVector.check(1, UpdateContext, "", "", 0));
 
   utExit();
 }

--- a/test/unittests/ngsi/ContextRegistrationResponseVector_test.cpp
+++ b/test/unittests/ngsi/ContextRegistrationResponseVector_test.cpp
@@ -53,18 +53,18 @@ TEST(ContextRegistrationResponseVector, all)
   crrV.present("");
 
   // check OK
-  rendered = crrV.check(1, RegisterContext, "", "", 0);
+  rendered = crrV.check(V1, RegisterContext, "", "", 0);
   EXPECT_EQ("OK", rendered);
 
   // Now telling the crr that we've found an instance of '<entityIdList></entityIdList>
   // but without any entities inside the vector
   crr.contextRegistration.entityIdVectorPresent = true;
-  rendered = crrV.check(1, RegisterContext, "", "", 0);
+  rendered = crrV.check(V1, RegisterContext, "", "", 0);
   EXPECT_EQ("Empty entityIdVector", rendered);
 
   EntityId             eId;   // Empty ID
 
   crr.contextRegistration.entityIdVector.push_back(&eId);
-  rendered = crrV.check(1, RegisterContext, "", "", 0);
+  rendered = crrV.check(V1, RegisterContext, "", "", 0);
   EXPECT_EQ("empty entityId:id", rendered);
 }

--- a/test/unittests/ngsi/ContextRegistrationResponseVector_test.cpp
+++ b/test/unittests/ngsi/ContextRegistrationResponseVector_test.cpp
@@ -53,18 +53,18 @@ TEST(ContextRegistrationResponseVector, all)
   crrV.present("");
 
   // check OK
-  rendered = crrV.check("v1", RegisterContext, "", "", 0);
+  rendered = crrV.check(1, RegisterContext, "", "", 0);
   EXPECT_EQ("OK", rendered);
 
   // Now telling the crr that we've found an instance of '<entityIdList></entityIdList>
   // but without any entities inside the vector
   crr.contextRegistration.entityIdVectorPresent = true;
-  rendered = crrV.check("v1", RegisterContext, "", "", 0);
+  rendered = crrV.check(1, RegisterContext, "", "", 0);
   EXPECT_EQ("Empty entityIdVector", rendered);
 
   EntityId             eId;   // Empty ID
 
   crr.contextRegistration.entityIdVector.push_back(&eId);
-  rendered = crrV.check("v1", RegisterContext, "", "", 0);
+  rendered = crrV.check(1, RegisterContext, "", "", 0);
   EXPECT_EQ("empty entityId:id", rendered);
 }

--- a/test/unittests/ngsi/ContextRegistrationResponse_test.cpp
+++ b/test/unittests/ngsi/ContextRegistrationResponse_test.cpp
@@ -71,7 +71,7 @@ TEST(ContextRegistrationResponse, check)
 
   utInit();
 
-  checked = crr.check(1, RegisterContext, "", "", 0);
+  checked = crr.check(V1, RegisterContext, "", "", 0);
   EXPECT_STREQ(expected.c_str(), checked.c_str());
 
   utExit();

--- a/test/unittests/ngsi/ContextRegistrationResponse_test.cpp
+++ b/test/unittests/ngsi/ContextRegistrationResponse_test.cpp
@@ -71,7 +71,7 @@ TEST(ContextRegistrationResponse, check)
 
   utInit();
 
-  checked = crr.check("v1", RegisterContext, "", "", 0);
+  checked = crr.check(1, RegisterContext, "", "", 0);
   EXPECT_STREQ(expected.c_str(), checked.c_str());
 
   utExit();

--- a/test/unittests/ngsi/Metadata_test.cpp
+++ b/test/unittests/ngsi/Metadata_test.cpp
@@ -92,13 +92,13 @@ TEST(Metadata, check)
 
   utInit();
 
-  checked = m1.check(1);
+  checked = m1.check(V1);
   EXPECT_STREQ("missing metadata name", checked.c_str());
 
-  checked = m2.check(1);
+  checked = m2.check(V1);
   EXPECT_STREQ("missing metadata value", checked.c_str());
   
-  checked = m3.check(1);
+  checked = m3.check(V1);
   EXPECT_STREQ("OK", checked.c_str());
 
   utExit();

--- a/test/unittests/ngsi/Metadata_test.cpp
+++ b/test/unittests/ngsi/Metadata_test.cpp
@@ -92,13 +92,13 @@ TEST(Metadata, check)
 
   utInit();
 
-  checked = m1.check("v1");
+  checked = m1.check(1);
   EXPECT_STREQ("missing metadata name", checked.c_str());
 
-  checked = m2.check("v1");
+  checked = m2.check(1);
   EXPECT_STREQ("missing metadata value", checked.c_str());
   
-  checked = m3.check("v1");
+  checked = m3.check(1);
   EXPECT_STREQ("OK", checked.c_str());
 
   utExit();

--- a/test/unittests/ngsi10/NotifyContextRequest_test.cpp
+++ b/test/unittests/ngsi10/NotifyContextRequest_test.cpp
@@ -68,7 +68,7 @@ TEST(NotifyContextRequest, json_ok)
   //
   ncrP->present("");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
-  rendered = ncrP->render("v1", false, "");
+  rendered = ncrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   ncrP->release();
@@ -151,7 +151,7 @@ TEST(NotifyContextRequest, json_render)
 
   // 1. Without ContextResponseList
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  rendered = ncrP->render("v1", false, "");
+  rendered = ncrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -162,7 +162,7 @@ TEST(NotifyContextRequest, json_render)
   cerP->statusCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  rendered = ncrP->render("v1", false, "");
+  rendered = ncrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -173,7 +173,7 @@ TEST(NotifyContextRequest, json_render)
   cerP->statusCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  rendered = ncrP->render("v1", false, "");
+  rendered = ncrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   utExit();

--- a/test/unittests/ngsi10/NotifyContextRequest_test.cpp
+++ b/test/unittests/ngsi10/NotifyContextRequest_test.cpp
@@ -68,7 +68,7 @@ TEST(NotifyContextRequest, json_ok)
   //
   ncrP->present("");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
-  rendered = ncrP->render(1, false, "");
+  rendered = ncrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   ncrP->release();
@@ -151,7 +151,7 @@ TEST(NotifyContextRequest, json_render)
 
   // 1. Without ContextResponseList
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  rendered = ncrP->render(1, false, "");
+  rendered = ncrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -162,7 +162,7 @@ TEST(NotifyContextRequest, json_render)
   cerP->statusCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  rendered = ncrP->render(1, false, "");
+  rendered = ncrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
 
@@ -173,7 +173,7 @@ TEST(NotifyContextRequest, json_render)
   cerP->statusCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  rendered = ncrP->render(1, false, "");
+  rendered = ncrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   utExit();

--- a/test/unittests/ngsi10/QueryContextResponse_test.cpp
+++ b/test/unittests/ngsi10/QueryContextResponse_test.cpp
@@ -69,7 +69,7 @@ TEST(QueryContextResponse, json_render)
   qcrP->contextElementResponseVector.push_back(cerP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -78,7 +78,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -89,7 +89,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -99,7 +99,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -110,7 +110,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.attributeDomainName.set("AttrDomain");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -120,7 +120,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -131,7 +131,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename7)) << "Error getting test data from '" << filename7 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -141,7 +141,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename8)) << "Error getting test data from '" << filename8 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -151,7 +151,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename9)) << "Error getting test data from '" << filename9 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -161,7 +161,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename10)) << "Error getting test data from '" << filename10 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   
 
@@ -174,7 +174,7 @@ TEST(QueryContextResponse, json_render)
   qcrP->contextElementResponseVector.push_back(cerP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename11)) << "Error getting test data from '" << filename11 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -184,7 +184,7 @@ TEST(QueryContextResponse, json_render)
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename12)) << "Error getting test data from '" << filename12 << "'";
   qcrP->errorCode.code = SccNone;
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -192,13 +192,13 @@ TEST(QueryContextResponse, json_render)
   qcrP->errorCode.fill(SccBadRequest, "no details");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename13)) << "Error getting test data from '" << filename13 << "'";
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 14. contextElementResponseVector is released and the render method should give an almost empty response
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename14)) << "Error getting test data from '" << filename14 << "'";
   qcrP->contextElementResponseVector.release();
-  out = qcrP->render("v1", false, "");
+  out = qcrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 

--- a/test/unittests/ngsi10/QueryContextResponse_test.cpp
+++ b/test/unittests/ngsi10/QueryContextResponse_test.cpp
@@ -69,7 +69,7 @@ TEST(QueryContextResponse, json_render)
   qcrP->contextElementResponseVector.push_back(cerP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -78,7 +78,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -89,7 +89,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -99,7 +99,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -110,7 +110,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.attributeDomainName.set("AttrDomain");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -120,7 +120,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -131,7 +131,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename7)) << "Error getting test data from '" << filename7 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -141,7 +141,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename8)) << "Error getting test data from '" << filename8 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -151,7 +151,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename9)) << "Error getting test data from '" << filename9 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -161,7 +161,7 @@ TEST(QueryContextResponse, json_render)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename10)) << "Error getting test data from '" << filename10 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   
 
@@ -174,7 +174,7 @@ TEST(QueryContextResponse, json_render)
   qcrP->contextElementResponseVector.push_back(cerP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename11)) << "Error getting test data from '" << filename11 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -184,7 +184,7 @@ TEST(QueryContextResponse, json_render)
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename12)) << "Error getting test data from '" << filename12 << "'";
   qcrP->errorCode.code = SccNone;
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -192,13 +192,13 @@ TEST(QueryContextResponse, json_render)
   qcrP->errorCode.fill(SccBadRequest, "no details");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename13)) << "Error getting test data from '" << filename13 << "'";
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   // 14. contextElementResponseVector is released and the render method should give an almost empty response
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename14)) << "Error getting test data from '" << filename14 << "'";
   qcrP->contextElementResponseVector.release();
-  out = qcrP->render(1, false, "");
+  out = qcrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 

--- a/test/unittests/ngsi10/UpdateContextResponse_test.cpp
+++ b/test/unittests/ngsi10/UpdateContextResponse_test.cpp
@@ -77,7 +77,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->errorCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -85,7 +85,7 @@ TEST(UpdateContextResponse, jsonRender)
   // Test 02. UpdateContextResponse::errorCode NOT OK and contextElementResponseVector filled id (with details)
   ucrP->errorCode.fill(SccBadRequest, "no details");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   ucrP->errorCode.fill(SccOk); // Cleanup
 
@@ -99,7 +99,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->contextElementResponseVector.push_back(cerP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -109,7 +109,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -120,7 +120,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   
@@ -130,7 +130,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   
 
@@ -140,7 +140,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.attributeDomainName.set("AttrDomain");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename7)) << "Error getting test data from '" << filename7 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -150,7 +150,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename8)) << "Error getting test data from '" << filename8 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -161,7 +161,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename9)) << "Error getting test data from '" << filename9 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -171,7 +171,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename10)) << "Error getting test data from '" << filename10 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -181,7 +181,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename11)) << "Error getting test data from '" << filename11 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -191,7 +191,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename12)) << "Error getting test data from '" << filename12 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -204,7 +204,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->contextElementResponseVector.push_back(cerP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename13)) << "Error getting test data from '" << filename13 << "'";
-  out = ucrP->render(1, false, "");
+  out = ucrP->render(V1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/ngsi10/UpdateContextResponse_test.cpp
+++ b/test/unittests/ngsi10/UpdateContextResponse_test.cpp
@@ -77,7 +77,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->errorCode.fill(SccOk);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename1)) << "Error getting test data from '" << filename1 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -85,7 +85,7 @@ TEST(UpdateContextResponse, jsonRender)
   // Test 02. UpdateContextResponse::errorCode NOT OK and contextElementResponseVector filled id (with details)
   ucrP->errorCode.fill(SccBadRequest, "no details");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename2)) << "Error getting test data from '" << filename2 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   ucrP->errorCode.fill(SccOk); // Cleanup
 
@@ -99,7 +99,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->contextElementResponseVector.push_back(cerP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename3)) << "Error getting test data from '" << filename3 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -109,7 +109,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename4)) << "Error getting test data from '" << filename4 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -120,7 +120,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename5)) << "Error getting test data from '" << filename5 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   
@@ -130,7 +130,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename6)) << "Error getting test data from '" << filename6 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
   
 
@@ -140,7 +140,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.attributeDomainName.set("AttrDomain");
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename7)) << "Error getting test data from '" << filename7 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -150,7 +150,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename8)) << "Error getting test data from '" << filename8 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -161,7 +161,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename9)) << "Error getting test data from '" << filename9 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -171,7 +171,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename10)) << "Error getting test data from '" << filename10 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -181,7 +181,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.contextAttributeVector.push_back(caP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename11)) << "Error getting test data from '" << filename11 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -191,7 +191,7 @@ TEST(UpdateContextResponse, jsonRender)
   cerP->contextElement.domainMetadataVector.push_back(mdP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename12)) << "Error getting test data from '" << filename12 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
 
@@ -204,7 +204,7 @@ TEST(UpdateContextResponse, jsonRender)
   ucrP->contextElementResponseVector.push_back(cerP);
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), filename13)) << "Error getting test data from '" << filename13 << "'";
-  out = ucrP->render("v1", false, "");
+  out = ucrP->render(1, false, "");
   EXPECT_STREQ(expectedBuf, out.c_str());
 
   utExit();

--- a/test/unittests/ngsi9/NotifyContextAvailabilityRequest_test.cpp
+++ b/test/unittests/ngsi9/NotifyContextAvailabilityRequest_test.cpp
@@ -83,7 +83,7 @@ TEST(NotifyContextAvailabilityRequest, check)
 
   utInit();
 
-  out = ncr.check("v1", "", "", 0);
+  out = ncr.check(1, "", "", 0);
   EXPECT_EQ("OK", out);
    
   utExit();

--- a/test/unittests/ngsi9/NotifyContextAvailabilityRequest_test.cpp
+++ b/test/unittests/ngsi9/NotifyContextAvailabilityRequest_test.cpp
@@ -83,7 +83,7 @@ TEST(NotifyContextAvailabilityRequest, check)
 
   utInit();
 
-  out = ncr.check(1, "", "", 0);
+  out = ncr.check(V1, "", "", 0);
   EXPECT_EQ("OK", out);
    
   utExit();

--- a/test/unittests/orionTypes/EntityTypeResponse_test.cpp
+++ b/test/unittests/orionTypes/EntityTypeResponse_test.cpp
@@ -58,9 +58,9 @@ TEST(EntityTypeResponse, check)
   etR1.entityType.type = "myType";
   etR2.entityType.type = "";
 
-  EXPECT_EQ("OK", etR1.check(1, false, false, false, ""));
-  EXPECT_NE("OK", etR2.check(1, false, false, false, ""));
-  EXPECT_NE("OK", etR1.check(1, false, false, false, "foo"));
+  EXPECT_EQ("OK", etR1.check(V1, false, false, false, ""));
+  EXPECT_NE("OK", etR2.check(V1, false, false, false, ""));
+  EXPECT_NE("OK", etR1.check(V1, false, false, false, "foo"));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityTypeResponse_test.cpp
+++ b/test/unittests/orionTypes/EntityTypeResponse_test.cpp
@@ -58,9 +58,9 @@ TEST(EntityTypeResponse, check)
   etR1.entityType.type = "myType";
   etR2.entityType.type = "";
 
-  EXPECT_EQ("OK", etR1.check("v1", false, false, false, "", ""));
-  EXPECT_NE("OK", etR2.check("v1", false, false, false, "", ""));
-  EXPECT_NE("OK", etR1.check("v1", false, false, false, "", "foo"));
+  EXPECT_EQ("OK", etR1.check(1, false, false, false, ""));
+  EXPECT_NE("OK", etR2.check(1, false, false, false, ""));
+  EXPECT_NE("OK", etR1.check(1, false, false, false, "foo"));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityTypeVectorResponse_test.cpp
+++ b/test/unittests/orionTypes/EntityTypeVectorResponse_test.cpp
@@ -65,11 +65,11 @@ TEST(EntityTypeVectorResponse, check)
   EntityTypeVectorResponse etRV2;
   etRV2.entityTypeVector.push_back((&et2));
 
-  EXPECT_EQ("OK", etRV1.check("v1", false, false, false, ""));
+  EXPECT_EQ("OK", etRV1.check(1, false, false, false, ""));
 
-  EXPECT_NE("OK", etRV1.check("v1", false, false, false, "foo"));
+  EXPECT_NE("OK", etRV1.check(1, false, false, false, "foo"));
 
-  EXPECT_NE("OK", etRV2.check("v1", false, false, false, ""));
+  EXPECT_NE("OK", etRV2.check(1, false, false, false, ""));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityTypeVectorResponse_test.cpp
+++ b/test/unittests/orionTypes/EntityTypeVectorResponse_test.cpp
@@ -65,11 +65,11 @@ TEST(EntityTypeVectorResponse, check)
   EntityTypeVectorResponse etRV2;
   etRV2.entityTypeVector.push_back((&et2));
 
-  EXPECT_EQ("OK", etRV1.check(1, false, false, false, ""));
+  EXPECT_EQ("OK", etRV1.check(V1, false, false, false, ""));
 
-  EXPECT_NE("OK", etRV1.check(1, false, false, false, "foo"));
+  EXPECT_NE("OK", etRV1.check(V1, false, false, false, "foo"));
 
-  EXPECT_NE("OK", etRV2.check(1, false, false, false, ""));
+  EXPECT_NE("OK", etRV2.check(V1, false, false, false, ""));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityTypeVector_test.cpp
+++ b/test/unittests/orionTypes/EntityTypeVector_test.cpp
@@ -62,11 +62,11 @@ TEST(EntityTypeVector, check)
   EntityTypeVector etV2;
   etV2.push_back(&et2);
 
-  EXPECT_EQ("OK", etV1.check(1, ""));
+  EXPECT_EQ("OK", etV1.check(V1, ""));
 
-  EXPECT_EQ("foo", etV1.check(1, "foo"));
+  EXPECT_EQ("foo", etV1.check(V1, "foo"));
 
-  EXPECT_EQ("Empty Type", etV2.check(1, ""));
+  EXPECT_EQ("Empty Type", etV2.check(V1, ""));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityTypeVector_test.cpp
+++ b/test/unittests/orionTypes/EntityTypeVector_test.cpp
@@ -62,11 +62,11 @@ TEST(EntityTypeVector, check)
   EntityTypeVector etV2;
   etV2.push_back(&et2);
 
-  EXPECT_EQ("OK", etV1.check("v1", ""));
+  EXPECT_EQ("OK", etV1.check(1, ""));
 
-  EXPECT_EQ("foo", etV1.check("v1", "foo"));
+  EXPECT_EQ("foo", etV1.check(1, "foo"));
 
-  EXPECT_EQ("Empty Type", etV2.check("v1", ""));
+  EXPECT_EQ("Empty Type", etV2.check(1, ""));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityType_test.cpp
+++ b/test/unittests/orionTypes/EntityType_test.cpp
@@ -53,9 +53,9 @@ TEST(EntityType, check)
   EntityType et1("myType");
   EntityType et2("");
 
-  EXPECT_EQ("OK", et1.check(1, ""));
-  EXPECT_EQ("Empty Type", et2.check(1, ""));
-  EXPECT_EQ("foo", et1.check(1, "foo"));
+  EXPECT_EQ("OK", et1.check(V1, ""));
+  EXPECT_EQ("Empty Type", et2.check(V1, ""));
+  EXPECT_EQ("foo", et1.check(V1, "foo"));
 
   utExit();
 }

--- a/test/unittests/orionTypes/EntityType_test.cpp
+++ b/test/unittests/orionTypes/EntityType_test.cpp
@@ -53,9 +53,9 @@ TEST(EntityType, check)
   EntityType et1("myType");
   EntityType et2("");
 
-  EXPECT_EQ("OK", et1.check("v1", ""));
-  EXPECT_EQ("Empty Type", et2.check("v1", ""));
-  EXPECT_EQ("foo", et1.check("v1", "foo"));
+  EXPECT_EQ("OK", et1.check(1, ""));
+  EXPECT_EQ("Empty Type", et2.check(1, ""));
+  EXPECT_EQ("foo", et1.check(1, "foo"));
 
   utExit();
 }

--- a/test/unittests/parse/CompoundValueNode_test.cpp
+++ b/test/unittests/parse/CompoundValueNode_test.cpp
@@ -128,7 +128,7 @@ TEST(CompoundValueNode, vectorInvalidAndOk)
   std::string rendered;
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile2)) << "Error getting test data from '" << outFile2 << "'";
-  rendered = tree->render("v1", "");
+  rendered = tree->render(1, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   tree->shortShow("");
@@ -174,7 +174,7 @@ TEST(CompoundValueNode, structInvalidAndOk)
   std::string rendered;
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile2)) << "Error getting test data from '" << outFile2 << "'";
-  rendered = tree->render("v1", "");
+  rendered = tree->render(1, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   tree->shortShow("");

--- a/test/unittests/parse/CompoundValueNode_test.cpp
+++ b/test/unittests/parse/CompoundValueNode_test.cpp
@@ -128,7 +128,7 @@ TEST(CompoundValueNode, vectorInvalidAndOk)
   std::string rendered;
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile2)) << "Error getting test data from '" << outFile2 << "'";
-  rendered = tree->render(1, "");
+  rendered = tree->render(V1, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   tree->shortShow("");
@@ -174,7 +174,7 @@ TEST(CompoundValueNode, structInvalidAndOk)
   std::string rendered;
   
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile2)) << "Error getting test data from '" << outFile2 << "'";
-  rendered = tree->render(1, "");
+  rendered = tree->render(V1, "");
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   tree->shortShow("");

--- a/test/unittests/parse/compoundValue_test.cpp
+++ b/test/unittests/parse/compoundValue_test.cpp
@@ -409,7 +409,7 @@ TEST(compoundValue, updateTwoStructsJson)
   EXPECT_TRUE(caP->compoundValueP != NULL);
 
   ci.outMimeType = JSON;
-  rendered = caP->render("v1", false, UpdateContext, "");
+  rendered = caP->render(1, false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), renderedFile)) << "Error getting test data from '" << renderedFile << "'";
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
@@ -557,7 +557,7 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_TRUE(caP->compoundValueP != NULL);
 
   ci.outMimeType = JSON;
-  rendered = caP->render("v1", false, UpdateContext, "");
+  rendered = caP->render(1, false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), renderedFile)) << "Error getting test data from '" << renderedFile << "'";
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
@@ -964,7 +964,7 @@ TEST(compoundValue, tenCompounds)
   utInit();
 
   upcrP = &reqData.upcr.res;
-  rendered = upcrP->render("v1", false, "");
+  rendered = upcrP->render(1, false, "");
 
   utExit();
 }

--- a/test/unittests/parse/compoundValue_test.cpp
+++ b/test/unittests/parse/compoundValue_test.cpp
@@ -409,7 +409,7 @@ TEST(compoundValue, updateTwoStructsJson)
   EXPECT_TRUE(caP->compoundValueP != NULL);
 
   ci.outMimeType = JSON;
-  rendered = caP->render(1, false, UpdateContext, "");
+  rendered = caP->render(V1, false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), renderedFile)) << "Error getting test data from '" << renderedFile << "'";
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
@@ -557,7 +557,7 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_TRUE(caP->compoundValueP != NULL);
 
   ci.outMimeType = JSON;
-  rendered = caP->render(1, false, UpdateContext, "");
+  rendered = caP->render(V1, false, UpdateContext, "");
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), renderedFile)) << "Error getting test data from '" << renderedFile << "'";
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
@@ -964,7 +964,7 @@ TEST(compoundValue, tenCompounds)
   utInit();
 
   upcrP = &reqData.upcr.res;
-  rendered = upcrP->render(1, false, "");
+  rendered = upcrP->render(V1, false, "");
 
   utExit();
 }

--- a/test/unittests/rest/rest_test.cpp
+++ b/test/unittests/rest/rest_test.cpp
@@ -93,7 +93,7 @@ TEST(rest, servicePathSplit)
   // 1. OK - as no Service Path has been received ...
   LM_M(("---- 1 -----"));
   ci1.servicePath = "";
-  ci1.apiVersion = "v1";
+  ci1.apiVersion = 1;
   r = servicePathSplit(&ci1);
   EXPECT_EQ(0, r);
   LM_M(("---- 1 -----"));
@@ -103,7 +103,7 @@ TEST(rest, servicePathSplit)
   ci2.httpHeaders.servicePathReceived = true;
   LM_M(("---- 2 -----"));
   ci2.servicePath = "/h1/_h2/h3/_h4/h5/_h6/h7/_h8/h9/_h10h10h10";
-  ci2.apiVersion = "v1";
+  ci2.apiVersion = 1;
   r = servicePathSplit(&ci2);
   EXPECT_EQ(0, r);
   LM_M(("---- 2 -----"));
@@ -112,7 +112,7 @@ TEST(rest, servicePathSplit)
   LM_M(("---- 3 -----"));
   ci3.httpHeaders.servicePathReceived = true;
   ci3.servicePath = "/h1/_h2/h3/_h4/h5/_h6/h7/_h8/h9/_h10h10h10, /1/2/3";
-  ci3.apiVersion = "v1";
+  ci3.apiVersion = 1;
   r = servicePathSplit(&ci3);
   EXPECT_EQ(0, r);
   EXPECT_STREQ("", ci3.answer.c_str());
@@ -122,7 +122,7 @@ TEST(rest, servicePathSplit)
   LM_M(("---- 4 -----"));
   ci4.httpHeaders.servicePathReceived = true;
   ci4.servicePath = "/home/kz/01, /home/kz/02, /home/kz/03, /home/kz/04, /home/kz/05, /home/kz/06, /home/kz/07, /home/kz/08, /home/kz/09";
-  ci4.apiVersion = "v1";
+  ci4.apiVersion = 1;
   r = servicePathSplit(&ci4);
   EXPECT_EQ(0, r);
   EXPECT_STREQ("", ci4.answer.c_str());
@@ -132,7 +132,7 @@ TEST(rest, servicePathSplit)
   LM_M(("---- 5 -----"));
   ci5.httpHeaders.servicePathReceived = true;
   ci5.servicePath = "/home/kz/01, /home/kz/02, /home/kz/03, /home/kz/04, /home/kz/05, /home/kz/06, /home/kz/07, /home/kz/08, /home/kz/09, /home/kz/10, /home/kz/11";
-  ci5.apiVersion = "v1";
+  ci5.apiVersion = 1;
   r = servicePathSplit(&ci5);
   EXPECT_EQ(-1, r);
   EXPECT_EQ(168, ci5.answer.size());

--- a/test/unittests/rest/rest_test.cpp
+++ b/test/unittests/rest/rest_test.cpp
@@ -93,7 +93,7 @@ TEST(rest, servicePathSplit)
   // 1. OK - as no Service Path has been received ...
   LM_M(("---- 1 -----"));
   ci1.servicePath = "";
-  ci1.apiVersion = 1;
+  ci1.apiVersion = V1;
   r = servicePathSplit(&ci1);
   EXPECT_EQ(0, r);
   LM_M(("---- 1 -----"));
@@ -103,7 +103,7 @@ TEST(rest, servicePathSplit)
   ci2.httpHeaders.servicePathReceived = true;
   LM_M(("---- 2 -----"));
   ci2.servicePath = "/h1/_h2/h3/_h4/h5/_h6/h7/_h8/h9/_h10h10h10";
-  ci2.apiVersion = 1;
+  ci2.apiVersion = V1;
   r = servicePathSplit(&ci2);
   EXPECT_EQ(0, r);
   LM_M(("---- 2 -----"));
@@ -112,7 +112,7 @@ TEST(rest, servicePathSplit)
   LM_M(("---- 3 -----"));
   ci3.httpHeaders.servicePathReceived = true;
   ci3.servicePath = "/h1/_h2/h3/_h4/h5/_h6/h7/_h8/h9/_h10h10h10, /1/2/3";
-  ci3.apiVersion = 1;
+  ci3.apiVersion = V1;
   r = servicePathSplit(&ci3);
   EXPECT_EQ(0, r);
   EXPECT_STREQ("", ci3.answer.c_str());
@@ -122,7 +122,7 @@ TEST(rest, servicePathSplit)
   LM_M(("---- 4 -----"));
   ci4.httpHeaders.servicePathReceived = true;
   ci4.servicePath = "/home/kz/01, /home/kz/02, /home/kz/03, /home/kz/04, /home/kz/05, /home/kz/06, /home/kz/07, /home/kz/08, /home/kz/09";
-  ci4.apiVersion = 1;
+  ci4.apiVersion = V1;
   r = servicePathSplit(&ci4);
   EXPECT_EQ(0, r);
   EXPECT_STREQ("", ci4.answer.c_str());
@@ -132,7 +132,7 @@ TEST(rest, servicePathSplit)
   LM_M(("---- 5 -----"));
   ci5.httpHeaders.servicePathReceived = true;
   ci5.servicePath = "/home/kz/01, /home/kz/02, /home/kz/03, /home/kz/04, /home/kz/05, /home/kz/06, /home/kz/07, /home/kz/08, /home/kz/09, /home/kz/10, /home/kz/11";
-  ci5.apiVersion = 1;
+  ci5.apiVersion = V1;
   r = servicePathSplit(&ci5);
   EXPECT_EQ(-1, r);
   EXPECT_EQ(168, ci5.answer.size());

--- a/test/unittests/serviceRoutines/badVerbAllFour_test.cpp
+++ b/test/unittests/serviceRoutines/badVerbAllFour_test.cpp
@@ -51,20 +51,18 @@ static RestService rs[] =
 TEST(badVerbAllFour, error)
 {
   ConnectionInfo ci1("/ngsi10/contextEntities/123",  "PUST", "1.1");
-  ConnectionInfo ci2("/ngsi10/contextEntities",      "PUST", "1.1");
-  ConnectionInfo ci3("/ngsi10/",                     "PUST", "1.1");
-  ConnectionInfo ci4("/ngsi10/1/2/3/4",              "PUST", "1.1");
+  ConnectionInfo ci2("/ngsi10/contextEntities",      "PUST", "1.1");  
   std::string    out;
 
   utInit();
 
-  ci1.apiVersion = 1;
+  ci1.apiVersion = V1;
   out = restService(&ci1, rs);
   EXPECT_EQ("", out);
   EXPECT_EQ("Allow", ci1.httpHeader[0]);
   EXPECT_EQ("POST, GET, PUT, DELETE", ci1.httpHeaderValue[0]);
 
-  ci2.apiVersion = 1;
+  ci2.apiVersion = V1;
   out = restService(&ci2, rs);
   EXPECT_EQ("", out);
   EXPECT_EQ("Allow", ci2.httpHeader[0]);

--- a/test/unittests/serviceRoutines/badVerbAllFour_test.cpp
+++ b/test/unittests/serviceRoutines/badVerbAllFour_test.cpp
@@ -58,13 +58,13 @@ TEST(badVerbAllFour, error)
 
   utInit();
 
-  ci1.apiVersion = "v1";
+  ci1.apiVersion = 1;
   out = restService(&ci1, rs);
   EXPECT_EQ("", out);
   EXPECT_EQ("Allow", ci1.httpHeader[0]);
   EXPECT_EQ("POST, GET, PUT, DELETE", ci1.httpHeaderValue[0]);
 
-  ci2.apiVersion = "v1";
+  ci2.apiVersion = 1;
   out = restService(&ci2, rs);
   EXPECT_EQ("", out);
   EXPECT_EQ("Allow", ci2.httpHeader[0]);

--- a/test/unittests/serviceRoutines/exitTreat_test.cpp
+++ b/test/unittests/serviceRoutines/exitTreat_test.cpp
@@ -63,7 +63,7 @@ TEST(exitTreat, error)
   utInit();
 
   harakiri = true;
-  ci1.apiVersion = "v1";
+  ci1.apiVersion = 1;
 
   out = restService(&ci1, rs);
   EXPECT_STREQ("DIE", out.c_str());

--- a/test/unittests/serviceRoutines/exitTreat_test.cpp
+++ b/test/unittests/serviceRoutines/exitTreat_test.cpp
@@ -63,7 +63,7 @@ TEST(exitTreat, error)
   utInit();
 
   harakiri = true;
-  ci1.apiVersion = 1;
+  ci1.apiVersion = V1;
 
   out = restService(&ci1, rs);
   EXPECT_STREQ("DIE", out.c_str());


### PR DESCRIPTION
Apart from the apiVersion from std::string to int refactor, some other minor things has been included (e.g. removing old FIXME PR leftover code, remove unneded parameters in some functions, simplyfing arguments with asJsonObject, etc).