### PR TITLE
Change the recognition of MHD_USE_EPOLL support

### DIFF
--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1593,7 +1593,7 @@ static int restStart(IpVersion ipVersion, const char* httpsKey = NULL, const cha
     // while in MHD 0.9.51, the name of the define has changed to MHD_USE_EPOLL.
     // So, to support both names, we need a ifdef/else cpp directive here.
     //
-#ifdef MHD_USE_EPOLL
+#if defined(MHD_USE_EPOLL) || MHD_VERSION >= 0x00095102
     serverMode = MHD_USE_SELECT_INTERNALLY | MHD_USE_EPOLL;
 #else
     serverMode = MHD_USE_SELECT_INTERNALLY | MHD_USE_EPOLL_LINUX_ONLY;


### PR DESCRIPTION
   In some newer versions of microhttpd.h, MHD_USE_EPOLL is
   an enum instead of being a #define.  This commit changes
   the #if guarding its use