### PR TITLE
bug/2452_q_for_attr_with_colon_in_name

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -18,6 +18,7 @@
 - Fix: Partial sanity check for custon url, only if the url contains no replacements using ${xxx} (#2280, #2279)
 - Fix: if entity::type is given but as an empty string, in payload of POST /v2/subscriptions or PATCH /v2/subscriptions/{sub}, an error is returned (#1985)
 - Fix: more intelligent, quote-aware, operator lookup inside q/mq string filters (#2452)
+- Fix: attribute names that include ':' now are supported, with the single-quote syntax. E.g. q='devices:location' (#2452)
 - Fix: admin requests (such as GET /version) with errors now return '400 Bad Request', not '200 OK'
 - Fix: attempt to create an entity with an error in service path (and probably more types of errors) now returns '400 Bad Request', not '200 OK' (#2763)
 - Fix: not calling regfree when regcomp fails. Potential fix for a crash (#2769)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -17,6 +17,7 @@
 - Add: Support for null values in string filters (#2359)
 - Fix: Partial sanity check for custon url, only if the url contains no replacements using ${xxx} (#2280, #2279)
 - Fix: if entity::type is given but as an empty string, in payload of POST /v2/subscriptions or PATCH /v2/subscriptions/{sub}, an error is returned (#1985)
+- Fix: more intelligent, quote-aware, operator lookup inside q/mq string filters (#2452)
 - Fix: admin requests (such as GET /version) with errors now return '400 Bad Request', not '200 OK'
 - Fix: attempt to create an entity with an error in service path (and probably more types of errors) now returns '400 Bad Request', not '200 OK' (#2763)
 - Fix: not calling regfree when regcomp fails. Potential fix for a crash (#2769)

--- a/test/functionalTest/cases/2452_q_for_attr_with_colon_in_name/q_for_attr_with_colon_in_name.test
+++ b/test/functionalTest/cases/2452_q_for_attr_with_colon_in_name/q_for_attr_with_colon_in_name.test
@@ -30,15 +30,20 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. Create entity E with attribute A:1
-# 02. GET /v2/entities?q=A:1, no hits (no attr named A)
-# 03. GET /v2/entities?q='A:1', see the entity E
+# 01. Create entity E1 with attribute A:1
+# 02. Create entity E2 with attribute A:2
+# 03. GET /v2/entities?q=A:1, no hits (no attr named A)
+# 04. GET /v2/entities?q='A:1', see the entity E1
+# 05. GET /v2/entities?q=!'A:1', see the entity E2
+# 06. GET /v2/entities?q=!'A:2', see the entity E1
+# 07. GET /v2/entities?q='A:3', no hits
+# 08. GET /v2/entities?q=!'A:3', see E1 and E2
 #
 
-echo "01. Create entity E with attribute A:1"
-echo "======================================"
+echo "01. Create entity E1 with attribute A:1"
+echo "======================================="
 payload='{
-  "id": "E",
+  "id": "E1",
   "A:1": { "value": 1 }
 }'
 orionCurl --url /v2/entities --payload "$payload"
@@ -46,32 +51,81 @@ echo
 echo
 
 
-echo "02. GET /v2/entities?q=A:1, no hits (no attr named A)"
+echo "02. Create entity E2 with attribute A:2"
+echo "======================================="
+payload='{
+  "id": "E2",
+  "A:2": { "value": 2 }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. GET /v2/entities?q=A:1, no hits (no attr named A)"
 echo "====================================================="
 orionCurl --url "/v2/entities?q=A:1"
 echo
 echo
 
 
-echo "03. GET /v2/entities?q='A:1', see the entity E"
-echo "=============================================="
+echo "04. GET /v2/entities?q='A:1', see the entity E1"
+echo "==============================================="
 orionCurl --url "/v2/entities?q='A:1'"
 echo
 echo
 
 
+echo "05. GET /v2/entities?q=!'A:1', see the entity E2"
+echo "================================================"
+orionCurl --url "/v2/entities?q=!'A:1'"
+echo
+echo
+
+
+echo "06. GET /v2/entities?q=!'A:2', see the entity E1"
+echo "================================================"
+orionCurl --url "/v2/entities?q=!'A:2'"
+echo
+echo
+
+
+echo "07. GET /v2/entities?q='A:3', no hits"
+echo "====================================="
+orionCurl --url "/v2/entities?q='A:3'"
+echo
+echo
+
+
+echo "08. GET /v2/entities?q=!'A:3', see E1 and E2"
+echo "============================================"
+orionCurl --url "/v2/entities?q=!'A:3'"
+echo
+echo
+
+
 --REGEXPECT--
-01. Create entity E with attribute A:1
-======================================
+01. Create entity E1 with attribute A:1
+=======================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Location: /v2/entities/E?type=Thing
+Location: /v2/entities/E1?type=Thing
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-02. GET /v2/entities?q=A:1, no hits (no attr named A)
+02. Create entity E2 with attribute A:2
+=======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E2?type=Thing
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. GET /v2/entities?q=A:1, no hits (no attr named A)
 =====================================================
 HTTP/1.1 200 OK
 Content-Length: 2
@@ -82,10 +136,10 @@ Date: REGEX(.*)
 []
 
 
-03. GET /v2/entities?q='A:1', see the entity E
-==============================================
+04. GET /v2/entities?q='A:1', see the entity E1
+===============================================
 HTTP/1.1 200 OK
-Content-Length: 75
+Content-Length: 76
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -97,7 +151,90 @@ Date: REGEX(.*)
             "type": "Number",
             "value": 1
         },
-        "id": "E",
+        "id": "E1",
+        "type": "Thing"
+    }
+]
+
+
+05. GET /v2/entities?q=!'A:1', see the entity E2
+================================================
+HTTP/1.1 200 OK
+Content-Length: 76
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A:2": {
+            "metadata": {},
+            "type": "Number",
+            "value": 2
+        },
+        "id": "E2",
+        "type": "Thing"
+    }
+]
+
+
+06. GET /v2/entities?q=!'A:2', see the entity E1
+================================================
+HTTP/1.1 200 OK
+Content-Length: 76
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A:1": {
+            "metadata": {},
+            "type": "Number",
+            "value": 1
+        },
+        "id": "E1",
+        "type": "Thing"
+    }
+]
+
+
+07. GET /v2/entities?q='A:3', no hits
+=====================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
+
+
+08. GET /v2/entities?q=!'A:3', see E1 and E2
+============================================
+HTTP/1.1 200 OK
+Content-Length: 151
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A:1": {
+            "metadata": {},
+            "type": "Number",
+            "value": 1
+        },
+        "id": "E1",
+        "type": "Thing"
+    },
+    {
+        "A:2": {
+            "metadata": {},
+            "type": "Number",
+            "value": 2
+        },
+        "id": "E2",
         "type": "Thing"
     }
 ]

--- a/test/functionalTest/cases/2452_q_for_attr_with_colon_in_name/q_for_attr_with_colon_in_name.test
+++ b/test/functionalTest/cases/2452_q_for_attr_with_colon_in_name/q_for_attr_with_colon_in_name.test
@@ -1,0 +1,108 @@
+# Copyright 2017 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+q for attr with colon in name
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with attribute A:1
+# 02. GET /v2/entities?q=A:1, no hits (no attr named A)
+# 03. GET /v2/entities?q='A:1', see the entity E
+#
+
+echo "01. Create entity E with attribute A:1"
+echo "======================================"
+payload='{
+  "id": "E",
+  "A:1": { "value": 1 }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. GET /v2/entities?q=A:1, no hits (no attr named A)"
+echo "====================================================="
+orionCurl --url "/v2/entities?q=A:1"
+echo
+echo
+
+
+echo "03. GET /v2/entities?q='A:1', see the entity E"
+echo "=============================================="
+orionCurl --url "/v2/entities?q='A:1'"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with attribute A:1
+======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=Thing
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. GET /v2/entities?q=A:1, no hits (no attr named A)
+=====================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
+
+
+03. GET /v2/entities?q='A:1', see the entity E
+==============================================
+HTTP/1.1 200 OK
+Content-Length: 75
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A:1": {
+            "metadata": {},
+            "type": "Number",
+            "value": 1
+        },
+        "id": "E",
+        "type": "Thing"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fixed issue #2452 with a MUCH better op-lookup that is a lot faster and also quote aware.

This means that, e.g. the string filter `q='a:12'>11` will no longer be misinterpreted as an `'a EQUALS 12'>11` (due to the colon inside quotes) but as `a:12  GT 11`, a:12 being the name of an attribute.

About being faster, instead of calling a complex function as `strstr` up to 8 times, we now do **one single fast loop** over the input.
