### PR TITLE
Change printing of 64bit ints to use %lld instead of %ld

### DIFF
--- a/src/lib/parseArgs/paLimitCheck.cpp
+++ b/src/lib/parseArgs/paLimitCheck.cpp
@@ -172,8 +172,8 @@ static int limits(PaiArgument* paList, PaiArgument* aP)
                        aP->name, i64Val, aP->min, aP->max));
     if ((lower && (i64Val < aP->min)) || (upper && (i64Val > aP->max)))
     {
-      snprintf(valS, sizeof(valS), "%ld", i64Val);
-      snprintf(w, sizeof(w), "%ld <= %ld <= %ld (%s)",
+      snprintf(valS, sizeof(valS), "%lld", i64Val);
+      snprintf(w, sizeof(w), "%lld <= %lld <= %lld (%s)",
                aP->min,
                i64Val,
                aP->max,
@@ -186,8 +186,8 @@ static int limits(PaiArgument* paList, PaiArgument* aP)
                        aP->name, ui64Val, aP->min, aP->max));
     if ((lower && (uiVal < (uint64_t) aP->min)) || (upper && (uiVal > (uint64_t) aP->max)))
     {
-      snprintf(valS, sizeof(valS), "%lu", ui64Val);
-      snprintf(w, sizeof(w), "%lu <= %lu <= %lu (%s)",
+      snprintf(valS, sizeof(valS), "%llu", ui64Val);
+      snprintf(w, sizeof(w), "%llu <= %llu <= %llu (%s)",
                aP->min,
                ui64Val,
                aP->max,

--- a/src/lib/parseArgs/paUsage.cpp
+++ b/src/lib/parseArgs/paUsage.cpp
@@ -166,10 +166,10 @@ static void getApVals
     break;
 
   case PaInt64:
-    snprintf(defVal,  defValLen,  "%ld", aP->def);
-    snprintf(minVal,  minValLen,  "%ld", aP->min);
-    snprintf(maxVal,  maxValLen,  "%ld", aP->max);
-    snprintf(realVal, realValLen, "%ld", *((int64_t*) aP->varP));
+    snprintf(defVal,  defValLen,  "%lld", aP->def);
+    snprintf(minVal,  minValLen,  "%lld", aP->min);
+    snprintf(maxVal,  maxValLen,  "%lld", aP->max);
+    snprintf(realVal, realValLen, "%lld", *((int64_t*) aP->varP));
     break;
 
   case PaIntU:
@@ -180,10 +180,10 @@ static void getApVals
     break;
 
   case PaIntU64:
-    snprintf(defVal,  defValLen,  "%lu", aP->def);
-    snprintf(minVal,  minValLen,  "%lu", aP->min);
-    snprintf(maxVal,  maxValLen,  "%lu", aP->max);
-    snprintf(realVal, realValLen, "%lu", *((uint64_t*) aP->varP));
+    snprintf(defVal,  defValLen,  "%llu", aP->def);
+    snprintf(minVal,  minValLen,  "%llu", aP->min);
+    snprintf(maxVal,  maxValLen,  "%llu", aP->max);
+    snprintf(realVal, realValLen, "%llu", *((uint64_t*) aP->varP));
     break;
 
   case PaShort:


### PR DESCRIPTION
    Another issue found when compiling with LLVM.

    At least under Mac OS X, when printing 64-bit ints,
    the printf string must be %lld as they are long long
    while long is just another name for 32-bit ints.

    Of course, this may be different in Linux and I don't
    have the ability to compile under 64-bit Linux.

    Please check that this works fine under 64-bit Linux
    before merging.