### PR TITLE
Fixed issue 2926

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 - Hardening: Mongo driver migrated to legacy-1.1.2 (several bugfixes in the legacy-1.0.7 to legacy-1.1.2 delta)
 - Hardening: Several changes in argument passing in mongoBackend library to avoid passing entire objects on the stack, from "X x" to "const X& x"
 - Hardening: Several changes in argument passing in mongoBackend library to add 'const' in references to objects that are not altered by the function
-- Fix: cleanup function for parseArgs library, called from main() once the CLI parsing has finished (#2926)
+- Fix: bug in parseArg lib that may cause problem printing the error message for wrong CLI usage
+

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - Hardening: Mongo driver migrated to legacy-1.1.2 (several bugfixes in the legacy-1.0.7 to legacy-1.1.2 delta)
 - Hardening: Several changes in argument passing in mongoBackend library to avoid passing entire objects on the stack, from "X x" to "const X& x"
 - Hardening: Several changes in argument passing in mongoBackend library to add 'const' in references to objects that are not altered by the function
+- Fix: cleanup function for parseArgs library, called from main() once the CLI parsing has finished (#2926)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,5 +1,4 @@
 - Hardening: Mongo driver migrated to legacy-1.1.2 (several bugfixes in the legacy-1.0.7 to legacy-1.1.2 delta)
 - Hardening: Several changes in argument passing in mongoBackend library to avoid passing entire objects on the stack, from "X x" to "const X& x"
 - Hardening: Several changes in argument passing in mongoBackend library to add 'const' in references to objects that are not altered by the function
-- Fix: bug in parseArg lib that may cause problem printing the error message for wrong CLI usage
-
+- Fix: bug in parseArg lib that may cause problem printing the error message for wrong CLI usage (#2926)

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -1670,6 +1670,8 @@ int main(int argC, char* argV[])
     exit(1);
   }
 
+  paCleanup();
+
 #ifdef DEBUG_develenv
   //
   // FIXME P9: Temporary setting trace level 250 in jenkins only, until the ftest-ftest-ftest bug is solved

--- a/src/lib/parseArgs/paParse.cpp
+++ b/src/lib/parseArgs/paParse.cpp
@@ -625,11 +625,24 @@ int paParse
     }
   }
 
-  free(paiList);
-  free(paRcFileName);
-  free(paUsageProgName);
-
   return 0;
+}
+
+
+
+/* ****************************************************************************
+*
+* paCleanup - free allocated variables
+*/
+void paCleanup(void)
+{
+  free(paUsageProgName);
+  free(paRcFileName);
+  free(paiList);
+
+  paUsageProgName = NULL;
+  paRcFileName    = NULL;
+  paiList         = NULL;
 }
 
 

--- a/src/lib/parseArgs/parseArgs.h
+++ b/src/lib/parseArgs/parseArgs.h
@@ -275,6 +275,14 @@ extern int paParse
 
 /* ****************************************************************************
 *
+* paCleanup - free allocated variables
+*/
+extern void paCleanup(void);
+
+
+
+/* ****************************************************************************
+*
 * paConfig -
 */
 // extern int paConfig(const char* item, const void* value, const void* value2 = NULL);

--- a/test/functionalTest/cases/0000_cli/tracelevel_without_logLevel_as_DEBUG.test
+++ b/test/functionalTest/cases/0000_cli/tracelevel_without_logLevel_as_DEBUG.test
@@ -28,7 +28,7 @@ contextBroker -t 0-255
 
 --REGEXPECT--
 incompatible options: traceLevels cannot be used without setting -logLevel to DEBUG
-Usage:                [option '-U' (extended usage)]
+Usage: contextBroker  [option '-U' (extended usage)]
                       [option '-u' (usage)]
                       [option '--version' (show version)]
                       [option '-logDir' <log file directory>]


### PR DESCRIPTION
Created a new function `paCleanup()` to free allocated variables once the CLI parsing has finished.
Fixes issue #2928
