### PR TITLE
FIX using libcurl to send notifications to HTTPS endpoints

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,5 @@
+- Add: HTTPS native notifications (#706), fixing at the same time issue #2844
+- Add: new option to accept self-signed certifications used by HTTPS notification endpoints: -acceptSelfSignedCert (#706)
 - Fix: libmicrohttpd now uses poll()/epoll() and not select() so fds greater than 1023 can be used for incoming connections (#2724, #2166)
 - Add: new option to set the timeout for REST request: -reqTimeout (#2762)
 - Fix: modified the upper limit for CLI '-maxConnections', from 1020 to UNLIMITED

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,5 +1,5 @@
 - Add: HTTPS native notifications (#706), fixing at the same time issue #2844
-- Add: new option to accept self-signed certifications used by HTTPS notification endpoints: -acceptSelfSignedCert (#706)
+- Add: new option to accept self-signed certifications used by HTTPS notification endpoints: -insecureNotif (#706)
 - Fix: libmicrohttpd now uses poll()/epoll() and not select() so fds greater than 1023 can be used for incoming connections (#2724, #2166)
 - Add: new option to set the timeout for REST request: -reqTimeout (#2762)
 - Fix: modified the upper limit for CLI '-maxConnections', from 1020 to UNLIMITED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ SET (DYNAMIC_LIBS
     gnutls
     pthread
     gcrypt
+    ssl
     uuid
 )
 

--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -9,6 +9,7 @@ The Orion Context Broker uses the following libraries as build dependencies:
 * boost: 1.41 (the one that comes in EPEL6 repository)
 * libmicrohttpd: 0.9.48 (from source)
 * libcurl: 7.19.7
+* openssl: 1.0.1e
 * libuuid: 2.17.2
 * Mongo Driver: legacy-1.0.7 (from source)
 * rapidjson: 1.0.2 (from source)
@@ -27,7 +28,7 @@ commands that require root privilege):
 
 * Install the required libraries (except what needs to be taken from source, described in following steps).
 
-        sudo yum install boost-devel libcurl-devel gnutls-devel libgcrypt-devel libuuid-devel
+        sudo yum install boost-devel libcurl-devel gnutls-devel libgcrypt-devel openssl-devel libuuid-devel
 
 * Install the Mongo Driver from source:
 

--- a/doc/manuals/admin/cli.md
+++ b/doc/manuals/admin/cli.md
@@ -157,3 +157,5 @@ The list of available options is the following:
 -   **-logForHumans**. To make the traces to standard out formated for humans (note that the traces in the log file are not affected)
 -   **-disableMetrics**. To turn off the 'metrics' feature. Gathering of metrics is a bit costly, as system calls and semaphores are involved.
     Use this parameter to start the broker without metrics overhead.
+-   **-insecureNotif**. Allow HTTPS notifications to peers which certificate cannot be authenticated with known CA certificates. This is similar
+    to the `-k` or `--insecure` parameteres of the curl command.

--- a/doc/manuals/admin/database_model.md
+++ b/doc/manuals/admin/database_model.md
@@ -381,7 +381,7 @@ Example document:
  {
    "_id": ObjectId("51756c2220be8dc1b5f415ff"),
    "expiration": 1360236300,
-   "reference": "`[`http://notify.me`](http://notify.me)`",
+   "reference": "http://notify.me",
    "entities": [
        {
            "id": "E5",

--- a/doc/manuals/user/security.md
+++ b/doc/manuals/user/security.md
@@ -19,21 +19,29 @@ GEis.
 ## HTTPS API
 
 Orion Context Broker supports HTTPS, using the `-https` options (which in addition needs the
--key and -cert options, to especify the files containing the private key
+`-key` and `-cert` options, to especify the files containing the private key
 and certificates for the server, respectively). Check the [command line
 options section in the administration manual for
 details](../admin/cli.md#command-line-options).
 Note that current Orion version cannot run in both HTTP and HTTPS at the
-same time, i.e. using -https disables HTTP.
+same time, i.e. using `-https` disables HTTP.
 
 ## HTTPS notifications
 
 Apart from using HTTPS in the API server exported by Orion, you can also use HTTPS in
-notifications. In order to do so:
+notifications. In order to do so you have to use the "https" protocol schema in URL in your
+subscriptions, e.g.
 
--   You have to use the "https" protocol schema in URL in you reference
-    element in subscribeContext or subscribeContextAvailability
-    subscriptions, e.g.
+
+NGSIv2:
+
+```
+  ...
+  "url": "https://mymachime.example.com:1028/notify"
+  ...
+```
+
+NGSIv1:
 
 ```
   ...
@@ -41,7 +49,10 @@ notifications. In order to do so:
   ...
 ```
 
--   You have to use Rush as relayer (as the HTTPS encoding is
-    implemented in Rush). See [how to run Orion using
-    Rush](../admin/rush.md)
-    for additional information on this topic.
+If you use Rush relayer (see [how to run Orion using Rush](../admin/rush.md)) then Orion to Rush request
+is sent in HTTP, then Rush will encrypt it using HTTPS towards the final receiver. If you don't use Rush
+relayer, then Orion will send HTTPS notification natively. In that case, note that by default Orion will
+reject connections to non-trusted endpoints (i.e. the ones which which certificate cannot be authenticated
+with known CA certificates). If you want to avoid this behaviour you need to use the `-insecureNotif`
+[CLI parameter](../admin/cli.md) but note that doing so is an insecure configuration (e.g. you could suffer
+[man-in-the-middle attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN \
       gnutls-devel \
       libgcrypt-devel \
       libcurl-devel \
+      openssl-devel \
       libuuid-devel \
       make \
       nc \

--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -76,6 +76,8 @@ def usage():
     print "  --url <server url>: server URL to use (default is /accumulate)"
     print "  --pretty-print: pretty print mode"
     print "  --https: start in https"
+    print "  --key: key file (only used if https is enabled)"
+    print "  --cert: cert file (only used if https is enabled)"
     print "  -v: verbose mode"
     print "  -u: print this usage message"
 
@@ -91,9 +93,11 @@ server_url = '/accumulate'
 verbose    = 0
 pretty     = False
 https      = False
+key_file   = None
+cert_file  = None
 
 try:
-    opts, args = getopt(sys.argv[1:], 'vu', ['host=', 'port=', 'url=', 'pretty-print', 'https' ])
+    opts, args = getopt(sys.argv[1:], 'vu', ['host=', 'port=', 'url=', 'pretty-print', 'https', 'key=', 'cert=' ])
 except GetoptError:
     usage_and_exit('wrong parameter')
 
@@ -116,8 +120,17 @@ for opt, arg in opts:
         pretty = True
     elif opt == '--https':
         https = True
+    elif opt == '--key':
+        key_file = arg
+    elif opt == '--cert':
+        cert_file = arg
     else:
         usage_and_exit()
+
+if https:
+    if key_file is None or cert_file is None:
+        print "if --https is used then you have to provide --key and --cert"
+        os.exit(1)
 
 if verbose:
     print "verbose mode is on"
@@ -126,6 +139,8 @@ if verbose:
     print "server_url: " + str(server_url)
     print "pretty: " + str(pretty)
     print "https: " + str(https)
+    print "key file: " + key_file
+    print "cert file: " + cert_file
 
 pid     = str(os.getpid())
 pidfile = "/tmp/accumulator." + str(port) + ".pid"
@@ -306,9 +321,8 @@ if __name__ == '__main__':
     # use debug=True below with care :)
     if (https):
       context = SSL.Context(SSL.SSLv23_METHOD)
-      # FIXME PR: unhardwire files
-      context.use_privatekey_file('domain.key')
-      context.use_certificate_file('domain.crt')
+      context.use_privatekey_file(key_file)
+      context.use_certificate_file(cert_file)
       app.run(host=host, port=port, debug=False, ssl_context=context)
     else:
       app.run(host=host, port=port)

--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -320,9 +320,12 @@ if __name__ == '__main__':
     # makes the calle os.path.isfile(pidfile) return True, even if the file doesn't exist. Thus,
     # use debug=True below with care :)
     if (https):
-      context = SSL.Context(SSL.SSLv23_METHOD)
-      context.use_privatekey_file(key_file)
-      context.use_certificate_file(cert_file)
+      # According to http://stackoverflow.com/questions/28579142/attributeerror-context-object-has-no-attribute-wrap-socket/28590266, the
+      # original way of using context is deprecated. New way is simpler
+      #context = SSL.Context(SSL.SSLv23_METHOD)
+      #context.use_privatekey_file(key_file)
+      #context.use_certificate_file(cert_file)
+      context = (cert_file, key_file)
       app.run(host=host, port=port, debug=False, ssl_context=context)
     else:
       app.run(host=host, port=port)

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -278,6 +278,7 @@ bool            disableCusNotif;
 bool            logForHumans;
 bool            disableMetrics;
 int             reqTimeout;
+bool            acceptSelfSignedCert;
 
 
 
@@ -334,6 +335,7 @@ int             reqTimeout;
 #define LOG_FOR_HUMANS_DESC    "human readible log to screen"
 #define METRICS_DESC           "turn off the 'metrics' feature"
 #define REQ_TMO_DESC           "connection timeout for REST requests (in seconds)"
+#define SELF_SIGNED_CRT_DESC   "accept self signed certificate when used by HTTPS notification endpoints"
 
 
 
@@ -401,6 +403,8 @@ PaArgument paArgs[] =
 
   { "-logForHumans",   &logForHumans,    "LOG_FOR_HUMANS",     PaBool, PaOpt, false, false, true,             LOG_FOR_HUMANS_DESC },
   { "-disableMetrics", &disableMetrics,  "DISABLE_METRICS",    PaBool, PaOpt, false, false, true,             METRICS_DESC        },
+
+  { "-acceptSelfSignedCert", &acceptSelfSignedCert, "ACCEPT_SELF_SIGNED_CRT", PaBool, PaOpt, false, false, true, SELF_SIGNED_CRT_DESC },
 
   PA_END_OF_ARGS
 };

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -278,7 +278,7 @@ bool            disableCusNotif;
 bool            logForHumans;
 bool            disableMetrics;
 int             reqTimeout;
-bool            acceptSelfSignedCert;
+bool            insecureNotif;
 
 
 
@@ -335,7 +335,7 @@ bool            acceptSelfSignedCert;
 #define LOG_FOR_HUMANS_DESC    "human readible log to screen"
 #define METRICS_DESC           "turn off the 'metrics' feature"
 #define REQ_TMO_DESC           "connection timeout for REST requests (in seconds)"
-#define SELF_SIGNED_CRT_DESC   "accept self signed certificate when used by HTTPS notification endpoints"
+#define INSECURE_NOTIF         "allow HTTPS notifications to peers which certificate cannot be authenticated with known CA certificates"
 
 
 
@@ -404,7 +404,7 @@ PaArgument paArgs[] =
   { "-logForHumans",   &logForHumans,    "LOG_FOR_HUMANS",     PaBool, PaOpt, false, false, true,             LOG_FOR_HUMANS_DESC },
   { "-disableMetrics", &disableMetrics,  "DISABLE_METRICS",    PaBool, PaOpt, false, false, true,             METRICS_DESC        },
 
-  { "-acceptSelfSignedCert", &acceptSelfSignedCert, "ACCEPT_SELF_SIGNED_CRT", PaBool, PaOpt, false, false, true, SELF_SIGNED_CRT_DESC },
+  { "-insecureNotif", &insecureNotif, "INSECURE_NOTIF", PaBool, PaOpt, false, false, true, INSECURE_NOTIF },
 
   PA_END_OF_ARGS
 };

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -1748,13 +1748,13 @@ int main(int argC, char* argV[])
   logSummaryInit(&lsPeriod);
 
   // According to http://stackoverflow.com/questions/28048885/initializing-ssl-and-libcurl-and-getting-out-of-memory/37295100,
-  // openSSL library needs to be initialized with SSL_library_init() before any use of it by other the other libraries
+  // openSSL library needs to be initialized with SSL_library_init() before any use of it by any other libraries
   SSL_library_init();
 
   // Startup libcurl
   if (curl_global_init(CURL_GLOBAL_SSL) != 0)
   {
-    LM_X(1, ("Fatal Error (could not init libcurl)"));
+    LM_X(1, ("Fatal Error (could not initialize libcurl)"));
   }
 
   if (rush[0] != 0)

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -1742,7 +1742,6 @@ int main(int argC, char* argV[])
   SemOpType policy = policyGet(reqMutexPolicy);
   orionInit(orionExit, ORION_VERSION, policy, statCounters, statSemWait, statTiming, statNotifQueue, strictIdv1);
   mongoInit(dbHost, rplSet, dbName, user, pwd, mtenant, dbTimeout, writeConcern, dbPoolSize, statSemWait);
-  contextBrokerInit(dbName, mtenant);
   alarmMgr.init(relogAlarms);
   metricsMgr.init(!disableMetrics, statSemWait);
   logSummaryInit(&lsPeriod);
@@ -1782,6 +1781,11 @@ int main(int argC, char* argV[])
   {
     LM_T(LmtSubCache, ("noCache == false"));
   }
+
+  // Given that contextBrokerInit() may create thread (in the threadpool notification mode,
+  // it has to be done before curl_global_init(), see https://curl.haxx.se/libcurl/c/threaded-ssl.html
+  // Otherwise, we have empirically checked that CB may randomly crash
+  contextBrokerInit(dbName, mtenant);
 
   if (https)
   {

--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -219,7 +219,7 @@ extern bool               notifQueueStatistics;
 extern bool               checkIdv1;
 extern bool               disableCusNotif;
 
-extern bool               acceptSelfSignedCert;
+extern bool               insecureNotif;
 
 
 

--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -219,6 +219,8 @@ extern bool               notifQueueStatistics;
 extern bool               checkIdv1;
 extern bool               disableCusNotif;
 
+extern bool               acceptSelfSignedCert;
+
 
 
 /* ****************************************************************************

--- a/src/lib/logMsg/logMsg.h
+++ b/src/lib/logMsg/logMsg.h
@@ -1822,14 +1822,14 @@ inline void lmTransactionReset()
 *
 * lmTransactionStart -
 */
-inline void lmTransactionStart(const char* keyword, const char* ip, int port, const char* path)
+inline void lmTransactionStart(const char* keyword, const char* schema, const char* ip, int port, const char* path)
 {
   transactionIdSet();
 
   snprintf(service,    sizeof(service),    "pending");
   snprintf(subService, sizeof(subService), "pending");
   snprintf(fromIp,     sizeof(fromIp),     "pending");
-  LM_I(("Starting transaction %s %s:%d%s", keyword, ip, port, path));
+  LM_I(("Starting transaction %s %s%s:%d%s", keyword, schema, ip, port, path));
 }
 
 

--- a/src/lib/ngsiNotify/Notifier.cpp
+++ b/src/lib/ngsiNotify/Notifier.cpp
@@ -140,6 +140,7 @@ void Notifier::sendNotifyContextAvailabilityRequest
 
     params->ip               = host;
     params->port             = port;
+    params->protocol         = protocol;
     params->verb             = "POST";
     params->tenant           = tenant;
     params->resource         = uriPath;   

--- a/src/lib/ngsiNotify/senderThread.cpp
+++ b/src/lib/ngsiNotify/senderThread.cpp
@@ -66,8 +66,6 @@ void* startSenderThread(void* p)
       std::string  out;
       int          r;
 
-      std::map<std::string, std::string> headers;
-
       r = httpRequestSend(params->ip,
                           params->port,
                           params->protocol,

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -240,7 +240,7 @@ int httpRequestSendWithCurl
    CURL*                                      curl,
    const std::string&                         _ip,
    unsigned short                             port,
-   const std::string&                         protocol,
+   const std::string&                         _protocol,
    const std::string&                         verb,
    const std::string&                         tenant,
    const std::string&                         servicePath,
@@ -260,7 +260,6 @@ int httpRequestSendWithCurl
 {
   char                            portAsString[STRING_SIZE_FOR_INT];
   static unsigned long long       callNo             = 0;
-  std::string                     result;
   std::string                     ip                 = _ip;
   struct curl_slist*              headers            = NULL;
   MemoryStruct*                   httpResponse       = NULL;
@@ -287,7 +286,7 @@ int httpRequestSendWithCurl
     timeoutInMilliseconds = defaultTimeout;
   }
 
-  lmTransactionStart("to", ip.c_str(), port, resource.c_str());
+  lmTransactionStart("to", (_protocol + "//").c_str(), + ip.c_str(), port, resource.c_str());
 
   // Preconditions check
   if (port == 0)
@@ -373,6 +372,8 @@ int httpRequestSendWithCurl
     useRush = false;
   }
 
+  std::string protocol = _protocol;
+
   if (useRush)
   {
     char         rushHeaderPortAsString[STRING_SIZE_FOR_INT];
@@ -393,8 +394,10 @@ int httpRequestSendWithCurl
                   extraHeaders,
                   usedExtraHeaders);
 
-    if (protocol == "https:")
+    if (_protocol == "https:")
     {
+      // "Switching" protocol https -> http is needed in this case, as CB->Rush request will use HTTP
+      protocol = "http:";
       headerRushHttp = "X-relayer-protocol: https";
       LM_T(LmtHttpHeaders, ("HTTP-HEADERS: '%s'", headerRushHttp.c_str()));
       httpHeaderAdd(&headers, "X-relayer-protocol", headerRushHttp, &outgoingMsgSize, extraHeaders, usedExtraHeaders);
@@ -522,10 +525,18 @@ int httpRequestSendWithCurl
   // Set up URL
   std::string url;
   if (isIPv6(ip))
+  {
     url = "[" + ip + "]";
+  }
   else
+  {
     url = ip;
-  url = url + ":" + portAsString + (resource.at(0) == '/'? "" : "/") + resource;
+  }
+  url = protocol + "//" + url + ":" + portAsString + (resource.at(0) == '/'? "" : "/") + resource;
+
+  // FIXME PR: I wonder if these next two should be disabled by default.
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L); // ignore self-signed certificates for SSL end-points
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
   // Prepare CURL handle with obtained options
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -286,7 +286,8 @@ int httpRequestSendWithCurl
     timeoutInMilliseconds = defaultTimeout;
   }
 
-  lmTransactionStart("to", (_protocol + "//").c_str(), + ip.c_str(), port, resource.c_str());
+  std::string protocol = _protocol + "//";
+  lmTransactionStart("to", protocol.c_str(), + ip.c_str(), port, resource.c_str());
 
   // Preconditions check
   if (port == 0)
@@ -372,8 +373,6 @@ int httpRequestSendWithCurl
     useRush = false;
   }
 
-  std::string protocol = _protocol;
-
   if (useRush)
   {
     char         rushHeaderPortAsString[STRING_SIZE_FOR_INT];
@@ -394,10 +393,10 @@ int httpRequestSendWithCurl
                   extraHeaders,
                   usedExtraHeaders);
 
-    if (_protocol == "https:")
+    if (protocol == "https://")
     {
       // "Switching" protocol https -> http is needed in this case, as CB->Rush request will use HTTP
-      protocol = "http:";
+      protocol = "http://";
       headerRushHttp = "X-relayer-protocol: https";
       LM_T(LmtHttpHeaders, ("HTTP-HEADERS: '%s'", headerRushHttp.c_str()));
       httpHeaderAdd(&headers, "X-relayer-protocol", headerRushHttp, &outgoingMsgSize, extraHeaders, usedExtraHeaders);
@@ -532,7 +531,7 @@ int httpRequestSendWithCurl
   {
     url = ip;
   }
-  url = protocol + "//" + url + ":" + portAsString + (resource.at(0) == '/'? "" : "/") + resource;
+  url = protocol + url + ":" + portAsString + (resource.at(0) == '/'? "" : "/") + resource;
 
   if (insecureNotif)
   {

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -534,9 +534,11 @@ int httpRequestSendWithCurl
   }
   url = protocol + "//" + url + ":" + portAsString + (resource.at(0) == '/'? "" : "/") + resource;
 
-  // FIXME PR: I wonder if these next two should be disabled by default.
-  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L); // ignore self-signed certificates for SSL end-points
-  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+  if (acceptSelfSignedCert)
+  {
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L); // ignore self-signed certificates for SSL end-points
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+  }
 
   // Prepare CURL handle with obtained options
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -534,7 +534,7 @@ int httpRequestSendWithCurl
   }
   url = protocol + "//" + url + ":" + portAsString + (resource.at(0) == '/'? "" : "/") + resource;
 
-  if (acceptSelfSignedCert)
+  if (insecureNotif)
   {
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L); // ignore self-signed certificates for SSL end-points
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1298,7 +1298,7 @@ static int connectionTreat
     //
     // Transaction starts here
     //
-    lmTransactionStart("from", ip, port, url);  // Incoming REST request starts
+    lmTransactionStart("from", "", ip, port, url);  // Incoming REST request starts
 
     /* X-Real-IP and X-Forwarded-For (used by a potential proxy on top of Orion) overrides ip.
        X-Real-IP takes preference over X-Forwarded-For, if both appear */

--- a/test/functionalTest/cases/0000_cli/bool_option_with_value.test
+++ b/test/functionalTest/cases/0000_cli/bool_option_with_value.test
@@ -87,6 +87,6 @@ Usage: contextBroker  [option '-U' (extended usage)]
                       [option '-disableCustomNotifications' (disable NGSIv2 custom notifications)]
                       [option '-logForHumans' (human readible log to screen)]
                       [option '-disableMetrics' (turn off the 'metrics' feature)]
-                      [option '-acceptSelfSignedCert' (accept self signed certificate when used by HTTPS notification endpoints)]
+                      [option '-insecureNotif' (allow HTTPS notifications to peers which certificate cannot be authenticated with known CA certificates)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/bool_option_with_value.test
+++ b/test/functionalTest/cases/0000_cli/bool_option_with_value.test
@@ -87,5 +87,6 @@ Usage: contextBroker  [option '-U' (extended usage)]
                       [option '-disableCustomNotifications' (disable NGSIv2 custom notifications)]
                       [option '-logForHumans' (human readible log to screen)]
                       [option '-disableMetrics' (turn off the 'metrics' feature)]
+                      [option '-acceptSelfSignedCert' (accept self signed certificate when used by HTTPS notification endpoints)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/command_line_options.test
+++ b/test/functionalTest/cases/0000_cli/command_line_options.test
@@ -76,5 +76,6 @@ Usage: contextBroker  [option '-U' (extended usage)]
                       [option '-disableCustomNotifications' (disable NGSIv2 custom notifications)]
                       [option '-logForHumans' (human readible log to screen)]
                       [option '-disableMetrics' (turn off the 'metrics' feature)]
+                      [option '-acceptSelfSignedCert' (accept self signed certificate when used by HTTPS notification endpoints)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/command_line_options.test
+++ b/test/functionalTest/cases/0000_cli/command_line_options.test
@@ -76,6 +76,6 @@ Usage: contextBroker  [option '-U' (extended usage)]
                       [option '-disableCustomNotifications' (disable NGSIv2 custom notifications)]
                       [option '-logForHumans' (human readible log to screen)]
                       [option '-disableMetrics' (turn off the 'metrics' feature)]
-                      [option '-acceptSelfSignedCert' (accept self signed certificate when used by HTTPS notification endpoints)]
+                      [option '-insecureNotif' (allow HTTPS notifications to peers which certificate cannot be authenticated with known CA certificates)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/tracelevel_without_logLevel_as_DEBUG.test
+++ b/test/functionalTest/cases/0000_cli/tracelevel_without_logLevel_as_DEBUG.test
@@ -77,6 +77,6 @@ Usage:                [option '-U' (extended usage)]
                       [option '-disableCustomNotifications' (disable NGSIv2 custom notifications)]
                       [option '-logForHumans' (human readible log to screen)]
                       [option '-disableMetrics' (turn off the 'metrics' feature)]
-                      [option '-acceptSelfSignedCert' (accept self signed certificate when used by HTTPS notification endpoints)]
+                      [option '-insecureNotif' (allow HTTPS notifications to peers which certificate cannot be authenticated with known CA certificates)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/tracelevel_without_logLevel_as_DEBUG.test
+++ b/test/functionalTest/cases/0000_cli/tracelevel_without_logLevel_as_DEBUG.test
@@ -77,5 +77,6 @@ Usage:                [option '-U' (extended usage)]
                       [option '-disableCustomNotifications' (disable NGSIv2 custom notifications)]
                       [option '-logForHumans' (human readible log to screen)]
                       [option '-disableMetrics' (turn off the 'metrics' feature)]
+                      [option '-acceptSelfSignedCert' (accept self signed certificate when used by HTTPS notification endpoints)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications.test
@@ -27,7 +27,7 @@ Direct HTTP notification (accepting self signed certs)
 ${SCRIPT_HOME}/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
 
 dbInit CB
-brokerStart CB 0 IPV4 -acceptSelfSignedCert
+brokerStart CB 0 IPV4 -insecureNotif
 accumulatorStart --pretty-print --https --key /tmp/harnessTest.key --cert /tmp/harnessTest.pem
 
 --SHELL--

--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications.test
@@ -1,0 +1,138 @@
+# Copyright 2017 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Direct HTTP notification (accepting self signed certs)
+
+--SHELL-INIT--
+${SCRIPT_HOME}/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
+
+dbInit CB
+brokerStart CB 0 IPV4 -acceptSelfSignedCert
+accumulatorStart --pretty-print --https --key /tmp/harnessTest.key --cert /tmp/harnessTest.pem
+
+--SHELL--
+
+#
+# 01. Create subscription to an HTTPS endpoint
+# 02. Create entity, triggering notification
+# 03. Dump accumulator and see 1 notification
+#
+
+
+echo "01. Create subscription to an HTTPS endpoint"
+echo "============================================"
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "idPattern": "E.*"
+      }
+    ],
+    "condition": {
+      "attrs": [ ]
+    }
+  },
+  "notification": {
+    "http": {"url": "https://localhost:'$LISTENER_PORT'/notify"}
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create entity, triggering notification"
+echo "=========================================="
+payload='{
+  "id": "E1",
+  "A1": {
+    "value": 1
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. Dump accumulator and see 1 notification"
+echo "==========================================="
+accumulatorDump IPV4 HTTPS
+echo
+echo
+
+
+--REGEXPECT--
+01. Create subscription to an HTTPS endpoint
+============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create entity, triggering notification
+==========================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=Thing
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Dump accumulator and see 1 notification
+===========================================
+POST https://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 128
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+
+{
+    "data": [
+        {
+            "A1": {
+                "metadata": {},
+                "type": "Number",
+                "value": 1
+            },
+            "id": "E1",
+            "type": "Thing"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+accumulatorStop
+rm -f /tmp/harnessTest.key /tmp/harnessTest.pem

--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
@@ -1,0 +1,125 @@
+# Copyright 2017 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Direct HTTP notification (not accepting self signed certs)
+
+--SHELL-INIT--
+${SCRIPT_HOME}/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
+
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print --https --key /tmp/harnessTest.key --cert /tmp/harnessTest.pem
+
+--SHELL--
+
+#
+# 01. Create subscription to an HTTPS endpoint
+# 02. Create entity, triggering notification
+# 03. Dump accumulator and see no notification
+# 04. Look in the CB log for the warning about cert not accepted
+#
+
+
+echo "01. Create subscription to an HTTPS endpoint"
+echo "============================================"
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "idPattern": "E.*"
+      }
+    ],
+    "condition": {
+      "attrs": [ ]
+    }
+  },
+  "notification": {
+    "http": {"url": "https://localhost:'$LISTENER_PORT'/notify"}
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create entity, triggering notification"
+echo "=========================================="
+payload='{
+  "id": "E1",
+  "A1": {
+    "value": 1
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. Dump accumulator and see no notification"
+echo "============================================"
+accumulatorDump IPV4 HTTPS
+echo
+echo
+
+echo "04. Look in the CB log for the warning about cert not accepted"
+echo "=============================================================="
+grep "(curl_easy_perform failed: Peer certificate cannot be authenticated with given CA certificates)" /tmp/contextBroker.log | awk -F "curl_easy_perform" '{ print "(curl_easy_perform" $2 }'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create subscription to an HTTPS endpoint
+============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create entity, triggering notification
+==========================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=Thing
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Dump accumulator and see no notification
+============================================
+
+
+04. Look in the CB log for the warning about cert not accepted
+==============================================================
+(curl_easy_perform failed: Peer certificate cannot be authenticated with given CA certificates)
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+accumulatorStop
+rm -f /tmp/harnessTest.key /tmp/harnessTest.pem

--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
@@ -81,7 +81,7 @@ accumulatorDump IPV4 HTTPS
 echo
 echo
 
-# Note the REGEX(given|known) in the REGEXPECT part for step 4. This is due to that the log message is slightly different
+# Note the REGEX(\S+) in the REGEXPECT part for step 4. This is due to that the log message is slightly different
 # depending on the libcurl version, some versions (newer ones) use "given" while other (older versions) use "known"
 
 echo "04. Look in the CB log for the warning about cert not accepted"
@@ -118,7 +118,7 @@ Date: REGEX(.*)
 
 04. Look in the CB log for the warning about cert not accepted
 ==============================================================
- failed: Peer certificate cannot be authenticated with REGEX((given)|(known)) CA certificates
+ failed: Peer certificate cannot be authenticated with REGEX(\S+) CA certificates
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
@@ -81,9 +81,12 @@ accumulatorDump IPV4 HTTPS
 echo
 echo
 
+# Note the REGEX(given|known) in the REGEXPECT part for step 4. This is due to the log message is slightly different
+# depending on libcurl version, some ones (newers) use "given" some others (older) use "known"
+
 echo "04. Look in the CB log for the warning about cert not accepted"
 echo "=============================================================="
-grep "(curl_easy_perform failed: Peer certificate cannot be authenticated with given CA certificates)" /tmp/contextBroker.log | awk -F "curl_easy_perform" '{ print "(curl_easy_perform" $2 }'
+grep "(curl_easy_perform failed: Peer certificate cannot be authenticated" /tmp/contextBroker.log | awk -F "curl_easy_perform" '{ print $2 }' | awk -F ")" '{ print $1 }'
 echo
 echo
 
@@ -115,7 +118,7 @@ Date: REGEX(.*)
 
 04. Look in the CB log for the warning about cert not accepted
 ==============================================================
-(curl_easy_perform failed: Peer certificate cannot be authenticated with given CA certificates)
+ failed: Peer certificate cannot be authenticated with REGEX(given|known) CA certificates
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
@@ -81,8 +81,8 @@ accumulatorDump IPV4 HTTPS
 echo
 echo
 
-# Note the REGEX(given|known) in the REGEXPECT part for step 4. This is due to the log message is slightly different
-# depending on libcurl version, some ones (newers) use "given" some others (older) use "known"
+# Note the REGEX(given|known) in the REGEXPECT part for step 4. This is due to that the log message is slightly different
+# depending on the libcurl version, some versions (newer ones) use "given" while other (older versions) use "known"
 
 echo "04. Look in the CB log for the warning about cert not accepted"
 echo "=============================================================="

--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
@@ -118,7 +118,7 @@ Date: REGEX(.*)
 
 04. Look in the CB log for the warning about cert not accepted
 ==============================================================
- failed: Peer certificate cannot be authenticated with REGEX(given|known) CA certificates
+ failed: Peer certificate cannot be authenticated with REGEX((given)|(known)) CA certificates
 
 
 --TEARDOWN--

--- a/test/unittests/main_UnitTest.cpp
+++ b/test/unittests/main_UnitTest.cpp
@@ -55,6 +55,7 @@ int           fwdPort               = -1;
 int           subCacheInterval      = 10;
 unsigned int  cprForwardLimit       = 1000;
 bool          noCache               = false;
+bool          insecureNotif         = false;
 char          fwdHost[64];
 char          notificationMode[64];
 bool          simulatedNotification;


### PR DESCRIPTION
This PR started as a bugfix for https://github.com/telefonicaid/fiware-orion/issues/2844. However, at the end it could be a definitive implementation for native HTTPS notifications (issue https://github.com/telefonicaid/fiware-orion/issues/706).

The PR is largely based on the PR #717 (original attempt to implement #706) and @mariolg contributions to acumulator-server.py