### PR TITLE
Feature/1960 last success and status failed

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -7,4 +7,4 @@
 - Fix: PATCH attr wrongly adding metadata item instead of replacing (#1788)
 - Add: support ISO8601 timezones at DateTime attributes and metadata creation/update time and filters (#2632)
 - Add: support for partial representation format at DateTime attributes and metadata creation/update and filters (#2631)
-- Add: notification failure information included in subscriptions (#1960)
+- Add: notification failure/recovery information included in subscriptions (#1960)

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -1759,8 +1759,6 @@ A `notification` object contains the following subfields:
 + `timesSent` (not editable, only present in GET operations): Number of notifications sent due to
    this subscription.
 + `lastNotification` (not editable, only present in GET operations): Last notification timestamp in ISO8601 format.
-+ `timesFailed` (not editable, only present in GET operations): Number of consecutive errors.
-  Not present if subscription is notifying correctly.
 + `lastFailure` (not editable, only present in GET operations): Last failure timestamp in ISO8601 format.
   Not present if subscription has never has a problem with notifications.
 
@@ -1847,7 +1845,6 @@ Response:
               "attrs": ["temperature", "humidity"],
               "timesSent": 12,
               "lastNotification": "2015-10-05T16:00:00.00Z",
-              "timesFailed": 4
               "lastFailure": "2015-10-06T16:00:00.00Z"
             },
             "expires": "2016-04-05T14:00:00.00Z",

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -1761,6 +1761,7 @@ A `notification` object contains the following subfields:
 + `lastNotification` (not editable, only present in GET operations): Last notification timestamp in ISO8601 format.
 + `lastFailure` (not editable, only present in GET operations): Last failure timestamp in ISO8601 format.
   Not present if subscription has never has a problem with notifications.
++ `lastSuccess` (not editable, only present in GET operations): Timestamp in ISO8601 format for last successful notification.
 
 An `http` object contains the following subfields:
 
@@ -1942,6 +1943,7 @@ Response:
             "attrs": ["temperature", "humidity"],
             "timesSent": 12,
             "lastNotification": "2015-10-05T16:00:00.00Z"
+            "lastSuccess": "2015-10-05T16:00:00.00Z"
           },
           "expires": "2016-04-05T14:00:00.00Z",
           "status": "active",

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -1760,8 +1760,9 @@ A `notification` object contains the following subfields:
    this subscription.
 + `lastNotification` (not editable, only present in GET operations): Last notification timestamp in ISO8601 format.
 + `lastFailure` (not editable, only present in GET operations): Last failure timestamp in ISO8601 format.
-  Not present if subscription has never has a problem with notifications.
+  Not present if subscription has never had a problem with notifications.
 + `lastSuccess` (not editable, only present in GET operations): Timestamp in ISO8601 format for last successful notification.
+  Not present if subscription has never had a successful notification.
 
 An `http` object contains the following subfields:
 

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -277,8 +277,7 @@ Fields:
     guide](../user/duration.md)). For permanent subscriptions (allowed in NGSIv2)
     an absurdly high value is used (see PERMANENT_SUBS_DATETIME in the source code).
 -   **lastNotification**: the time when last notification was sent. This
-    is updated each time a notification is sent, to avoid
-    violating throttling.
+    is updated each time a notification is sent, to avoid violating throttling.
 -   **throttling**: minimum interval between notifications. 0 or -1 means no throttling.
 -   **reference**: the URL for notifications
 -   **entities**: an array of entities (mandatory). The JSON for each
@@ -309,8 +308,8 @@ Fields:
 -   **payload**: optional field to store the payload for notification customization functionality in NGSIv2.
 -   **lastFailure**: the time when last notification failure occurred.
     Not present if the subscription has never failed.
--   **timesFailed**: number of consecutive notification errors for the subscription.
-    Not present if the subscription has never failed.
+-   **lastSuccess**: the time when last successful notification occurred.
+    Not present if the subscription has never provoked a notification.
 
 Example document:
 

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -309,7 +309,7 @@ Fields:
 -   **lastFailure**: the time when last notification failure occurred.
     Not present if the subscription has never failed.
 -   **lastSuccess**: the time when last successful notification occurred.
-    Not present if the subscription has never provoked a notification.
+    Not present if the subscription has never provoked a successful notification.
 
 Example document:
 

--- a/src/lib/apiTypesV2/Subscription.cpp
+++ b/src/lib/apiTypesV2/Subscription.cpp
@@ -67,15 +67,26 @@ namespace ngsiv2
     JsonHelper jh;
 
     jh.addString("id", this->id);
+
     if (this->description != "")
     {
       jh.addString("description", this->description);
     }
+
     if (this->expires != PERMANENT_SUBS_DATETIME)
     {
       jh.addDate("expires", this->expires);
     }
-    jh.addString("status", this->status);
+
+    if ((this->notification.lastFailure > 0) && (this->notification.lastFailure > this->notification.lastSuccess))
+    {
+      jh.addString("status", "failed");
+    }
+    else
+    {
+      jh.addString("status", this->status);
+    }
+
     jh.addRaw("subject", this->subject.toJson());
     jh.addRaw("notification", this->notification.toJson(renderFormatToString(this->attrsFormat, true, true)));
 
@@ -140,9 +151,9 @@ namespace ngsiv2
       jh.addDate("lastFailure", this->lastFailure);
     }
 
-    if (this->timesFailed != 0)
+    if (this->lastSuccess > 0)
     {
-      jh.addNumber("timesFailed", this->timesFailed);
+      jh.addDate("lastSuccess", this->lastSuccess);
     }
 
     return jh.str();

--- a/src/lib/apiTypesV2/Subscription.h
+++ b/src/lib/apiTypesV2/Subscription.h
@@ -53,6 +53,7 @@ struct EntID
     type(typeA),
     typePattern(typePatternA)
   {}
+
   EntID()
   {}
 
@@ -60,7 +61,7 @@ struct EntID
 
 inline bool operator==(const EntID& lhs, const EntID& rhs)
 {
-  return (lhs.id == rhs.id) && (lhs.idPattern == rhs.idPattern)
+  return (lhs.id   == rhs.id)   && (lhs.idPattern   == rhs.idPattern)
       && (lhs.type == rhs.type) && (lhs.typePattern == rhs.typePattern);
 }
 
@@ -76,7 +77,7 @@ struct Notification
   HttpInfo                 httpInfo;
   std::string              toJson(const std::string& attrsFormat);
   int                      lastFailure;
-  int                      timesFailed;
+  int                      lastSuccess;
   Notification():
     attributes(),
     blacklist(false),
@@ -84,7 +85,7 @@ struct Notification
     lastNotification(-1),
     httpInfo(),
     lastFailure(-1),
-    timesFailed(0)
+    lastSuccess(-1)
   {}
 };
 

--- a/src/lib/cache/subCache.cpp
+++ b/src/lib/cache/subCache.cpp
@@ -1337,15 +1337,17 @@ void subCacheItemNotificationErrorStatus(const std::string& tenant, const std::s
 {
   if (noCache)
   {
+    // The field 'count' has already been taken care of. Set to 0 in the calls to mongoSubCountersUpdate()
+
     time_t now = time(NULL);
 
     if (errors == 0)
     {
-      mongoSubCountersUpdate(tenant, subscriptionId, 1, now, -1, now);  // lastFailure == -1
+      mongoSubCountersUpdate(tenant, subscriptionId, 0, now, -1, now);  // lastFailure == -1
     }
     else
     {
-      mongoSubCountersUpdate(tenant, subscriptionId, 1, now, now, -1);  // lastSuccess == -1
+      mongoSubCountersUpdate(tenant, subscriptionId, 0, now, now, -1);  // lastSuccess == -1, count == 0
     }
 
     return;

--- a/src/lib/cache/subCache.cpp
+++ b/src/lib/cache/subCache.cpp
@@ -754,6 +754,8 @@ void subCacheItemInsert
   RenderFormat                       renderFormat,
   bool                               notificationDone,
   int64_t                            lastNotificationTime,
+  int64_t                            lastNotificationSuccessTime,
+  int64_t                            lastNotificationFailureTime,
   StringFilter*                      stringFilterP,
   StringFilter*                      mdStringFilterP,
   const std::string&                 status,
@@ -781,8 +783,8 @@ void subCacheItemInsert
   cSubP->expirationTime        = expirationTime;
   cSubP->throttling            = throttling;
   cSubP->lastNotificationTime  = lastNotificationTime;
-  cSubP->lastFailure           = -1;
-  cSubP->timesFailed           = 0;
+  cSubP->lastFailure           = lastNotificationFailureTime;
+  cSubP->lastSuccess           = lastNotificationSuccessTime;
   cSubP->renderFormat          = renderFormat;
   cSubP->next                  = NULL;
   cSubP->count                 = (notificationDone == true)? 1 : 0;
@@ -1121,7 +1123,7 @@ typedef struct CachedSubSaved
   int64_t  lastNotificationTime;
   int64_t  count;
   int64_t  lastFailure;
-  int64_t  timesFailed;
+  int64_t  lastSuccess;
 } CachedSubSaved;
 
 
@@ -1130,15 +1132,15 @@ typedef struct CachedSubSaved
 *
 * subCacheSync -
 *
-* 1. Save subscriptionId, lastNotificationTime, count, lastFailure, and timesFailed for all items in cache (savedSubV)
+* 1. Save subscriptionId, lastNotificationTime, count, lastFailure, and lastSuccess for all items in cache (savedSubV)
 * 2. Refresh cache (count set to 0)
-* 3. Compare lastNotificationTime/lastFailure in savedSubV with the new cache-contents and:
+* 3. Compare lastNotificationTime/lastFailure/lastSuccess in savedSubV with the new cache-contents and:
 *    3.1 Update cache-items where 'saved lastNotificationTime' > 'cached lastNotificationTime'
 *    3.2 Remember this more correct lastNotificationTime (must be flushed to mongo) -
 *        by clearing out (set to 0) those lastNotificationTimes that are newer in cache
-*    Same same with lastFailure
-* 4. Update 'count/timesFailed' for each item in savedSubV where non-zero
-* 5. Update 'lastNotificationTime/lastFailure' foreach item in savedSubV where non-zero
+*    Same same with lastFailure and lastSuccess.
+* 4. Update 'count' for each item in savedSubV where non-zero
+* 5. Update 'lastNotificationTime/lastFailure/lastSuccess' for each item in savedSubV where non-zero
 * 6. Free the vector created in step 1 - savedSubV
 *
 * NOTE
@@ -1151,7 +1153,7 @@ typedef struct CachedSubSaved
 *   To fix this little problem, we have created a variable 'subCacheState' that is set to ScsSynchronizing while
 *   the sub-cache synchronization is working.
 *   In serviceRoutines/exitTreat.cpp this variable is checked and if iot is set to ScsSynchronizing, then a
-*   sleep for a few seconds is performed beofre the broker exits (this is only for DEBUG compilations).
+*   sleep for a few seconds is performed before the broker exits (this is only for DEBUG compilations).
 */
 void subCacheSync(void)
 {
@@ -1162,7 +1164,7 @@ void subCacheSync(void)
 
 
   //
-  // 1. Save subscriptionId, lastNotificationTime, count, lastFailure, and timesFailed for all items in cache
+  // 1. Save subscriptionId, lastNotificationTime, count, lastFailure, and lastSuccess for all items in cache
   //
   CachedSubscription* cSubP = subCache.head;
 
@@ -1183,7 +1185,7 @@ void subCacheSync(void)
     cssP->lastNotificationTime = cSubP->lastNotificationTime;
     cssP->count                = cSubP->count;
     cssP->lastFailure          = cSubP->lastFailure;
-    cssP->timesFailed          = cSubP->timesFailed;
+    cssP->lastSuccess          = cSubP->lastSuccess;
 
     savedSubV[cSubP->subscriptionId] = cssP;
     cSubP = cSubP->next;
@@ -1199,7 +1201,7 @@ void subCacheSync(void)
 
 
   //
-  // 3. Compare lastNotificationTime/lastFailure in savedSubV with the new cache-contents
+  // 3. Compare lastNotificationTime/lastFailure/lastSuccess in savedSubV with the new cache-contents
   //
   cSubP = subCache.head;
   while (cSubP != NULL)
@@ -1219,6 +1221,12 @@ void subCacheSync(void)
         // cssP->lastFailure is older than what's currently in DB => throw away
         cssP->lastFailure = 0;
       }
+
+      if (cssP->lastSuccess < cSubP->lastSuccess)
+      {
+        // cssP->lastSuccess is older than what's currently in DB => throw away
+        cssP->lastSuccess = 0;
+      }
     }
 
     cSubP = cSubP->next;
@@ -1226,8 +1234,8 @@ void subCacheSync(void)
 
 
   //
-  // 4. Update 'count/timesFailed' for each item in savedSubV where non-zero
-  // 5. Update 'lastNotificationTime/lastFailure' for each item in savedSubV where non-zero
+  // 4. Update 'count' for each item in savedSubV where non-zero
+  // 5. Update 'lastNotificationTime/lastFailure/lastSuccess' for each item in savedSubV where non-zero
   //
   cSubP = subCache.head;
   while (cSubP != NULL)
@@ -1238,13 +1246,16 @@ void subCacheSync(void)
     {
       std::string tenant = (cSubP->tenant == NULL)? "" : cSubP->tenant;
 
-      mongoSubCountersUpdate(tenant, cSubP->subscriptionId, cssP->count, cssP->lastNotificationTime, cssP->lastFailure, cssP->timesFailed);
+      mongoSubCountersUpdate(tenant,
+                             cSubP->subscriptionId,
+                             cssP->count,
+                             cssP->lastNotificationTime,
+                             cssP->lastFailure,
+                             cssP->lastSuccess);
 
-      // Keeping lastFailure in sub cache
+      // Keeping lastFailure and lastSuccess in sub cache
       cSubP->lastFailure = cssP->lastFailure;
-
-      // Setting timesFailed to zero, as DB already incremented
-      cSubP->timesFailed = 0;
+      cSubP->lastSuccess = cssP->lastSuccess;
     }
 
     cSubP = cSubP->next;
@@ -1326,7 +1337,17 @@ void subCacheItemNotificationErrorStatus(const std::string& tenant, const std::s
 {
   if (noCache)
   {
-    mongoSubCountersUpdate(tenant, subscriptionId, 0, 0, time(NULL), errors);
+    time_t now = time(NULL);
+
+    if (errors == 0)
+    {
+      mongoSubCountersUpdate(tenant, subscriptionId, 1, now, -1, now);  // lastFailure == -1
+    }
+    else
+    {
+      mongoSubCountersUpdate(tenant, subscriptionId, 1, now, now, -1);  // lastSuccess == -1
+    }
+
     return;
   }
 
@@ -1340,14 +1361,14 @@ void subCacheItemNotificationErrorStatus(const std::string& tenant, const std::s
     return;
   }
 
+  time_t now = time(NULL);
+
   if (errors == 0)
   {
-    subP->lastFailure  = -1;
-    subP->timesFailed  = 0;
+    subP->lastSuccess  = now;
   }
   else
   {
-    subP->lastFailure  = time(NULL);
-    subP->timesFailed += errors;
+    subP->lastFailure  = now;
   }
 }

--- a/src/lib/cache/subCache.h
+++ b/src/lib/cache/subCache.h
@@ -110,8 +110,8 @@ struct CachedSubscription
   SubscriptionExpression      expression;
   bool                        blacklist;
   ngsiv2::HttpInfo            httpInfo;
-  int64_t                     lastFailure;  // timestamp of last failure, -1 if sub is working
-  int64_t                     timesFailed;  // number of consecutive errors, 0 if sub is working
+  int64_t                     lastFailure;  // timestamp of last notification failure
+  int64_t                     lastSuccess;  // timestamp of last successful notification
   struct CachedSubscription*  next;
 };
 
@@ -212,6 +212,8 @@ extern void subCacheItemInsert
   RenderFormat                       renderFormat,
   bool                               notificationDone,
   int64_t                            lastNotificationTime,
+  int64_t                            lastNotificationSuccessTime,
+  int64_t                            lastNotificationFailureTime,
   StringFilter*                      stringFilterP,
   StringFilter*                      mdStringFilterP,
   const std::string&                 status,
@@ -333,6 +335,11 @@ extern void subCacheStatisticsReset(const char* by);
 *
 * subCacheItemNotificationErrorStatus - 
 */
-extern void subCacheItemNotificationErrorStatus(const std::string& tenant, const std::string& subscriptionId, int errors);
+extern void subCacheItemNotificationErrorStatus
+(
+  const std::string&  tenant,
+  const std::string&  subscriptionId,
+  int                 errors
+);
 
 #endif  // SRC_LIB_CACHE_SUBCACHE_H_

--- a/src/lib/mongoBackend/MongoCommonSubscription.cpp
+++ b/src/lib/mongoBackend/MongoCommonSubscription.cpp
@@ -298,7 +298,7 @@ void setCondsAndInitialNotify
   // the original subscription has to be taken; the caller deal with that)
 
   /* Conds vector (and maybe an initial notification) */
-  *notificationDone    = false;
+  *notificationDone = false;
 
   BSONArray  conds = processConditionVector(sub.subject.condition.attributes,
                                             sub.subject.entities,

--- a/src/lib/mongoBackend/MongoCommonSubscription.cpp
+++ b/src/lib/mongoBackend/MongoCommonSubscription.cpp
@@ -298,7 +298,7 @@ void setCondsAndInitialNotify
   // the original subscription has to be taken; the caller deal with that)
 
   /* Conds vector (and maybe an initial notification) */
-  *notificationDone = false;
+  *notificationDone    = false;
 
   BSONArray  conds = processConditionVector(sub.subject.condition.attributes,
                                             sub.subject.entities,
@@ -362,12 +362,12 @@ void setLastFailure(long long lastFailure, BSONObjBuilder* b)
 
 /* ****************************************************************************
 *
-* setTimesFailed -
+* setLastSuccess -
 */
-void setTimesFailed(long long timesFailed, BSONObjBuilder* b)
+void setLastSuccess(long long lastSuccess, BSONObjBuilder* b)
 {
-  b->append(CSUB_TIMESFAILED, timesFailed);
-  LM_T(LmtMongo, ("Subscription timesFailed: %lu", timesFailed));
+  b->append(CSUB_LASTSUCCESS, lastSuccess);
+  LM_T(LmtMongo, ("Subscription lastSuccess: %lu", lastSuccess));
 }
 
 

--- a/src/lib/mongoBackend/MongoCommonSubscription.h
+++ b/src/lib/mongoBackend/MongoCommonSubscription.h
@@ -167,9 +167,9 @@ extern void setLastFailure(long long lastFailure, BSONObjBuilder* b);
 
 /* ****************************************************************************
 *
-* setTimesFailed -
+* setLastSuccess -
 */
-extern void setTimesFailed(long long timesFailed, BSONObjBuilder* b);
+extern void setLastSuccess(long long lastSuccess, BSONObjBuilder* b);
 
 
 

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1961,7 +1961,7 @@ static bool processOnChangeConditionForSubscription
   rawCerV.release();
 
 #if 0
-  // FIXME #920: disabled by the moment, maybe removed at the end
+  // FIXME #920: disabled for the moment, maybe to be removed in the end
   /* Append notification metadata */
   if (metadataFlags)
   {

--- a/src/lib/mongoBackend/dbConstants.h
+++ b/src/lib/mongoBackend/dbConstants.h
@@ -101,7 +101,7 @@
 #define CSUB_PAYLOAD               "payload"
 #define CSUB_BLACKLIST             "blacklist"
 #define CSUB_LASTFAILURE           "lastFailure"
-#define CSUB_TIMESFAILED           "timesFailed"
+#define CSUB_LASTSUCCESS           "lastSuccess"
 
 #define CASUB_EXPIRATION        "expiration"
 #define CASUB_REFERENCE         "reference"

--- a/src/lib/mongoBackend/mongoCreateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoCreateSubscription.cpp
@@ -56,7 +56,9 @@ static void insertInCache
   const std::string&   tenant,
   const std::string&   servicePath,
   bool                 notificationDone,
-  long long            lastNotification
+  long long            lastNotification,
+  long long            lastFailure,
+  long long            lastSuccess
 )
 {
   // Insert in csub cache
@@ -97,6 +99,8 @@ static void insertInCache
                      sub.attrsFormat,
                      notificationDone,
                      lastNotification,
+                     lastFailure,
+                     lastSuccess,
                      stringFilterP,
                      mdStringFilterP,
                      sub.status,
@@ -138,6 +142,8 @@ std::string mongoCreateSubscription
   std::string    servicePath = servicePathV[0] == "" ? DEFAULT_SERVICE_PATH_QUERIES : servicePathV[0];
   bool           notificationDone = false;
   long long      lastNotification = 0;
+  long long      lastFailure      = 0;
+  long long      lastSuccess      = 0;
 
   const std::string subId = setNewSubscriptionId(&b);
   setExpiration(sub, &b);
@@ -178,7 +184,7 @@ std::string mongoCreateSubscription
 
   if (!noCache)
   {
-    insertInCache(sub, subId, tenant, servicePath, false, lastNotification);
+    insertInCache(sub, subId, tenant, servicePath, false, lastNotification, lastFailure, lastSuccess);
   }
 
   reqSemGive(__FUNCTION__, "ngsiv2 create subscription request", reqSemTaken);

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -147,7 +147,7 @@ static void setNotification(Subscription* subP, const BSONObj& r, const std::str
   subP->notification.timesSent        = r.hasField(CSUB_COUNT)?            getIntOrLongFieldAsLongF(r, CSUB_COUNT)            : -1;
   subP->notification.blacklist        = r.hasField(CSUB_BLACKLIST)?        getBoolFieldF(r, CSUB_BLACKLIST)                   : false;
   subP->notification.lastFailure      = r.hasField(CSUB_LASTFAILURE)?      getIntOrLongFieldAsLongF(r, CSUB_LASTFAILURE)      : -1;
-  subP->notification.timesFailed      = r.hasField(CSUB_TIMESFAILED)?      getIntOrLongFieldAsLongF(r, CSUB_TIMESFAILED)      : 0;
+  subP->notification.lastSuccess      = r.hasField(CSUB_LASTSUCCESS)?      getIntOrLongFieldAsLongF(r, CSUB_LASTSUCCESS)      : -1;
 
   // Attributes format
   subP->attrsFormat = r.hasField(CSUB_FORMAT)? stringToRenderFormat(getStringFieldF(r, CSUB_FORMAT)) : NGSI_V1_LEGACY;
@@ -185,9 +185,9 @@ static void setNotification(Subscription* subP, const BSONObj& r, const std::str
       subP->notification.lastFailure = cSubP->lastFailure;
     }
 
-    if (cSubP->timesFailed > 0)
+    if (cSubP->lastSuccess > subP->notification.lastSuccess)
     {
-      subP->notification.timesFailed += cSubP->timesFailed;
+      subP->notification.lastSuccess = cSubP->lastSuccess;
     }
   }
   cacheSemGive(__FUNCTION__, "get lastNotification and count");

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -593,12 +593,6 @@ static void mongoSubCountersUpdateLastSuccess
 *
 * mongoSubCountersUpdate - update subscription counters and timestamps in mongo
 *
-* FIXME P4:
-*   This function the way it is implemented right now might perform FIVE consecutive
-*   updates in mongo.
-*   There must be some faster way to do this:
-*     1. Read first, update only what's necessary OR
-*     2. Do a 'mega update' with all five fields (have the functions concatenate to final mongo 'query')
 */
 void mongoSubCountersUpdate
 (

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -110,7 +110,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
   cSubP->status                = sub.hasField(CSUB_STATUS)?           getStringFieldF(sub, CSUB_STATUS).c_str()            : "active";
   cSubP->blacklist             = sub.hasField(CSUB_BLACKLIST)?        getBoolFieldF(sub, CSUB_BLACKLIST)                   : false;
   cSubP->lastFailure           = sub.hasField(CSUB_LASTFAILURE)?      getIntOrLongFieldAsLongF(sub, CSUB_LASTFAILURE)      : -1;
-  cSubP->timesFailed           = sub.hasField(CSUB_TIMESFAILED)?      getIntOrLongFieldAsLongF(sub, CSUB_TIMESFAILED)      : 0;
+  cSubP->lastSuccess           = sub.hasField(CSUB_LASTSUCCESS)?      getIntOrLongFieldAsLongF(sub, CSUB_LASTSUCCESS)      : -1;
   cSubP->count                 = 0;
   cSubP->next                  = NULL;
 
@@ -244,7 +244,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
 *  -4: Subscription not valid for sub-cache (no entity ids)
 *
 *
-* Note that the 'count' and 'timesFailed' of the inserted subscription is set to ZERO.
+* Note that the 'count' of the inserted subscription is set to ZERO.
 * This is because the sub cache only counts the increments in these accumulating counters,
 * so that other CBs, operating on the same DB will not overwrite the value of these accumulators
 */
@@ -256,6 +256,7 @@ int mongoSubCacheItemInsert
   const char*         servicePath,
   int                 lastNotificationTime,
   int                 lastFailure,
+  int                 lastSuccess,
   long long           expirationTime,
   const std::string&  status,
   const std::string&  q,
@@ -480,7 +481,124 @@ void mongoSubCacheRefresh(const std::string& database)
 
 /* ****************************************************************************
 *
-* mongoSubCountersUpdate - update subscription in mongo with count and lastNotificationTime
+* mongoSubCountersUpdateCount - 
+*/
+static void mongoSubCountersUpdateCount
+(
+  const std::string&  collection,
+  const std::string&  subId,
+  long long           count
+)
+{
+  BSONObj      condition;
+  BSONObj      update;
+  std::string  err;
+
+  condition = BSON("_id"  << OID(subId));
+  update    = BSON("$inc" << BSON(CSUB_COUNT << count));
+
+  if (collectionUpdate(collection, condition, update, false, &err) != true)
+  {
+    LM_E(("Internal Error (error updating 'count' for a subscription)"));
+  }
+}
+
+
+
+/* ****************************************************************************
+*
+* mongoSubCountersUpdateLastNotificationTime - 
+*/
+static void mongoSubCountersUpdateLastNotificationTime
+(
+  const std::string&  collection,
+  const std::string&  subId,
+  long long           lastNotificationTime
+)
+{
+  BSONObj      condition;
+  BSONObj      update;
+  std::string  err;
+
+  condition = BSON("_id" << OID(subId) << "$or" << BSON_ARRAY(
+                     BSON(CSUB_LASTNOTIFICATION << BSON("$lt" << lastNotificationTime)) <<
+                     BSON(CSUB_LASTNOTIFICATION << BSON("$exists" << false))));
+  update    = BSON("$set" << BSON(CSUB_LASTNOTIFICATION << lastNotificationTime));
+
+  if (collectionUpdate(collection, condition, update, false, &err) != true)
+  {
+    LM_E(("Internal Error (error updating 'lastNotification' for a subscription)"));
+  }
+}
+
+
+
+/* ****************************************************************************
+*
+* mongoSubCountersUpdateLastFailure - 
+*/
+static void mongoSubCountersUpdateLastFailure
+(
+  const std::string&  collection,
+  const std::string&  subId,
+  long long           lastFailure
+)
+{
+  BSONObj      condition;
+  BSONObj      update;
+  std::string  err;
+
+  condition = BSON("_id" << OID(subId) << "$or" << BSON_ARRAY(
+                     BSON(CSUB_LASTFAILURE << BSON("$lt" << lastFailure)) <<
+                     BSON(CSUB_LASTFAILURE << BSON("$exists" << false))));
+  update    = BSON("$set" << BSON(CSUB_LASTFAILURE << lastFailure));
+
+  if (collectionUpdate(collection, condition, update, false, &err) != true)
+  {
+    LM_E(("Internal Error (error updating 'lastFailure' for a subscription)"));
+  }
+}
+
+
+
+/* ****************************************************************************
+*
+* mongoSubCountersUpdateLastSuccess - 
+*/
+static void mongoSubCountersUpdateLastSuccess
+(
+  const std::string&  collection,
+  const std::string&  subId,
+  long long           lastSuccess
+)
+{
+  BSONObj      condition;
+  BSONObj      update;
+  std::string  err;
+
+  condition = BSON("_id" << OID(subId) << "$or" << BSON_ARRAY(
+                     BSON(CSUB_LASTSUCCESS << BSON("$lt" << lastSuccess)) <<
+                     BSON(CSUB_LASTSUCCESS << BSON("$exists" << false))));
+  update    = BSON("$set" << BSON(CSUB_LASTSUCCESS << lastSuccess));
+
+  if (collectionUpdate(collection, condition, update, false, &err) != true)
+  {
+    LM_E(("Internal Error (error updating 'lastSuccess' for a subscription)"));
+  }
+}
+
+
+
+/* ****************************************************************************
+*
+* mongoSubCountersUpdate - update subscription counters and timestamps in mongo
+*
+* FIXME P4:
+*   This function the way it is implemented right now might perform FIVE consecutive
+*   updates in mongo.
+*   There must be some faster way to do this:
+*     1. Read first, update only what's necessary OR
+*     2. Do a 'mega update' with all five fields (have the functions concatenate to final mongo 'query')
 */
 void mongoSubCountersUpdate
 (
@@ -489,79 +607,28 @@ void mongoSubCountersUpdate
   long long          count,
   long long          lastNotificationTime,
   long long          lastFailure,
-  long long          timesFailed
+  long long          lastSuccess
 )
 {
-  std::string  collection  = getSubscribeContextCollectionName(tenant);
-  BSONObj      condition;
-  BSONObj      update;
-  std::string  err;
+  std::string  collection = getSubscribeContextCollectionName(tenant);
 
   if (count > 0)
   {
-    // Update count
-    condition = BSON("_id"  << OID(subId));
-    update    = BSON("$inc" << BSON(CSUB_COUNT << count));
-
-    if (collectionUpdate(collection, condition, update, false, &err) != true)
-    {
-      LM_E(("Internal Error (error updating 'count' for a subscription)"));
-    }
+    mongoSubCountersUpdateCount(collection, subId, count);
   }
-
 
   if (lastNotificationTime > 0)
   {
-    // Update lastNotificationTime    
-    condition = BSON("_id" << OID(subId) << "$or" << BSON_ARRAY(
-                       BSON(CSUB_LASTNOTIFICATION << BSON("$lt" << lastNotificationTime)) <<
-                       BSON(CSUB_LASTNOTIFICATION << BSON("$exists" << false)))
-                    );
-    update    = BSON("$set" << BSON(CSUB_LASTNOTIFICATION << lastNotificationTime));
-
-    if (collectionUpdate(collection, condition, update, false, &err) != true)
-    {
-      LM_E(("Internal Error (error updating 'lastNotification' for a subscription)"));
-    }
+    mongoSubCountersUpdateLastNotificationTime(collection, subId, lastNotificationTime);
   }
 
-
-  if (lastFailure > 0)
+  if (lastFailure > lastSuccess)
   {
-    // Update lastFailure    
-    condition = BSON("_id" << OID(subId) << "$or" << BSON_ARRAY(
-                       BSON(CSUB_LASTFAILURE << BSON("$lt" << lastFailure)) <<
-                       BSON(CSUB_LASTFAILURE << BSON("$exists" << false)))
-                    );
-    update    = BSON("$set" << BSON(CSUB_LASTFAILURE << lastFailure));
-
-    if (collectionUpdate(collection, condition, update, false, &err) != true)
-    {
-      LM_E(("Internal Error (error updating 'lastFailure' for a subscription)"));
-    }
-  }
-  else
-  {
-    // Set lastFailure to -1
-    condition = BSON("_id" << OID(subId));
-    update    = BSON("$set" << BSON(CSUB_LASTFAILURE << (long long) -1));
-
-    if (collectionUpdate(collection, condition, update, false, &err) != true)
-    {
-      LM_E(("Internal Error (error updating 'lastFailure' for a subscription)"));
-    }
+    mongoSubCountersUpdateLastFailure(collection, subId, lastFailure);
   }
 
-
-  if (timesFailed > 0)
+  if (lastSuccess > lastFailure)
   {
-    // Update timesFailed
-    condition = BSON("_id"  << OID(subId));
-    update    = BSON("$inc" << BSON(CSUB_TIMESFAILED << timesFailed));
-
-    if (collectionUpdate(collection, condition, update, false, &err) != true)
-    {
-      LM_E(("Internal Error (error updating 'timesFailed' for a subscription)"));
-    }
+    mongoSubCountersUpdateLastSuccess(collection, subId, lastSuccess);
   }
 }

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -622,12 +622,12 @@ void mongoSubCountersUpdate
     mongoSubCountersUpdateLastNotificationTime(collection, subId, lastNotificationTime);
   }
 
-  if (lastFailure > lastSuccess)
+  if (lastFailure > 0)
   {
     mongoSubCountersUpdateLastFailure(collection, subId, lastFailure);
   }
 
-  if (lastSuccess > lastFailure)
+  if (lastSuccess > 0)
   {
     mongoSubCountersUpdateLastSuccess(collection, subId, lastSuccess);
   }

--- a/src/lib/mongoBackend/mongoSubCache.h
+++ b/src/lib/mongoBackend/mongoSubCache.h
@@ -57,6 +57,7 @@ extern int mongoSubCacheItemInsert
   const char*         servicePath,
   int                 lastNotificationTime,
   int                 lastFailure,
+  int                 lastSuccess,
   long long           expirationTime,
   const std::string&  status,
   const std::string&  q,
@@ -90,7 +91,7 @@ extern void mongoSubCountersUpdate
   long long           count,
   long long           lastNotificationTime,
   long long           lastFailure,
-  long long           timesFailed
+  long long           lastSuccess
 );
 
 #endif  // SRC_LIB_MONGOBACKEND_MONGOSUBCACHE_H_

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -464,22 +464,18 @@ static void setLastNotification(const BSONObj& subOrig, CachedSubscription* subC
 */
 static long long setLastFailure(const BSONObj& subOrig, CachedSubscription* subCacheP, BSONObjBuilder* b)
 {
-  if (subCacheP == NULL)
-  {
-    return -1;
-  }
-
   long long lastFailure = getIntOrLongFieldAsLongF(subOrig, CSUB_LASTFAILURE);
 
   //
   // Compare with 'lastFailure' from the sub-cache.
   // If the cached value of lastFailure is higher, then use it.
   //
-  if (subCacheP->lastFailure > lastFailure)
+  if ((subCacheP != NULL) && (subCacheP->lastFailure > lastFailure))
   {
     lastFailure = subCacheP->lastFailure;
-    setLastFailure(lastFailure, b);
   }
+
+  setLastFailure(lastFailure, b);
 
   return lastFailure;
 }
@@ -492,22 +488,18 @@ static long long setLastFailure(const BSONObj& subOrig, CachedSubscription* subC
 */
 static long long setLastSuccess(const BSONObj& subOrig, CachedSubscription* subCacheP, BSONObjBuilder* b)
 {
-  if (subCacheP == NULL)
-  {
-    return -1;
-  }
-
   long long lastSuccess = getIntOrLongFieldAsLongF(subOrig, CSUB_LASTSUCCESS);
 
   //
   // Compare with 'lastSuccess' from the sub-cache.
   // If the cached value of lastSuccess is higher, then use it.
   //
-  if (subCacheP->lastSuccess > lastSuccess)
+  if ((subCacheP != NULL) && (subCacheP->lastSuccess > lastSuccess))
   {
     lastSuccess = subCacheP->lastSuccess;
-    setLastSuccess(lastSuccess, b);
   }
+
+  setLastSuccess(lastSuccess, b);
 
   return lastSuccess;
 }

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -430,6 +430,13 @@ static void setCount(long long inc, const BSONObj& subOrig, BSONObjBuilder* b)
 /* ****************************************************************************
 *
 * setLastNotification -
+*
+* NOTE
+*   Unlike setLastFailure() and setLastSucces(), this function doesn't return any value.
+*   This is due to the fact that lastNotification is added to before sending the notification
+*   while the other two (lastSuccess/lastFailure) need to wait until after - to know the status
+*   of the notification and the resulting values are stored in the sub-cache only,
+*   to be added to mongo when a sub cache refresh is performed.
 */
 static void setLastNotification(const BSONObj& subOrig, CachedSubscription* subCacheP, BSONObjBuilder* b)
 {

--- a/src/lib/ngsiNotify/ContextSubscriptionInfo.h
+++ b/src/lib/ngsiNotify/ContextSubscriptionInfo.h
@@ -25,21 +25,27 @@
 *
 * Author: Fermin Galan
 */
-
 #include "common/MimeType.h"
 #include "ngsi/EntityIdVector.h"
 #include "ngsi/AttributeList.h"
 
-typedef struct ContextSubscriptionInfo {
-    EntityIdVector         entityIdVector;
-    AttributeList          attributeList;
-    std::string            url;
-    MimeType               mimeType;
-    int                    lastNotification;
-    long long              expiration;
-    long long              throttling;
 
-    void         release(void);
+
+/* ****************************************************************************
+*
+* ContextSubscriptionInfo - 
+*/
+typedef struct ContextSubscriptionInfo
+{
+  EntityIdVector  entityIdVector;
+  AttributeList   attributeList;
+  std::string     url;
+  MimeType        mimeType;
+  int             lastNotification;
+  long long       expiration;
+  long long       throttling;
+
+  void            release(void);
 } ContextSubscriptionInfo;
 
 #endif

--- a/src/lib/ngsiNotify/Notifier.cpp
+++ b/src/lib/ngsiNotify/Notifier.cpp
@@ -75,11 +75,10 @@ void Notifier::sendNotifyContextRequest
     bool                             blackList
 )
 {
-
   pthread_t                         tid;
-  std::vector<SenderThreadParams*>  *paramsV = Notifier::buildSenderParams(ncrP, httpInfo, tenant, xauthToken, fiwareCorrelator, renderFormat, attrsOrder, metadataFilter, blackList);
+  std::vector<SenderThreadParams*>* paramsV = Notifier::buildSenderParams(ncrP, httpInfo, tenant, xauthToken, fiwareCorrelator, renderFormat, attrsOrder, metadataFilter, blackList);
 
-  if (!paramsV->empty()) // al least one param, an empty vector means an error happened
+  if (!paramsV->empty()) // al least one param, an empty vector means an error occurred
   {
     int ret = pthread_create(&tid, NULL, startSenderThread, paramsV);
     if (ret != 0)

--- a/src/lib/ngsiNotify/QueueNotifier.cpp
+++ b/src/lib/ngsiNotify/QueueNotifier.cpp
@@ -62,29 +62,39 @@ int QueueNotifier::start()
 */
 void QueueNotifier::sendNotifyContextRequest
 (
-    NotifyContextRequest*            ncr,
-    const ngsiv2::HttpInfo&          httpInfo,
-    const std::string&               tenant,
-    const std::string&               xauthToken,
-    const std::string&               fiwareCorrelator,
-    RenderFormat                     renderFormat,
-    const std::vector<std::string>&  attrsOrder,
-    const std::vector<std::string>&  metadataFilter,
-    bool                             blacklist
+  NotifyContextRequest*            ncr,
+  const ngsiv2::HttpInfo&          httpInfo,
+  const std::string&               tenant,
+  const std::string&               xauthToken,
+  const std::string&               fiwareCorrelator,
+  RenderFormat                     renderFormat,
+  const std::vector<std::string>&  attrsOrder,
+  const std::vector<std::string>&  metadataFilter,
+  bool                             blacklist
 )
 {
-  std::vector<SenderThreadParams*> *paramsV = Notifier::buildSenderParams(ncr, httpInfo, tenant, xauthToken, fiwareCorrelator, renderFormat, attrsOrder, metadataFilter, blacklist);
+  std::vector<SenderThreadParams*>* paramsV = Notifier::buildSenderParams(ncr,
+                                                                          httpInfo,
+                                                                          tenant,
+                                                                          xauthToken,
+                                                                          fiwareCorrelator,
+                                                                          renderFormat,
+                                                                          attrsOrder,
+                                                                          metadataFilter,
+                                                                          blacklist);
 
-  for (unsigned ix = 0; ix < paramsV->size(); ix++) {
+  for (unsigned ix = 0; ix < paramsV->size(); ix++)
+  {
     clock_gettime(CLOCK_REALTIME, &(((*paramsV)[ix])->timeStamp));
   }
+
   bool enqueued = queue.try_push(paramsV);
   if (!enqueued)
   {
     QueueStatistics::incReject(paramsV->size());
-
     LM_E(("Runtime Error (notification queue is full)"));
-    for (unsigned ix = 0; ix < paramsV->size(); ix++) {
+    for (unsigned ix = 0; ix < paramsV->size(); ix++)
+    {
       delete (*paramsV)[ix];
     }
     delete paramsV;
@@ -93,5 +103,4 @@ void QueueNotifier::sendNotifyContextRequest
   }
 
   QueueStatistics::incIn(paramsV->size());
-
 }

--- a/src/lib/ngsiNotify/QueueWorkers.cpp
+++ b/src/lib/ngsiNotify/QueueWorkers.cpp
@@ -88,7 +88,8 @@ static void* workerFunc(void* pSyncQ)
   {
     std::vector<SenderThreadParams*>* paramsV = queue->pop();
 
-    for (unsigned ix = 0; ix < paramsV->size(); ix++) {
+    for (unsigned ix = 0; ix < paramsV->size(); ix++)
+    {
       struct timespec     now;
       struct timespec     howlong;
       size_t              estimatedQSize;
@@ -154,6 +155,7 @@ static void* workerFunc(void* pSyncQ)
           statisticsUpdate(NotifyContextSent, params->mimeType);
           QueueStatistics::incSentOK();
           alarmMgr.notificationErrorReset(url);
+          subCacheItemNotificationErrorStatus(params->tenant, params->subscriptionId, 0);
         }
         else
         {

--- a/src/lib/ngsiNotify/senderThread.cpp
+++ b/src/lib/ngsiNotify/senderThread.cpp
@@ -88,6 +88,7 @@ void* startSenderThread(void* p)
       {
         statisticsUpdate(NotifyContextSent, params->mimeType);
         alarmMgr.notificationErrorReset(url);
+        subCacheItemNotificationErrorStatus(params->tenant, params->subscriptionId, 0);
       }
       else
       {

--- a/test/functionalTest/cases/1048_subscription_cache/csub_update_with_notif.test
+++ b/test/functionalTest/cases/1048_subscription_cache/csub_update_with_notif.test
@@ -194,7 +194,7 @@ Date: REGEX(.*)
 03. Check subscription timesSent value (1)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 330
+Content-Length: 370
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -209,6 +209,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 1
     },
     "status": "active",
@@ -249,7 +250,7 @@ Date: REGEX(.*)
 06. Check subscription timesSent value (2)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 330
+Content-Length: 370
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -264,6 +265,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 2
     },
     "status": "active",
@@ -304,7 +306,7 @@ Date: REGEX(.*)
 09. Check subscription timesSent value (3)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 330
+Content-Length: 370
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -319,6 +321,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 3
     },
     "status": "active",

--- a/test/functionalTest/cases/1126_GET_v2_subscriptions/GET_v2_all_subscriptions.test
+++ b/test/functionalTest/cases/1126_GET_v2_subscriptions/GET_v2_all_subscriptions.test
@@ -256,7 +256,7 @@ Date: REGEX(.*)
 04. GET /v2/subscriptions (now seeing the timesSent and lastNotification in one sub)
 ====================================================================================
 HTTP/1.1 200 OK
-Content-Length: 822
+Content-Length: 806
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -311,10 +311,9 @@ Date: REGEX(.*)
             },
             "lastFailure": "REGEX(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.00Z)",
             "lastNotification": "REGEX(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.00Z)",
-            "timesFailed": 1,
             "timesSent": 1
         },
-        "status": "active",
+        "status": "failed",
         "subject": {
             "condition": {
                 "attrs": [

--- a/test/functionalTest/cases/1156_mq_as_uri_param_for_metadata/mq_as_uri_param_for_metadata.test
+++ b/test/functionalTest/cases/1156_mq_as_uri_param_for_metadata/mq_as_uri_param_for_metadata.test
@@ -401,7 +401,7 @@ Date: REGEX(.*)
 05b. GET subscription to see 'mq' correctly rendered
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 352
+Content-Length: 392
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -416,6 +416,7 @@ Date: REGEX(.*)
             "url": "http://localhost:REGEX(\d+)/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 1
     },
     "status": "active",

--- a/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_existence_subs.test
+++ b/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_existence_subs.test
@@ -633,7 +633,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 16. Check sub counts in order to see sub1, sub4 and sub6 has been triggered twice
 =================================================================================
 HTTP/1.1 200 OK
-Content-Length: 347
+Content-Length: 387
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -648,6 +648,7 @@ Date: REGEX(.*)
             "url": "http://localhost:REGEX(\d+)/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 2
     },
     "status": "active",
@@ -668,7 +669,7 @@ Date: REGEX(.*)
 
 
 HTTP/1.1 200 OK
-Content-Length: 349
+Content-Length: 389
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -683,6 +684,7 @@ Date: REGEX(.*)
             "url": "http://localhost:REGEX(\d+)/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 2
     },
     "status": "active",
@@ -703,7 +705,7 @@ Date: REGEX(.*)
 
 
 HTTP/1.1 200 OK
-Content-Length: 348
+Content-Length: 388
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -718,6 +720,7 @@ Date: REGEX(.*)
             "url": "http://localhost:REGEX(\d+)/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 2
     },
     "status": "active",

--- a/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_notif_cache.test
+++ b/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_notif_cache.test
@@ -252,7 +252,7 @@ Date: REGEX(.*)
 06. Check subscription timesSent value (1)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 330
+Content-Length: 370
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -267,6 +267,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 1
     },
     "status": "active",

--- a/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_notif_cache.test
+++ b/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_notif_cache.test
@@ -308,7 +308,7 @@ Date: REGEX(.*)
 09. Check subscription timesSent value (1)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 332
+Content-Length: 372
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -323,6 +323,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 1
     },
     "status": "inactive",

--- a/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_notif_nocache.test
+++ b/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_notif_nocache.test
@@ -306,7 +306,7 @@ Date: REGEX(.*)
 09. Check subscription timesSent value (1)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 332
+Content-Length: 372
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -321,6 +321,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 1
     },
     "status": "inactive",

--- a/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_notif_nocache.test
+++ b/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_notif_nocache.test
@@ -250,7 +250,7 @@ Date: REGEX(.*)
 06. Check subscription timesSent value (1)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 330
+Content-Length: 370
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -265,6 +265,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 1
     },
     "status": "active",

--- a/test/functionalTest/cases/1853_typePattern_3a/subcache_typepattern.test
+++ b/test/functionalTest/cases/1853_typePattern_3a/subcache_typepattern.test
@@ -151,7 +151,7 @@ Date: REGEX(.*)
 03. Check subscription timesSent value (1)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 339
+Content-Length: 379
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -166,6 +166,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 1
     },
     "status": "active",

--- a/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications.test
+++ b/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications.test
@@ -260,7 +260,7 @@ Date: REGEX(.*)
 05. GET subscription, see NO error stats in notification field
 ==============================================================
 HTTP/1.1 200 OK
-Content-Length: 275
+Content-Length: 315
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -275,6 +275,7 @@ Date: REGEX(.*)
                 "url": "http://localhost:REGEX(\d+)/notify"
             },
             "lastNotification": "REGEX(.*)",
+            "lastSuccess": "REGEX(.*)",
             "timesSent": 2
         },
         "status": "active",
@@ -304,7 +305,7 @@ Date: REGEX(.*)
 07. GET subscription, see NO error stats in notification field
 ==============================================================
 HTTP/1.1 200 OK
-Content-Length: 275
+Content-Length: 315
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -319,6 +320,7 @@ Date: REGEX(.*)
                 "url": "http://localhost:REGEX(\d+)/notify"
             },
             "lastNotification": "REGEX(.*)",
+            "lastSuccess": "REGEX(.*)",
             "timesSent": 3
         },
         "status": "active",
@@ -435,5 +437,5 @@ Date: REGEX(.*)
 
 --TEARDOWN--
 brokerStop CB
-dbDrop CB
 accumulatorStop
+#dbDrop CB

--- a/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications.test
+++ b/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications.test
@@ -260,7 +260,7 @@ Date: REGEX(.*)
 05. GET subscription, see NO error stats in notification field
 ==============================================================
 HTTP/1.1 200 OK
-Content-Length: 315
+Content-Length: 355
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -274,6 +274,7 @@ Date: REGEX(.*)
             "http": {
                 "url": "http://localhost:REGEX(\d+)/notify"
             },
+            "lastFailure": "REGEX(.*)",
             "lastNotification": "REGEX(.*)",
             "lastSuccess": "REGEX(.*)",
             "timesSent": 2
@@ -305,7 +306,7 @@ Date: REGEX(.*)
 07. GET subscription, see NO error stats in notification field
 ==============================================================
 HTTP/1.1 200 OK
-Content-Length: 315
+Content-Length: 355
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -319,6 +320,7 @@ Date: REGEX(.*)
             "http": {
                 "url": "http://localhost:REGEX(\d+)/notify"
             },
+            "lastFailure": "REGEX(.*)",
             "lastNotification": "REGEX(.*)",
             "lastSuccess": "REGEX(.*)",
             "timesSent": 3
@@ -402,7 +404,7 @@ Date: REGEX(.*)
 10. GET subscription, see error stats in notification field
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 312
+Content-Length: 352
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -418,6 +420,7 @@ Date: REGEX(.*)
             },
             "lastFailure": "REGEX(.*)",
             "lastNotification": "REGEX(.*)",
+            "lastSuccess": "REGEX(.*)",
             "timesSent": 4
         },
         "status": "failed",

--- a/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications.test
+++ b/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications.test
@@ -31,7 +31,6 @@ accumulatorStart --pretty-print
 --SHELL--
 
 #
-#
 # 01. Create entity E1
 # 02. Create sub (with invalid url), matching E1
 # 03. GET subscription, see error stats in notification field
@@ -41,9 +40,7 @@ accumulatorStart --pretty-print
 # 07. GET subscription, see NO error stats in notification field
 # 08. Dump accelerator, see 2 notification
 # 09. Update sub (with invalid url)
-# 10. GET subscription, see a 1 in timesFailed
-# 11. Update E1, to provoke notification that doesn't work
-# 12. GET subscription, see a 2 in timesFailed
+# 10. GET subscription, see error stats in notification field
 #
 
 echo "01. Create entity E1"
@@ -85,7 +82,7 @@ echo
 
 
 # Sleep > 3 seconds to get a cache refresh
-sleep 3.1
+sleep 3.5
 
 
 echo "03. GET subscription, see error stats in notification field"
@@ -121,7 +118,7 @@ echo
 
 
 # Await sub-cache contents to be dumped into database
-sleep 3.1
+sleep 3.5
 
 
 echo "05. GET subscription, see NO error stats in notification field"
@@ -142,7 +139,7 @@ echo
 
 
 # Await sub-cache contents to be dumped into database
-sleep 3.1
+sleep 3.5
 
 
 echo "07. GET subscription, see NO error stats in notification field"
@@ -185,30 +182,10 @@ echo
 
 
 # Await sub-cache contents to be dumped into database
-sleep 3.1
+sleep 3.5
 
-echo "10. GET subscription, see a 1 in timesFailed"
-echo "============================================"
-orionCurl --url /v2/subscriptions
-echo
-echo
-
-
-echo "11. Update E1, to provoke notification that doesn't work"
-echo "========================================================"
-payload='{
-  "A1": 11
-}'
-orionCurl --url /v2/entities/E1/attrs?options=keyValues --payload "$payload"
-echo
-echo
-
-
-# Sleep a little to let previous step terminate
-sleep 0.5
-
-echo "12. GET subscription, see a 2 in timesFailed"
-echo "============================================"
+echo "10. GET subscription, see error stats in notification field"
+echo "==========================================================="
 orionCurl --url /v2/subscriptions
 echo
 echo
@@ -238,7 +215,7 @@ Date: REGEX(.*)
 03. GET subscription, see error stats in notification field
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 328
+Content-Length: 312
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -254,10 +231,9 @@ Date: REGEX(.*)
             },
             "lastFailure": "REGEX(.*)",
             "lastNotification": "REGEX(.*)",
-            "timesFailed": 1,
             "timesSent": 1
         },
-        "status": "active",
+        "status": "failed",
         "subject": {
             "condition": {
                 "attrs": []
@@ -421,10 +397,10 @@ Date: REGEX(.*)
 
 
 
-10. GET subscription, see a 1 in timesFailed
-============================================
+10. GET subscription, see error stats in notification field
+===========================================================
 HTTP/1.1 200 OK
-Content-Length: 328
+Content-Length: 312
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -440,56 +416,9 @@ Date: REGEX(.*)
             },
             "lastFailure": "REGEX(.*)",
             "lastNotification": "REGEX(.*)",
-            "timesFailed": 1,
             "timesSent": 4
         },
-        "status": "active",
-        "subject": {
-            "condition": {
-                "attrs": []
-            },
-            "entities": [
-                {
-                    "id": "E1"
-                }
-            ]
-        }
-    }
-]
-
-
-11. Update E1, to provoke notification that doesn't work
-========================================================
-HTTP/1.1 204 No Content
-Content-Length: 0
-Fiware-Correlator: REGEX([0-9a-f\-]{36})
-Date: REGEX(.*)
-
-
-
-12. GET subscription, see a 2 in timesFailed
-============================================
-HTTP/1.1 200 OK
-Content-Length: 328
-Content-Type: application/json
-Fiware-Correlator: REGEX([0-9a-f\-]{36})
-Date: REGEX(.*)
-
-[
-    {
-        "id": "REGEX([0-9a-f]{24})",
-        "notification": {
-            "attrs": [],
-            "attrsFormat": "normalized",
-            "http": {
-                "url": "http://nohost:REGEX(\d+)/notify"
-            },
-            "lastFailure": "REGEX(.*)",
-            "lastNotification": "REGEX(.*)",
-            "timesFailed": 2,
-            "timesSent": 5
-        },
-        "status": "active",
+        "status": "failed",
         "subject": {
             "condition": {
                 "attrs": []

--- a/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications.test
+++ b/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications.test
@@ -438,4 +438,4 @@ Date: REGEX(.*)
 --TEARDOWN--
 brokerStop CB
 accumulatorStop
-#dbDrop CB
+dbDrop CB

--- a/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications_stop_start_accumulator.test
+++ b/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications_stop_start_accumulator.test
@@ -1,0 +1,313 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+failure stats in db and notifications
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0 IPv4 -subCacheIval 3
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity E1
+# 02. Create sub (with valid url), matching E1
+#     Sleep 3.5 seconds to get a sub-cache-refresh
+# 03. GET subscription, see lastSuccess but not lastFailure and status==active
+# 04. Stop accumulator
+# 05. Update E1, to provoke notification that now fails
+#     Sleep 3.5 seconds to get a sub-cache-refresh
+# 06. GET subscription, see lastFailure GT lastSuccess and status==failed
+# 07. Start accumulator again
+# 08. Update E1, to provoke notification that now works
+#     Sleep 3.5 seconds to get a sub-cache-refresh
+# 09. GET subscription, see lastSuccess GT lastFailure and status==active
+#
+
+echo "01. Create entity E1"
+echo "===================="
+payload='{
+  "id": "E1",
+  "type": "T1",
+  "A1": 1
+}'
+orionCurl --url '/v2/entities?options=keyValues' --payload "$payload"
+echo
+echo
+
+
+echo "02. Create sub (with valid url), matching E1"
+echo "============================================"
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E1"
+      }
+    ],
+    "condition": {
+      "attrs": []
+    }
+  },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    },
+    "attrs": [ ]
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+subId=$(echo "$_responseHeaders" | grep Location | awk -F/ '{ print $4 }' | tr -d "\r\n")
+echo
+echo
+
+
+# Sleep > 3 seconds to get a cache refresh
+sleep 3.5
+
+
+echo "03. GET subscription, see lastSuccess but not lastFailure and status==active"
+echo "============================================================================"
+orionCurl --url /v2/subscriptions
+echo
+echo
+
+
+echo "04. Stop accumulator"
+echo "===================="
+accumulatorStop
+echo
+echo
+
+
+echo "05. Update E1, to provoke notification that now fails"
+echo "====================================================="
+payload='{
+  "A1": 6
+}'
+orionCurl --url /v2/entities/E1/attrs?options=keyValues --payload "$payload"
+echo
+echo
+
+
+# Await sub-cache contents to be dumped into database
+sleep 3.5
+
+
+echo "06. GET subscription, see lastFailure GT lastSuccess and status==failed"
+echo "======================================================================="
+orionCurl --url /v2/subscriptions
+echo
+echo
+
+echo "07. Start accumulator again"
+echo "==========================="
+accumulatorStart
+sleep 0.5
+echo
+echo
+
+
+echo "08. Update E1, to provoke notification that now works"
+echo "====================================================="
+payload='{
+  "A1": 8
+}'
+orionCurl --url /v2/entities/E1/attrs?options=keyValues --payload "$payload"
+echo
+echo
+
+
+# Await sub-cache contents to be dumped into database
+sleep 3.5
+
+echo "09. GET subscription, see lastSuccess GT lastFailure and status==active"
+echo "======================================================================="
+orionCurl --url /v2/subscriptions
+echo
+echo
+
+--REGEXPECT--
+01. Create entity E1
+====================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=T1
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub (with valid url), matching E1
+============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. GET subscription, see lastSuccess but not lastFailure and status==active
+============================================================================
+HTTP/1.1 200 OK
+Content-Length: 315
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "id": "REGEX([0-9a-f]{24})",
+        "notification": {
+            "attrs": [],
+            "attrsFormat": "normalized",
+            "http": {
+                "url": "http://localhost:REGEX(\d+)/notify"
+            },
+            "lastNotification": "REGEX(.*)",
+            "lastSuccess": "REGEX(.*)",
+            "timesSent": 1
+        },
+        "status": "active",
+        "subject": {
+            "condition": {
+                "attrs": []
+            },
+            "entities": [
+                {
+                    "id": "E1"
+                }
+            ]
+        }
+    }
+]
+
+
+04. Stop accumulator
+====================
+
+
+05. Update E1, to provoke notification that now fails
+=====================================================
+HTTP/1.1 204 No Content
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. GET subscription, see lastFailure GT lastSuccess and status==failed
+=======================================================================
+HTTP/1.1 200 OK
+Content-Length: 355
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "id": "REGEX([0-9a-f]{24})",
+        "notification": {
+            "attrs": [],
+            "attrsFormat": "normalized",
+            "http": {
+                "url": "http://localhost:REGEX(\d+)/notify"
+            },
+            "lastFailure": "REGEX(.*)",
+            "lastNotification": "REGEX(.*)",
+            "lastSuccess": "REGEX(.*)",
+            "timesSent": 2
+        },
+        "status": "failed",
+        "subject": {
+            "condition": {
+                "attrs": []
+            },
+            "entities": [
+                {
+                    "id": "E1"
+                }
+            ]
+        }
+    }
+]
+
+
+07. Start accumulator again
+===========================
+accumulator running as PID REGEX(\d+)
+Connection to REGEX(.*)
+
+
+08. Update E1, to provoke notification that now works
+=====================================================
+HTTP/1.1 204 No Content
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+09. GET subscription, see lastSuccess GT lastFailure and status==active
+=======================================================================
+HTTP/1.1 200 OK
+Content-Length: 355
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "id": "REGEX([0-9a-f]{24})",
+        "notification": {
+            "attrs": [],
+            "attrsFormat": "normalized",
+            "http": {
+                "url": "http://localhost:REGEX(\d+)/notify"
+            },
+            "lastFailure": "REGEX(.*)",
+            "lastNotification": "REGEX(.*)",
+            "lastSuccess": "REGEX(.*)",
+            "timesSent": 3
+        },
+        "status": "active",
+        "subject": {
+            "condition": {
+                "attrs": []
+            },
+            "entities": [
+                {
+                    "id": "E1"
+                }
+            ]
+        }
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB

--- a/test/functionalTest/cases/2064_attrs_blacklist_subs/2064_attrs_blacklist_complex.test
+++ b/test/functionalTest/cases/2064_attrs_blacklist_subs/2064_attrs_blacklist_complex.test
@@ -203,7 +203,7 @@ Date: REGEX(.*)
 03. Check subscription timesSent value (1)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 343
+Content-Length: 383
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -221,6 +221,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 1
     },
     "status": "active",
@@ -261,7 +262,7 @@ Date: REGEX(.*)
 06. Check subscription timesSent value (2)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 343
+Content-Length: 383
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -279,6 +280,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 2
     },
     "status": "active",
@@ -319,7 +321,7 @@ Date: REGEX(.*)
 09. Check subscription timesSent value (3)
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 343
+Content-Length: 383
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -337,6 +339,7 @@ Date: REGEX(.*)
             "url": "http://localhost:9997/notify"
         },
         "lastNotification": "REGEX(.*)",
+        "lastSuccess": "REGEX(.*)",
         "timesSent": 3
     },
     "status": "active",

--- a/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
@@ -4329,7 +4329,7 @@ TEST(mongoUpdateContextSubscription, MongoDbUpdateFail)
     EXPECT_EQ(SccReceiverInternalError, res.subscribeError.errorCode.code);
     EXPECT_EQ("Internal Server Error", res.subscribeError.errorCode.reasonPhrase);
     EXPECT_EQ("Database Error (collection: utest.csubs "
-              "- update(): <{ _id: ObjectId('51307b66f481db11bf860001') },{ expiration: 1360250700, reference: \"http://notify1.me\", custom: false, servicePath: \"/#\", entities: [ { id: \"E1\", type: \"T1\", isPattern: \"false\" } ], attrs: [], metadata: [], blacklist: false, conditions: [], lastNotification: 15000000, expression: { q: \"\", mq: \"\", geometry: \"\", coords: \"\", georel: \"\" }, format: \"JSON\" }> "
+              "- update(): <{ _id: ObjectId('51307b66f481db11bf860001') },{ expiration: 1360250700, reference: \"http://notify1.me\", custom: false, servicePath: \"/#\", entities: [ { id: \"E1\", type: \"T1\", isPattern: \"false\" } ], attrs: [], metadata: [], blacklist: false, conditions: [], lastNotification: 15000000, lastFailure: -1, lastSuccess: -1, expression: { q: \"\", mq: \"\", geometry: \"\", coords: \"\", georel: \"\" }, format: \"JSON\" }> "
               "- exception: boom!!)", res.subscribeError.errorCode.details);
 
     /* Restore real DB connection */


### PR DESCRIPTION
Removed `timesFailed` and added `lastSuccess` for subscriptions.

FIXED:
_One thing is missing in the PR: it seems that lastFailure and lastSuccess have become mutually exclusive. Everything still works (as the newer of the two is always present in the database) but this was not my intention and I would like to ask for some help to fix this problem (or we decide that it is OK as is).
Because of this problem, the documentation is unfinished.
To be decided ..._