### PR TITLE
Change paClearAt type in src/lib/parseArgs

### DIFF
--- a/src/lib/parseArgs/paBuiltin.cpp
+++ b/src/lib/parseArgs/paBuiltin.cpp
@@ -47,7 +47,7 @@ bool            paHelpVar;      /* the -help option                   */
 bool            paVersion;
 char            paHome[512];
 bool            paNoClear;
-bool            paClearAt;
+int             paClearAt;
 int             paKeepLines;
 int             paLastLines;
 bool            paLogAppend;

--- a/src/lib/parseArgs/paBuiltin.h
+++ b/src/lib/parseArgs/paBuiltin.h
@@ -35,7 +35,7 @@
 */
 extern char            paHome[512];
 extern bool            paNoClear;
-extern bool            paClearAt;
+extern int             paClearAt;
 extern bool            paAssertAtExit;
 extern int             paKeepLines;
 extern int             paLastLines;


### PR DESCRIPTION
    Yet another bug found by LLVM.  paClearAt is clearly
    used as an integer, and declared as an integer in the
    options list, but syntactically declared as a bool.

    This commit simply changed the type from bool to int