### PR TITLE
FIX wrongly overlogging metadata abscense in csub docs as Runtime Error

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -8,6 +8,7 @@
 - Add: new CLI '-disableMetrics' to disable metrics (#2750)
 - Fix: timeout of 6 seconds (hardcoded for now) for all incoming REST requests (temporal fix, see #2762)
 - Fix: NGSIv1 updateContext APPEND on existing geo:point attributes (and probably other geo: attributes) failing to update location (#2770)
+- Fix: wrongly overlogging metadata abscense in csub docs as Runtime Error (#2796)
 - Fix: if HTTP header Content-Length contains a value above the maximum payload size, an error is returned and the message is not read (#2761)
 - Add: one more semaphore (the metrics semaphore) to the semWait block in GET /statistics and to the list in GET /admin/sem (#2750)
 - Fix: no longer accepting a service path with an empty component (e.g. /comp1//comp3) (#2772)

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1551,7 +1551,10 @@ static bool addTriggeredSubscriptions_noCache
 
       trigs->blacklist = sub.hasField(CSUB_BLACKLIST)? getBoolFieldF(sub, CSUB_BLACKLIST) : false;
 
-      setStringVectorF(sub, CSUB_METADATA, &(trigs->metadata));
+      if (sub.hasField(CSUB_METADATA))
+      {
+        setStringVectorF(sub, CSUB_METADATA, &(trigs->metadata));
+      }
 
       if (sub.hasField(CSUB_EXPR))
       {

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -139,7 +139,10 @@ static void setNotification(Subscription* subP, const BSONObj& r, const std::str
   setStringVectorF(r, CSUB_ATTRS, &(subP->notification.attributes));
 
   // Metadata
-  setStringVectorF(r, CSUB_METADATA, &(subP->notification.metadata));
+  if (r.hasField(CSUB_METADATA))
+  {
+    setStringVectorF(r, CSUB_METADATA, &(subP->notification.metadata));
+  }
 
   subP->notification.httpInfo.fill(r);
 

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -405,7 +405,10 @@ int mongoSubCacheItemInsert
   //
   // 07. Push metadata names to Metadata Vector (cSubP->metadatas)
   //
-  setStringVectorF(sub, CSUB_METADATA, &(cSubP->metadata));
+  if (sub.hasField(CSUB_METADATA))
+  {
+    setStringVectorF(sub, CSUB_METADATA, &(cSubP->metadata));
+  }
 
   //
   // 08. Fill in cSubP->notifyConditionV from condVec

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -289,7 +289,10 @@ static void setCondsAndInitialNotifyNgsiv1
   setStringVectorF(subOrig, CSUB_ATTRS, &attributes);
 
   std::vector<std::string> metadata;
-  setStringVectorF(subOrig, CSUB_METADATA, &metadata);
+  if (subOrig.hasField(CSUB_METADATA))
+  {
+    setStringVectorF(subOrig, CSUB_METADATA, &metadata);
+  }
 
   /* Conds vector (and maybe an initial notification) */
   *notificationDone = false;
@@ -362,8 +365,11 @@ static void setCondsAndInitialNotify
     {
       httpInfo.fill(subOrig);
       blacklist = subOrig.hasField(CSUB_BLACKLIST)? getBoolFieldF(subOrig, CSUB_BLACKLIST) : false;
-      setStringVectorF(subOrig, CSUB_METADATA, &metadataV);
       setStringVectorF(subOrig, CSUB_ATTRS, &notifAttributesV);
+      if (subOrig.hasField(CSUB_METADATA))
+      {
+        setStringVectorF(subOrig, CSUB_METADATA, &metadataV);
+      }
     }
 
     RenderFormat attrsFormat;
@@ -598,7 +604,13 @@ static void setMetadata(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
   }
   else
   {
-    BSONArray metadata = getArrayFieldF(subOrig, CSUB_METADATA);
+    // Note that if subOrig doesn't have CSUB_METADATA (e.g. old subscription in the DB created before
+    // this feature) BSONArray constructor ensures an empty array
+    BSONArray metadata;
+    if (subOrig.hasField(CSUB_METADATA))
+    {
+      metadata = getArrayFieldF(subOrig, CSUB_METADATA);
+    }
     b->append(CSUB_METADATA, metadata);
     LM_T(LmtMongo, ("Subscription metadata: %s", metadata.toString().c_str()));
   }


### PR DESCRIPTION
Fixes https://github.com/telefonicaid/fiware-orion/issues/2796

Tested:

* 100% unit test regression ok
* 100% ft regression ok
* Manual test:
  * Create a subscription
  * Remove `metatada` field in DB
  * `GET /v2/subscriptions` and check that no log output is generated