### PR TITLE
Add bc dependency to the documentation on how to run the valgrind suite

### DIFF
--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -94,7 +94,7 @@ The Orion Context Broker comes with a suite of valgrind and end-to-end tests tha
 
 * Install the required tools:
 
-        sudo yum install python python-flask python-jinja2 curl libxml2 nc mongodb valgrind libxslt
+        sudo yum install python python-flask python-jinja2 curl libxml2 nc mongodb valgrind libxslt bc
 
 * Run valgrind tests (it takes some time, please be patient):
 


### PR DESCRIPTION
After installing all dependencies documented in the [Build from sources guide](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/admin/build_source.md)

```
$ make valgrind

....

[100%] Built target contextBroker
make[2]: Leaving directory '/root/src/fiware-orion/BUILD_DEBUG'
Install the project...
-- Install configuration: "DEBUG"
-- Up-to-date: //usr/bin/contextBroker
make[1]: Leaving directory '/root/src/fiware-orion/BUILD_DEBUG'
For detailed info: tail -f /tmp/valgrindTestSuiteLog
test/valgrind/valgrindTestSuite.sh
Fri Jul  7 08:50:20 UTC 2017
Test 001/927: 0000_bad_requests/erroneous_input .............................................
    ........................................................ 
    test/valgrind/valgrindTestSuite.sh: line 683: bc: command not found

....
```