### PR TITLE
FIX proper 500 Internal Server Error response with descriptive text when "sort fail" at DB occur

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Fix: libmicrohttpd now uses poll()/epoll() and not select() so fds greater than 1023 can be used for incoming connections (#2724, #2166)
 - Fix: modified the upper limit for CLI '-maxConnections', from 1020 to UNLIMITED
+- Fix: proper 500 Internal Server Error response with descriptive text when "sort fail" at DB occur (#2752)

--- a/doc/manuals/admin/database_admin.md
+++ b/doc/manuals/admin/database_admin.md
@@ -207,7 +207,7 @@ Ej:
 
 ## Orion Errors due to Database
 
-If you are getting entities using a large offset value and get this error (NGSIv1):
+If you are retreiving entities using a large offset value and get this error (NGSIv1):
 
 ```
 GET  /v1/contextEntities?offset=54882
@@ -241,8 +241,8 @@ GET /v2/entities?offset=54882
 }
 ```
 
-then the DB has raised an error related with sorting operation fail due to lack of resources. You can
-check that Orion log contain an ERROR trace similar to this one:
+then the DB has raised an error related to sorting operation failure due to lack of resources. You can
+check that the Orion log file contains an ERROR trace similar to this one:
 
 ```
 Raising alarm DatabaseError: nextSafe(): { $err: "Executor error: OperationFailed Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit.", code: 17144 }

--- a/doc/manuals/admin/database_admin.md
+++ b/doc/manuals/admin/database_admin.md
@@ -223,7 +223,7 @@ GET  /v1/contextEntities?offset=54882
       "statusCode" : {
         "code" : "500",
         "reasonPhrase" : "Internal Server Error",
-        "details" : "Sort operation used more than the maximum RAM. You should create an index. Check Database Administration section at Orion documentation."
+        "details" : "Sort operation used more than the maximum RAM. You should create an index. Check the Database Administration section in Orion documentation."
       }
     }
   ]
@@ -236,7 +236,7 @@ or this other (NGSIv2):
 GET /v2/entities?offset=54882
 
 {
-    "description": "Sort operation used more than the maximum RAM. You should create an index. Check Database Administration section at Orion documentation.",
+    "description": "Sort operation used more than the maximum RAM. You should create an index. Check the Database Administration section in Orion documentation.",
     "error": "InternalServerError"
 }
 ```

--- a/src/lib/apiTypesV2/Entities.cpp
+++ b/src/lib/apiTypesV2/Entities.cpp
@@ -149,9 +149,10 @@ void Entities::fill(QueryContextResponse* qcrsP)
 
     if (scP->code == SccReceiverInternalError)
     {
-      // Do we need to release the memory allocated in 'vec' before returning? I don't
+      // FIXME P4: Do we need to release the memory allocated in 'vec' before returning? I don't
       // think so, as the releasing logic in the upper layer will deal with that but
-      // let's do anyway just in case...
+      // let's do anyway just in case... (we don't have a ft covering this, so valgrind suite
+      // cannot help here and it is better to ensure)
       oe.fill(SccReceiverInternalError, scP->details, "InternalServerError");
       vec.release();
       return;

--- a/src/lib/apiTypesV2/Entities.cpp
+++ b/src/lib/apiTypesV2/Entities.cpp
@@ -145,15 +145,29 @@ void Entities::fill(QueryContextResponse* qcrsP)
   for (unsigned int ix = 0; ix < qcrsP->contextElementResponseVector.size(); ++ix)
   {
     ContextElement* ceP = &qcrsP->contextElementResponseVector[ix]->contextElement;
-    Entity*         eP  = new Entity();
+    StatusCode* scP = &qcrsP->contextElementResponseVector[ix]->statusCode;
 
-    eP->id        = ceP->entityId.id;
-    eP->type      = ceP->entityId.type;
-    eP->isPattern = ceP->entityId.isPattern;
-    eP->creDate   = ceP->entityId.creDate;
-    eP->modDate   = ceP->entityId.modDate;
+    if (scP->code == SccReceiverInternalError)
+    {
+      // Do we need to release the memory allocated in 'vec' before returning? I don't
+      // think so, as the releasing logic in the upper layer will deal with that but
+      // let's do anyway just in case...
+      oe.fill(SccReceiverInternalError, scP->details, "InternalServerError");
+      vec.release();
+      return;
+    }
+    else
+    {
+      Entity*         eP  = new Entity();
 
-    eP->attributeVector.fill(&ceP->contextAttributeVector);
-    vec.push_back(eP);
+      eP->id        = ceP->entityId.id;
+      eP->type      = ceP->entityId.type;
+      eP->isPattern = ceP->entityId.isPattern;
+      eP->creDate   = ceP->entityId.creDate;
+      eP->modDate   = ceP->entityId.modDate;
+
+      eP->attributeVector.fill(&ceP->contextAttributeVector);
+      vec.push_back(eP);
+    }
   }
 }

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1285,7 +1285,7 @@ bool entitiesQuery
       }
       else if (strncmp(exErr.c_str(), sortError, strlen(sortError)) == 0)
       {
-        exErr = "Sort operation used more than the maximum RAM. You should create an index. Check Database Administration section at Orion documentation.";
+        exErr = "Sort operation used more than the maximum RAM. You should create an index. Check the Database Administration section in Orion documentation.";
       }
       else
       {

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1274,6 +1274,7 @@ bool entitiesQuery
       // So, we can just match the error and send a less descriptive text.
       //
       const char* invalidPolygon      = "Exterior shell of polygon is invalid";
+      const char* sortError           = "nextSafe(): { $err: \"Executor error: OperationFailed Sort operation used more than the maximum";
       const char* defaultErrorString  = "Error at querying MongoDB";
 
       alarmMgr.dbError(exErr);
@@ -1281,6 +1282,10 @@ bool entitiesQuery
       if (strncmp(exErr.c_str(), invalidPolygon, strlen(invalidPolygon)) == 0)
       {
         exErr = invalidPolygon;
+      }
+      else if (strncmp(exErr.c_str(), sortError, strlen(sortError)) == 0)
+      {
+        exErr = "Sort operation used more than the maximum RAM. You should create an index. Check Database Administration section at Orion documentation.";
       }
       else
       {


### PR DESCRIPTION
Fixes #2752 

Manually tested (unfortunatelly this requires a particular DB to raise the problem, not easy to automate in functional tests):

```
fermin@neodeb:~/src/fiware-orion/test/functionalTest$ curl -vvvv -s -S 'localhost:1026/v1/contextEntities?offset=54882' 
* Hostname was NOT found in DNS cache
*   Trying ::1...
* Connected to localhost (::1) port 1026 (#0)
> GET /v1/contextEntities?offset=54882 HTTP/1.1
> User-Agent: curl/7.38.0
> Host: localhost:1026
> Accept: */*
> 
< HTTP/1.1 200 OK
< Connection: Keep-Alive
< Content-Length: 416
< Content-Type: application/json
< Fiware-Correlator: 05eeb236-bc51-11e6-bab4-000c29173617
< Date: Wed, 07 Dec 2016 07:44:46 GMT
< 
{
  "contextResponses" : [
    {
      "contextElement" : {
        "type" : "",
        "isPattern" : "true",
        "id" : ".*"
      },
      "statusCode" : {
        "code" : "500",
        "reasonPhrase" : "Internal Server Error",
        "details" : "Sort operation used more than the maximum RAM. You should create an index. Check Database Administration section at Orion documentation."
      }
    }
  ]
}
* Connection #0 to host localhost left intact
fermin@neodeb:~/src/fiware-orion/test/functionalTest$ curl -vvvv -s -S 'localhost:1026/v2/entities?offset=54882' | python -mjson.tool
* Hostname was NOT found in DNS cache
*   Trying ::1...
* Connected to localhost (::1) port 1026 (#0)
> GET /v2/entities?offset=54882 HTTP/1.1
> User-Agent: curl/7.38.0
> Host: localhost:1026
> Accept: */*
> 
< HTTP/1.1 500 Internal Server Error
< Connection: Keep-Alive
< Content-Length: 184
< Content-Type: application/json
< Fiware-Correlator: 07dad78c-bc51-11e6-8930-000c29173617
< Date: Wed, 07 Dec 2016 07:44:49 GMT
< 
{ [data not shown]
* Connection #0 to host localhost left intact
{
    "description": "Sort operation used more than the maximum RAM. You should create an index. Check Database Administration section at Orion documentation.",
    "error": "InternalServerError"
}
```