### PR TITLE
Feature/2750 ignore metrics for error in service and service path

### DIFF
--- a/src/lib/common/defaultValues.h
+++ b/src/lib/common/defaultValues.h
@@ -28,8 +28,9 @@
 
 
 
-#define  DEFAULT_SERVICE_PATH_UPDATES  "/"
-#define  DEFAULT_SERVICE_PATH_QUERIES  "/#"
-
+#define  DEFAULT_SERVICE_PATH_UPDATES         "/"
+#define  DEFAULT_SERVICE_PATH_QUERIES         "/#"
+#define  DEFAULT_SERVICE_KEY_FOR_METRICS      "default-service"
+#define  DEFAULT_SUB_SERVICE_KEY_FOR_METRICS  "root-subserv"
 
 #endif  // SRC_LIB_COMMON_DEFAULTVALUES_H_

--- a/src/lib/common/defaultValues.h
+++ b/src/lib/common/defaultValues.h
@@ -30,7 +30,5 @@
 
 #define  DEFAULT_SERVICE_PATH_UPDATES         "/"
 #define  DEFAULT_SERVICE_PATH_QUERIES         "/#"
-#define  DEFAULT_SERVICE_KEY_FOR_METRICS      "default-service"
-#define  DEFAULT_SUB_SERVICE_KEY_FOR_METRICS  "root-subserv"
 
 #endif  // SRC_LIB_COMMON_DEFAULTVALUES_H_

--- a/src/lib/metricsMgr/MetricsManager.cpp
+++ b/src/lib/metricsMgr/MetricsManager.cpp
@@ -33,10 +33,18 @@
 #include "logMsg/traceLevels.h"
 
 #include "common/JsonHelper.h"
-#include "common/defaultValues.h"
 #include "rest/rest.h"
 #include "rest/RestService.h"
 #include "metricsMgr/MetricsManager.h"
+
+
+
+/* ****************************************************************************
+*
+* Default values for metrics - 
+*/
+#define  DEFAULT_SERVICE_KEY_FOR_METRICS      "default-service"
+#define  ROOT_SUB_SERVICE_KEY_FOR_METRICS     "root-subserv"
 
 
 
@@ -370,7 +378,7 @@ std::string MetricsManager::_toJson(void)
         }
         else
         {
-          jhSubService.addRaw(DEFAULT_SUB_SERVICE_KEY_FOR_METRICS, subServiceString);
+          jhSubService.addRaw(ROOT_SUB_SERVICE_KEY_FOR_METRICS, subServiceString);
         }
       }
     }
@@ -412,7 +420,7 @@ std::string MetricsManager::_toJson(void)
     }
     else
     {
-      jhSubServ.addRaw(DEFAULT_SUB_SERVICE_KEY_FOR_METRICS, subServiceString);
+      jhSubServ.addRaw(ROOT_SUB_SERVICE_KEY_FOR_METRICS, subServiceString);
     }
   }
 

--- a/src/lib/metricsMgr/MetricsManager.cpp
+++ b/src/lib/metricsMgr/MetricsManager.cpp
@@ -172,12 +172,18 @@ int64_t MetricsManager::semWaitTimeGet(void)
 * MetricsManager::servicePathForMetrics - 
 *
 * PARAMETERS
-*   sp:            original service path (input)
+*   spathIn:       original service path (input)
 *   subServiceP    pointer to resulting service path (output)
 */
-bool MetricsManager::servicePathForMetrics(char* sp, std::string* subServiceP)
+bool MetricsManager::servicePathForMetrics(const std::string& spathIn, std::string* subServiceP)
 {
-  char* spath  = strdup(sp);
+  if (spathIn == "")
+  {
+    *subServiceP = "";
+    return true;
+  }
+
+  char* spath  = strdup(spathIn.c_str());
   char* toFree = spath;
 
   if (subServiceValid(spath) == false)
@@ -238,9 +244,17 @@ void MetricsManager::add(const std::string& srv, const std::string& subServ, con
 {
   std::string subService = "not-set";
 
-  if ((on == false)                 ||
-      (serviceValid(srv) == false)  ||
-      (servicePathForMetrics((char*) subServ.c_str(), &subService) == false))
+  if (on == false)
+  {
+    return;
+  }
+
+  if (serviceValid(srv) == false)
+  {
+    return;
+  }
+
+  if (servicePathForMetrics(subServ, &subService) == false)
   {
     return;
   }

--- a/src/lib/metricsMgr/MetricsManager.cpp
+++ b/src/lib/metricsMgr/MetricsManager.cpp
@@ -33,6 +33,8 @@
 #include "logMsg/traceLevels.h"
 
 #include "common/JsonHelper.h"
+#include "rest/rest.h"
+#include "rest/RestService.h"
 #include "metricsMgr/MetricsManager.h"
 
 
@@ -127,6 +129,20 @@ int64_t MetricsManager::semWaitTimeGet(void)
 void MetricsManager::add(const std::string& srv, const std::string& subServ, const std::string& metric, uint64_t value)
 {
   if (on == false)
+  {
+    return;
+  }
+
+  // FIXME P4: See github issue #2781
+  if (tenantCheck(srv) != "OK")
+  {
+    return;
+  }
+
+  // FIXME P4: See github issue #2781
+  ConnectionInfo ci;
+  ci.httpHeaders.servicePathReceived = true;
+  if (servicePathCheck(&ci, subServ.c_str()) != 0)
   {
     return;
   }

--- a/src/lib/metricsMgr/MetricsManager.cpp
+++ b/src/lib/metricsMgr/MetricsManager.cpp
@@ -33,6 +33,7 @@
 #include "logMsg/traceLevels.h"
 
 #include "common/JsonHelper.h"
+#include "common/defaultValues.h"
 #include "rest/rest.h"
 #include "rest/RestService.h"
 #include "metricsMgr/MetricsManager.h"
@@ -329,7 +330,14 @@ std::string MetricsManager::_toJson(void)
 
       if (subServiceString != "{}")
       {
-        jhSubService.addRaw(subService, subServiceString);
+        if (subService != "")
+        {
+          jhSubService.addRaw(subService, subServiceString);
+        }
+        else
+        {
+          jhSubService.addRaw(DEFAULT_SUB_SERVICE_KEY_FOR_METRICS, subServiceString);
+        }
       }
     }
 
@@ -338,7 +346,15 @@ std::string MetricsManager::_toJson(void)
     std::string serviceSumString = metricsRender(&serviceSum);
 
     subServiceTop.addRaw("sum", serviceSumString);
-    services.addRaw(service, subServiceTop.str());
+
+    if (service != "")
+    {
+      services.addRaw(service, subServiceTop.str());
+    }
+    else
+    {
+      services.addRaw(DEFAULT_SERVICE_KEY_FOR_METRICS, subServiceTop.str());
+    }
   }
 
   //
@@ -355,7 +371,15 @@ std::string MetricsManager::_toJson(void)
     std::string  subServiceString;
 
     subServiceString = metricsRender(&it->second);
-    jhSubServ.addRaw(subService, subServiceString);
+
+    if (subService != "")
+    {
+      jhSubServ.addRaw(subService, subServiceString);
+    }
+    else
+    {
+      jhSubServ.addRaw(DEFAULT_SUB_SERVICE_KEY_FOR_METRICS, subServiceString);
+    }
   }
 
   lastSum.addRaw("subservs", jhSubServ.str());

--- a/src/lib/metricsMgr/MetricsManager.h
+++ b/src/lib/metricsMgr/MetricsManager.h
@@ -133,6 +133,7 @@ class MetricsManager
   std::string     _toJson(void);
   bool            serviceValid(const std::string& srv);
   bool            subServiceValid(const std::string& subsrv);
+  bool            servicePathForMetrics(char* spath, std::string* subServiceP);
 
  public:
   MetricsManager();

--- a/src/lib/metricsMgr/MetricsManager.h
+++ b/src/lib/metricsMgr/MetricsManager.h
@@ -131,6 +131,8 @@ class MetricsManager
   void            semGive(void);
   void            _reset(void);
   std::string     _toJson(void);
+  bool            serviceValid(const std::string& srv);
+  bool            subServiceValid(const std::string& subsrv);
 
  public:
   MetricsManager();

--- a/src/lib/metricsMgr/MetricsManager.h
+++ b/src/lib/metricsMgr/MetricsManager.h
@@ -133,7 +133,7 @@ class MetricsManager
   std::string     _toJson(void);
   bool            serviceValid(const std::string& srv);
   bool            subServiceValid(const std::string& subsrv);
-  bool            servicePathForMetrics(char* spath, std::string* subServiceP);
+  bool            servicePathForMetrics(const std::string& spath, std::string* subServiceP);
 
  public:
   MetricsManager();

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -148,6 +148,11 @@ std::string payloadParse
 /* ****************************************************************************
 *
 * tenantCheck - 
+*
+* This function used to be 'static', but as it is now used by MetricsMgr::serviceValid
+* it has been mede 'extern'.
+* This might change when github issue #2781 is looked into and if we stop using the
+* function, is should go back to being 'static'.
 */
 std::string tenantCheck(const std::string& tenant)
 {

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -537,7 +537,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
 
       LM_T(LmtParsedPayload, ("Parsing payload for URL '%s', method '%s', service vector index: %d", ciP->url.c_str(), ciP->method.c_str(), ix));
       ciP->parseDataP = &parseData;
-      metricsMgr.add(ciP->httpHeaders.tenant, ciP->httpHeaders.servicePath, METRIC_TRANS_IN_REQ_SIZE, ciP->payloadSize);
+      metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN_REQ_SIZE, ciP->payloadSize);
       LM_T(LmtPayload, ("Parsing payload '%s'", ciP->payload));
       response = payloadParse(ciP, &parseData, &serviceV[ix], &jsonReqP, &jsonRelease, compV);
       LM_T(LmtParsedPayload, ("payloadParse returns '%s'", response.c_str()));

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -149,9 +149,9 @@ std::string payloadParse
 *
 * tenantCheck - 
 */
-extern std::string tenantCheck(const std::string& tenant)
+std::string tenantCheck(const std::string& tenant)
 {
-  char*        name    = (char*) tenant.c_str();
+  char*  name = (char*) tenant.c_str();
 
   if (strlen(name) > SERVICE_NAME_MAX_LEN)
   {

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -149,7 +149,7 @@ std::string payloadParse
 *
 * tenantCheck - 
 */
-static std::string tenantCheck(const std::string& tenant)
+std::string tenantCheck(const std::string& tenant)
 {
   char*        name    = (char*) tenant.c_str();
 

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -149,7 +149,7 @@ std::string payloadParse
 *
 * tenantCheck - 
 */
-std::string tenantCheck(const std::string& tenant)
+extern std::string tenantCheck(const std::string& tenant)
 {
   char*        name    = (char*) tenant.c_str();
 

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -534,10 +534,11 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
     if ((ciP->payload != NULL) && (ciP->payloadSize != 0) && (ciP->payload[0] != 0) && (serviceV[ix].verb != "*"))
     {
       std::string response;
+      std::string spath = (ciP->servicePathV.size() > 0)? ciP->servicePathV[0] : "";
 
       LM_T(LmtParsedPayload, ("Parsing payload for URL '%s', method '%s', service vector index: %d", ciP->url.c_str(), ciP->method.c_str(), ix));
       ciP->parseDataP = &parseData;
-      metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN_REQ_SIZE, ciP->payloadSize);
+      metricsMgr.add(ciP->httpHeaders.tenant, spath, METRIC_TRANS_IN_REQ_SIZE, ciP->payloadSize);
       LM_T(LmtPayload, ("Parsing payload '%s'", ciP->payload));
       response = payloadParse(ciP, &parseData, &serviceV[ix], &jsonReqP, &jsonRelease, compV);
       LM_T(LmtParsedPayload, ("payloadParse returns '%s'", response.c_str()));

--- a/src/lib/rest/RestService.h
+++ b/src/lib/rest/RestService.h
@@ -83,4 +83,12 @@ extern std::string payloadParse
   std::vector<std::string>&  compV
 );
 
+
+
+/* ****************************************************************************
+*
+* tenantCheck - 
+*/
+extern std::string tenantCheck(const std::string& tenant);
+
 #endif

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -301,7 +301,7 @@ int httpRequestSendWithCurl
   // Preconditions check
   if (port == 0)
   {
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_ERRORS, 1);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_ERRORS, 1);
     LM_E(("Runtime Error (port is ZERO)"));
     lmTransactionEnd();
 
@@ -311,7 +311,7 @@ int httpRequestSendWithCurl
 
   if (ip.empty())
   {
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_ERRORS, 1);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_ERRORS, 1);
     LM_E(("Runtime Error (ip is empty)"));
     lmTransactionEnd();
 
@@ -321,7 +321,7 @@ int httpRequestSendWithCurl
 
   if (verb.empty())
   {
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_ERRORS, 1);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_ERRORS, 1);
     LM_E(("Runtime Error (verb is empty)"));
     lmTransactionEnd();
 
@@ -331,7 +331,7 @@ int httpRequestSendWithCurl
 
   if (resource.empty())
   {
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_ERRORS, 1);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_ERRORS, 1);
     LM_E(("Runtime Error (resource is empty)"));
     lmTransactionEnd();
 
@@ -341,7 +341,7 @@ int httpRequestSendWithCurl
 
   if ((content_type.empty()) && (!content.empty()))
   {
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_ERRORS, 1);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_ERRORS, 1);
     LM_E(("Runtime Error (Content-Type is empty but there is actual content)"));
     lmTransactionEnd();
 
@@ -351,7 +351,7 @@ int httpRequestSendWithCurl
 
   if ((!content_type.empty()) && (content.empty()))
   {
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_ERRORS, 1);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_ERRORS, 1);
     LM_E(("Runtime Error (Content-Type non-empty but there is no content)"));
     lmTransactionEnd();
 
@@ -514,7 +514,7 @@ int httpRequestSendWithCurl
   // Check if total outgoing message size is too big
   if (outgoingMsgSize > MAX_DYN_MSG_SIZE)
   {
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_ERRORS, 1);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_ERRORS, 1);
     LM_E(("Runtime Error (HTTP request to send is too large: %d bytes)", outgoingMsgSize));
 
     curl_slist_free_all(headers);
@@ -586,7 +586,7 @@ int httpRequestSendWithCurl
     alarmMgr.notificationError(url, "(curl_easy_perform failed: " + std::string(curl_easy_strerror(res)) + ")");
     *outP = "notification failure";
 
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_ERRORS, 1);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_ERRORS, 1);
   }
   else
   {
@@ -598,12 +598,12 @@ int httpRequestSendWithCurl
     LM_I(("Notification Successfully Sent to %s", url.c_str()));
     outP->assign(httpResponse->memory, httpResponse->size);
 
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_RESP_SIZE, payloadLen);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_RESP_SIZE, payloadLen);
   }
 
   if (payloadSize > 0)
   {
-    metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_REQ_SIZE, payloadSize);
+    metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_REQ_SIZE, payloadSize);
   }
 
   // Cleanup curl environment

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -23,6 +23,7 @@
 * Author: developer
 */
 #include <unistd.h>                             // close()
+#include <string.h>                             // strchr()
 #include <sys/types.h>                          // system types ...
 #include <sys/socket.h>                         // socket, bind, listen
 #include <sys/un.h>                             // sockaddr_un
@@ -266,8 +267,21 @@ int httpRequestSendWithCurl
   int                             outgoingMsgSize       = 0;
   std::string                     content_type(orig_content_type);
   std::map<std::string, bool>     usedExtraHeaders;
+  char                            servicePath0[64];  // 64 > 50 (max component length in service path)
+  char*                           spEnd;
 
-  metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT, 1);
+  memset(servicePath0, 0, sizeof(servicePath0));
+
+  if ((spEnd = strchr((char*) servicePath.c_str(), ',')) != NULL)
+  {
+    strncpy(servicePath0, servicePath.c_str(), spEnd - servicePath.c_str());
+  }
+  else
+  {
+    strncpy(servicePath0, servicePath.c_str(), sizeof(servicePath0));
+  }
+
+  metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT, 1);
 
   ++callNo;
 

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -666,6 +666,12 @@ int httpRequestSend
   get_curl_context(_ip, &cc);
   if (cc.curl == NULL)
   {
+    //
+    // FIXME P4: servicePath may contain more than one service path, i.e.  /A,/B.
+    //           Only if coming from a forward of a query (postQueryContext())
+    //           This is taken care of in metricsMgr.add(), but could be moved here instead
+    //           as it is the only place where this can happen (99% sure about this).
+    //
     metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT,        1);
     metricsMgr.add(tenant, servicePath, METRIC_TRANS_OUT_ERRORS, 1);
 

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -213,28 +213,6 @@ static int contentLenParse(char* s)
 
 /* ****************************************************************************
 *
-* servicePathForMetrics - extract first component of service-path
-*/
-static void servicePathForMetrics(const char* servicePath, char* servicePath0, int servicePath0Len)
-{
-  char* spEnd;
-
-  memset(servicePath0, 0, servicePath0Len);
-
-  if ((spEnd = strchr((char*) servicePath, ',')) != NULL)
-  {
-    strncpy(servicePath0, servicePath, spEnd - servicePath);
-  }
-  else
-  {
-    strncpy(servicePath0, servicePath, servicePath0Len);
-  }
-}
-
-
-
-/* ****************************************************************************
-*
 * httpRequestSendWithCurl -
 *
 * The waitForResponse arguments specifies if the method has to wait for response
@@ -291,7 +269,7 @@ int httpRequestSendWithCurl
   std::map<std::string, bool>     usedExtraHeaders;
   char                            servicePath0[SERVICE_PATH_MAX_COMPONENT_LEN + 1];  // +1 for zero termination
 
-  servicePathForMetrics(servicePath.c_str(), servicePath0, sizeof(servicePath0));
+  firstServicePath(servicePath.c_str(), servicePath0, sizeof(servicePath0));
 
   metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT, 1);
 
@@ -680,7 +658,7 @@ int httpRequestSend
   {
     char servicePath0[SERVICE_PATH_MAX_COMPONENT_LEN + 1];  // +1 for zero termination
 
-    servicePathForMetrics(servicePath.c_str(), servicePath0, sizeof(servicePath0));
+    firstServicePath(servicePath.c_str(), servicePath0, sizeof(servicePath0));
 
     metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT,        1);
     metricsMgr.add(tenant, servicePath0, METRIC_TRANS_OUT_ERRORS, 1);

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -673,8 +673,6 @@ static void requestCompleted
 * to make sure there is only ONE service path and that there is no '#' present.
 *
 * FIXME P5: updates should also call the other servicePathCheck (in common lib)
-*
-* [ Not static just to let unit tests call this function ]
 */
 int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
 {

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -581,6 +581,7 @@ static void requestCompleted
 )
 {
   ConnectionInfo*  ciP      = (ConnectionInfo*) *con_cls;
+  std::string      spath    = (ciP->servicePathV.size() > 0)? ciP->servicePathV[0] : "";
   struct timespec  reqEndTime;
 
   if ((ciP->payload != NULL) && (ciP->payload != static_buffer))
@@ -634,7 +635,7 @@ static void requestCompleted
   //
   // Metrics
   //
-  metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN, 1);
+  metricsMgr.add(ciP->httpHeaders.tenant, spath, METRIC_TRANS_IN, 1);
 
 
   //
@@ -642,7 +643,7 @@ static void requestCompleted
   //
   if (ciP->httpStatusCode >= SccBadRequest)
   {
-    metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN_ERRORS, 1);
+    metricsMgr.add(ciP->httpHeaders.tenant, spath, METRIC_TRANS_IN_ERRORS, 1);
   }
 
   if (metricsMgr.isOn() && (ciP->transactionStart.tv_sec != 0))
@@ -655,7 +656,7 @@ static void requestCompleted
         (end.tv_sec  - ciP->transactionStart.tv_sec) * 1000000 + 
         (end.tv_usec - ciP->transactionStart.tv_usec);
 
-      metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], _METRIC_TOTAL_SERVICE_TIME, elapsed);
+      metricsMgr.add(ciP->httpHeaders.tenant, spath, _METRIC_TOTAL_SERVICE_TIME, elapsed);
     }
   }
 
@@ -778,6 +779,28 @@ static char* removeTrailingSlash(std::string path)
   }
 
   return cpath;
+}
+
+
+
+/* ****************************************************************************
+*
+* firstServicePath - extract first component of service-path
+*/
+void firstServicePath(const char* servicePath, char* servicePath0, int servicePath0Len)
+{
+  char* spEnd;
+
+  memset(servicePath0, 0, servicePath0Len);
+
+  if ((spEnd = strchr((char*) servicePath, ',')) != NULL)
+  {
+    strncpy(servicePath0, servicePath, spEnd - servicePath);
+  }
+  else
+  {
+    strncpy(servicePath0, servicePath, servicePath0Len);
+  }
 }
 
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -529,7 +529,6 @@ static int httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, co
   {
     headerP->servicePath         = value;
     headerP->servicePathReceived = true;
-    LM_W(("KZ: Got servicePath: '%s'", value));
   }
   else
   {
@@ -855,8 +854,6 @@ int servicePathSplit(ConnectionInfo* ciP)
     LM_I(("Service Path %d: '%s'", ix, ciP->servicePathV[ix].c_str()));
   }
 
-
-  // KZ: ciP->servicePath = ciP->servicePathV[0];
 
   for (int ix = 0; ix < servicePaths; ++ix)
   {

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -529,6 +529,7 @@ static int httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, co
   {
     headerP->servicePath         = value;
     headerP->servicePathReceived = true;
+    LM_W(("KZ: Got servicePath: '%s'", value));
   }
   else
   {
@@ -669,7 +670,7 @@ static void requestCompleted
 * servicePathCheck - check vector of service paths
 *
 * This function is called for ALL requests, when a service-path URI-parameter is found.
-* So, '#' is considered a valid character at it is valid for discoveries and queries.
+* So, '#' is considered a valid character as it is valid for discoveries and queries.
 * Later on, if the request is a registration or notification, another function is called
 * to make sure there is only ONE service path and that there is no '#' present.
 *
@@ -834,13 +835,8 @@ int servicePathSplit(ConnectionInfo* ciP)
     LM_I(("Service Path %d: '%s'", ix, ciP->servicePathV[ix].c_str()));
   }
 
-  //
-  // stringSplit destroys ciP->servicePath.
-  //
-  // After splitting ciP->servicePath to ciP->servicePathV, we need
-  // to make ciP->servicePath point to ciP->servicePathV[0] for metrics
-  //
-  ciP->httpHeaders.servicePath = ciP->servicePathV[0];
+
+  // KZ: ciP->servicePath = ciP->servicePathV[0];
 
   for (int ix = 0; ix < servicePaths; ++ix)
   {

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -567,6 +567,7 @@ static void serve(ConnectionInfo* ciP)
 }
 
 
+
 /* ****************************************************************************
 *
 * requestCompleted -
@@ -832,6 +833,14 @@ int servicePathSplit(ConnectionInfo* ciP)
     //
     LM_I(("Service Path %d: '%s'", ix, ciP->servicePathV[ix].c_str()));
   }
+
+  //
+  // stringSplit destroys ciP->servicePath.
+  //
+  // After splitting ciP->servicePath to ciP->servicePathV, we need
+  // to make ciP->servicePath point to ciP->servicePathV[0] for metrics
+  //
+  ciP->httpHeaders.servicePath = ciP->servicePathV[0];
 
   for (int ix = 0; ix < servicePaths; ++ix)
   {

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -634,7 +634,7 @@ static void requestCompleted
   //
   // Metrics
   //
-  metricsMgr.add(ciP->httpHeaders.tenant, ciP->httpHeaders.servicePath, METRIC_TRANS_IN, 1);
+  metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN, 1);
 
 
   //
@@ -642,7 +642,7 @@ static void requestCompleted
   //
   if (ciP->httpStatusCode >= SccBadRequest)
   {
-    metricsMgr.add(ciP->httpHeaders.tenant, ciP->httpHeaders.servicePath, METRIC_TRANS_IN_ERRORS, 1);
+    metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN_ERRORS, 1);
   }
 
   if (metricsMgr.isOn() && (ciP->transactionStart.tv_sec != 0))
@@ -655,7 +655,7 @@ static void requestCompleted
         (end.tv_sec  - ciP->transactionStart.tv_sec) * 1000000 + 
         (end.tv_usec - ciP->transactionStart.tv_usec);
 
-      metricsMgr.add(ciP->httpHeaders.tenant, ciP->httpHeaders.servicePath, _METRIC_TOTAL_SERVICE_TIME, elapsed);
+      metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], _METRIC_TOTAL_SERVICE_TIME, elapsed);
     }
   }
 

--- a/src/lib/rest/rest.h
+++ b/src/lib/rest/rest.h
@@ -113,4 +113,12 @@ extern void restInit
 */
 extern int servicePathCheck(ConnectionInfo* ciP, const char* servicePath);
 
+
+
+/* ****************************************************************************
+*
+* firstServicePath - extract first component of service-path
+*/
+extern void firstServicePath(const char* servicePath, char* servicePath0, int servicePath0Len);
+
 #endif

--- a/src/lib/rest/rest.h
+++ b/src/lib/rest/rest.h
@@ -105,4 +105,12 @@ extern void restInit
    RestServeFunction   _serveFunction     = NULL
 );
 
+
+
+/* ****************************************************************************
+*
+* servicePathCheck - 
+*/
+extern int servicePathCheck(ConnectionInfo* ciP, const char* servicePath);
+
 #endif

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -66,6 +66,7 @@ void restReply(ConnectionInfo* ciP, const std::string& answer)
 {
   MHD_Response*  response;
   uint64_t       answerLen = answer.length();
+  std::string    spath     = (ciP->servicePathV.size() > 0)? ciP->servicePathV[0] : "";
 
   ++replyIx;
   LM_T(LmtServiceOutPayload, ("Response %d: responding with %d bytes, Status Code %d", replyIx, answerLen, ciP->httpStatusCode));
@@ -74,14 +75,14 @@ void restReply(ConnectionInfo* ciP, const std::string& answer)
   response = MHD_create_response_from_buffer(answerLen, (void*) answer.c_str(), MHD_RESPMEM_MUST_COPY);
   if (!response)
   {
-    metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN_ERRORS, 1);
+    metricsMgr.add(ciP->httpHeaders.tenant, spath, METRIC_TRANS_IN_ERRORS, 1);
     LM_E(("Runtime Error (MHD_create_response_from_buffer FAILED)"));
     return;
   }
 
   if (answerLen > 0)
   {
-    metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN_RESP_SIZE, answerLen);
+    metricsMgr.add(ciP->httpHeaders.tenant, spath, METRIC_TRANS_IN_RESP_SIZE, answerLen);
   }
 
   for (unsigned int hIx = 0; hIx < ciP->httpHeader.size(); ++hIx)

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -74,14 +74,14 @@ void restReply(ConnectionInfo* ciP, const std::string& answer)
   response = MHD_create_response_from_buffer(answerLen, (void*) answer.c_str(), MHD_RESPMEM_MUST_COPY);
   if (!response)
   {
-    metricsMgr.add(ciP->httpHeaders.tenant, ciP->httpHeaders.servicePath, METRIC_TRANS_IN_ERRORS, 1);
+    metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN_ERRORS, 1);
     LM_E(("Runtime Error (MHD_create_response_from_buffer FAILED)"));
     return;
   }
 
   if (answerLen > 0)
   {
-    metricsMgr.add(ciP->httpHeaders.tenant, ciP->httpHeaders.servicePath, METRIC_TRANS_IN_RESP_SIZE, answerLen);
+    metricsMgr.add(ciP->httpHeaders.tenant, ciP->servicePathV[0], METRIC_TRANS_IN_RESP_SIZE, answerLen);
   }
 
   for (unsigned int hIx = 0; hIx < ciP->httpHeader.size(); ++hIx)

--- a/test/functionalTest/cases/2750_common_metrics/2750_complex_service_path.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_complex_service_path.test
@@ -33,8 +33,8 @@ brokerStart CB
 # 01. Send a GET /v2/entities with service path /A1/#
 # 02. Send a GET /v2/entities with service path /A2,/B2
 # 03. Send a GET /v2/entities with service path /#
-# 04. Send a GET /v2/entities without service path (/# is default service path)
-# 05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'default service path'
+# 04. Send a GET /v2/entities without service path (/# is used as service path)
+# 05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'root service path'
 #
 
 echo "01. Send a GET /v2/entities with service path /A1/#"
@@ -58,15 +58,15 @@ echo
 echo
 
 
-echo "04. Send a GET /v2/entities without service path (/# is default service path)"
+echo "04. Send a GET /v2/entities without service path (/# is used as service path)"
 echo "============================================================================="
 orionCurl --url /v2/entities
 echo
 echo
 
 
-echo "05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'default service path'"
-echo "=========================================================================================="
+echo "05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'root service path'"
+echo "======================================================================================="
 orionCurl --url /admin/metrics
 echo
 echo
@@ -106,7 +106,7 @@ Date: REGEX(.*)
 []
 
 
-04. Send a GET /v2/entities without service path (/# is default service path)
+04. Send a GET /v2/entities without service path (/# is used as service path)
 =============================================================================
 HTTP/1.1 200 OK
 Content-Length: 2
@@ -117,8 +117,8 @@ Date: REGEX(.*)
 []
 
 
-05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'default service path'
-==========================================================================================
+05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'root service path'
+=======================================================================================
 HTTP/1.1 200 OK
 Content-Length: 842
 Content-Type: application/json

--- a/test/functionalTest/cases/2750_common_metrics/2750_complex_service_path.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_complex_service_path.test
@@ -1,0 +1,184 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Incoming Transactions and Common Metrics
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Send a GET /v2/entities with service path /A1/#
+# 02. Send a GET /v2/entities with service path /A2,/B2
+# 03. Send a GET /v2/entities with service path /#
+# 04. Send a GET /v2/entities without service path (/# is default service path)
+# 05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'default service path'
+#
+
+echo "01. Send a GET /v2/entities with service path /A1/#"
+echo "==================================================="
+orionCurl --url /v2/entities --servicePath '/A1/#'
+echo
+echo
+
+
+echo "02. Send a GET /v2/entities with service path /A2,/B2"
+echo "====================================================="
+orionCurl --url /v2/entities --servicePath '/A2,/B2'
+echo
+echo
+
+
+echo "03. Send a GET /v2/entities with service path /#"
+echo "================================================"
+orionCurl --url /v2/entities --servicePath '/#'
+echo
+echo
+
+
+echo "04. Send a GET /v2/entities without service path (/# is default service path)"
+echo "============================================================================="
+orionCurl --url /v2/entities
+echo
+echo
+
+
+echo "05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'default service path'"
+echo "=========================================================================================="
+orionCurl --url /admin/metrics
+echo
+echo
+
+
+--REGEXPECT--
+01. Send a GET /v2/entities with service path /A1/#
+===================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
+
+
+02. Send a GET /v2/entities with service path /A2,/B2
+=====================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
+
+
+03. Send a GET /v2/entities with service path /#
+================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
+
+
+04. Send a GET /v2/entities without service path (/# is default service path)
+=============================================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
+
+
+05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'default service path'
+==========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 842
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "services": {
+        "default-service": {
+            "subservs": {
+                "A1": {
+                    "incomingTransactionResponseSize": 2,
+                    "incomingTransactions": 1,
+                    "serviceTime": REGEX(.*)
+                },
+                "A2": {
+                    "incomingTransactionResponseSize": 2,
+                    "incomingTransactions": 1,
+                    "serviceTime": REGEX(.*)
+                },
+                "root-subserv": {
+                    "incomingTransactionResponseSize": 4,
+                    "incomingTransactions": 2,
+                    "serviceTime": REGEX(.*)
+                }
+            },
+            "sum": {
+                "incomingTransactionResponseSize": 8,
+                "incomingTransactions": 4,
+                "serviceTime": REGEX(.*)
+            }
+        }
+    },
+    "sum": {
+        "subservs": {
+            "A1": {
+                "incomingTransactionResponseSize": 2,
+                "incomingTransactions": 1,
+                "serviceTime": REGEX(.*)
+            },
+            "A2": {
+                "incomingTransactionResponseSize": 2,
+                "incomingTransactions": 1,
+                "serviceTime": REGEX(.*)
+            },
+            "root-subserv": {
+                "incomingTransactionResponseSize": 4,
+                "incomingTransactions": 2,
+                "serviceTime": REGEX(.*)
+            }
+        },
+        "sum": {
+            "incomingTransactionResponseSize": 8,
+            "incomingTransactions": 4,
+            "serviceTime": REGEX(.*)
+        }
+    }
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/2750_common_metrics/2750_forwards.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_forwards.test
@@ -214,14 +214,14 @@ Date: REGEX(.*)
 06. Ask for metrics, see 3 outgoing transactions
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 1107
+Content-Length: 1122
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
                 "SP": {
                     "incomingTransactionErrors": 1,
@@ -304,20 +304,15 @@ Date: REGEX(.*)
 09. Ask for metrics, see 1 error in outgoing transactions
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 1871
+Content-Length: 1910
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
-                "": {
-                    "incomingTransactionResponseSize": 1107,
-                    "incomingTransactions": 1,
-                    "serviceTime": REGEX(.*)
-                },
                 "SP": {
                     "incomingTransactionErrors": 1,
                     "incomingTransactionRequestSize": 164,
@@ -337,12 +332,17 @@ Date: REGEX(.*)
                     "outgoingTransactionRequestSize": 103,
                     "outgoingTransactions": 1,
                     "serviceTime": REGEX(.*)
+                },
+                "root-subserv": {
+                    "incomingTransactionResponseSize": 1122,
+                    "incomingTransactions": 1,
+                    "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
                 "incomingTransactionErrors": 2,
                 "incomingTransactionRequestSize": 304,
-                "incomingTransactionResponseSize": 1520,
+                "incomingTransactionResponseSize": 1535,
                 "incomingTransactions": 7,
                 "outgoingTransactionErrors": 1,
                 "outgoingTransactionRequestSize": 576,
@@ -354,11 +354,6 @@ Date: REGEX(.*)
     },
     "sum": {
         "subservs": {
-            "": {
-                "incomingTransactionResponseSize": 1107,
-                "incomingTransactions": 1,
-                "serviceTime": REGEX(.*)
-            },
             "SP": {
                 "incomingTransactionErrors": 1,
                 "incomingTransactionRequestSize": 164,
@@ -378,12 +373,17 @@ Date: REGEX(.*)
                 "outgoingTransactionRequestSize": 103,
                 "outgoingTransactions": 1,
                 "serviceTime": REGEX(.*)
+            },
+            "root-subserv": {
+                "incomingTransactionResponseSize": 1122,
+                "incomingTransactions": 1,
+                "serviceTime": REGEX(.*)
             }
         },
         "sum": {
             "incomingTransactionErrors": 2,
             "incomingTransactionRequestSize": 304,
-            "incomingTransactionResponseSize": 1520,
+            "incomingTransactionResponseSize": 1535,
             "incomingTransactions": 7,
             "outgoingTransactionErrors": 1,
             "outgoingTransactionRequestSize": 576,

--- a/test/functionalTest/cases/2750_common_metrics/2750_incoming_errors.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_incoming_errors.test
@@ -90,12 +90,13 @@ brokerStart CB
 # 05. Send a request with an Invalid Service Path
 # 06. Send a request with an Invalid Content-Type
 # 07. Send a request with invalid value for URI param /options/
-# 08. Send a request with Content-Length > PAYLOAD_MAX_SIZE
+# 08. Send a request with a component-name too long in ServicePath
 # 09. Send a request with no acceptable mime-type in accept header
 # 10. Send a request with an invalid character in a URI parameter
 # 11. Send a request with too many components in ServicePath
 # 12. Send a PUT /v2/entities/<id>/attrs/<attrName>/value for an non-existing entity E_NOPE
-# 13. Ask for metrics and see 10 errors
+# 13. Send a request with an Invalid Tenant
+# 14. Ask for metrics and see 7 errors (as Service Path and Tenant errors are ignored in metrics)
 #
 
 
@@ -202,8 +203,14 @@ echo
 echo
 
 
-echo "13. Ask for metrics and see 10 errors"
-echo "====================================="
+echo "13. Send a request with an Invalid Tenant"
+echo "========================================="
+orionCurl --url /v2/entities --tenant 'a.b'
+echo
+echo
+
+echo "14. Ask for metrics and see 7 errors (as Service Path and Tenant errors are ignored in metrics)"
+echo "==============================================================================================="
 orionCurl --url /admin/metrics --servicePath /SP/get/metrics
 echo
 echo
@@ -476,10 +483,24 @@ Date: REGEX(.*)
 }
 
 
-13. Ask for metrics and see 10 errors
-=====================================
+13. Send a request with an Invalid Tenant
+=========================================
+HTTP/1.1 400 Bad Request
+Content-Length: 125
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "bad character in tenant name - only underscore and alphanumeric characters are allowed",
+    "error": "BadRequest"
+}
+
+
+14. Ask for metrics and see 7 errors (as Service Path and Tenant errors are ignored in metrics)
+===============================================================================================
 HTTP/1.1 200 OK
-Content-Length: 2323
+Content-Length: 1397
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -491,18 +512,6 @@ Date: REGEX(.*)
                 "": {
                     "incomingTransactionErrors": 1,
                     "incomingTransactionResponseSize": 73,
-                    "incomingTransactions": 1,
-                    "serviceTime": REGEX(.*)
-                },
-                "SP/L1/L2/L3/L4/L5/L6/L7/L8/L9/L10": {
-                    "incomingTransactionErrors": 1,
-                    "incomingTransactionResponseSize": 73,
-                    "incomingTransactions": 1,
-                    "serviceTime": REGEX(.*)
-                },
-                "SP/b12345678901234567890123456789012345678901234567890/c": {
-                    "incomingTransactionErrors": 1,
-                    "incomingTransactionResponseSize": 77,
                     "incomingTransactions": 1,
                     "serviceTime": REGEX(.*)
                 },
@@ -522,19 +531,13 @@ Date: REGEX(.*)
                     "incomingTransactionResponseSize": 1602,
                     "incomingTransactions": 2,
                     "serviceTime": REGEX(.*)
-                },
-                "SPX": {
-                    "incomingTransactionErrors": 1,
-                    "incomingTransactionResponseSize": 111,
-                    "incomingTransactions": 1,
-                    "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
-                "incomingTransactionErrors": 10,
+                "incomingTransactionErrors": 7,
                 "incomingTransactionRequestSize": 39,
-                "incomingTransactionResponseSize": 2557,
-                "incomingTransactions": 13,
+                "incomingTransactionResponseSize": 2296,
+                "incomingTransactions": 10,
                 "serviceTime": REGEX(.*)
             }
         }
@@ -544,18 +547,6 @@ Date: REGEX(.*)
             "": {
                 "incomingTransactionErrors": 1,
                 "incomingTransactionResponseSize": 73,
-                "incomingTransactions": 1,
-                "serviceTime": REGEX(.*)
-            },
-            "SP/L1/L2/L3/L4/L5/L6/L7/L8/L9/L10": {
-                "incomingTransactionErrors": 1,
-                "incomingTransactionResponseSize": 73,
-                "incomingTransactions": 1,
-                "serviceTime": REGEX(.*)
-            },
-            "SP/b12345678901234567890123456789012345678901234567890/c": {
-                "incomingTransactionErrors": 1,
-                "incomingTransactionResponseSize": 77,
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             },
@@ -575,19 +566,13 @@ Date: REGEX(.*)
                 "incomingTransactionResponseSize": 1602,
                 "incomingTransactions": 2,
                 "serviceTime": REGEX(.*)
-            },
-            "SPX": {
-                "incomingTransactionErrors": 1,
-                "incomingTransactionResponseSize": 111,
-                "incomingTransactions": 1,
-                "serviceTime": REGEX(.*)
             }
         },
         "sum": {
-            "incomingTransactionErrors": 10,
+            "incomingTransactionErrors": 7,
             "incomingTransactionRequestSize": 39,
-            "incomingTransactionResponseSize": 2557,
-            "incomingTransactions": 13,
+            "incomingTransactionResponseSize": 2296,
+            "incomingTransactions": 10,
             "serviceTime": REGEX(.*)
         }
     }

--- a/test/functionalTest/cases/2750_common_metrics/2750_incoming_errors.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_incoming_errors.test
@@ -231,14 +231,14 @@ Date: REGEX(.*)
 01. Ask for metrics and see no errors
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 457
+Content-Length: 472
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
                 "SP/get/entities": {
                     "incomingTransactionResponseSize": 2,
@@ -287,14 +287,14 @@ Date: REGEX(.*)
 03. Ask for metrics and see one error
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 1145
+Content-Length: 1160
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
                 "SP/error": {
                     "incomingTransactionErrors": 1,
@@ -309,7 +309,7 @@ Date: REGEX(.*)
                     "serviceTime": REGEX(.*)
                 },
                 "SP/get/metrics": {
-                    "incomingTransactionResponseSize": 457,
+                    "incomingTransactionResponseSize": 472,
                     "incomingTransactions": 1,
                     "serviceTime": REGEX(.*)
                 }
@@ -317,7 +317,7 @@ Date: REGEX(.*)
             "sum": {
                 "incomingTransactionErrors": 1,
                 "incomingTransactionRequestSize": 24,
-                "incomingTransactionResponseSize": 609,
+                "incomingTransactionResponseSize": 624,
                 "incomingTransactions": 3,
                 "serviceTime": REGEX(.*)
             }
@@ -338,7 +338,7 @@ Date: REGEX(.*)
                 "serviceTime": REGEX(.*)
             },
             "SP/get/metrics": {
-                "incomingTransactionResponseSize": 457,
+                "incomingTransactionResponseSize": 472,
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             }
@@ -346,7 +346,7 @@ Date: REGEX(.*)
         "sum": {
             "incomingTransactionErrors": 1,
             "incomingTransactionRequestSize": 24,
-            "incomingTransactionResponseSize": 609,
+            "incomingTransactionResponseSize": 624,
             "incomingTransactions": 3,
             "serviceTime": REGEX(.*)
         }
@@ -500,21 +500,15 @@ Date: REGEX(.*)
 14. Ask for metrics and see 7 errors (as Service Path and Tenant errors are ignored in metrics)
 ===============================================================================================
 HTTP/1.1 200 OK
-Content-Length: 1397
+Content-Length: 1436
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
-                "": {
-                    "incomingTransactionErrors": 1,
-                    "incomingTransactionResponseSize": 73,
-                    "incomingTransactions": 1,
-                    "serviceTime": REGEX(.*)
-                },
                 "SP/error": {
                     "incomingTransactionErrors": 6,
                     "incomingTransactionRequestSize": 39,
@@ -528,15 +522,21 @@ Date: REGEX(.*)
                     "serviceTime": REGEX(.*)
                 },
                 "SP/get/metrics": {
-                    "incomingTransactionResponseSize": 1602,
+                    "incomingTransactionResponseSize": 1632,
                     "incomingTransactions": 2,
+                    "serviceTime": REGEX(.*)
+                },
+                "root-subserv": {
+                    "incomingTransactionErrors": 1,
+                    "incomingTransactionResponseSize": 73,
+                    "incomingTransactions": 1,
                     "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
                 "incomingTransactionErrors": 7,
                 "incomingTransactionRequestSize": 39,
-                "incomingTransactionResponseSize": 2296,
+                "incomingTransactionResponseSize": 2326,
                 "incomingTransactions": 10,
                 "serviceTime": REGEX(.*)
             }
@@ -544,12 +544,6 @@ Date: REGEX(.*)
     },
     "sum": {
         "subservs": {
-            "": {
-                "incomingTransactionErrors": 1,
-                "incomingTransactionResponseSize": 73,
-                "incomingTransactions": 1,
-                "serviceTime": REGEX(.*)
-            },
             "SP/error": {
                 "incomingTransactionErrors": 6,
                 "incomingTransactionRequestSize": 39,
@@ -563,15 +557,21 @@ Date: REGEX(.*)
                 "serviceTime": REGEX(.*)
             },
             "SP/get/metrics": {
-                "incomingTransactionResponseSize": 1602,
+                "incomingTransactionResponseSize": 1632,
                 "incomingTransactions": 2,
+                "serviceTime": REGEX(.*)
+            },
+            "root-subserv": {
+                "incomingTransactionErrors": 1,
+                "incomingTransactionResponseSize": 73,
+                "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             }
         },
         "sum": {
             "incomingTransactionErrors": 7,
             "incomingTransactionRequestSize": 39,
-            "incomingTransactionResponseSize": 2296,
+            "incomingTransactionResponseSize": 2326,
             "incomingTransactions": 10,
             "serviceTime": REGEX(.*)
         }

--- a/test/functionalTest/cases/2750_common_metrics/2750_notifications.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_notifications.test
@@ -133,14 +133,14 @@ Date: REGEX(.*)
 03. Ask for metrics, see 1 outgoing transaction
 ===============================================
 HTTP/1.1 200 OK
-Content-Length: 683
+Content-Length: 698
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
                 "SP": {
                     "incomingTransactionRequestSize": 177,
@@ -197,14 +197,14 @@ Date: REGEX(.*)
 06. Ask for metrics, see 2 outgoing transaction of which 1 failed
 =================================================================
 HTTP/1.1 200 OK
-Content-Length: 1095
+Content-Length: 1110
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
                 "SP": {
                     "incomingTransactionRequestSize": 227,
@@ -215,14 +215,14 @@ Date: REGEX(.*)
                     "serviceTime": REGEX(.*)
                 },
                 "SP/get/metrics": {
-                    "incomingTransactionResponseSize": 683,
+                    "incomingTransactionResponseSize": 698,
                     "incomingTransactions": 1,
                     "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
                 "incomingTransactionRequestSize": 227,
-                "incomingTransactionResponseSize": 683,
+                "incomingTransactionResponseSize": 698,
                 "incomingTransactions": 4,
                 "outgoingTransactionErrors": 1,
                 "outgoingTransactionRequestSize": 248,
@@ -242,14 +242,14 @@ Date: REGEX(.*)
                 "serviceTime": REGEX(.*)
             },
             "SP/get/metrics": {
-                "incomingTransactionResponseSize": 683,
+                "incomingTransactionResponseSize": 698,
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             }
         },
         "sum": {
             "incomingTransactionRequestSize": 227,
-            "incomingTransactionResponseSize": 683,
+            "incomingTransactionResponseSize": 698,
             "incomingTransactions": 4,
             "outgoingTransactionErrors": 1,
             "outgoingTransactionRequestSize": 248,

--- a/test/functionalTest/cases/2750_common_metrics/2750_reset_metrics.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_reset_metrics.test
@@ -95,14 +95,14 @@ Date: REGEX(.*)
 02. Ask for Metrics, see 1 Incoming Transaction
 ===============================================
 HTTP/1.1 200 OK
-Content-Length: 457
+Content-Length: 472
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
                 "SP/get/entities": {
                     "incomingTransactionResponseSize": 2,
@@ -146,14 +146,14 @@ Date: REGEX(.*)
 04. Ask for Metrics, see 1 Incoming Transaction (the reset-request in step 03 :-)
 =================================================================================
 HTTP/1.1 200 OK
-Content-Length: 317
+Content-Length: 332
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
                 "SP/delete/metrics": {
                     "incomingTransactions": 1,
@@ -184,27 +184,27 @@ Date: REGEX(.*)
 05. Ask for Metrics, with ?reset=true to reset after responding
 ===============================================================
 HTTP/1.1 200 OK
-Content-Length: 581
+Content-Length: 620
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
-                "": {
-                    "incomingTransactionResponseSize": 317,
+                "SP/delete/metrics": {
                     "incomingTransactions": 1,
                     "serviceTime": REGEX(.*)
                 },
-                "SP/delete/metrics": {
+                "root-subserv": {
+                    "incomingTransactionResponseSize": 332,
                     "incomingTransactions": 1,
                     "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
-                "incomingTransactionResponseSize": 317,
+                "incomingTransactionResponseSize": 332,
                 "incomingTransactions": 2,
                 "serviceTime": REGEX(.*)
             }
@@ -212,18 +212,18 @@ Date: REGEX(.*)
     },
     "sum": {
         "subservs": {
-            "": {
-                "incomingTransactionResponseSize": 317,
+            "SP/delete/metrics": {
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             },
-            "SP/delete/metrics": {
+            "root-subserv": {
+                "incomingTransactionResponseSize": 332,
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             }
         },
         "sum": {
-            "incomingTransactionResponseSize": 317,
+            "incomingTransactionResponseSize": 332,
             "incomingTransactions": 2,
             "serviceTime": REGEX(.*)
         }
@@ -234,23 +234,23 @@ Date: REGEX(.*)
 06. Ask for Metrics, see 1 Incoming Transaction (step 05)
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 441
+Content-Length: 456
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
                 "SP5": {
-                    "incomingTransactionResponseSize": 581,
+                    "incomingTransactionResponseSize": 620,
                     "incomingTransactions": 1,
                     "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
-                "incomingTransactionResponseSize": 581,
+                "incomingTransactionResponseSize": 620,
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             }
@@ -259,13 +259,13 @@ Date: REGEX(.*)
     "sum": {
         "subservs": {
             "SP5": {
-                "incomingTransactionResponseSize": 581,
+                "incomingTransactionResponseSize": 620,
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             }
         },
         "sum": {
-            "incomingTransactionResponseSize": 581,
+            "incomingTransactionResponseSize": 620,
             "incomingTransactions": 1,
             "serviceTime": REGEX(.*)
         }

--- a/test/functionalTest/cases/2750_common_metrics/2750_totalPayloadAsMetric.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_totalPayloadAsMetric.test
@@ -166,16 +166,16 @@ Date: REGEX(.*)
 04. Ask for Metrics, see 3 Incoming Transactions, and 50 bytes in incomingTransactionRequestSize
 ================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 884
+Content-Length: 923
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
-                "": {
+                "root-subserv": {
                     "incomingTransactionRequestSize": 50,
                     "incomingTransactionResponseSize": 435,
                     "incomingTransactions": 2,
@@ -206,15 +206,15 @@ Date: REGEX(.*)
     },
     "sum": {
         "subservs": {
-            "": {
-                "incomingTransactionRequestSize": 50,
-                "incomingTransactionResponseSize": 435,
-                "incomingTransactions": 2,
-                "serviceTime": REGEX(.*)
-            },
             "SP1": {
                 "incomingTransactionResponseSize": 2,
                 "incomingTransactions": 1,
+                "serviceTime": REGEX(.*)
+            },
+            "root-subserv": {
+                "incomingTransactionRequestSize": 50,
+                "incomingTransactionResponseSize": 435,
+                "incomingTransactions": 2,
                 "serviceTime": REGEX(.*)
             }
         },
@@ -241,25 +241,25 @@ Date: REGEX(.*)
 06. Ask for Metrics, see 5 Incoming Transactions, and 150 bytes in incomingTransactionRequestSize
 =================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 892
+Content-Length: 931
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
-                "": {
+                "root-subserv": {
                     "incomingTransactionRequestSize": 150,
-                    "incomingTransactionResponseSize": 1319,
+                    "incomingTransactionResponseSize": 1358,
                     "incomingTransactions": 4,
                     "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
                 "incomingTransactionRequestSize": 150,
-                "incomingTransactionResponseSize": 1319,
+                "incomingTransactionResponseSize": 1358,
                 "incomingTransactions": 4,
                 "serviceTime": REGEX(.*)
             }
@@ -281,21 +281,21 @@ Date: REGEX(.*)
     },
     "sum": {
         "subservs": {
-            "": {
-                "incomingTransactionRequestSize": 150,
-                "incomingTransactionResponseSize": 1319,
-                "incomingTransactions": 4,
-                "serviceTime": REGEX(.*)
-            },
             "SP1": {
                 "incomingTransactionResponseSize": 2,
                 "incomingTransactions": 1,
+                "serviceTime": REGEX(.*)
+            },
+            "root-subserv": {
+                "incomingTransactionRequestSize": 150,
+                "incomingTransactionResponseSize": 1358,
+                "incomingTransactions": 4,
                 "serviceTime": REGEX(.*)
             }
         },
         "sum": {
             "incomingTransactionRequestSize": 150,
-            "incomingTransactionResponseSize": 1321,
+            "incomingTransactionResponseSize": 1360,
             "incomingTransactions": 5,
             "serviceTime": REGEX(.*)
         }
@@ -317,30 +317,30 @@ Date: REGEX(.*)
 08. Ask for Metrics, see 8, and see incomingTransactionResponseSize
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 1106
+Content-Length: 1145
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "services": {
-        "": {
+        "default-service": {
             "subservs": {
-                "": {
-                    "incomingTransactionRequestSize": 150,
-                    "incomingTransactionResponseSize": 2211,
-                    "incomingTransactions": 5,
-                    "serviceTime": REGEX(.*)
-                },
                 "SP/get/entities": {
                     "incomingTransactionResponseSize": 2,
                     "incomingTransactions": 1,
+                    "serviceTime": REGEX(.*)
+                },
+                "root-subserv": {
+                    "incomingTransactionRequestSize": 150,
+                    "incomingTransactionResponseSize": 2289,
+                    "incomingTransactions": 5,
                     "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
                 "incomingTransactionRequestSize": 150,
-                "incomingTransactionResponseSize": 2213,
+                "incomingTransactionResponseSize": 2291,
                 "incomingTransactions": 6,
                 "serviceTime": REGEX(.*)
             }
@@ -362,12 +362,6 @@ Date: REGEX(.*)
     },
     "sum": {
         "subservs": {
-            "": {
-                "incomingTransactionRequestSize": 150,
-                "incomingTransactionResponseSize": 2211,
-                "incomingTransactions": 5,
-                "serviceTime": REGEX(.*)
-            },
             "SP/get/entities": {
                 "incomingTransactionResponseSize": 2,
                 "incomingTransactions": 1,
@@ -377,11 +371,17 @@ Date: REGEX(.*)
                 "incomingTransactionResponseSize": 2,
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
+            },
+            "root-subserv": {
+                "incomingTransactionRequestSize": 150,
+                "incomingTransactionResponseSize": 2289,
+                "incomingTransactions": 5,
+                "serviceTime": REGEX(.*)
             }
         },
         "sum": {
             "incomingTransactionRequestSize": 150,
-            "incomingTransactionResponseSize": 2215,
+            "incomingTransactionResponseSize": 2293,
             "incomingTransactions": 7,
             "serviceTime": REGEX(.*)
         }


### PR DESCRIPTION
Fixed last "known and decided part" of #2750:
* No metrics for erroneous tenants and service paths
* Special names for default tenant and service path in metrics
* Complex Service Paths to use a simplification of the service path for metrics