### PR TITLE
FIX use --prety-print in accumulstorStart in all .test in all cases where it makes sense

### DIFF
--- a/test/functionalTest/cases/0000_ipv6_support/ipv4_ipv6_both.test
+++ b/test/functionalTest/cases/0000_ipv6_support/ipv4_ipv6_both.test
@@ -26,8 +26,8 @@ IPv6 IPv4 Both
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart 0.0.0.0 ${LISTENER_PORT}
-accumulatorStart :: ${LISTENER2_PORT}
+accumulatorStart --pretty-print 0.0.0.0 ${LISTENER_PORT}
+accumulatorStart --pretty-print :: ${LISTENER2_PORT}
 
 --SHELL--
 echo "1: ++++++++++++++++++++"
@@ -232,28 +232,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L23"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L23"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 7: ++++++++++++++++++++
@@ -266,28 +266,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L23"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L23"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_large_requests/notification_different_sizes.test
+++ b/test/functionalTest/cases/0000_large_requests/notification_different_sizes.test
@@ -26,7 +26,7 @@ Notifications of different sizes
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 #
 # Taking into account that the notification size depends on (but is not exactly equal to)

--- a/test/functionalTest/cases/0000_ngsi10_compound_values/compound_subscription_json.test
+++ b/test/functionalTest/cases/0000_ngsi10_compound_values/compound_subscription_json.test
@@ -26,7 +26,7 @@ Subscription sequence ONCHANGE with compound values JSON
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 echo "1: +++++++++ Prepare subscription +++++++++++"
@@ -193,41 +193,41 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "att",
-            "type" : "compound",
-            "value" : [
-              "22",
-              {
-                "x" : [
-                  "x1",
-                  "x2"
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "compound",
+                        "value": [
+                            "22",
+                            {
+                                "x": [
+                                    "x1",
+                                    "x2"
+                                ],
+                                "y": "3"
+                            },
+                            [
+                                "z1",
+                                "z2"
+                            ]
+                        ]
+                    }
                 ],
-                "y" : "3"
-              },
-              [
-                "z1",
-                "z2"
-              ]
-            ]
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+                "id": "E",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -239,37 +239,37 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "att",
-            "type" : "compound",
-            "value" : {
-              "x" : {
-                "x1" : "a",
-                "x2" : "b"
-              },
-              "y" : [
-                "y1",
-                "y2"
-              ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "compound",
+                        "value": {
+                            "x": {
+                                "x1": "a",
+                                "x2": "b"
+                            },
+                            "y": [
+                                "y1",
+                                "y2"
+                            ]
+                        }
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
             }
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange.test
+++ b/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange.test
@@ -26,7 +26,7 @@ Subscription sequence ONCHANGE
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 payload='{
@@ -521,28 +521,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "ligthstatus",
-            "type" : "light",
-            "value" : "L23"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "ligthstatus",
+                        "type": "light",
+                        "value": "L23"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -554,33 +554,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "ligthstatus",
-            "type" : "light",
-            "value" : "L23"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t100"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "ligthstatus",
+                        "type": "light",
+                        "value": "L23"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t100"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -592,33 +592,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "ligthstatus",
-            "type" : "light",
-            "value" : "L53"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t100"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "ligthstatus",
+                        "type": "light",
+                        "value": "L53"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t100"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -630,33 +630,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "ligthstatus",
-            "type" : "light",
-            "value" : "L63"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t39"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "ligthstatus",
+                        "type": "light",
+                        "value": "L63"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t39"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange_nocache.test
+++ b/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange_nocache.test
@@ -26,7 +26,7 @@ Subscription sequence ONCHANGE without subCache
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0 IPv4 -noCache
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 url="/v1/contextSubscriptions"
@@ -542,28 +542,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "ligthstatus",
-            "type" : "light",
-            "value" : "L23"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "ligthstatus",
+                        "type": "light",
+                        "value": "L23"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -575,33 +575,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "ligthstatus",
-            "type" : "light",
-            "value" : "L23"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t100"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "ligthstatus",
+                        "type": "light",
+                        "value": "L23"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t100"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -613,33 +613,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "ligthstatus",
-            "type" : "light",
-            "value" : "L53"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t100"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "ligthstatus",
+                        "type": "light",
+                        "value": "L53"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t100"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -651,33 +651,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "ligthstatus",
-            "type" : "light",
-            "value" : "L63"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t39"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "ligthstatus",
+                        "type": "light",
+                        "value": "L63"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t39"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_id_metadata.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_id_metadata.test
@@ -26,7 +26,7 @@ Subscription ID metadata
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -173,47 +173,47 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "23.5",
-            "metadatas" : [
-              {
-                "name" : "ID",
-                "type" : "string",
-                "value" : "floor"
-              }
-            ]
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "25.6",
-            "metadatas" : [
-              {
-                "name" : "ID",
-                "type" : "string",
-                "value" : "ceiling"
-              }
-            ]
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "metadatas": [
+                            {
+                                "name": "ID",
+                                "type": "string",
+                                "value": "floor"
+                            }
+                        ],
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "23.5"
+                    },
+                    {
+                        "metadatas": [
+                            {
+                                "name": "ID",
+                                "type": "string",
+                                "value": "ceiling"
+                            }
+                        ],
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "25.6"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange.test
@@ -26,7 +26,7 @@ Subscription sequence ONCHANGE
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 payload='{
@@ -564,28 +564,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L23"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L23"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -597,33 +597,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L23"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t100"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L23"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t100"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -635,33 +635,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L53"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t100"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L53"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t100"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -673,33 +673,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L63"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t39"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L63"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t39"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange_expiration.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange_expiration.test
@@ -26,7 +26,7 @@ Subscription sequence ONCHANGE expiration check
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -190,28 +190,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "27"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "27"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange_nocache.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange_nocache.test
@@ -26,7 +26,7 @@ Subscription sequence ONCHANGE without subCache
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0 IPv4 -noCache
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -583,28 +583,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L23"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L23"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -616,33 +616,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L23"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t100"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L23"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t100"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -654,33 +654,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L53"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t100"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L53"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t100"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -692,33 +692,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "lightstatus",
-            "type" : "light",
-            "value" : "L63"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t39"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "lightstatus",
+                        "type": "light",
+                        "value": "L63"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t39"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_append-simpler.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_append-simpler.test
@@ -26,7 +26,7 @@ Subscription sequence wildcards ONCHANGE append
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -157,28 +157,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "pressure",
-            "type" : "clima",
-            "value" : "p23"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "pressure",
+                        "type": "clima",
+                        "value": "p23"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_append.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_append.test
@@ -26,7 +26,7 @@ Subscription sequence wildcards ONCHANGE append
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 101
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -450,28 +450,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "pressure",
-            "type" : "clima",
-            "value" : "p23"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "pressure",
+                        "type": "clima",
+                        "value": "p23"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -483,28 +483,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "pressure",
-            "type" : "clima",
-            "value" : "p83"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "pressure",
+                        "type": "clima",
+                        "value": "p83"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -516,28 +516,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom2",
-        "attributes" : [
-          {
-            "name" : "pressure",
-            "type" : "clima",
-            "value" : "p23"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "pressure",
+                        "type": "clima",
+                        "value": "p23"
+                    }
+                ],
+                "id": "OfficeRoom2",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -549,33 +549,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "pressure",
-            "type" : "clima",
-            "value" : "p83"
-          },
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t39"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "pressure",
+                        "type": "clima",
+                        "value": "p83"
+                    },
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t39"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_update.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_wildcards_onchange_update.test
@@ -26,7 +26,7 @@ Subscription sequence wildcards ONCHANGE update
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -334,28 +334,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t39"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t39"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -367,28 +367,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t50"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t50"
+                    }
+                ],
+                "id": "OfficeRoom",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -400,28 +400,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom2",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t51"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t51"
+                    }
+                ],
+                "id": "OfficeRoom2",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -433,28 +433,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "OfficeRoom2",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "value" : "t52"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "temperature",
+                        "type": "degree",
+                        "value": "t52"
+                    }
+                ],
+                "id": "OfficeRoom2",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsi9_subscriptions/subscription_availability_expiration.test
+++ b/test/functionalTest/cases/0000_ngsi9_subscriptions/subscription_availability_expiration.test
@@ -26,7 +26,7 @@ Subscription availability expiration check
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -183,28 +183,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "ConferenceRoom"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://localhost:1028"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "ConferenceRoom",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://localhost:1028"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0000_ngsi9_subscriptions/subscription_availability_sequence.test
+++ b/test/functionalTest/cases/0000_ngsi9_subscriptions/subscription_availability_sequence.test
@@ -26,7 +26,7 @@ Subscription availability sequence
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -428,28 +428,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "ConferenceRoom"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor1:1028"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "ConferenceRoom",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor1:1028"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -461,28 +461,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "BathRoom"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor2:1028"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "BathRoom",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor2:1028"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -494,28 +494,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "ConferenceRoom"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor1:1028"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "ConferenceRoom",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor1:1028"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -527,28 +527,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "LivingRoom"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor5:1028"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "LivingRoom",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor5:1028"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0000_ngsi9_subscriptions/subscription_availability_wildcards_sequence.test
+++ b/test/functionalTest/cases/0000_ngsi9_subscriptions/subscription_availability_wildcards_sequence.test
@@ -26,7 +26,7 @@ Subscription availability sequence with wildcards
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 url="/v1/registry/registerContext"
@@ -285,47 +285,47 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "ConferenceRoom"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor1:1028"
-      }
-    },
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "ConferenceRoom2"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor2:1028"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "ConferenceRoom",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor1:1028"
+            }
+        },
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "ConferenceRoom2",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor2:1028"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -337,28 +337,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "ConferenceRoom3"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor3:1028"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "ConferenceRoom3",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor3:1028"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -370,47 +370,47 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "OfficeRoom"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor1:1028"
-      }
-    },
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "OfficeRoom2"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor2:1028"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "OfficeRoom",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor1:1028"
+            }
+        },
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "OfficeRoom2",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor2:1028"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -422,28 +422,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "Room",
-            "isPattern" : "false",
-            "id" : "OfficeRoom3"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "degree",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://sensor4:1028"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "temperature",
+                        "type": "degree"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "OfficeRoom3",
+                        "isPattern": "false",
+                        "type": "Room"
+                    }
+                ],
+                "providingApplication": "http://sensor4:1028"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/deleteSubscriptionConvOp.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/deleteSubscriptionConvOp.test
@@ -26,7 +26,7 @@ ConvOp deleteSubscriptionConvOp: DELETE /v1/contextSubscriptions/{subscriptionId
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -248,28 +248,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "4"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "4"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -334,28 +334,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "4"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "4"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/postSubscribeContextAvailabilityConvOp.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/postSubscribeContextAvailabilityConvOp.test
@@ -26,7 +26,7 @@ ConvOp postSubscribeContextAvailabilityConvOp: POST /v1/registry/contextAvailabi
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -198,28 +198,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "T1",
-            "isPattern" : "false",
-            "id" : "E1"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://kz.tid.es/abc"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "A1",
+                        "type": "string"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "E1",
+                        "isPattern": "false",
+                        "type": "T1"
+                    }
+                ],
+                "providingApplication": "http://kz.tid.es/abc"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/postSubscribeContextConvOp.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/postSubscribeContextConvOp.test
@@ -26,7 +26,7 @@ ConvOp postSubscribeContextConvOp: POST /v1/contextSubscriptions
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -236,28 +236,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "a",
-            "value" : "E1/T1/A1"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "a",
+                        "value": "E1/T1/A1"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/putAvailabilitySubscriptionConvOp.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/putAvailabilitySubscriptionConvOp.test
@@ -26,7 +26,7 @@ ConvOp putAvailabilitySubscriptionConvOp: PUT /v1/registry/contextAvailabilitySu
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -329,28 +329,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "T1",
-            "isPattern" : "false",
-            "id" : "E1"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "A2",
-            "type" : "string",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://localhost:REGEX(\d+)/notify"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "A2",
+                        "type": "string"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "E1",
+                        "isPattern": "false",
+                        "type": "T1"
+                    }
+                ],
+                "providingApplication": "http://localhost:9997/notify"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -380,28 +380,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "contextRegistrationResponses" : [
-    {
-      "contextRegistration" : {
-        "entities" : [
-          {
-            "type" : "T1",
-            "isPattern" : "false",
-            "id" : "E1"
-          }
-        ],
-        "attributes" : [
-          {
-            "name" : "A2",
-            "type" : "string",
-            "isDomain" : "false"
-          }
-        ],
-        "providingApplication" : "http://localhost:REGEX(\d+)/notify"
-      }
-    }
-  ]
+    "contextRegistrationResponses": [
+        {
+            "contextRegistration": {
+                "attributes": [
+                    {
+                        "isDomain": "false",
+                        "name": "A2",
+                        "type": "string"
+                    }
+                ],
+                "entities": [
+                    {
+                        "id": "E1",
+                        "isPattern": "false",
+                        "type": "T1"
+                    }
+                ],
+                "providingApplication": "http://localhost:9997/notify"
+            }
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/putSubscriptionConvOp.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/putSubscriptionConvOp.test
@@ -26,7 +26,7 @@ ConvOp putSubscriptionConvOp: PUT /v1/contextSubscriptions/{subscriptionId}
 --SHELL-INIT--
 dbInit CB
 brokerStart CB  0
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -386,33 +386,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "1"
-          },
-          {
-            "name" : "A2",
-            "type" : "string",
-            "value" : "2"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "1"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "string",
+                        "value": "2"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -445,33 +445,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "1"
-          },
-          {
-            "name" : "A2",
-            "type" : "string",
-            "value" : "2"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "1"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "string",
+                        "value": "2"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -483,33 +483,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "1"
-          },
-          {
-            "name" : "A2",
-            "type" : "string",
-            "value" : "2"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "1"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "string",
+                        "value": "2"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -557,33 +557,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "1"
-          },
-          {
-            "name" : "A2",
-            "type" : "string",
-            "value" : "2"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "1"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "string",
+                        "value": "2"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -595,33 +595,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "1"
-          },
-          {
-            "name" : "A2",
-            "type" : "string",
-            "value" : "2"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "1"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "string",
+                        "value": "2"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -669,33 +669,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "1"
-          },
-          {
-            "name" : "A2",
-            "type" : "string",
-            "value" : "2"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "1"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "string",
+                        "value": "2"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -707,33 +707,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "1"
-          },
-          {
-            "name" : "A2",
-            "type" : "string",
-            "value" : "2"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "1"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "string",
+                        "value": "2"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -745,33 +745,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "string",
-            "value" : "11"
-          },
-          {
-            "name" : "A2",
-            "type" : "string",
-            "value" : "09"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "11"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "string",
+                        "value": "09"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0251_rush_support/rush.test
+++ b/test/functionalTest/cases/0251_rush_support/rush.test
@@ -25,7 +25,7 @@ Rush
 
 --SHELL-INIT--
 dbInit CB
-accumulatorStart localhost $LISTENER_PORT
+accumulatorStart --pretty-print localhost $LISTENER_PORT
 brokerStart CB 0-255 IPV4 -rush localhost:$LISTENER_PORT
 
 --SHELL--
@@ -150,28 +150,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Test",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "att",
-            "type" : "XXX",
-            "value" : "02"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "XXX",
+                        "value": "02"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "Test"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0251_rush_support/rush_default_port.test
+++ b/test/functionalTest/cases/0251_rush_support/rush_default_port.test
@@ -25,7 +25,7 @@ Rush (default port)
 
 --SHELL-INIT--
 dbInit CB
-accumulatorStart localhost $LISTENER_PORT
+accumulatorStart --pretty-print localhost $LISTENER_PORT
 brokerStart CB 0-255 IPV4 -rush localhost:$LISTENER_PORT
 
 --SHELL--
@@ -150,28 +150,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Test",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "att",
-            "type" : "XXX",
-            "value" : "02"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "XXX",
+                        "value": "02"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "Test"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0251_rush_support/rush_https.test
+++ b/test/functionalTest/cases/0251_rush_support/rush_https.test
@@ -25,7 +25,7 @@ Rush with HTTPS
 
 --SHELL-INIT--
 dbInit CB
-accumulatorStart localhost $LISTENER_PORT
+accumulatorStart --pretty-print localhost $LISTENER_PORT
 brokerStart CB 0-255 IPV4 -rush localhost:$LISTENER_PORT
 
 --SHELL--
@@ -152,28 +152,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Test",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "att",
-            "type" : "XXX",
-            "value" : "02"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "XXX",
+                        "value": "02"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "Test"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0251_rush_support/rush_https_default_port.test
+++ b/test/functionalTest/cases/0251_rush_support/rush_https_default_port.test
@@ -25,7 +25,7 @@ Rush with HTTPS
 
 --SHELL-INIT--
 dbInit CB
-accumulatorStart localhost $LISTENER_PORT
+accumulatorStart --pretty-print localhost $LISTENER_PORT
 brokerStart CB 0-255 IPV4 -rush localhost:$LISTENER_PORT
 
 --SHELL--
@@ -152,28 +152,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Test",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "att",
-            "type" : "XXX",
-            "value" : "02"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "XXX",
+                        "value": "02"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "Test"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0252_ngsi10_custom_metadata/custom_metadata_onchange.test
+++ b/test/functionalTest/cases/0252_ngsi10_custom_metadata/custom_metadata_onchange.test
@@ -26,7 +26,7 @@ Custom metadata ONCHANGE subscription
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart 127.0.0.1 "$LISTENER_PORT"
+accumulatorStart --pretty-print 127.0.0.1 "$LISTENER_PORT"
 
 --SHELL--
 echo "=== 1. Create ONCHANGE subscription"
@@ -465,40 +465,40 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "Room1",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "centigrade",
-            "value" : "43",
-            "metadatas" : [
-              {
-                "name" : "colour",
-                "type" : "string",
-                "value" : "red"
-              },
-              {
-                "name" : "feeling",
-                "type" : "string",
-                "value" : "angry"
-              }
-            ]
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "metadatas": [
+                            {
+                                "name": "colour",
+                                "type": "string",
+                                "value": "red"
+                            },
+                            {
+                                "name": "feeling",
+                                "type": "string",
+                                "value": "angry"
+                            }
+                        ],
+                        "name": "temperature",
+                        "type": "centigrade",
+                        "value": "43"
+                    }
+                ],
+                "id": "Room1",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -510,40 +510,40 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "Room1",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "centigrade",
-            "value" : "28",
-            "metadatas" : [
-              {
-                "name" : "colour",
-                "type" : "string",
-                "value" : "red"
-              },
-              {
-                "name" : "feeling",
-                "type" : "string",
-                "value" : "angry"
-              }
-            ]
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "metadatas": [
+                            {
+                                "name": "colour",
+                                "type": "string",
+                                "value": "red"
+                            },
+                            {
+                                "name": "feeling",
+                                "type": "string",
+                                "value": "angry"
+                            }
+                        ],
+                        "name": "temperature",
+                        "type": "centigrade",
+                        "value": "28"
+                    }
+                ],
+                "id": "Room1",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -555,40 +555,40 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "Room1",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "centigrade",
-            "value" : "28",
-            "metadatas" : [
-              {
-                "name" : "colour",
-                "type" : "string",
-                "value" : "red"
-              },
-              {
-                "name" : "feeling",
-                "type" : "string",
-                "value" : "happy"
-              }
-            ]
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "metadatas": [
+                            {
+                                "name": "colour",
+                                "type": "string",
+                                "value": "red"
+                            },
+                            {
+                                "name": "feeling",
+                                "type": "string",
+                                "value": "happy"
+                            }
+                        ],
+                        "name": "temperature",
+                        "type": "centigrade",
+                        "value": "28"
+                    }
+                ],
+                "id": "Room1",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -600,40 +600,40 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Room",
-        "isPattern" : "false",
-        "id" : "Room1",
-        "attributes" : [
-          {
-            "name" : "temperature",
-            "type" : "centigrade",
-            "value" : "12",
-            "metadatas" : [
-              {
-                "name" : "colour",
-                "type" : "string",
-                "value" : "white"
-              },
-              {
-                "name" : "feeling",
-                "type" : "string",
-                "value" : "happy"
-              }
-            ]
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "metadatas": [
+                            {
+                                "name": "colour",
+                                "type": "string",
+                                "value": "white"
+                            },
+                            {
+                                "name": "feeling",
+                                "type": "string",
+                                "value": "happy"
+                            }
+                        ],
+                        "name": "temperature",
+                        "type": "centigrade",
+                        "value": "12"
+                    }
+                ],
+                "id": "Room1",
+                "isPattern": "false",
+                "type": "Room"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0322_multitenancy/http_tenant_subscribe_and_update.test
+++ b/test/functionalTest/cases/0322_multitenancy/http_tenant_subscribe_and_update.test
@@ -28,8 +28,8 @@ dbInit CB
 dbInit ${CB_DB_NAME} t_01
 dbInit ${CB_DB_NAME} t_02
 brokerStart CB 0-255 IPV4 -multiservice
-accumulatorStart 
-accumulatorStart 127.0.0.1 $LISTENER2_PORT
+accumulatorStart  --pretty-print
+accumulatorStart 127.0.0.1 $LISTENER2_PORT --pretty-print
 
 --SHELL--
 
@@ -252,28 +252,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Test",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "att",
-            "type" : "test",
-            "value" : "accu_t01"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "test",
+                        "value": "accu_t01"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "Test"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -289,28 +289,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Test",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "att",
-            "type" : "test",
-            "value" : "accu_t02"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "test",
+                        "value": "accu_t02"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "Test"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0322_multitenancy/tenant_in_notification.test
+++ b/test/functionalTest/cases/0322_multitenancy/tenant_in_notification.test
@@ -26,7 +26,7 @@ Tenant as HTTP header in Notification
 --SHELL-INIT--
 dbInit CB
 dbInit kz
-accumulatorStart localhost $LISTENER_PORT
+accumulatorStart --pretty-print localhost $LISTENER_PORT
 brokerStart CB 30,60,185 IPV4 -multiservice
 
 --SHELL--
@@ -151,28 +151,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Test",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "att",
-            "type" : "XXX",
-            "value" : "02"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "att",
+                        "type": "XXX",
+                        "value": "02"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "Test"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 --TEARDOWN--

--- a/test/functionalTest/cases/0350_onanychange_subscriptions/onanychange_empty_cond_values.test
+++ b/test/functionalTest/cases/0350_onanychange_subscriptions/onanychange_empty_cond_values.test
@@ -26,7 +26,7 @@ ONANYCHANGE with empty cond values
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -276,33 +276,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "10"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "20"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "10"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "20"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -314,33 +314,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "20"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "20"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -352,33 +352,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "bb"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "bb"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -390,38 +390,38 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "bb"
-          },
-          {
-            "name" : "A3",
-            "type" : "",
-            "value" : "cc"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "bb"
+                    },
+                    {
+                        "name": "A3",
+                        "type": "",
+                        "value": "cc"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0350_onanychange_subscriptions/onanychange_empty_cond_values_nocache.test
+++ b/test/functionalTest/cases/0350_onanychange_subscriptions/onanychange_empty_cond_values_nocache.test
@@ -26,7 +26,7 @@ ONANYCHANGE with empty cond values without subs cache
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0 IPv4 -noCache
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -276,33 +276,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "10"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "20"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "10"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "20"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -314,33 +314,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "20"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "20"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -352,33 +352,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "bb"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "bb"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -390,38 +390,38 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "bb"
-          },
-          {
-            "name" : "A3",
-            "type" : "",
-            "value" : "cc"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "bb"
+                    },
+                    {
+                        "name": "A3",
+                        "type": "",
+                        "value": "cc"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0350_onanychange_subscriptions/onanychange_omit_cond_values.test
+++ b/test/functionalTest/cases/0350_onanychange_subscriptions/onanychange_omit_cond_values.test
@@ -26,7 +26,7 @@ ONANYCHANGE omitting cond values
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -276,33 +276,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "10"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "20"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "10"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "20"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -314,33 +314,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "20"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "20"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -352,33 +352,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "bb"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "bb"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -390,38 +390,38 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "bb"
-          },
-          {
-            "name" : "A3",
-            "type" : "",
-            "value" : "cc"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "bb"
+                    },
+                    {
+                        "name": "A3",
+                        "type": "",
+                        "value": "cc"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0350_onanychange_subscriptions/onanychange_omit_cond_values_nocache.test
+++ b/test/functionalTest/cases/0350_onanychange_subscriptions/onanychange_omit_cond_values_nocache.test
@@ -26,7 +26,7 @@ ONANYCHANGE omitting cond values without csubs cache
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0 IPv4 -noCache
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -275,33 +275,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "10"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "20"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "10"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "20"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -313,33 +313,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "20"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "20"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -351,33 +351,33 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "bb"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "bb"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -389,38 +389,38 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "",
-            "value" : "aa"
-          },
-          {
-            "name" : "A2",
-            "type" : "",
-            "value" : "bb"
-          },
-          {
-            "name" : "A3",
-            "type" : "",
-            "value" : "cc"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "",
+                        "value": "aa"
+                    },
+                    {
+                        "name": "A2",
+                        "type": "",
+                        "value": "bb"
+                    },
+                    {
+                        "name": "A3",
+                        "type": "",
+                        "value": "cc"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0640_attribute_name_unique_key_field/notify_type_change.test
+++ b/test/functionalTest/cases/0640_attribute_name_unique_key_field/notify_type_change.test
@@ -26,7 +26,7 @@ Update attribute type
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -196,28 +196,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "TEnt",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "T",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "T",
+                        "value": "V"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "TEnt"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -229,28 +229,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "TEnt",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "T2",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "T2",
+                        "value": "V"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "TEnt"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0673_xauth_token/auth_token_from_subscribe_request.test
+++ b/test/functionalTest/cases/0673_xauth_token/auth_token_from_subscribe_request.test
@@ -26,7 +26,7 @@ X-Auth-Token From Subscribe Request
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -200,28 +200,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})"
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "V"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -259,28 +259,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "V"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0673_xauth_token/auth_token_three_steps.test
+++ b/test/functionalTest/cases/0673_xauth_token/auth_token_three_steps.test
@@ -28,7 +28,7 @@ dbInit CB
 dbInit CP1
 brokerStart CB 0-255
 brokerStart CP1 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -245,28 +245,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "V"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -322,28 +322,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "V2"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "V2"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0673_xauth_token/subscription.test
+++ b/test/functionalTest/cases/0673_xauth_token/subscription.test
@@ -26,7 +26,7 @@ X-Auth-Token In Notifications
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -150,28 +150,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})"
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "V"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0674_servicepath_in_notifications/service_path_in_onchange_notification.test
+++ b/test/functionalTest/cases/0674_servicepath_in_notifications/service_path_in_onchange_notification.test
@@ -26,7 +26,7 @@ Service Path In ONCHANGE Notification
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -250,46 +250,46 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "string",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    },
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E2",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "string",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "string",
+                        "value": "V"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        },
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "string",
+                        "value": "V"
+                    }
+                ],
+                "id": "E2",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0674_servicepath_in_notifications/service_path_in_single_onchange_notification.test
+++ b/test/functionalTest/cases/0674_servicepath_in_notifications/service_path_in_single_onchange_notification.test
@@ -26,7 +26,7 @@ Service Path In Single ONCHANGE Notification
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -185,28 +185,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "string",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "string",
+                        "value": "V"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_both_cities_with_isPattern_and_deeper_service_path.test
+++ b/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_both_cities_with_isPattern_and_deeper_service_path.test
@@ -26,7 +26,7 @@ Simple NGSI10 subscription for both cities with isPattern and with deep recursiv
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -199,28 +199,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "Madrid"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "Madrid"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://127.0.0.1:REGEX(\d+)/notify
@@ -233,28 +233,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "Barcelona"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "Barcelona"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_exact_city_with_isPattern_and_deeper_service_path.test
+++ b/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_exact_city_with_isPattern_and_deeper_service_path.test
@@ -26,7 +26,7 @@ Simple NGSI10 subscription for EXACT city and isPattern and deeper service path
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -198,28 +198,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "Madrid"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "Madrid"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_isPattern_and_deeper_service_path.test
+++ b/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_isPattern_and_deeper_service_path.test
@@ -26,7 +26,7 @@ Simple NGSI10 subscription with isPattern and deeper service path
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -198,28 +198,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "Madrid"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "Madrid"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_recursive_service_path.test
+++ b/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_recursive_service_path.test
@@ -26,7 +26,7 @@ Simple NGSI10 subscription with recursive service path
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -198,28 +198,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "Madrid"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "Madrid"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_recursive_service_path_and_isPattern.test
+++ b/test/functionalTest/cases/0675_servicePath_in_ngsi10_subscriptions/simple_ngsi10_subscription_with_recursive_service_path_and_isPattern.test
@@ -26,7 +26,7 @@ Simple NGSI10 subscription with recursive service path and isPattern
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -198,28 +198,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "Madrid"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "Madrid"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0684_entity_type_missing/entity_type_missing_in_v1_contextEntities.test
+++ b/test/functionalTest/cases/0684_entity_type_missing/entity_type_missing_in_v1_contextEntities.test
@@ -26,7 +26,7 @@ Entity Type Missing In /v1/contextEntities
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 

--- a/test/functionalTest/cases/0691_empty_type_and_subscriptions/simple_ngsi10_subscriptions_with_empty_type_and_service_path.test
+++ b/test/functionalTest/cases/0691_empty_type_and_subscriptions/simple_ngsi10_subscriptions_with_empty_type_and_service_path.test
@@ -26,7 +26,7 @@ Simple NGSI10 subscription with empty type
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -145,28 +145,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "Madrid"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "Madrid"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0691_empty_type_and_subscriptions/simple_ngsi10_subscriptions_with_no_type_and_service_path.test
+++ b/test/functionalTest/cases/0691_empty_type_and_subscriptions/simple_ngsi10_subscriptions_with_no_type_and_service_path.test
@@ -26,7 +26,7 @@ Simple NGSI10 subscriptions with service path
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -197,28 +197,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T",
-        "isPattern" : "false",
-        "id" : "E",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "AT",
-            "value" : "Madrid"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "AT",
+                        "value": "Madrid"
+                    }
+                ],
+                "id": "E",
+                "isPattern": "false",
+                "type": "T"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/0714_propagate_service_path/no_propagation_of_service_path_when_not_present.test
+++ b/test/functionalTest/cases/0714_propagate_service_path/no_propagation_of_service_path_when_not_present.test
@@ -27,7 +27,7 @@ Do NOT propagate Service-Path when not in initial frequest
 dbInit CB
 
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -140,21 +140,21 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "contextElements" : [
-    {
-      "type" : "T",
-      "isPattern" : "false",
-      "id" : "E1",
-      "attributes" : [
+    "contextElements": [
         {
-          "name" : "A1",
-          "type" : "string",
-          "value" : "W1-CB"
+            "attributes": [
+                {
+                    "name": "A1",
+                    "type": "string",
+                    "value": "W1-CB"
+                }
+            ],
+            "id": "E1",
+            "isPattern": "false",
+            "type": "T"
         }
-      ]
-    }
-  ],
-  "updateAction" : "UPDATE"
+    ],
+    "updateAction": "UPDATE"
 }
 =======================================
 

--- a/test/functionalTest/cases/0715_forward_xauth_token_to_cprs/propagate_xauth_token_for_update_and_query_standard_ops.test
+++ b/test/functionalTest/cases/0715_forward_xauth_token_to_cprs/propagate_xauth_token_for_update_and_query_standard_ops.test
@@ -27,7 +27,7 @@ Propagate Service-Path for Update and Query Requests
 dbInit CB
 
 brokerStart CB 0
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -252,21 +252,21 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "contextElements" : [
-    {
-      "type" : "T",
-      "isPattern" : "false",
-      "id" : "E1",
-      "attributes" : [
+    "contextElements": [
         {
-          "name" : "A1",
-          "type" : "string",
-          "value" : "W1-CB"
+            "attributes": [
+                {
+                    "name": "A1",
+                    "type": "string",
+                    "value": "W1-CB"
+                }
+            ],
+            "id": "E1",
+            "isPattern": "false",
+            "type": "T"
         }
-      ]
-    }
-  ],
-  "updateAction" : "UPDATE"
+    ],
+    "updateAction": "UPDATE"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/v1/queryContext
@@ -279,16 +279,16 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "entities" : [
-    {
-      "type" : "T",
-      "isPattern" : "false",
-      "id" : "E1"
-    }
-  ],
-  "attributes" : [
-    "A1"
-  ]
+    "attributes": [
+        "A1"
+    ],
+    "entities": [
+        {
+            "id": "E1",
+            "isPattern": "false",
+            "type": "T"
+        }
+    ]
 }
 =======================================
 POST http://localhost:REGEX(\d+)/v1/updateContext
@@ -300,21 +300,21 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "contextElements" : [
-    {
-      "type" : "T",
-      "isPattern" : "false",
-      "id" : "E1",
-      "attributes" : [
+    "contextElements": [
         {
-          "name" : "A1",
-          "type" : "string",
-          "value" : "W1-CB"
+            "attributes": [
+                {
+                    "name": "A1",
+                    "type": "string",
+                    "value": "W1-CB"
+                }
+            ],
+            "id": "E1",
+            "isPattern": "false",
+            "type": "T"
         }
-      ]
-    }
-  ],
-  "updateAction" : "UPDATE"
+    ],
+    "updateAction": "UPDATE"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/v1/queryContext
@@ -326,16 +326,16 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "entities" : [
-    {
-      "type" : "T",
-      "isPattern" : "false",
-      "id" : "E1"
-    }
-  ],
-  "attributes" : [
-    "A1"
-  ]
+    "attributes": [
+        "A1"
+    ],
+    "entities": [
+        {
+            "id": "E1",
+            "isPattern": "false",
+            "type": "T"
+        }
+    ]
 }
 =======================================
 

--- a/test/functionalTest/cases/0880_timeout_for_forward_and_notifications/forward_that_times_out.test
+++ b/test/functionalTest/cases/0880_timeout_for_forward_and_notifications/forward_that_times_out.test
@@ -26,7 +26,7 @@ Forward That Times Out
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 

--- a/test/functionalTest/cases/0880_timeout_for_forward_and_notifications/notification_that_times_out.test
+++ b/test/functionalTest/cases/0880_timeout_for_forward_and_notifications/notification_that_times_out.test
@@ -26,7 +26,7 @@ Notification That Times Out
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 

--- a/test/functionalTest/cases/0943_overnotification_bug/overnotification_bug.test
+++ b/test/functionalTest/cases/0943_overnotification_bug/overnotification_bug.test
@@ -26,7 +26,7 @@ Notification caused by update in not covered attribute
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 

--- a/test/functionalTest/cases/1308_subscription_cache/cache_reset_from_db.test
+++ b/test/functionalTest/cases/1308_subscription_cache/cache_reset_from_db.test
@@ -28,9 +28,9 @@ dbInit CB
 dbInit CB t1
 dbInit CB t2
 brokerStart CB 0-255 IPv4 -multiservice -subCacheIval 5
-accumulatorStart localhost $LISTENER_PORT
-accumulatorStart localhost $LISTENER2_PORT
-accumulatorStart localhost $LISTENER3_PORT
+accumulatorStart --pretty-print localhost $LISTENER_PORT
+accumulatorStart --pretty-print localhost $LISTENER2_PORT
+accumulatorStart --pretty-print localhost $LISTENER3_PORT
 
 --SHELL--
 
@@ -325,28 +325,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Number",
-            "value" : 4
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Number",
+                        "value": 4
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -363,28 +363,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s11",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Number",
-            "value" : 5
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Number",
+                        "value": 5
+                    }
+                ],
+                "id": "s11",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -401,28 +401,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s21",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Number",
-            "value" : 6
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Number",
+                        "value": 6
+                    }
+                ],
+                "id": "s21",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -469,28 +469,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Number",
-            "value" : 4
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Number",
+                        "value": 4
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -502,28 +502,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Number",
-            "value" : 11
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Number",
+                        "value": 11
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -540,28 +540,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s11",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Number",
-            "value" : 5
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Number",
+                        "value": 5
+                    }
+                ],
+                "id": "s11",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -574,28 +574,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s11",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Number",
-            "value" : 12
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Number",
+                        "value": 12
+                    }
+                ],
+                "id": "s11",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 
@@ -612,28 +612,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s21",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Number",
-            "value" : 6
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Number",
+                        "value": 6
+                    }
+                ],
+                "id": "s21",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -646,28 +646,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s21",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Number",
-            "value" : 13
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Number",
+                        "value": 13
+                    }
+                ],
+                "id": "s21",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/1308_subscription_cache/subCacheMixedSubscriptionsWithUpdatesAndDeletes.test
+++ b/test/functionalTest/cases/1308_subscription_cache/subCacheMixedSubscriptionsWithUpdatesAndDeletes.test
@@ -26,7 +26,7 @@ Subscription Cache Mixed wildcard and not and removes and updates
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 38,101 IPv4 --cache
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 

--- a/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpiration.test
+++ b/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpiration.test
@@ -26,7 +26,7 @@ Subscription Cache Throttling and expiration
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 38,101 IPv4 -multiservice -subCacheIval 5
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -237,28 +237,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Text",
-            "value" : "03. Creation"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Text",
+                        "value": "03. Creation"
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -270,28 +270,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Text",
-            "value" : "07. Modification"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Text",
+                        "value": "07. Modification"
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpirationAfterRefresh.test
+++ b/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpirationAfterRefresh.test
@@ -27,7 +27,7 @@ Subscription Cache Throttling and expiration after Refresh
 dbInit CB
 dbInit CB t1
 brokerStart CB 38,101 IPv4 -multiservice -subCacheIval 10 --cache
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -276,28 +276,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Text",
-            "value" : "03. Creation"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Text",
+                        "value": "03. Creation"
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -309,28 +309,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Text",
-            "value" : "07. Modification"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Text",
+                        "value": "07. Modification"
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpirationAfterSubUpdate.test
+++ b/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpirationAfterSubUpdate.test
@@ -26,7 +26,7 @@ Subscription Cache Throttling and Expiration After Sub-Update
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 38,101 IPv4 -multiservice -subCacheIval 5
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -275,28 +275,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Text",
-            "value" : "03. Creation"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Text",
+                        "value": "03. Creation"
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -308,28 +308,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Text",
-            "value" : "07. Modification"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Text",
+                        "value": "07. Modification"
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpirationAfterSubUpdateWhenSubExpired.test
+++ b/test/functionalTest/cases/1308_subscription_cache/subCacheThrottlingAndExpirationAfterSubUpdateWhenSubExpired.test
@@ -26,7 +26,7 @@ Subscription Cache Throttling and Expiration After Sub-Update once the subscript
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 38,101 IPv4 -multiservice -subCacheIval 5
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -276,28 +276,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Text",
-            "value" : "03. Creation"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Text",
+                        "value": "03. Creation"
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -309,28 +309,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "s01",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "Text",
-            "value" : "07. Modification"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "Text",
+                        "value": "07. Modification"
+                    }
+                ],
+                "id": "s01",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/1308_subscription_cache/sub_expired_and_updated_then_cache_refresh.test
+++ b/test/functionalTest/cases/1308_subscription_cache/sub_expired_and_updated_then_cache_refresh.test
@@ -26,7 +26,7 @@ notifyFormat_ngsi10
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 38,101,102 IPv4 -subCacheIval 8 --cache
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -359,28 +359,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "E10",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "Text",
-            "value" : "01. Creation"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "Text",
+                        "value": "01. Creation"
+                    }
+                ],
+                "id": "E10",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -392,28 +392,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "E10",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "Text",
-            "value" : "09. Updated"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "Text",
+                        "value": "09. Updated"
+                    }
+                ],
+                "id": "E10",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -425,28 +425,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "E10",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "Text",
-            "value" : "10. Updated"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "Text",
+                        "value": "10. Updated"
+                    }
+                ],
+                "id": "E10",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -458,28 +458,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "Thing",
-        "isPattern" : "false",
-        "id" : "E10",
-        "attributes" : [
-          {
-            "name" : "A1",
-            "type" : "Text",
-            "value" : "11. Updated"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "Text",
+                        "value": "11. Updated"
+                    }
+                ],
+                "id": "E10",
+                "isPattern": "false",
+                "type": "Thing"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/1358_v1_empty_attribute_values/empty_attribute_values_notification.test
+++ b/test/functionalTest/cases/1358_v1_empty_attribute_values/empty_attribute_values_notification.test
@@ -26,7 +26,7 @@ NGSIv1: Empty attribute values in notifications
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -377,28 +377,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "attr",
-            "type" : "T",
-            "value" : ""
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "attr",
+                        "type": "T",
+                        "value": ""
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -410,28 +410,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "attr",
-            "type" : "T",
-            "value" : "foo"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "attr",
+                        "type": "T",
+                        "value": "foo"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -443,28 +443,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "attr",
-            "type" : "T",
-            "value" : ""
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "attr",
+                        "type": "T",
+                        "value": ""
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 POST http://localhost:REGEX(\d+)/notify
@@ -476,28 +476,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "T1",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "attr",
-            "type" : "T",
-            "value" : "bar"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "attr",
+                        "type": "T",
+                        "value": "bar"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/1449_notification_mode_cases/onchange_persisent.test
+++ b/test/functionalTest/cases/1449_notification_mode_cases/onchange_persisent.test
@@ -26,7 +26,7 @@ Service Path In Single ONCHANGE Notification
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0 IPv4 -notificationMode persistent
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -143,28 +143,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "string",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "string",
+                        "value": "V"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/1449_notification_mode_cases/onchange_simulated.test
+++ b/test/functionalTest/cases/1449_notification_mode_cases/onchange_simulated.test
@@ -26,7 +26,7 @@ Service Path In Single ONCHANGE Notification
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0 IPv4 -simulatedNotification
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 

--- a/test/functionalTest/cases/1449_notification_mode_cases/onchange_threadpool.test
+++ b/test/functionalTest/cases/1449_notification_mode_cases/onchange_threadpool.test
@@ -26,7 +26,7 @@ Service Path In Single ONCHANGE Notification
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0 IPv4 -notificationMode threadpool:2:1
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -143,28 +143,28 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "subscriptionId" : "REGEX([0-9a-f]{24})",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "type" : "ET",
-        "isPattern" : "false",
-        "id" : "E1",
-        "attributes" : [
-          {
-            "name" : "A",
-            "type" : "string",
-            "value" : "V"
-          }
-        ]
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A",
+                        "type": "string",
+                        "value": "V"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "ET"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ],
+    "originator": "localhost",
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
 =======================================
 

--- a/test/functionalTest/cases/1661_bad_input_on_notification_error/bad_input_on_notification_error.test
+++ b/test/functionalTest/cases/1661_bad_input_on_notification_error/bad_input_on_notification_error.test
@@ -26,7 +26,7 @@ Bad Input On Notification Error
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255 IPv4 -subCacheIval 5
-accumulatorStart 0.0.0.0 ${LISTENER_PORT}
+accumulatorStart --pretty-print 0.0.0.0 ${LISTENER_PORT}
 
 --SHELL--
 

--- a/test/functionalTest/cases/1661_bad_input_on_notification_error/bad_input_on_notification_error_api_v1.test
+++ b/test/functionalTest/cases/1661_bad_input_on_notification_error/bad_input_on_notification_error_api_v1.test
@@ -26,7 +26,7 @@ Bad Input On Notification Error for API v1
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255 IPv4 -subCacheIval 5
-accumulatorStart 0.0.0.0 ${LISTENER_PORT}
+accumulatorStart --pretty-print 0.0.0.0 ${LISTENER_PORT}
 
 --SHELL--
 

--- a/test/functionalTest/cases/1661_bad_input_on_notification_error/bad_input_on_notification_error_with_relogged_alarms.test
+++ b/test/functionalTest/cases/1661_bad_input_on_notification_error/bad_input_on_notification_error_with_relogged_alarms.test
@@ -26,7 +26,7 @@ Bad Input On Notification Error (with relogged alarms)
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255 IPv4 -subCacheIval 5 -relogAlarms
-accumulatorStart 0.0.0.0 ${LISTENER_PORT}
+accumulatorStart --pretty-print 0.0.0.0 ${LISTENER_PORT}
 
 --SHELL--
 

--- a/test/functionalTest/cases/1661_bad_input_on_notification_error/bad_input_on_notification_error_with_relogged_alarms_api_v1.test
+++ b/test/functionalTest/cases/1661_bad_input_on_notification_error/bad_input_on_notification_error_with_relogged_alarms_api_v1.test
@@ -26,7 +26,7 @@ Bad Input On Notification Error for API v1 (with relogged alarms)
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255 IPv4 -subCacheIval 5 -relogAlarms
-accumulatorStart 0.0.0.0 ${LISTENER_PORT}
+accumulatorStart --pretty-print 0.0.0.0 ${LISTENER_PORT}
 
 --SHELL--
 

--- a/test/functionalTest/cases/1875_NGSIv2_notification_formats/NGSIv2_notification_formats_order.test
+++ b/test/functionalTest/cases/1875_NGSIv2_notification_formats/NGSIv2_notification_formats_order.test
@@ -24,6 +24,8 @@
 NGSIv2 notification formats (different from values)
 
 --SHELL-INIT--
+# Note that accumulatorStart doesn't use --pretty-print as the purpose of the
+# test is to check attribute ordering and the pretty print changes that order
 dbInit CB
 brokerStart CB 0
 accumulatorStart

--- a/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications_stop_start_accumulator.test
+++ b/test/functionalTest/cases/1960_failure_stats_in_db_and_notifications/failure_stats_in_db_and_notifications_stop_start_accumulator.test
@@ -123,7 +123,7 @@ echo
 
 echo "07. Start accumulator again"
 echo "==========================="
-accumulatorStart
+accumulatorStart --pretty-print
 sleep 0.5
 echo
 echo

--- a/test/functionalTest/cases/2015_notification_templates/notification_templates_payload_as_xml.test
+++ b/test/functionalTest/cases/2015_notification_templates/notification_templates_payload_as_xml.test
@@ -24,6 +24,8 @@
 Notification Templates with payload as XML for notifications
 
 --SHELL-INIT--
+# Note that accumulatorStart doesn't use --pretty-print as in this case the accumulator is
+# not receiving JSON payloads
 dbInit CB
 brokerStart CB
 accumulatorStart

--- a/test/functionalTest/cases/2015_notification_templates/notification_templates_with_decoded_chars_in_notifications.test
+++ b/test/functionalTest/cases/2015_notification_templates/notification_templates_with_decoded_chars_in_notifications.test
@@ -24,6 +24,8 @@
 Notification Templates, with decoded chars in notifications
 
 --SHELL-INIT--
+# Note that accumulatorStart doesn't use --pretty-print as in this case the accumulator is
+# not receiving JSON payloads
 dbInit CB
 brokerStart CB
 accumulatorStart

--- a/test/functionalTest/cases/2237_compound_values_in_forwarded_messages/compound_values_in_forwarded_messages_exactly_as_issue.test
+++ b/test/functionalTest/cases/2237_compound_values_in_forwarded_messages/compound_values_in_forwarded_messages_exactly_as_issue.test
@@ -26,7 +26,7 @@ Compound values forwarded to context providers - exactly as issue 2237
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -232,25 +232,25 @@ Content-Type: application/json; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 
 {
-  "contextElements" : [
-    {
-      "type" : "device",
-      "isPattern" : "false",
-      "id" : "devicetest",
-      "attributes" : [
+    "contextElements": [
         {
-          "name" : "ping",
-          "type" : "command",
-          "value" : {
-            "param3" : "33",
-            "param2" : "22",
-            "param1" : "11"
-          }
+            "attributes": [
+                {
+                    "name": "ping",
+                    "type": "command",
+                    "value": {
+                        "param1": "11",
+                        "param2": "22",
+                        "param3": "33"
+                    }
+                }
+            ],
+            "id": "devicetest",
+            "isPattern": "false",
+            "type": "device"
         }
-      ]
-    }
-  ],
-  "updateAction" : "UPDATE"
+    ],
+    "updateAction": "UPDATE"
 }
 =======================================
 

--- a/test/functionalTest/cases/2750_common_metrics/2750_notifications.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_notifications.test
@@ -26,7 +26,7 @@ Notifications and Common Metrics
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart
+accumulatorStart --pretty-print
 
 --SHELL--
 


### PR DESCRIPTION
I needed this as I worked on #2760. Otherwise, all the all cases in NGSIv1 gets collapsed to one line after v indent refactoring.

Note that althoguth the PR is pretty large, no Content-Lenght has been changed, ensuring that it isn't any actual change in the .test. This is the only aspect relevant to be reviewed in this PR, the actual changes in the payload shown by the diff are not relevant.