### PR TITLE
Add #include <string> to src/lib/jsonParseV2/utilsParse.h

### DIFF
--- a/src/lib/jsonParseV2/utilsParse.h
+++ b/src/lib/jsonParseV2/utilsParse.h
@@ -26,6 +26,7 @@
 * Author: Orion dev team
 */
 
+#include <string>
 #include "rapidjson/document.h"
 
 template <typename T>


### PR DESCRIPTION
   Without this patch compilation fails with LLVM under Mac OS X with the
   following and other related errors:

   In file included from fiware-orion/src/lib/jsonParseV2/utilsParse.cpp:27:
   fiware-orion/src/lib/jsonParseV2/utilsParse.h:41:15: error:
      implicit instantiation of undefined template
      'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
   std::string error;