### PR TITLE
Bug/2761 no response if not all payload is read

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,6 +5,7 @@
 - Add: metrics REST API (#2750)
 - Add: new CLI '-disableMetrics' to disable metrics (#2750)
 - Fix: timeout of 6 seconds (hardcoded for now) for all incoming REST requests (temporal fix, see #2762)
+- Fix: if HTTP header Content-Length contains a value above the maximum payload size, an error is returned and the message is not read (#2761)
 - Add: one more semaphore (the metrics semaphore) to the semWait block in GET /statistics and to the list in GET /admin/sem (#2750)
 - Fix: bug in notification queue statistics, "in" value (#2744)
 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,6 +1,7 @@
 - Fix: libmicrohttpd now uses poll()/epoll() and not select() so fds greater than 1023 can be used for incoming connections (#2724, #2166)
 - Fix: modified the upper limit for CLI '-maxConnections', from 1020 to UNLIMITED
 - Fix: proper 500 Internal Server Error response with descriptive text when "sort fail" at DB occur (#2752)
+- Fix: giving a descriptive response with payload, without reading the request for too big payloads (#2761)
 - Add: metrics REST API (#2750)
 - Add: new CLI '-disableMetrics' to disable metrics (#2750)
 - Fix: timeout of 6 seconds (hardcoded for now) for all incoming REST requests (Temporal fix, see #2762)

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1216,6 +1216,18 @@ static int connectionTreat
     ciP->httpHeader.push_back("Fiware-Correlator");
     ciP->httpHeaderValue.push_back(ciP->httpHeaders.correlator);
 
+    if (ciP->httpHeaders.contentLength > PAYLOAD_MAX_SIZE)
+    {
+      char details[256];
+      snprintf(details, sizeof(details), "payload size: %d, max size supported: %d", ciP->httpHeaders.contentLength, PAYLOAD_MAX_SIZE);
+
+      OrionError oe(SccRequestEntityTooLarge, details);
+
+      ciP->httpStatusCode = oe.code;
+      restReply(ciP, oe.smartRender(ciP->apiVersion));
+      return MHD_YES;
+    }
+
     //
     // Transaction starts here
     //

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1216,7 +1216,7 @@ static int connectionTreat
     ciP->httpHeader.push_back("Fiware-Correlator");
     ciP->httpHeaderValue.push_back(ciP->httpHeaders.correlator);
 
-    if (ciP->httpHeaders.contentLength > PAYLOAD_MAX_SIZE)
+    if ((ciP->httpHeaders.contentLength > PAYLOAD_MAX_SIZE) && (ciP->apiVersion == V2))
     {
       char details[256];
       snprintf(details, sizeof(details), "payload size: %d, max size supported: %d", ciP->httpHeaders.contentLength, PAYLOAD_MAX_SIZE);

--- a/test/functionalTest/cases/2761_no_response_if_not_all_payload_is_read/no_response_if_not_all_payload_is_read.test
+++ b/test/functionalTest/cases/2761_no_response_if_not_all_payload_is_read/no_response_if_not_all_payload_is_read.test
@@ -1,0 +1,64 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+No response at all if broker doesn't read entire message
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Send a POST /v2/entites of a few bytes but set Content-Length to 2 Mb in HTTP header - see response
+#
+
+echo "01. Send a POST /v2/entites of a few bytes but set Content-Length to 2 Mb in HTTP header - see response"
+echo "======================================================================================================="
+payload='{
+  "id": "E1",
+  "type": "T1"
+}'
+orionCurl --url /v2/entities --payload "$payload" -H "Content-Length: 2097152"
+echo
+echo
+
+
+--REGEXPECT--
+01. Send a POST /v2/entites of a few bytes but set Content-Length to 2 Mb in HTTP header - see response
+=======================================================================================================
+HTTP/1.1 413 Request Entity Too Large
+Content-Length: 100
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "payload size: 2097152, max size supported: 1048576",
+    "error": "RequestEntityTooLarge"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Checking HTTP header 'Content-Length' for **too long** message before even starting to read the message body, and returning error if the body is too long (according to Content-Length).

Fixes issue #2761 