### PR TITLE
Prepare SUB_ID, REG_ID, etc. grab code in .test to work even when NGSIv1 responses are one-liners instaead of multi-line pretty-print

### DIFF
--- a/test/functionalTest/cases/0000_deprecated_checkings/get_entity_dates_with_options.test
+++ b/test/functionalTest/cases/0000_deprecated_checkings/get_entity_dates_with_options.test
@@ -122,7 +122,6 @@ echo "===================================="
 orionCurl --url /v2/entities/E?options=dateCreated,dateModified,keyValues
 CRE_DATE=$(echo "$_response" | python -mjson.tool | grep dateCreated | awk -F '"' '{print $4}')
 MOD_DATE=$(echo "$_response" | python -mjson.tool | grep dateModified | awk -F '"' '{print $4}')
-#echo "$_response" | python -mjson.tool | grep dateCreated
 echo
 echo
 

--- a/test/functionalTest/cases/0000_json_parse/jsonParseContextEntitiesByEntityId.test
+++ b/test/functionalTest/cases/0000_json_parse/jsonParseContextEntitiesByEntityId.test
@@ -49,7 +49,7 @@ payload='{
 }'
 orionCurl --url "$url" --payload "${payload}"
 
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 
 # Make a discovery to see that the registration went OK
 echo "2: ++++++++++++++++++++"

--- a/test/functionalTest/cases/0000_json_parse/jsonParseContextEntityAttributes.test
+++ b/test/functionalTest/cases/0000_json_parse/jsonParseContextEntityAttributes.test
@@ -49,7 +49,7 @@ payload='{
 }'
 orionCurl --url ${url} --payload "${payload}"
 
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 
 # Make a discovery to see that the registration went OK
 echo "2: ++++++++++++++++++++"

--- a/test/functionalTest/cases/0000_json_parse/jsonParseEntityByIdAttributeByName.test
+++ b/test/functionalTest/cases/0000_json_parse/jsonParseEntityByIdAttributeByName.test
@@ -49,7 +49,7 @@ payload='{
 }'
 orionCurl --url ${url} --payload "${payload}"
 
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 
 # Make a discovery to see that the registration went OK
 echo "2: ++++++++++++++++++++"

--- a/test/functionalTest/cases/0000_log_operation/log_rest.test
+++ b/test/functionalTest/cases/0000_log_operation/log_rest.test
@@ -136,6 +136,7 @@ Date: REGEX(.*)
 
 
 
+
 === 5. PUT trace level
 HTTP/1.1 200 OK
 Content-Length: 30

--- a/test/functionalTest/cases/0000_ngsi9_convenience/post_context_entity_types.test
+++ b/test/functionalTest/cases/0000_ngsi9_convenience/post_context_entity_types.test
@@ -49,7 +49,7 @@ payload='{
 }'
 orionCurl --url "$url" --payload "$payload"
 
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 
 echo "1: ++++++++++++++++++++"
 url="/v1/registry/contextEntityTypes/Room"

--- a/test/functionalTest/cases/0000_ngsi9_convenience/post_context_entity_types_attribute.test
+++ b/test/functionalTest/cases/0000_ngsi9_convenience/post_context_entity_types_attribute.test
@@ -49,7 +49,7 @@ payload='{
 }'
 orionCurl --url "$url" --payload "$payload"
 
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 
 echo "1: ++++++++++++++++++++"
 url="/v1/registry/contextEntityTypes/Room/attributes/temperature"

--- a/test/functionalTest/cases/0000_ngsi9_convenience/post_context_entity_types_attribute_container.test
+++ b/test/functionalTest/cases/0000_ngsi9_convenience/post_context_entity_types_attribute_container.test
@@ -49,7 +49,7 @@ payload='{
 }'
 orionCurl --url "$url" --payload "$payload"
 
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 
 echo "1: ++++++++++++++++++++"
 url="/v1/registry/contextEntityTypes/Room/attributes"

--- a/test/functionalTest/cases/0000_ngsi9_registration_and_discover/registration_ok.test
+++ b/test/functionalTest/cases/0000_ngsi9_registration_and_discover/registration_ok.test
@@ -57,8 +57,7 @@ payload='{
   "duration": "PT1H"
 }'
 orionCurl --url "$url" --payload "$payload"
-#REG_ID=$(echo "$_response" | grep registrationId | awk -F '>' '{print $2}' | awk -F '<' '{print $1}' | grep -v '^$' )
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 
 echo "++++++++++++++++++++"
 

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntitiesByEntityId.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntitiesByEntityId.test
@@ -48,7 +48,7 @@ payload='{
   "providingApplication": "none"
 }'
 orionCurl --url /v1/registry/contextEntities/E1 --payload "$payload"
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 echo
 echo
 

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntitiesByEntityIdAndType.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntitiesByEntityIdAndType.test
@@ -80,7 +80,7 @@ payload='{
   "providingApplication": "http://kz.tid.es/part02"
 }'
 orionCurl --url /v1/registry/contextEntities/type/T1/id/E1 --payload "$payload"
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 echo
 echo
 

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntityAttributes.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntityAttributes.test
@@ -48,7 +48,7 @@ payload='{
   "providingApplication": "none"
 }'
 orionCurl --url /v1/registry/contextEntities/E1 --payload "$payload"
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 echo
 echo
 

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntityTypeAttribute.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntityTypeAttribute.test
@@ -46,7 +46,7 @@ payload='{
   "providingApplication": "none"
 }'
 orionCurl --url /v1/registry/contextEntityTypes/ET/attributes/A1 --payload "$payload"
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 echo
 echo
 

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntityTypes.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/postContextEntityTypes.test
@@ -46,7 +46,7 @@ payload='{
   "providingApplication": "none"
 }'
 orionCurl --url /v1/registry/contextEntityTypes/ET --payload "$payload"
-REG_ID=$(echo "$_response" | grep -Po '(?<="registrationId" : ")[^"]*')
+REG_ID=$(echo "$_response" | grep registrationId | awk -F\" '{ print $4}')
 echo
 echo
 

--- a/test/functionalTest/cases/0876_entity_dates/get_entity_dates.test
+++ b/test/functionalTest/cases/0876_entity_dates/get_entity_dates.test
@@ -122,7 +122,6 @@ echo "===================================="
 orionCurl --url '/v2/entities/E?options=keyValues&attrs=dateCreated,dateModified,*'
 CRE_DATE=$(echo "$_response" | python -mjson.tool | grep dateCreated | awk -F '"' '{print $4}')
 MOD_DATE=$(echo "$_response" | python -mjson.tool | grep dateModified | awk -F '"' '{print $4}')
-#echo "$_response" | python -mjson.tool | grep dateCreated
 echo
 echo
 

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -1150,7 +1150,12 @@ function orionCurl()
       if [ "$payloadCheckFormat" == json ] || [ "$payloadCheckFormat" == "" ]
       then
         vMsg Running python tool for $_response
-        echo $_response | python -mjson.tool
+        #
+        # We need to apply pretty-print on _response. Otherwise positional processing used in .test
+        # (e.g. to get SUB_ID typically grep and awk are used) will break
+        #
+        _response=$(echo $_response | python -mjson.tool)
+        echo "$_response"
       else
         dMsg Unknown payloadCheckFormat
       fi


### PR DESCRIPTION
Note there aren't actual changes in .test (only in the way in which REG_ID is grabbed in some cases)