### PR TITLE
Slight change in MHD EPOLL detection

### DIFF
--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1593,7 +1593,10 @@ static int restStart(IpVersion ipVersion, const char* httpsKey = NULL, const cha
     // while in MHD 0.9.51, the name of the define has changed to MHD_USE_EPOLL.
     // So, to support both names, we need a ifdef/else cpp directive here.
     //
-#if defined(MHD_USE_EPOLL) || MHD_VERSION >= 0x00095102
+    // And, in some newer versions of microhttpd, MHD_USE_EPOLL is an enum and not a define,
+    // so, an additional check in needed
+    //
+#if defined(MHD_USE_EPOLL) || MHD_VERSION >= 0x00095100
     serverMode = MHD_USE_SELECT_INTERNALLY | MHD_USE_EPOLL;
 #else
     serverMode = MHD_USE_SELECT_INTERNALLY | MHD_USE_EPOLL_LINUX_ONLY;


### PR DESCRIPTION
Slight modification of the PR so kindly offered by @pekkanikander 

Adding a line of explanation and changing the constant of MHD version to coincide 'exactly' with the comment: 0x00095102 => 0x00095100 (as comment says MHD 0.9.51 ...).

As I am not 100% sure that the change 0x00095102 => 0x00095100 might have some negative impact in mac ... Pekka, could you test in your machine and let me know if you have any problem with this change, please? And if so, propose a fix that works for you too ...
