### PR TITLE
Remove a semicolon from the end of an if statement

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -754,7 +754,7 @@ static bool updateAttribute
     /* Custom metadata */
     BSONObj    md;
     BSONArray  mdNames;
-    if (contextAttributeCustomMetadataToBson(&md, &mdNames, caP, apiVersion == V2));
+    if (contextAttributeCustomMetadataToBson(&md, &mdNames, caP, apiVersion == V2))
     {
       newAttr.append(ENT_ATTRS_MD, md);
     }


### PR DESCRIPTION
    Yet another bug found with LLVM.

    This appears to be a bug, but since I don't know the
    program logic, the extra semicolon just *might* be
    a very dubious feature.