### PR TITLE
Fix strncat usage in src/lib/logMsg/logMsg.cpp

### DIFF
--- a/src/lib/logMsg/logMsg.cpp
+++ b/src/lib/logMsg/logMsg.cpp
@@ -173,7 +173,8 @@ do                                         \
                                            \
   xin[0] = c;                              \
   xin[1] = 0;                              \
-  strncat(line, xin, sizeof(xin) - 1);     \
+  strncat(line, xin,                       \
+          lineLen - strlen(line) - 1);     \
                                            \
   fi += l;                                 \
 } while (0)
@@ -189,11 +190,12 @@ do                                                \
 {                                                 \
   if (s != NULL)                                  \
   {                                               \
-    strncat(line, s, lineLen - 1);                \
+    strncat(line, s, lineLen - strlen(line) - 1); \
   }                                               \
   else                                            \
   {                                               \
-    strncat(line, "noprogname", lineLen - 1);     \
+    strncat(line, "noprogname",                   \
+	    lineLen - strlen(line) - 1);	  \
   }                                               \
                                                   \
   fi += l;                                        \
@@ -211,7 +213,8 @@ do                                         \
   char xin[20];                            \
                                            \
   snprintf(xin, sizeof(xin), "%d", i);     \
-  strncat(line, xin, lineLen - 1);         \
+  strncat(line, xin,                       \
+	  lineLen - strlen(line) - 1);	   \
                                            \
   fi += l;                                 \
 } while (0)
@@ -236,7 +239,7 @@ do                                                \
     snprintf(xin, sizeof(xin), "%03d", tLev);     \
   }                                               \
                                                   \
-  strncat(line, xin, lineLen - 1);                \
+  strncat(line, xin, lineLen - strlen(line) - 1); \
   fi += 4;                                        \
 } while (0)
 
@@ -519,14 +522,14 @@ char* lmProgName(char* pn, int levels, bool pid, const char* extra)
   if (pid == true)
   {
     char  pid[8];
-    strncat(pName, "_", sizeof(pName) - 1);
+    strncat(pName, "_", sizeof(pName) - strlen(pName) - 1);
     snprintf(pid, sizeof(pid), "%d", (int) getpid());
-    strncat(pName, pid, sizeof(pName) - 1);
+    strncat(pName, pid, sizeof(pName) - strlen(pName) - 1);
   }
 
   if (extra != NULL)
   {
-    strncat(pName, extra, sizeof(pName) - 1);
+    strncat(pName, extra, sizeof(pName) - strlen(pName) - 1);
   }
 
   printf("pName: %s\n", pName);
@@ -1208,7 +1211,7 @@ static char* lmLineFix
     strncpy(xin, "\n", sizeof(xin));
   }
 
-  strncat(line, xin, lineLen - 1);
+  strncat(line, xin, lineLen - strlen(line) - 1);
 
   return line;
 }
@@ -1288,7 +1291,7 @@ static void asciiToLeft
 
   while (offset-- >= 0)
   {
-    strncat(line, " ", lineLen - 1);
+    strncat(line, " ", lineLen - strlen(line) - 1);
   }
 
   for (i = 0; i < size; i++)
@@ -1306,7 +1309,7 @@ static void asciiToLeft
       strncpy(tmp, ".", sizeof(tmp));
     }
 
-    strncat(line, tmp, lineLen - 1);
+    strncat(line, tmp, lineLen - strlen(line) - 1);
   }
 }
 
@@ -1572,17 +1575,17 @@ char* lmTraceGet(char* levelString, int levelStringSize)
     else if (before && !after)
     {
       snprintf(str, sizeof(str), "-%d", diss);
-      strncat(levelString, str, levelStringSize - 1);
+      strncat(levelString, str, levelStringSize - strlen(levelString) - 1);
     }
     else if (!before && after)
     {
       snprintf(str, sizeof(str), ", %d", diss);
-      strncat(levelString, str, levelStringSize - 1);
+      strncat(levelString, str, levelStringSize - strlen(levelString) - 1);
     }
     else if (!before && !after)
     {
       snprintf(str, sizeof(str), ", %d", diss);
-      strncat(levelString, str, levelStringSize - 1);
+      strncat(levelString, str, levelStringSize - strlen(levelString) - 1);
     }
   }
 
@@ -1646,17 +1649,17 @@ char* lmTraceGet(char* levelString, int levelStringSize, char* traceV)
     else if (before && !after)
     {
       snprintf(str, sizeof(str), "-%d", diss);
-      strncat(levelString, str, levelStringSize - 1);
+      strncat(levelString, str, levelStringSize - strlen(levelString) - 1);
     }
     else if (!before && after)
     {
       snprintf(str, sizeof(str), ", %d", diss);
-      strncat(levelString, str, levelStringSize - 1);
+      strncat(levelString, str, levelStringSize - strlen(levelString) - 1);
     }
     else if (!before && !after)
     {
       snprintf(str, sizeof(str), ", %d", diss);
-      strncat(levelString, str, levelStringSize - 1);
+      strncat(levelString, str, levelStringSize - strlen(levelString) - 1);
     }
   }
 
@@ -2373,7 +2376,7 @@ LmStatus lmOut
 
     if (stre != NULL)
     {
-      strncat(line, stre, LINE_MAX - 1);
+      strncat(line, stre, LINE_MAX - strlen(stre) - 1);
     }
 
     sz = strlen(line);
@@ -2647,14 +2650,14 @@ int lmBufferPresent
       if (bIndex + 4 <= size)
       {
         snprintf(tmp, sizeof(tmp), "%.8x ", *((int*) &buffer[bIndex]));
-        strncat(line, tmp, sizeof(line) - 1);
+        strncat(line, tmp, sizeof(line) - strlen(line) - 1);
         bIndex += 4;
       }
       else if (bIndex + 1 == size)
       {
         snprintf(tmp, sizeof(tmp), "%.2xxxxxxx",
                  (*((int*) &buffer[bIndex]) & 0xFF000000) >> 24);
-        strncat(line, tmp, sizeof(line) - 1);
+        strncat(line, tmp, sizeof(line) - strlen(line) - 1);
         bIndex += 1;
         xx      = 1;
       }
@@ -2662,14 +2665,14 @@ int lmBufferPresent
       {
         snprintf(tmp, sizeof(tmp), "%.4xxxxx",
                  (*((int*) &buffer[bIndex]) & 0xFFFF0000) >> 16);
-        strncat(line, tmp, sizeof(line) - 1);
+        strncat(line, tmp, sizeof(line) - strlen(line) - 1);
         bIndex += 2;
         xx      = 2;
       }
       else if (bIndex + 3 == size)
       {
         snprintf(tmp, sizeof(tmp), "%.6xxx", (*((int*) &buffer[bIndex]) & 0xFFFFFF00) >> 8);
-        strncat(line, tmp, sizeof(line) - 1);
+        strncat(line, tmp, sizeof(line) - strlen(line) - 1);
         bIndex += 3;
         xx      = 3;
       }
@@ -2679,13 +2682,13 @@ int lmBufferPresent
       if (bIndex + 2 <= size)
       {
         snprintf(tmp, sizeof(tmp), "%.4x ", *((int16_t*) &buffer[bIndex]) & 0xFFFF);
-        strncat(line, tmp, sizeof(line) - 1);
+        strncat(line, tmp, sizeof(line) - strlen(line) - 1);
         bIndex += 2;
       }
       else
       {
         snprintf(tmp, sizeof(tmp), "%.2xxx", (*((int16_t*) &buffer[bIndex]) & 0xFF00) >> 8);
-        strncat(line, tmp, sizeof(line) - 1);
+        strncat(line, tmp, sizeof(line) - strlen(line) - 1);
         bIndex += 1;
         xx      = 1;
       }
@@ -2693,7 +2696,7 @@ int lmBufferPresent
 
     case LmfByte:
       snprintf(tmp, sizeof(tmp), "%.2x ", buffer[bIndex] & 0xFF);
-      strncat(line, tmp, sizeof(line) - 1);
+      strncat(line, tmp, sizeof(line) - strlen(line) - 1);
       bIndex += 1;
       break;
     }


### PR DESCRIPTION
    Another bug found by LLVM.  strncat is particularly
    tricky to use.  This commit attempts to fix the errors
    found by LLVM.  Careful inspection is needed, this has
    not been tested.