### PR TITLE
FIX status code OK -> Bad Request when op update uses empty entities vector

### DIFF
--- a/src/lib/serviceRoutinesV2/postBatchUpdate.cpp
+++ b/src/lib/serviceRoutinesV2/postBatchUpdate.cpp
@@ -76,6 +76,7 @@ std::string postBatchUpdate
 
     TIMED_RENDER(answer = oe.toJson());
 
+    ciP->httpStatusCode = SccBadRequest;
     return answer;
   }
 

--- a/test/functionalTest/cases/2720_op_update_crash/op_update_crash.test
+++ b/test/functionalTest/cases/2720_op_update_crash/op_update_crash.test
@@ -55,7 +55,7 @@ echo
 --REGEXPECT--
 01. Update with empty entities list
 ===================================
-HTTP/1.1 200 OK
+HTTP/1.1 400 Bad Request
 Content-Length: 61
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})


### PR DESCRIPTION
A little missing part in the fix for #2720