### PR TITLE
Fixes sending update with v1 API and generating v2 notifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,8 @@ add_definitions(-fPIC)
 
 # Baseline compiler flags, any change here will affect all build types
 #set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror")
-set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -fno-var-tracking-assignments")
+set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -fno-var-tracking-assignments -I${CMAKE_INCLUDE_PATH}")
+set (CMAKE_EXE_LINKER_FLAGS "-L${CMAKE_LIBRARY_PATH}")
 
 #
 # Platform checks
@@ -104,7 +105,7 @@ if (${CMAKE_BUILD_TYPE} STREQUAL DEBUG)
         remove_definitions(-DLM_ON)
         # Removing LM_T macros make that some variables get unused, thus -Wno-unused-variable have to be used
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -fprofile-arcs -ftest-coverage")
-        set (CMAKE_EXE_LINKER_FLAGS "-fprofile-arcs -ftest-coverage")
+        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
     endif (COVERAGE)
 
     if (UNIT_TEST)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:centos6.6
 MAINTAINER FIWARE Orion Context Broker Team. Telefónica I+D
 
 ENV ORION_USER orion
-ENV GIT_REV_ORION bug-fixes
+ENV GIT_REV_ORION cpqd_master
 ENV CLEAN_DEV_TOOLS 1
 
 WORKDIR /opt
@@ -44,7 +44,8 @@ RUN \
     # Install rapidjson from source
     curl -kOL https://github.com/miloyip/rapidjson/archive/v1.0.2.tar.gz && \
     tar xfz v1.0.2.tar.gz && \
-    mv rapidjson-1.0.2/include/rapidjson/ /usr/local/include && \
+    mv rapidjson-1.0.2/include/rapidjson/ /usr/local/include
+RUN \
     # Install orion from source
     git clone https://github.com/giovannicuriel/fiware-orion && \
     cd fiware-orion && \
@@ -57,7 +58,8 @@ RUN \
     mkdir -p /var/log/contextBroker && \
     mkdir -p /var/run/contextBroker && \
     chown ${ORION_USER} /var/log/contextBroker && \
-    chown ${ORION_USER} /var/run/contextBroker && \
+    chown ${ORION_USER} /var/run/contextBroker
+RUN \
     cd /opt && \
     if [ ${CLEAN_DEV_TOOLS} -eq 0 ] ; then yum clean all && exit 0 ; fi && \
     # cleanup sources, dev tools, locales and yum cache to reduce the final image size

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:centos6.6
 MAINTAINER FIWARE Orion Context Broker Team. Telefónica I+D
 
 ENV ORION_USER orion
-ENV GIT_REV_ORION master
+ENV GIT_REV_ORION bug-fixes
 ENV CLEAN_DEV_TOOLS 1
 
 WORKDIR /opt
@@ -46,7 +46,7 @@ RUN \
     tar xfz v1.0.2.tar.gz && \
     mv rapidjson-1.0.2/include/rapidjson/ /usr/local/include && \
     # Install orion from source
-    git clone https://github.com/telefonicaid/fiware-orion && \
+    git clone https://github.com/giovannicuriel/fiware-orion && \
     cd fiware-orion && \
     git checkout ${GIT_REV_ORION} && \
     make && \

--- a/makefile
+++ b/makefile
@@ -29,6 +29,14 @@ ifndef INSTALL_DIR
 	INSTALL_DIR=/usr
 endif
 
+ifndef INCLUDE_PATH
+	INCLUDE_PATH=${INSTALL_DIR}/include
+endif
+
+ifndef LIBRARY_PATH
+	LIBRARY_PATH=${INSTALL_DIR}/lib
+endif
+
 ifndef CPU_COUNT
 	CPU_COUNT:=$(shell cat /proc/cpuinfo | grep processor | wc -l)
 endif
@@ -76,20 +84,20 @@ compile_info_release:
 
 prepare_release: compile_info_release
 	mkdir -p  BUILD_RELEASE || true
-	cd BUILD_RELEASE && cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_ARCH=$(BUILD_ARCH) -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
+	cd BUILD_RELEASE && cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_ARCH=$(BUILD_ARCH) -DCMAKE_LIBRARY_PATH=${LIBRARY_PATH} -DCMAKE_INCLUDE_PATH=${INCLUDE_PATH} -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
 
 prepare_debug: compile_info
 	mkdir -p  BUILD_DEBUG || true
-	cd BUILD_DEBUG && cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_ARCH=$(BUILD_ARCH) -DDEBUG=True -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
+	cd BUILD_DEBUG && cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_ARCH=$(BUILD_ARCH) -DDEBUG=True -DCMAKE_LIBRARY_PATH=${LIBRARY_PATH} -DCMAKE_INCLUDE_PATH=${INCLUDE_PATH} -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
 
 prepare_coverage: compile_info
 	mkdir -p  BUILD_COVERAGE || true
-	cd BUILD_COVERAGE && cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_ARCH=$(BUILD_ARCH) -DUNIT_TEST=True -DCOVERAGE=True -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
+	cd BUILD_COVERAGE && cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_ARCH=$(BUILD_ARCH) -DUNIT_TEST=True -DCOVERAGE=True -DCMAKE_LIBRARY_PATH=${LIBRARY_PATH} -DCMAKE_INCLUDE_PATH=${INCLUDE_PATH} -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
 
 prepare_unit_test: compile_info
 	@echo '------------------------------- prepare_unit_test starts ---------------------------------'
 	mkdir -p  BUILD_UNITTEST || true
-	cd BUILD_UNITTEST && cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_ARCH=$(BUILD_ARCH) -DUNIT_TEST=True -DCOVERAGE=True -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
+	cd BUILD_UNITTEST && cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_ARCH=$(BUILD_ARCH) -DUNIT_TEST=True -DCOVERAGE=True -DCMAKE_LIBRARY_PATH=${LIBRARY_PATH} -DCMAKE_INCLUDE_PATH=${INCLUDE_PATH} -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
 	@echo '------------------------------- prepare_unit_test ended ---------------------------------'
 
 release: prepare_release

--- a/src/lib/jsonParse/jsonUpdateContextRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextRequest.cpp
@@ -159,8 +159,28 @@ static std::string attributeType(const std::string& path, const std::string& val
   LM_T(LmtParse, ("Set 'type' to '%s' for a contextElement attribute", reqDataP->upcr.attributeP->type.c_str()));
 
   // Updating value field
-  if (value == "integer") {
+  if ((value == "integer") || (value == "float") || (value == "double") || (value == "number")) {
     reqDataP->upcr.attributeP->valueType = orion::ValueTypeNumber;
+
+    // If the value has already been set, update it to the proper field.
+    if (reqDataP->upcr.attributeP->stringValue != "") {
+      reqDataP->upcr.attributeP->numberValue = atof(reqDataP->upcr.attributeP->stringValue.c_str());
+      reqDataP->upcr.attributeP->stringValue = "";
+    }
+  } else if (value == "bool") {
+    reqDataP->upcr.attributeP->valueType = orion::ValueTypeBoolean;
+    // If the value has already been set, update it to the proper field.
+    if (reqDataP->upcr.attributeP->stringValue != "") {
+      // False, false or 0
+      if (reqDataP->upcr.attributeP->stringValue[0] == 'f' ||
+          reqDataP->upcr.attributeP->stringValue[0] == 'F' ||
+          reqDataP->upcr.attributeP->stringValue[0] == '0') {
+        reqDataP->upcr.attributeP->boolValue = false;
+      } else {
+        reqDataP->upcr.attributeP->boolValue = true;
+      }
+      reqDataP->upcr.attributeP->stringValue = "";
+    }
   } else {
     reqDataP->upcr.attributeP->valueType = orion::ValueTypeString;
   } 
@@ -179,15 +199,20 @@ static std::string attributeValue(const std::string& path, const std::string& va
   parseDataP->lastContextAttribute = parseDataP->upcr.attributeP;
   LM_T(LmtCompoundValue, ("Set parseDataP->lastContextAttribute to: %p", parseDataP->lastContextAttribute));
 
-  if (parseDataP->upcr.attributeP->valueType != orion::ValueTypeNumber) {
+  if (parseDataP->upcr.attributeP->valueType == orion::ValueTypeNumber) {
+    parseDataP->upcr.attributeP->numberValue = atof(value.c_str());
+  } else if (parseDataP->upcr.attributeP->valueType == orion::ValueTypeBoolean) {
+      if (value[0] == 'f' ||
+          value[0] == 'F' ||
+          value[0] == '0') {
+        parseDataP->upcr.attributeP->boolValue = false;
+      } else {
+        parseDataP->upcr.attributeP->boolValue = true;
+      }
+  } else {
     parseDataP->upcr.attributeP->valueType = orion::ValueTypeString;
     parseDataP->upcr.attributeP->stringValue = value;
-  } else {
-    parseDataP->upcr.attributeP->numberValue = atof(value.c_str());
   }
-
-  // parseDataP->upcr.attributeP->stringValue = value;
-  // parseDataP->upcr.attributeP->valueType = orion::ValueTypeString;
   LM_T(LmtParse, ("Set value to '%s' for a contextElement attribute", parseDataP->upcr.attributeP->stringValue.c_str()));
 
   return "OK";

--- a/src/lib/jsonParse/jsonUpdateContextRequest.cpp
+++ b/src/lib/jsonParse/jsonUpdateContextRequest.cpp
@@ -158,6 +158,13 @@ static std::string attributeType(const std::string& path, const std::string& val
   reqDataP->upcr.attributeP->type = value;
   LM_T(LmtParse, ("Set 'type' to '%s' for a contextElement attribute", reqDataP->upcr.attributeP->type.c_str()));
 
+  // Updating value field
+  if (value == "integer") {
+    reqDataP->upcr.attributeP->valueType = orion::ValueTypeNumber;
+  } else {
+    reqDataP->upcr.attributeP->valueType = orion::ValueTypeString;
+  } 
+
   return "OK";
 }
 
@@ -172,8 +179,15 @@ static std::string attributeValue(const std::string& path, const std::string& va
   parseDataP->lastContextAttribute = parseDataP->upcr.attributeP;
   LM_T(LmtCompoundValue, ("Set parseDataP->lastContextAttribute to: %p", parseDataP->lastContextAttribute));
 
-  parseDataP->upcr.attributeP->stringValue = value;
-  parseDataP->upcr.attributeP->valueType = orion::ValueTypeString;
+  if (parseDataP->upcr.attributeP->valueType != orion::ValueTypeNumber) {
+    parseDataP->upcr.attributeP->valueType = orion::ValueTypeString;
+    parseDataP->upcr.attributeP->stringValue = value;
+  } else {
+    parseDataP->upcr.attributeP->numberValue = atof(value.c_str());
+  }
+
+  // parseDataP->upcr.attributeP->stringValue = value;
+  // parseDataP->upcr.attributeP->valueType = orion::ValueTypeString;
   LM_T(LmtParse, ("Set value to '%s' for a contextElement attribute", parseDataP->upcr.attributeP->stringValue.c_str()));
 
   return "OK";


### PR DESCRIPTION
There was a problem when sending v1 attribute updates and v2 notification. As processing v1 updates will always set the value type as 'string', the v2 part of the notification generation process checks whether the value type is in accordance to the 'condition' of the subscription being analyzed (in StringFilterItem::compatibleType). If the attribute is anything but a string, this will fail.

This PR fixes the value type attribution while parsing v1 updates.