### PR TITLE
Bug/2763 bug fix not refactor

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -15,6 +15,9 @@
 - Fix: bug when tenants are over 44 bytes long (#2811)
 - Add: Support for null values in string filters (#2359)
 - Fix: Partial sanity check for custon url, only if the url contains no replacements using ${xxx} (#2280, #2279)
+- Fix: if entity::type is given but as an empty string, an error is returned (#1985)
+- Fix: admin requests with errors now return '400 Bad Request', not '200 OK'
+- Fix: attempt to create an entity with an error in service path (and probably more types of errors) now returns '400 Bad Request', not '200 OK' (#2763)
 - Fix: not calling regfree when regcomp fails. Potential fix for a crash (#2769)
 - Fix: wrongly overlogging metadata abscense in csub docs as Runtime Error (#2796)
 - Fix: if HTTP header Content-Length contains a value above the maximum payload size, an error is returned and the message is not read (#2761)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -15,7 +15,7 @@
 - Fix: bug when tenants are over 44 bytes long (#2811)
 - Add: Support for null values in string filters (#2359)
 - Fix: Partial sanity check for custon url, only if the url contains no replacements using ${xxx} (#2280, #2279)
-- Fix: if entity::type is given but as an empty string, an error is returned (#1985)
+- Fix: if entity::type is given but as an empty string, in payload of POST /v2/subscriptions or PATCH /v2/subscriptions/{sub}, an error is returned (#1985)
 - Fix: admin requests (such as GET /version) with errors now return '400 Bad Request', not '200 OK'
 - Fix: attempt to create an entity with an error in service path (and probably more types of errors) now returns '400 Bad Request', not '200 OK' (#2763)
 - Fix: not calling regfree when regcomp fails. Potential fix for a crash (#2769)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -16,7 +16,7 @@
 - Add: Support for null values in string filters (#2359)
 - Fix: Partial sanity check for custon url, only if the url contains no replacements using ${xxx} (#2280, #2279)
 - Fix: if entity::type is given but as an empty string, an error is returned (#1985)
-- Fix: admin requests with errors now return '400 Bad Request', not '200 OK'
+- Fix: admin requests (such as GET /version) with errors now return '400 Bad Request', not '200 OK'
 - Fix: attempt to create an entity with an error in service path (and probably more types of errors) now returns '400 Bad Request', not '200 OK' (#2763)
 - Fix: not calling regfree when regcomp fails. Potential fix for a crash (#2769)
 - Fix: wrongly overlogging metadata abscense in csub docs as Runtime Error (#2796)

--- a/doc/manuals/user/ngsiv2_implementation_notes.md
+++ b/doc/manuals/user/ngsiv2_implementation_notes.md
@@ -144,7 +144,7 @@ The particular validations that Orion implements on NGSIv2 subscription payloads
         * **id** or **idPattern**: one of them is mandatory (but both at the same time is not allowed). id
             must follow NGSIv2 restrictions for IDs. idPattern must be not empty and a valid regex.
         * **type** or **typePattern**: optional (but both at the same time is not allowed). type must 
-            follow NGSIv2 restrictions for IDs. typePattern must be not empty and a valid regex.
+            follow NGSIv2 restrictions for IDs. type must not be empty. typePattern must be a valid regex, and non-empty.
     * **condition**: optional (but if present it must have a content, i.e. `{}` is not allowed)
         * **attrs**: optional (but if present it must be a list; empty list is allowed)
         * **expression**: optional (but if present it must have a content, i.e. `{}` is not allowed)

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -216,8 +216,8 @@ std::string Entity::check(ApiVersion apiVersion, RequestType requestType)
   {
     if (forbiddenIdChars(apiVersion, id.c_str()))
     {
-      alarmMgr.badInput(clientIp, "found a forbidden character in the id of an entity");
-      return "Invalid characters in entity id";
+      alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID);
+      return ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID;
     }
   }
 
@@ -244,8 +244,8 @@ std::string Entity::check(ApiVersion apiVersion, RequestType requestType)
   {
     if (forbiddenIdChars(apiVersion, type.c_str()))
     {
-      alarmMgr.badInput(clientIp, "found a forbidden character in the type of an entity");
-      return "Invalid characters in entity type";
+      alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE);
+      return ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE;
     }
   }
 

--- a/src/lib/common/errorMessages.h
+++ b/src/lib/common/errorMessages.h
@@ -56,6 +56,8 @@
 #define ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_TYPE      "entity type length: 0, min length supported: "    STR(MIN_ID_LEN)
 #define ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD          "empty payload"
 #define ERROR_DESC_BAD_REQUEST_EMPTY_ENTITIES_VECTOR  "empty entities vector"
+#define ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID     "Invalid characters in entity id"
+#define ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE   "Invalid characters in entity type"
 
 #define ERROR_NOT_FOUND                               "NotFound"
 #define ERROR_DESC_NOT_FOUND_ENTITY                   "The requested entity has not been found. Check type and id"
@@ -67,6 +69,6 @@
 #define ERROR_TOO_MANY                                "TooManyResults"
 #define ERROR_DESC_TOO_MANY_ENTITIES                  "More than one matching entity. Please refine your query"
 
-#define ERROR_DESC_BAD_VERB                       "method not allowed"
+#define ERROR_DESC_BAD_VERB                           "method not allowed"
 
 #endif // SRC_LIB_COMMON_ERRORMESSAGES_H

--- a/src/lib/common/errorMessages.h
+++ b/src/lib/common/errorMessages.h
@@ -60,6 +60,10 @@
 #define ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE   "Invalid characters in entity type"
 #define ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTID    "Invalid JSON type for entity id"
 #define ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTTYPE  "Invalid JSON type for entity type"
+#define ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTIDPATTERN     "Invalid JSON type for entity idPattern"
+#define ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTTYPEPATTERN   "Invalid JSON type for entity typePattern"
+#define ERROR_DESC_BAD_REQUEST_INVALID_REGEX_ENTIDPATTERN     "Invalid regex for entity idPattern"
+#define ERROR_DESC_BAD_REQUEST_INVALID_REGEX_ENTTYPEPATTERN   "Invalid regex for entity typePattern"
 
 #define ERROR_NOT_FOUND                               "NotFound"
 #define ERROR_DESC_NOT_FOUND_ENTITY                   "The requested entity has not been found. Check type and id"

--- a/src/lib/common/errorMessages.h
+++ b/src/lib/common/errorMessages.h
@@ -58,6 +58,8 @@
 #define ERROR_DESC_BAD_REQUEST_EMPTY_ENTITIES_VECTOR  "empty entities vector"
 #define ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID     "Invalid characters in entity id"
 #define ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE   "Invalid characters in entity type"
+#define ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTID    "Invalid JSON type for entity id"
+#define ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTTYPE  "Invalid JSON type for entity type"
 
 #define ERROR_NOT_FOUND                               "NotFound"
 #define ERROR_DESC_NOT_FOUND_ENTITY                   "The requested entity has not been found. Check type and id"

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -153,11 +153,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
 
         if (forbiddenIdChars(ciP->apiVersion, eP->id.c_str(), ""))
         {
-          const char* errorText = "Invalid characters in entity id";
-
-          alarmMgr.badInput(clientIp, errorText);
+          alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID);
           ciP->httpStatusCode = SccBadRequest;
-          OrionError oe(SccBadRequest, errorText, "BadRequest");
+          OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID, "BadRequest");
 
           return oe.toJson();
         }
@@ -202,11 +200,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
 
       if (forbiddenIdChars(ciP->apiVersion, eP->type.c_str(), ""))
       {
-        const char* errorText = "Invalid characters in entity type";
-
-        alarmMgr.badInput(clientIp, errorText);
+        alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE);
         ciP->httpStatusCode = SccBadRequest;
-        OrionError oe(SccBadRequest, errorText, "BadRequest");
+        OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE, "BadRequest");
 
         return oe.toJson();
       }

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -167,6 +167,14 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
 
       eP->type      = iter->value.GetString();
       eP->typeGiven = true;
+
+      if (eP->type.empty())
+      {
+        alarmMgr.badInput(clientIp, "empty entity type");
+        ciP->httpStatusCode = SccBadRequest;
+        OrionError oe(SccBadRequest, "empty entity type", "BadRequest");
+        return oe.toJson();
+      }
     }
     else  // attribute
     {

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -150,6 +150,17 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         }
 
         eP->id = iter->value.GetString();
+
+        if (forbiddenIdChars(ciP->apiVersion, eP->id.c_str(), ""))
+        {
+          const char* errorText = "Invalid characters in entity id";
+
+          alarmMgr.badInput(clientIp, errorText);
+          ciP->httpStatusCode = SccBadRequest;
+          OrionError oe(SccBadRequest, errorText, "BadRequest");
+
+          return oe.toJson();
+        }
       }
       else  // "id" is present in payload for /v2/entities/<eid> - not a valid payload
       {
@@ -189,7 +200,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         return oe.toJson();
       }
 
-      if (forbiddenChars(eP->type.c_str(), ""))
+      if (forbiddenIdChars(ciP->apiVersion, eP->type.c_str(), ""))
       {
         const char* errorText = "Invalid characters in entity type";
 

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -172,7 +172,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       {
         alarmMgr.badInput(clientIp, "empty entity type");
         ciP->httpStatusCode = SccBadRequest;
-        OrionError oe(SccBadRequest, "empty entity type", "BadRequest");
+        OrionError oe(SccBadRequest, "entity type length: 0, min length supported: 1", "BadRequest");
         return oe.toJson();
       }
     }

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -32,6 +32,7 @@
 #include "jsonParseV2/jsonParseTypeNames.h"
 #include "jsonParseV2/parseEntity.h"
 #include "jsonParseV2/parseContextAttribute.h"
+#include "parse/forbiddenChars.h"
 #include "alarmMgr/alarmMgr.h"
 
 using namespace rapidjson;
@@ -139,9 +140,12 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       {
         if (type != "String")
         {
-          alarmMgr.badInput(clientIp, "invalid JSON type for entity id");
-          ciP->httpStatusCode = SccBadRequest;;
-          OrionError oe(SccBadRequest, "invalid JSON type for entity id", "BadRequest");
+          const char* errorText = "Invalid JSON type for entity id";
+
+          alarmMgr.badInput(clientIp, errorText);
+          ciP->httpStatusCode = SccBadRequest;
+          OrionError oe(SccBadRequest, errorText, "BadRequest");
+
           return oe.toJson();
         }
 
@@ -149,9 +153,12 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       }
       else  // "id" is present in payload for /v2/entities/<eid> - not a valid payload
       {
-        alarmMgr.badInput(clientIp, "'id' is not a valid attribute");
-        ciP->httpStatusCode = SccBadRequest;;
-        OrionError oe(SccBadRequest, "invalid input, 'id' as attribute", "BadRequest");
+        const char* errorText = "invalid input, 'id' as attribute";
+
+        alarmMgr.badInput(clientIp, errorText);
+        ciP->httpStatusCode = SccBadRequest;
+        OrionError oe(SccBadRequest, errorText, "BadRequest");
+
         return oe.toJson();
       }
     }
@@ -159,9 +166,12 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     {
       if (type != "String")
       {
-        alarmMgr.badInput(clientIp, "invalid JSON type for entity type");
+        const char* errorText = "Invalid JSON type for entity type";
+
+        alarmMgr.badInput(clientIp, errorText);
         ciP->httpStatusCode = SccBadRequest;
-        OrionError oe(SccBadRequest, "invalid JSON type for entity type", "BadRequest");
+        OrionError oe(SccBadRequest, errorText, "BadRequest");
+
         return oe.toJson();
       }
 
@@ -170,9 +180,23 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
 
       if (eP->type.empty())
       {
-        alarmMgr.badInput(clientIp, "empty entity type");
+        const char* errorText = "entity type length: 0, min length supported: 1";
+
+        alarmMgr.badInput(clientIp, errorText);
         ciP->httpStatusCode = SccBadRequest;
-        OrionError oe(SccBadRequest, "entity type length: 0, min length supported: 1", "BadRequest");
+        OrionError oe(SccBadRequest, errorText, "BadRequest");
+
+        return oe.toJson();
+      }
+
+      if (forbiddenChars(eP->type.c_str(), ""))
+      {
+        const char* errorText = "Invalid characters in entity type";
+
+        alarmMgr.badInput(clientIp, errorText);
+        ciP->httpStatusCode = SccBadRequest;
+        OrionError oe(SccBadRequest, errorText, "BadRequest");
+
         return oe.toJson();
       }
     }

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -140,11 +140,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       {
         if (type != "String")
         {
-          const char* errorText = "Invalid JSON type for entity id";
-
-          alarmMgr.badInput(clientIp, errorText);
+          alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTID);
           ciP->httpStatusCode = SccBadRequest;
-          OrionError oe(SccBadRequest, errorText, "BadRequest");
+          OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTID, "BadRequest");
 
           return oe.toJson();
         }
@@ -175,11 +173,9 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     {
       if (type != "String")
       {
-        const char* errorText = "Invalid JSON type for entity type";
-
-        alarmMgr.badInput(clientIp, errorText);
+        alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTTYPE);
         ciP->httpStatusCode = SccBadRequest;
-        OrionError oe(SccBadRequest, errorText, "BadRequest");
+        OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTTYPE, "BadRequest");
 
         return oe.toJson();
       }

--- a/src/lib/jsonParseV2/parseEntityObject.cpp
+++ b/src/lib/jsonParseV2/parseEntityObject.cpp
@@ -107,7 +107,7 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
 
       if (eP->type.empty())
       {
-        return "empty entity type";
+        return "entity type length: 0, min length supported: 1";
       }
 
       if (forbiddenChars(eP->type.c_str(), ""))

--- a/src/lib/jsonParseV2/parseEntityObject.cpp
+++ b/src/lib/jsonParseV2/parseEntityObject.cpp
@@ -24,6 +24,7 @@
 */
 #include "rapidjson/document.h"
 
+#include "common/errorMessages.h"
 #include "rest/ConnectionInfo.h"
 #include "ngsi/ParseData.h"
 #include "ngsi/Request.h"
@@ -75,7 +76,7 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
 
       if (forbiddenIdChars(ciP->apiVersion, eP->id.c_str(), ""))
       {
-        return "Invalid characters in entity id";
+        return ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID;
       }
     }
     else if (name == "idPattern")
@@ -112,7 +113,7 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
 
       if (forbiddenIdChars(ciP->apiVersion, eP->type.c_str(), ""))
       {
-        return "Invalid characters in entity type";
+        return ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE;
       }
     }
     else if (name == "typePattern")

--- a/src/lib/jsonParseV2/parseEntityObject.cpp
+++ b/src/lib/jsonParseV2/parseEntityObject.cpp
@@ -105,6 +105,11 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
       eP->type      = iter->value.GetString();
       eP->typeGiven = true;
 
+      if (eP->type.empty())
+      {
+        return "empty entity type";
+      }
+
       if (forbiddenChars(eP->type.c_str(), ""))
       {
         return "Invalid characters in entity type";

--- a/src/lib/jsonParseV2/parseEntityObject.cpp
+++ b/src/lib/jsonParseV2/parseEntityObject.cpp
@@ -69,7 +69,7 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
     {
       if (type != "String")
       {
-        return "invalid JSON type for entity id";
+        return ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTID;
       }
 
       eP->id = iter->value.GetString();
@@ -83,13 +83,13 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
     {
       if (type != "String")
       {
-        return "invalid JSON type for entity idPattern";
+        return ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTIDPATTERN;
       }
 
       regex_t re;
       if (regcomp(&re, iter->value.GetString(), REG_EXTENDED) != 0)
       {
-        return "invalid regex for entity id pattern";
+        return ERROR_DESC_BAD_REQUEST_INVALID_REGEX_ENTIDPATTERN;
       }
       regfree(&re);  // If regcomp fails it frees up itself (see glibc sources for details)
 
@@ -100,7 +100,7 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
     {
       if (type != "String")
       {
-        return "invalid JSON type for entity type";
+        return ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTTYPE;
       }
 
       eP->type      = iter->value.GetString();
@@ -120,13 +120,13 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
     {
       if (type != "String")
       {
-        return "invalid JSON type for entity typePattern";
+        return ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTTYPEPATTERN;
       }
 
       regex_t re;
       if (regcomp(&re, iter->value.GetString(), REG_EXTENDED) != 0)
       {
-        return "invalid regex for entity type pattern";
+        return ERROR_DESC_BAD_REQUEST_INVALID_REGEX_ENTTYPEPATTERN;
       }
       regfree(&re);  // If regcomp fails it frees up itself (see glibc sources for details)
 

--- a/src/lib/jsonParseV2/parseEntityObject.cpp
+++ b/src/lib/jsonParseV2/parseEntityObject.cpp
@@ -73,7 +73,7 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
 
       eP->id = iter->value.GetString();
 
-      if (forbiddenChars(eP->id.c_str(), ""))
+      if (forbiddenIdChars(ciP->apiVersion, eP->id.c_str(), ""))
       {
         return "Invalid characters in entity id";
       }
@@ -110,7 +110,7 @@ std::string parseEntityObject(ConnectionInfo* ciP, Value::ConstValueIterator val
         return "entity type length: 0, min length supported: 1";
       }
 
-      if (forbiddenChars(eP->type.c_str(), ""))
+      if (forbiddenIdChars(ciP->apiVersion, eP->type.c_str(), ""))
       {
         return "Invalid characters in entity type";
       }

--- a/src/lib/jsonParseV2/parseSubscription.cpp
+++ b/src/lib/jsonParseV2/parseSubscription.cpp
@@ -384,6 +384,10 @@ static std::string parseEntitiesVector(ConnectionInfo* ciP, std::vector<EntID>* 
         {
           return badInput(ciP, "max type length exceeded");
         }
+        if (typeOpt.value.empty())
+        {
+          return badInput(ciP, "entity type length: 0, min length supported: 1");
+        }
         type = typeOpt.value;
       }
     }

--- a/src/lib/jsonParseV2/parseSubscription.cpp
+++ b/src/lib/jsonParseV2/parseSubscription.cpp
@@ -362,7 +362,7 @@ static std::string parseEntitiesVector(ConnectionInfo* ciP, std::vector<EntID>* 
         regex_t re;
         if (regcomp(&re, idPattern.c_str(), REG_EXTENDED) != 0)
         {
-          return badInput(ciP, "Invalid regex for entity id pattern");
+          return badInput(ciP, ERROR_DESC_BAD_REQUEST_INVALID_REGEX_ENTIDPATTERN);
         }
         regfree(&re);  // If regcomp fails it frees up itself
       }
@@ -411,7 +411,7 @@ static std::string parseEntitiesVector(ConnectionInfo* ciP, std::vector<EntID>* 
         regex_t re;
         if (regcomp(&re, typePattern.c_str(), REG_EXTENDED) != 0)
         {
-          return badInput(ciP, "Invalid regex for entity id pattern");
+          return badInput(ciP, ERROR_DESC_BAD_REQUEST_INVALID_REGEX_ENTTYPEPATTERN);
         }
         regfree(&re);  // If regcomp fails it frees up itself
       }

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -109,7 +109,7 @@ std::string OrionError::smartRender(ApiVersion apiVersion)
 */
 std::string OrionError::setStatusCodeAndSmartRender(ApiVersion apiVersion, HttpStatusCode* scP)
 {
-  if (apiVersion == V2)
+  if ((apiVersion == V2) || (apiVersion == ADMIN_API))
   {
     *scP = code;
   }

--- a/src/lib/serviceRoutinesV2/postEntities.cpp
+++ b/src/lib/serviceRoutinesV2/postEntities.cpp
@@ -100,12 +100,21 @@ std::string postEntities
   // 02. Call standard op postUpdateContext
   postUpdateContext(ciP, components, compV, parseDataP, NGSIV2_FLAVOUR_ONCREATE);
 
-  // 03. Check error
+  //
+  // 03. Check error - 3 different ways to get an error from postUpdateContext ... :-(
+  //     FIXME P4: make postUpdateContext have ONE way to return errors. See github issue #2763
+  //
   std::string  answer = "";
-  if (parseDataP->upcrs.res.oe.code != SccNone )
+  if (parseDataP->upcrs.res.oe.code != SccNone)
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
     ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
+  }
+  else if (parseDataP->upcrs.res.errorCode.code != SccOk)
+  {
+    ciP->httpStatusCode = parseDataP->upcrs.res.errorCode.code;
+    TIMED_RENDER(answer = parseDataP->upcrs.res.errorCode.toJson(true));
+    ciP->answer         = answer;
   }
   else
   {

--- a/test/functionalTest/cases/0970_create_entity/errors_at_creation.test
+++ b/test/functionalTest/cases/0970_create_entity/errors_at_creation.test
@@ -185,7 +185,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "invalid JSON type for entity id", 
+    "description": "Invalid JSON type for entity id", 
     "error": "BadRequest"
 }
 
@@ -199,7 +199,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "invalid JSON type for entity id", 
+    "description": "Invalid JSON type for entity id", 
     "error": "BadRequest"
 }
 
@@ -213,7 +213,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "invalid JSON type for entity type", 
+    "description": "Invalid JSON type for entity type", 
     "error": "BadRequest"
 }
 
@@ -227,7 +227,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "invalid JSON type for entity type", 
+    "description": "Invalid JSON type for entity type", 
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1108_non_string_fields/non_string_fields.test
+++ b/test/functionalTest/cases/1108_non_string_fields/non_string_fields.test
@@ -120,7 +120,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "invalid JSON type for entity id",
+    "description": "Invalid JSON type for entity id",
     "error": "BadRequest"
 }
 
@@ -134,7 +134,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "invalid JSON type for entity type",
+    "description": "Invalid JSON type for entity type",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1601_restrict_chars_in_ids/restrict_chars_entity.test
+++ b/test/functionalTest/cases/1601_restrict_chars_in_ids/restrict_chars_entity.test
@@ -30,77 +30,55 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. POST /v2/entities to create España/T1
-# 02. GET /v2/entities/España to see that A2 has not been added
-# 03. POST /v2/entities to create E1/Olé
-# 04. GET /v2/entities/E1 to see that E1 has not been added
-# 05. POST /v2/entities to create E#/T1""
-# 06. GET /v2/entities/E# that E# has not been added
-# 07. POST /v2/entities to create E1/A#
-# 08. GET /v2/entities/E1 to see that E1 has not been added
+# 01. POST /v2/entities: attempt to create Espa<a/T1 (error in ID)
+# 02. POST /v2/entities: attempt to create E1/T( (error in TYPE)
+# 03. POST /v2/entities: attempt to create E=/T1 (error in ID)
+# 04. POST /v2/entities: attempt to create E1/T" (error in TYPE)
+# 05. GET /v2/entities to see that no entity has been added
 #
 
-echo '01. POST /v2/entities to create España/T1'
-echo "========================================="
-payload='{ "id": "España", "type": "T1", "A1": "" }'
+echo '01. POST /v2/entities: attempt to create Espa<a/T1 (error in ID)'
+echo "================================================================"
+payload='{ "id": "Espa<a", "type": "T1", "A1": "" }'
 orionCurl --url '/v2/entities?options=keyValues' --payload "$payload"
 echo
 echo
 
 
-echo '02. GET /v2/entities/España to see that A2 has not been added'
-echo "============================================================="
-orionCurl --url /v2/entities/E1
-echo
-echo
-
-
-echo '03. POST /v2/entities to create E1/Olé'
-echo "======================================"
-payload='{ "id": "E1", "type": "Olé", "A2": { "value": "" }}'
+echo '02. POST /v2/entities: attempt to create E1/T( (error in TYPE)'
+echo "=============================================================="
+payload='{ "id": "E1", "type": "T(", "A1": { "value": "" }}'
 orionCurl --url /v2/entities --payload "$payload"
 echo
 echo
 
 
-echo '04. GET /v2/entities/E1 to see that E1 has not been added'
+echo '03. POST /v2/entities: attempt to create E=/T1 (error in ID)'
+echo "============================================================"
+payload='{ "id": "E=", "type": "T1", "A2": { "value": "" }}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '04. POST /v2/entities: attempt to create E1/T" (error in TYPE)'
+echo "=============================================================="
+payload='{ "id": "E1", "type": "T\"", "A2": { "value": "" }}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '05. GET /v2/entities to see that no entity has been added'
 echo "========================================================="
-orionCurl --url /v2/entities/E1
-echo
-echo
-
-echo '05. POST /v2/entities to create E#/T1'
-echo "======================================"
-payload='{ "id": "E#", "type": "T1", "A2": { "value": "" }}'
-orionCurl --url /v2/entities --payload "$payload"
-echo
-echo
-
-
-echo '06. GET /v2/entities/E# that E# has not been added'
-echo "=================================================="
-orionCurl --url /v2/entities/E1
-echo
-echo
-
-echo '07. POST /v2/entities to create E1/A#'
-echo "====================================="
-payload='{ "id": "E1", "type": "A#", "A2": { "value": "" }}'
-orionCurl --url /v2/entities --payload "$payload"
-echo
-echo
-
-
-echo '08. GET /v2/entities/E1 to see that E1 has not been added'
-echo "========================================================="
-orionCurl --url /v2/entities/E1
+orionCurl --url /v2/entities
 echo
 echo
 
 
 --REGEXPECT--
-01. POST /v2/entities to create España/T1
-=========================================
+01. POST /v2/entities: attempt to create Espa<a/T1 (error in ID)
+================================================================
 HTTP/1.1 400 Bad Request
 Content-Length: 70
 Content-Type: application/json
@@ -113,22 +91,8 @@ Date: REGEX(.*)
 }
 
 
-02. GET /v2/entities/España to see that A2 has not been added
-=============================================================
-HTTP/1.1 404 Not Found
-Content-Length: 95
-Content-Type: application/json
-Fiware-Correlator: REGEX([0-9a-f\-]{36})
-Date: REGEX(.*)
-
-{
-    "description": "The requested entity has not been found. Check type and id",
-    "error": "NotFound"
-}
-
-
-03. POST /v2/entities to create E1/Olé
-======================================
+02. POST /v2/entities: attempt to create E1/T( (error in TYPE)
+==============================================================
 HTTP/1.1 400 Bad Request
 Content-Length: 72
 Content-Type: application/json
@@ -141,22 +105,8 @@ Date: REGEX(.*)
 }
 
 
-04. GET /v2/entities/E1 to see that E1 has not been added
-=========================================================
-HTTP/1.1 404 Not Found
-Content-Length: 95
-Content-Type: application/json
-Fiware-Correlator: REGEX([0-9a-f\-]{36})
-Date: REGEX(.*)
-
-{
-    "description": "The requested entity has not been found. Check type and id",
-    "error": "NotFound"
-}
-
-
-05. POST /v2/entities to create E#/T1
-======================================
+03. POST /v2/entities: attempt to create E=/T1 (error in ID)
+============================================================
 HTTP/1.1 400 Bad Request
 Content-Length: 70
 Content-Type: application/json
@@ -169,22 +119,8 @@ Date: REGEX(.*)
 }
 
 
-06. GET /v2/entities/E# that E# has not been added
-==================================================
-HTTP/1.1 404 Not Found
-Content-Length: 95
-Content-Type: application/json
-Fiware-Correlator: REGEX([0-9a-f\-]{36})
-Date: REGEX(.*)
-
-{
-    "description": "The requested entity has not been found. Check type and id",
-    "error": "NotFound"
-}
-
-
-07. POST /v2/entities to create E1/A#
-=====================================
+04. POST /v2/entities: attempt to create E1/T" (error in TYPE)
+==============================================================
 HTTP/1.1 400 Bad Request
 Content-Length: 72
 Content-Type: application/json
@@ -197,18 +133,15 @@ Date: REGEX(.*)
 }
 
 
-08. GET /v2/entities/E1 to see that E1 has not been added
+05. GET /v2/entities to see that no entity has been added
 =========================================================
-HTTP/1.1 404 Not Found
-Content-Length: 95
+HTTP/1.1 200 OK
+Content-Length: 2
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
-{
-    "description": "The requested entity has not been found. Check type and id",
-    "error": "NotFound"
-}
+[]
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/1728_bug_forbidden_chars/forbidden_chars_entity.test
+++ b/test/functionalTest/cases/1728_bug_forbidden_chars/forbidden_chars_entity.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Restict chars in id (old set)
+Forbidden chars in id (old set)
 
 --SHELL-INIT--
 dbInit CB

--- a/test/functionalTest/cases/1985_empty_entity_type/empty_entity_type_in_subscription.test
+++ b/test/functionalTest/cases/1985_empty_entity_type/empty_entity_type_in_subscription.test
@@ -1,0 +1,78 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Empty entity type in subscription
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Attempt to create a subscription with an empty entity type, see error
+#
+
+echo "01. Attempt to create a subscription with an empty entity type, see error"
+echo "========================================================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": ""
+      }
+    ],
+    "condition": {
+      "attrs": [ ]
+    }
+  },
+  "notification": {
+    "http": {"url": "http://localhost:'$LISTENER_PORT'/notify"},
+    "metadata": [ "dateCreated", "dateModified" ]
+  },
+  "expires": "2050-04-05T14:00:00.00Z"
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+--REGEXPECT--
+01. Attempt to create a subscription with an empty entity type, see error
+=========================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 85
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "entity type length: 0, min length supported: 1",
+    "error": "BadRequest"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/1985_empty_entity_type/empty_entity_type_in_subscription.test
+++ b/test/functionalTest/cases/1985_empty_entity_type/empty_entity_type_in_subscription.test
@@ -31,6 +31,8 @@ brokerStart CB
 
 #
 # 01. Attempt to create a subscription with an empty entity type, see error
+# 02. Create a subscription
+# 03. Attempt to modify a subscription with an empty entity type, see error
 #
 
 echo "01. Attempt to create a subscription with an empty entity type, see error"
@@ -58,8 +60,76 @@ echo
 echo
 
 
+echo "02. Create a subscription"
+echo "========================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ],
+    "condition": {
+      "attrs": [ ]
+    }
+  },
+  "notification": {
+    "http": {"url": "http://localhost:'$LISTENER_PORT'/notify"},
+    "metadata": [ "dateCreated", "dateModified" ]
+  },
+  "expires": "2050-04-05T14:00:00.00Z"
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+SUB_ID=$(echo "$_responseHeaders" | grep Location | awk -F/ '{ print $4 }' | tr -d "\r\n")
+echo
+echo
+
+
+echo "03. Attempt to modify a subscription with an empty entity type, see error"
+echo "========================================================================="
+payload='
+{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": ""
+      }
+    ]
+  }
+}'
+orionCurl -X PATCH --url /v2/subscriptions/$SUB_ID --payload "$payload"
+echo
+echo
+
+
 --REGEXPECT--
 01. Attempt to create a subscription with an empty entity type, see error
+=========================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 85
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "entity type length: 0, min length supported: 1",
+    "error": "BadRequest"
+}
+
+
+02. Create a subscription
+=========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Attempt to modify a subscription with an empty entity type, see error
 =========================================================================
 HTTP/1.1 400 Bad Request
 Content-Length: 85

--- a/test/functionalTest/cases/2257_crash_with_invalid_subscription_when_matching/crash_with_invalid_subscription_when_matching.test
+++ b/test/functionalTest/cases/2257_crash_with_invalid_subscription_when_matching/crash_with_invalid_subscription_when_matching.test
@@ -70,13 +70,13 @@ echo
 01. Create subscription with invalid regex in idPattern
 =======================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 74
+Content-Length: 73
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "Invalid regex for entity id pattern",
+    "description": "Invalid regex for entity idPattern",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/2763_postUpdateContext_error_return/invalid_service_path_gives_400_bad_request.test
+++ b/test/functionalTest/cases/2763_postUpdateContext_error_return/invalid_service_path_gives_400_bad_request.test
@@ -1,0 +1,56 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+invalid_service_path_gives_400_bad_request
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+echo "01. Send a /version request with an Invalid Service Path, see 400 Bad Request"
+echo "============================================================================="
+orionCurl --url /version --servicePath "notStartingWithSlash"
+echo
+echo
+
+
+--REGEXPECT--
+01. Send a /version request with an Invalid Service Path, see 400 Bad Request
+=============================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 111
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Only /absolute/ Service Paths allowed [a service path must begin with /]",
+    "error": "BadRequest"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/2763_postUpdateContext_error_return/postEntities_with_errors_in_service_path.test
+++ b/test/functionalTest/cases/2763_postUpdateContext_error_return/postEntities_with_errors_in_service_path.test
@@ -31,7 +31,7 @@ brokerStart CB
 
 #
 # 01. Try to create an entity with more than one service path - see error
-# 02. Make sure the entity doesn't exist in the database
+# 02. Make sure the entity hasn't been created
 #
 
 echo "01. Try to create an entity with more than one service path - see error"
@@ -42,9 +42,9 @@ echo
 echo
 
 
-echo "02. Make sure the entity doesn't exist in the database"
-echo "======================================================"
-echo "db.entities.findOne()" | mongo ftest
+echo "02. Make sure the entity hasn't been created"
+echo "============================================"
+orionCurl --url /v2/entities
 echo
 echo
 
@@ -64,12 +64,15 @@ Date: REGEX(.*)
 }
 
 
-02. Make sure the entity doesn't exist in the database
-======================================================
-MongoDB shell version: REGEX(.*)
-connecting to: ftest
-null
-bye
+02. Make sure the entity hasn't been created
+============================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/2763_postUpdateContext_error_return/postEntities_with_errors_in_service_path.test
+++ b/test/functionalTest/cases/2763_postUpdateContext_error_return/postEntities_with_errors_in_service_path.test
@@ -1,0 +1,77 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+postEntities with errors in service-path
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Try to create an entity with more than one service path - see error
+# 02. Make sure the entity doesn't exist in the database
+#
+
+echo "01. Try to create an entity with more than one service path - see error"
+echo "======================================================================="
+payload='{ "id": "E1", "type": "T1" }'
+orionCurl --url /v2/entities --payload "$payload" --servicePath /E1,/E2
+echo
+echo
+
+
+echo "02. Make sure the entity doesn't exist in the database"
+echo "======================================================"
+echo "db.entities.findOne()" | mongo ftest
+echo
+echo
+
+
+--REGEXPECT--
+01. Try to create an entity with more than one service path - see error
+=======================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 79
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "code": "400",
+    "details": "more than one service path in context update request"
+}
+
+
+02. Make sure the entity doesn't exist in the database
+======================================================
+MongoDB shell version: REGEX(.*)
+connecting to: ftest
+null
+bye
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/2819_forbiddenChars_in_batch-query_and_NOT_in_URI_param_typePattern/forbiddenChars_in_batch-query_and_NOT_in_URI_param_typePattern.test
+++ b/test/functionalTest/cases/2819_forbiddenChars_in_batch-query_and_NOT_in_URI_param_typePattern/forbiddenChars_in_batch-query_and_NOT_in_URI_param_typePattern.test
@@ -117,13 +117,13 @@ Date: REGEX(.*)
 02. POST /v2/op/query with forbidden chars '<>=;' in entity::id, see it fail due to forbidden chars
 ===================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 67
+Content-Length: 70
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "forbidden chars in entity id",
+    "description": "Invalid characters in entity id",
     "error": "BadRequest"
 }
 
@@ -131,13 +131,13 @@ Date: REGEX(.*)
 03. POST /v2/op/query with forbidden chars '<>=;' in entity::type, see it fail due to forbidden chars
 =====================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 69
+Content-Length: 72
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "forbidden chars in entity type",
+    "description": "Invalid characters in entity type",
     "error": "BadRequest"
 }
 

--- a/test/unittests/apiTypesV2/Entity_test.cpp
+++ b/test/unittests/apiTypesV2/Entity_test.cpp
@@ -22,9 +22,11 @@
 *
 * Author: Fermin Galan
 */
-
 #include "apiTypesV2/Entity.h"
+#include "common/errorMessages.h"
 #include "unittest.h"
+
+
 
 /* ****************************************************************************
 *
@@ -72,14 +74,14 @@ TEST(Entity, check)
   EXPECT_EQ("No Entity ID", enP->check(V1, EntitiesRequest));
 
   enP->id = "E<1>";
-  EXPECT_EQ("Invalid characters in entity id", enP->check(V1, EntitiesRequest));
+  EXPECT_EQ(ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID, enP->check(V1, EntitiesRequest));
   enP->isPattern = "true";
   EXPECT_EQ("OK", enP->check(V1, EntitiesRequest));
   enP->id        = "E";
   enP->isPattern = "false";
 
   enP->type = "T<1>";
-  EXPECT_EQ("Invalid characters in entity type", enP->check(V1, EntitiesRequest));
+  EXPECT_EQ(ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE, enP->check(V1, EntitiesRequest));
   enP->isTypePattern  = true;
   EXPECT_EQ("OK", enP->check(V1, EntitiesRequest));
   enP->type = "T";


### PR DESCRIPTION
Three fixes:
* if entity::type is given but as an empty string, an error is returned (#1985)
* admin requests with errors now return '400 Bad Request', not '200 OK' (no issue, I think)
* attempt to create an entity with an error in service path (and probably more types of errors) now returns '400 Bad Request', not '200 OK' (#2763)
