### PR TITLE
hardening/valgrind_test_suite_problem_in_jenkins

### DIFF
--- a/test/valgrind/valgrindTestSuite.sh
+++ b/test/valgrind/valgrindTestSuite.sh
@@ -370,7 +370,7 @@ function valgrindErrorInfo()
   # Get info from valgrind file
   #
 
-  valgrindErrors=$(grep -i "ERROR SUMMARY:" $filename | grep -v "ERROR SUMMARY: 0" | awk '{ print $4 }')
+  valgrindErrors=$(grep -i "ERROR SUMMARY:" $filename | tail -1 | awk '{ print $4 }')
 }
 
 


### PR DESCRIPTION
Changed `grep -v "ERROR SUMMARY: 0"` for `tail -1`   as Jenkins reports an error