### PR TITLE
Fix invalid json body in the Retrieve subscription section

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_05_31.apib
@@ -1744,7 +1744,7 @@ Response:
           },
           "expires": "2016-04-05T14:00:00.00Z",
           "status": "active",
-          "throttling": 5,
+          "throttling": 5
         }
 
 

--- a/doc/apiary/v2/fiware-ngsiv2-rc-2016_10_31.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2016_10_31.apib
@@ -1838,7 +1838,7 @@ Response:
           },
           "expires": "2016-04-05T14:00:00.00Z",
           "status": "active",
-          "throttling": 5,
+          "throttling": 5
         }
 
 

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -1948,7 +1948,7 @@ Response:
           },
           "expires": "2016-04-05T14:00:00.00Z",
           "status": "active",
-          "throttling": 5,
+          "throttling": 5
         }
 
 


### PR DESCRIPTION
The *Subscription* / *Subscriptions By Id* / *Retrieve subscription* section of the apiary documentation contains a small bug making invalid JSON the response body provided as example.