### PR TITLE
Bug/error in macro substitute

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,4 +2,4 @@
 - Hardening: Several changes in argument passing in mongoBackend library to avoid passing entire objects on the stack, from "X x" to "const X& x"
 - Hardening: Several changes in argument passing in mongoBackend library to add 'const' in references to objects that are not altered by the function
 - Fix: bug in parseArg lib that may cause problem printing the error message for wrong CLI usage (#2926)
-- Fix: bug in variable substitution of custom notifications that limited the size of a custom notification to 1024 bytes
+- Fix: bug in variable substitution of custom notifications that limited the size of the payload of a custom notification to 1024 bytes (new limit: 8Mb)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,4 +2,4 @@
 - Hardening: Several changes in argument passing in mongoBackend library to avoid passing entire objects on the stack, from "X x" to "const X& x"
 - Hardening: Several changes in argument passing in mongoBackend library to add 'const' in references to objects that are not altered by the function
 - Fix: bug in parseArg lib that may cause problem printing the error message for wrong CLI usage (#2926)
-- Fix: bug in variable substitution of custom notifications that limited the size of the payload of a custom notification to 1024 bytes (new limit: 8Mb)
+- Fix: bug in variable substitution of custom notifications that limited the size of the payload of a custom notification to 1024 bytes (new limit: 8MB)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - Hardening: Several changes in argument passing in mongoBackend library to avoid passing entire objects on the stack, from "X x" to "const X& x"
 - Hardening: Several changes in argument passing in mongoBackend library to add 'const' in references to objects that are not altered by the function
 - Fix: bug in parseArg lib that may cause problem printing the error message for wrong CLI usage (#2926)
+- Fix: bug in variable substitution of custom notifications that limited the size of a custom notification to 1024 bytes

--- a/src/lib/common/macroSubstitute.cpp
+++ b/src/lib/common/macroSubstitute.cpp
@@ -123,7 +123,22 @@ static void attributeValue(std::string* valueP, const std::vector<ContextAttribu
 #define CHUNK_SIZE 1024
 bool macroSubstitute(std::string* to, const std::string& from, const ContextElement& ce)
 {
+  //
   // Initial size check: is the string to convert too big?
+  //
+  // If the string to convert is bigger than the maximum allowed buffer size (MAX_DYN_MSG_SIZE),
+  // then there is an important probability that the resulting string after substitution is also > MAX_DYN_MSG_SIZE.
+  //
+  // This check avoids to copy 8MB to later only throw it away and return an error
+  // That is the advantage.
+  //
+  // There is an inconvenience as well.
+  //
+  // The inconvenience is for buffers that are larger before substitution than they are after substitution.
+  // Those buffers aren't let through this check, and end up in an error.
+  //
+  // We assume that this second case is more than rare
+  //
   if (from.size() > MAX_DYN_MSG_SIZE)
   {
     *to = "";

--- a/src/lib/common/macroSubstitute.cpp
+++ b/src/lib/common/macroSubstitute.cpp
@@ -242,6 +242,9 @@ void macroSubstitute(std::string* to, const std::string& from, const ContextElem
           *to = "";
           return;
         }
+
+        // Clearing non-used bytes
+        memset(&toP[toIx], 0, toLen - toIx);
       }
 
       //
@@ -271,13 +274,15 @@ void macroSubstitute(std::string* to, const std::string& from, const ContextElem
       {
         toP    = (char*) realloc(toP, toLen + CHUNK_SIZE);
         toLen += CHUNK_SIZE;
-
         if (toP == NULL)
         {
           LM_E(("Runtime Error (out of memory)"));
           *to = "";
           return;
         }
+
+        // Clearing non-used bytes
+        memset(&toP[toIx], 0, toLen - toIx);
       }
 
       //

--- a/src/lib/common/macroSubstitute.cpp
+++ b/src/lib/common/macroSubstitute.cpp
@@ -108,7 +108,7 @@ static void attributeValue(std::string* valueP, const std::vector<ContextAttribu
 * out-buffer is not big enough, it is realloced with another CHUNK_SIZE.
 *
 * 1024 is set as CHUNK_SIZE and hopefully for most substitutions it will be enough with ONE allocation.
-* Allocation a is very costly operation ...
+* Allocation is a very costly operation ...
 * This function could be a lot faster is we took the first 1024 bytes from the stack instead of using calloc.
 * However, the function gets a little more complicated like that as the first realloc would have to be a normal malloc and a memcpy.
 *

--- a/src/lib/common/macroSubstitute.h
+++ b/src/lib/common/macroSubstitute.h
@@ -35,6 +35,6 @@
 *
 * macroSubstitute - 
 */
-extern void macroSubstitute(std::string* sP, const std::string& in, const ContextElement& ce);
+extern bool macroSubstitute(std::string* sP, const std::string& in, const ContextElement& ce);
 
 #endif  // SRC_LIB_COMMON_MACROSUBSTITUTE_H_

--- a/src/lib/ngsiNotify/Notifier.cpp
+++ b/src/lib/ngsiNotify/Notifier.cpp
@@ -221,7 +221,6 @@ static std::vector<SenderThreadParams*>* buildSenderParamsCustom
     //
     // 3. Payload
     //
-
     if (httpInfo.payload == "")
     {
       NotifyContextRequest   ncr;
@@ -235,7 +234,14 @@ static std::vector<SenderThreadParams*>* buildSenderParamsCustom
     }
     else
     {
-      macroSubstitute(&payload, httpInfo.payload, ce);
+      bool b = macroSubstitute(&payload, httpInfo.payload, ce);
+
+      if (b == false)
+      {
+        LM_E(("Bad Input (not sending NotifyContextRequest: payload too large)"));
+        return paramsV;  // empty vector
+      }
+
       char* pload  = curl_unescape(payload.c_str(), payload.length());
       payload      = std::string(pload);
       renderFormat = NGSI_V2_CUSTOM;
@@ -295,7 +301,7 @@ static std::vector<SenderThreadParams*>* buildSenderParamsCustom
     if (!parseUrl(url, host, port, uriPath, protocol))
     {
       LM_E(("Runtime Error (not sending NotifyContextRequest: malformed URL: '%s')", httpInfo.url.c_str()));
-      return paramsV;  //empty vector
+      return paramsV;  // empty vector
     }
 
 

--- a/src/lib/ngsiNotify/Notifier.cpp
+++ b/src/lib/ngsiNotify/Notifier.cpp
@@ -234,11 +234,9 @@ static std::vector<SenderThreadParams*>* buildSenderParamsCustom
     }
     else
     {
-      bool b = macroSubstitute(&payload, httpInfo.payload, ce);
-
-      if (b == false)
+      if (macroSubstitute(&payload, httpInfo.payload, ce) == false)
       {
-        LM_E(("Bad Input (not sending NotifyContextRequest: payload too large)"));
+        LM_W(("Bad Input (not sending NotifyContextRequest: payload too large)"));
         return paramsV;  // empty vector
       }
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -95,6 +95,7 @@ SET (SOURCES
     common/commonSem_test.cpp
     common/commonStatistics_test.cpp
     common/commonWsStrip_test.cpp
+    common/commonMacroSubstitute_test.cpp
 
     ngsi9/RegisterContextRequest_test.cpp
     ngsi9/RegisterContextResponse_test.cpp

--- a/test/unittests/common/commonMacroSubstitute_test.cpp
+++ b/test/unittests/common/commonMacroSubstitute_test.cpp
@@ -95,9 +95,9 @@ TEST(commonMacroSubstitute, withRealloc)
 
 /* ****************************************************************************
 *
-* bufferTooBigInitially - max size of the substituted buffer is 8Mb (MAX_DYN_MSG_SIZE)
+* bufferTooBigInitially - max size of the substituted buffer is 8MB (MAX_DYN_MSG_SIZE)
 *
-* This unit test provokes a buffer size > 8Mb to see the error returned
+* This unit test provokes a buffer size > 8MB to see the error returned
 */
 TEST(commonMacroSubstitute, bufferTooBigInitially)
 {
@@ -127,11 +127,11 @@ TEST(commonMacroSubstitute, bufferTooBigInitially)
 
 /* ****************************************************************************
 *
-* bufferTooBigAfterSubstitution - max size of the substituted buffer is 8Mb (MAX_DYN_MSG_SIZE)
+* bufferTooBigAfterSubstitution - max size of the substituted buffer is 8MB (MAX_DYN_MSG_SIZE)
 *
-* This unit test provokes a buffer size > 8Mb to see the error returned.
-* However, unlike 'bufferTooBigInitially', this test has an incoming buffer < 8Mb but
-* as the buffer grows as substitutions are made, the resulting buffer is > 8Mb and an
+* This unit test provokes a buffer size > 8MB to see the error returned.
+* However, unlike 'bufferTooBigInitially', this test has an incoming buffer < 8MB but
+* as the buffer grows as substitutions are made, the resulting buffer is > 8MB and an
 * error should be returned
 */
 TEST(commonMacroSubstitute, bufferTooBigAfterSubstitution)
@@ -142,14 +142,14 @@ TEST(commonMacroSubstitute, bufferTooBigAfterSubstitution)
 
   ce.contextAttributeVector.push_back(caP);
 
-  char* base = (char*) malloc(MAX_DYN_MSG_SIZE + 2 - 16);  // -16 so that '${id}/${type}' fits inside 8Mb
+  char* base = (char*) malloc(MAX_DYN_MSG_SIZE + 2 - 16);  // -16 so that '${id}/${type}' fits inside 8MB
                                                            // but 'EntityId000001/EntityType000001' does not
 
   memset(base, 'a', MAX_DYN_MSG_SIZE + 2 - 16);
   base[MAX_DYN_MSG_SIZE + 2 - 16] = 0;
 
-  std::string s1      = std::string(base) + "${id}/${type}";                   // < 8Mb
-  //          correct = std::string(base) + "EntityId000001/EntityType000001"; // > 8Mb after substitutions
+  std::string s1      = std::string(base) + "${id}/${type}";                   // < 8MB
+  //          correct = std::string(base) + "EntityId000001/EntityType000001"; // > 8MB after substitutions
   std::string result;
 
   b = macroSubstitute(&result, s1, ce);

--- a/test/unittests/common/commonMacroSubstitute_test.cpp
+++ b/test/unittests/common/commonMacroSubstitute_test.cpp
@@ -1,0 +1,88 @@
+/*
+*
+* Copyright 2017 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Ken Zangelin
+*/
+#include "gtest/gtest.h"
+
+#include "logMsg/logMsg.h"
+#include "logMsg/traceLevels.h"
+#include "ngsi/ContextElement.h"
+#include "ngsi/ContextAttribute.h"
+
+#include "common/macroSubstitute.h"
+
+
+
+/* ****************************************************************************
+*
+* simple - 
+*/
+TEST(commonMacroSubstitute, simple)
+{
+  ContextElement          ce("E1", "T1", "false");
+  ContextAttribute*       caP = new ContextAttribute("A1", "T1", "attr1");
+
+  ce.contextAttributeVector.push_back(caP);
+
+  const char* s1      = "Entity ${id}/${type}, attribute '${A1}'";
+  const char* correct = "Entity E1/T1, attribute 'attr1'";
+  std::string result;
+
+  macroSubstitute(&result, s1, ce);
+  EXPECT_STREQ(correct, result.c_str());
+}
+
+
+
+/* ****************************************************************************
+*
+* withRealloc - 
+*/
+TEST(commonMacroSubstitute, withRealloc)
+{
+  ContextElement          ce("E1", "T1", "false");
+  ContextAttribute*       caP = new ContextAttribute("A1", "T1", "attr1");
+
+  ce.contextAttributeVector.push_back(caP);
+
+  const char* base = 
+    "The test string needs to be longer than 1024 chars to test reallocs in Macro substitution"
+    "So, this line is just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ..."
+    " ---------------------------------------------------------------------------- this line is also just filling, and ...";
+  
+  std::string s1      = std::string(base) + "Now, finally something to substitute: Entity ${id}/${type}, attribute '${A1}'";
+  std::string correct = std::string(base) + "Now, finally something to substitute: Entity E1/T1, attribute 'attr1'";
+  std::string result;
+
+  macroSubstitute(&result, s1, ce);
+  EXPECT_STREQ(correct.c_str(), result.c_str());
+}


### PR DESCRIPTION
Fixed a bug in the function that does the substitution of ${xxx} in custom notification payloads.
After reallocating a buffer (when > 1024 bytes), the new part of the buffer needs to be reset for the algorithm to work correctly. 