### PR TITLE
Declare MongoDB 3.4 support

### DIFF
--- a/doc/manuals/admin/install.md
+++ b/doc/manuals/admin/install.md
@@ -22,8 +22,8 @@ building from sources, check [this document](build_source.md).
 * Operating system: CentOS/RedHat. The reference operating system is CentOS 6.3
   but it should work also in any later CentOS/RedHat 6.x version.
 * Database: MongoDB is required to run either in the same host where Orion Context Broker is to be installed or in a different host accessible through the network. The recommended MongoDB versions
-  are 2.6/3.0/3.2. It is not recommended using MongoDB 2.4.x., as some [geolocated queries](../user/geolocation.md) may not work.
-    * In the case of using MongoDB 3.0/3.2 with its new authentication mechanism (SCRAM_SHA1) you may need to compile from sources using special switches for the MongoDB driver.
+  are 2.6/3.0/3.2/3.4. It is not recommended using MongoDB 2.4.x., as some [geolocated queries](../user/geolocation.md) may not work.
+    * In the case of using MongoDB 3.0/3.2/3.4 with its new authentication mechanism (SCRAM_SHA1) you may need to compile from sources using special switches for the MongoDB driver.
       See [this issue](https://github.com/telefonicaid/fiware-orion/issues/1061) for details.
 * RPM dependencies (some of these packages could not be in the official CentOS/RedHat repository but in EPEL, in which case you have to configure EPEL repositories, see <http://fedoraproject.org/wiki/EPEL>):
     * The contextBroker package (mandatory) depends on the following packages: boost-filesystem, boost-thread, gnutls, libgcrypt, logrotate and libcurl.
@@ -79,9 +79,9 @@ You only need to pay attention to this if your upgrade path crosses 0.11.0 or 0.
 
 * Orion versions previous to 0.11.0 recommend MongoDB 2.2
 * Orion version from 0.11.0 to 0.20.0 recommend MongoDB 2.4. Check [the 2.4 upgrade procedure in the oficial MongoDB documentation.](http://docs.mongodb.org/master/release-notes/2.4-upgrade/)
-* Orion version from 0.21.0 on recommend MongoDB 2.6/3.0/3.2. check [the 2.6 upgrade procedure](http://docs.mongodb.org/master/release-notes/2.6-upgrade/),
-  [the 3.0 upgrade procedure](http://docs.mongodb.org/master/release-notes/3.0-upgrade/) or [the 3.2 upgrade procedure](http://docs.mongodb.org/master/release-notes/3.2-upgrade/) in the oficial
-  MongoDB documentation.
+* Orion version from 0.21.0 on recommend MongoDB 2.6/3.0/3.2/3.4. check [the 2.6 upgrade procedure](http://docs.mongodb.org/master/release-notes/2.6-upgrade/),
+  [the 3.0 upgrade procedure](http://docs.mongodb.org/master/release-notes/3.0-upgrade/), [the 3.2 upgrade procedure](http://docs.mongodb.org/master/release-notes/3.2-upgrade/)
+  or [the 3.4 upgrade procedure](https://docs.mongodb.com/master/release-notes/3.4/) in the oficial MongoDB documentation.
 
 ### Migrating the data stored in DB
 

--- a/doc/manuals/admin/perf_tuning.md
+++ b/doc/manuals/admin/perf_tuning.md
@@ -17,12 +17,12 @@
 
 ##  MongoDB configuration
 
-Since version 0.21.0, Orion supports MongoDB 2.6, 3.0 and 3.2 without difference from a functional
-point of view. However, MongoDB 2.6 implements a per-collection lock, while MongoDB 3.0/3.2 (when configured
-to use WireTiger storage engine) implements per-document lock. Thus, the lock system in MongoDB 3.0/3.2
+Since version 0.21.0, Orion supports MongoDB 2.6, 3.0, 3.2 andd 3.4 without difference from a functional
+point of view. However, MongoDB 2.6 implements a per-collection lock, while MongoDB 3.0/3.2/3.4 (when configured
+to use WireTiger storage engine) implements per-document lock. Thus, the lock system in MongoDB 3.0/3.2/3.4
 (with WireTiger) is less restrictive than the one used by MongoDB 2.6.
 
-From a performance point of view, it is recommended to use MongoDB 3.0/3.2 with WireTiger, especially
+From a performance point of view, it is recommended to use MongoDB 3.0/3.2/3.4 with WireTiger, especially
 in update-intensive scenarios.
 
 In addition, take into account the following information from the official MongoDB documentation, as it may have

--- a/doc/manuals/admin/perf_tuning.md
+++ b/doc/manuals/admin/perf_tuning.md
@@ -17,7 +17,7 @@
 
 ##  MongoDB configuration
 
-Since version 0.21.0, Orion supports MongoDB 2.6, 3.0, 3.2 andd 3.4 without difference from a functional
+Since version 0.21.0, Orion supports MongoDB 2.6, 3.0, 3.2 and 3.4 without difference from a functional
 point of view. However, MongoDB 2.6 implements a per-collection lock, while MongoDB 3.0/3.2/3.4 (when configured
 to use WireTiger storage engine) implements per-document lock. Thus, the lock system in MongoDB 3.0/3.2/3.4
 (with WireTiger) is less restrictive than the one used by MongoDB 2.6.

--- a/test/functionalTest/cases/0676_servicepath_context_types/servicepath_sametype.test
+++ b/test/functionalTest/cases/0676_servicepath_context_types/servicepath_sametype.test
@@ -321,6 +321,7 @@ Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
+#SORT_START
 {
     "statusCode": {
         "code": "200",
@@ -329,16 +330,17 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
-                "e",
-                "d",
-                "c",
-                "b",
-                "a"
+                "e"REGEX(,?)
+                "d"REGEX(,?)
+                "c"REGEX(,?)
+                "b"REGEX(,?)
+                "a"REGEX(,?)
             ],
             "name": "T"
         }
     ]
 }
+#SORT_END
 
 
 04. Query types on /A (returns: T - [b, c])

--- a/test/functionalTest/cases/1367_time_measures/time_measure_stats.test
+++ b/test/functionalTest/cases/1367_time_measures/time_measure_stats.test
@@ -410,6 +410,7 @@ Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
+#SORT_START
 {
     "statusCode": {
         "code": "200",
@@ -418,16 +419,17 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
-                "A5",
-                "A2",
-                "A4",
-                "A3",
-                "A1"
+                "A5"REGEX(,?)
+                "A2"REGEX(,?)
+                "A4"REGEX(,?)
+                "A3"REGEX(,?)
+                "A1"REGEX(,?)
             ],
             "name": "Test"
         }
     ]
 }
+#SORT_END
 
 
 07. GET /statistics


### PR DESCRIPTION
Orion supports MongoDB 3.4 without any change. It has been checked with the functional test regression (with a small adjust).