### PR TITLE
Hardening/1368 style in unittest api types v2

### DIFF
--- a/scripts/style_check.sh
+++ b/scripts/style_check.sh
@@ -147,6 +147,7 @@ then
   verbose=on
 fi
 
+typeset -i lines
 
 if [ "$dir" == "" ]
 then
@@ -158,9 +159,33 @@ then
 else
   vMsg "Running TID/google style-guide check on $dir"
   scripts/cpplint.py $dir/*.cpp $dir/*.h 2> LINT
-  lines=$(wc -l $dir/*.cpp $dir/*.h | grep -v src/ | awk '{ print $1 }')
-  filesCpp=$(find $dir -name "*.cpp" | wc -l)
-  filesH=$(find $dir -name "*.h" | wc -l)
+
+  typeset -i lines1
+  typeset -i lines2
+
+  lines1=0
+  lines2=0
+
+  filesCpp=$(ls $dir/*.cpp 2> /dev/null | wc -l)
+  filesH=$(ls $dir/*.h 2> /dev/null | wc -l)
+
+  if [ "$filesCpp" == "1" ]
+  then
+    lines1=$(wc -l $dir/*.cpp 2> /dev/null | awk '{ print $1 }')
+  elif [ "$filesCpp" != "0" ]
+  then
+    lines1=$(wc -l $dir/*.cpp 2> /dev/null | grep ' total' | awk '{ print $1 }')
+  fi
+
+  if [ "$filesH" == "1" ]
+  then
+    lines2=$(wc -l $dir/*.h 2> /dev/null | awk '{ print $1 }')
+  elif [ "$filesH" != "0" ]
+  then
+    lines2=$(wc -l $dir/*.h 2> /dev/null | grep ' total' | awk '{ print $1 }')
+  fi
+
+  lines=$lines1+$lines2
 fi
 
 totalErrors=$(grep "Total errors found" LINT | awk -F:\  '{ print $2 }')
@@ -168,7 +193,14 @@ totalErrors=$(grep "Total errors found" LINT | awk -F:\  '{ print $2 }')
 typeset -i files
 
 files=$filesCpp+$filesH
-percentage=$(echo "scale=2; $totalErrors*100/$lines" | bc)
+vMsg $lines lines in $files files in dir $dir
+
+if [ "$files" != 0 ]
+then
+  percentage=$(echo "scale=2; $totalErrors*100/$lines" | bc)
+else
+  percentage=0
+fi
 
 
 

--- a/scripts/style_check_in_makefile.sh
+++ b/scripts/style_check_in_makefile.sh
@@ -45,6 +45,7 @@ function style_check
   fi
 }
 
+style_check test/unittests/apiTypesV2
 style_check test/unittests/cache
 style_check test/unittests/mongoBackend
 style_check test/unittests
@@ -74,7 +75,6 @@ style_check src/lib/metricsMgr
 # style_check src/lib/serviceRoutinesV2
 # style_check src/app/contextBroker
 
-# style_check test/unittests/apiTypesV2
 # style_check test/unittests/common
 # style_check test/unittests/convenience
 # style_check test/unittests/jsonParse

--- a/test/unittests/apiTypesV2/Entities_test.cpp
+++ b/test/unittests/apiTypesV2/Entities_test.cpp
@@ -22,9 +22,10 @@
 *
 * Author: Fermin Galan
 */
-
 #include "apiTypesV2/Entities.h"
-#include "unittest.h"
+#include "unittests/unittest.h"
+
+
 
 /* ****************************************************************************
 *
@@ -50,6 +51,7 @@ TEST(Entities, present)
 
   utExit();
 }
+
 
 
 /* ****************************************************************************

--- a/test/unittests/apiTypesV2/EntityVector_test.cpp
+++ b/test/unittests/apiTypesV2/EntityVector_test.cpp
@@ -22,9 +22,10 @@
 *
 * Author: Fermin Galan
 */
-
 #include "apiTypesV2/EntityVector.h"
-#include "unittest.h"
+#include "unittests/unittest.h"
+
+
 
 /* ****************************************************************************
 *
@@ -49,6 +50,7 @@ TEST(EntityVector, present)
 
   utExit();
 }
+
 
 
 /* ****************************************************************************

--- a/test/unittests/apiTypesV2/Entity_test.cpp
+++ b/test/unittests/apiTypesV2/Entity_test.cpp
@@ -24,7 +24,7 @@
 */
 #include "apiTypesV2/Entity.h"
 #include "common/errorMessages.h"
-#include "unittest.h"
+#include "unittests/unittest.h"
 
 
 
@@ -50,13 +50,13 @@ TEST(Entity, present)
 }
 
 
+
 /* ****************************************************************************
 *
 * check
 */
 TEST(Entity, check)
 {
-
   utInit();
 
   Entity* enP         = new Entity();


### PR DESCRIPTION
Fixed style in apiTypesV2 unit tests
Fixed the style check script that didn't work for:

* dirs that have no header files (all unittest dirs)
* dirs that have a tree of dirs under it (test/unittests)