### PR TITLE
FIX missing lastsuccess and lastfailure

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: missing lastSuccess/lastFailure associated to initial notification on subscription creation some times when csub cache is in use (#2974)

--- a/src/lib/mongoBackend/mongoCreateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoCreateSubscription.cpp
@@ -163,6 +163,13 @@ std::string mongoCreateSubscription
 
   std::string status = sub.status == ""?  STATUS_ACTIVE : sub.status;
 
+  // We need to insert the csub in the cache before (potentially) sending the
+  // initial notification (have a look to issue #2974 for details)
+  if (!noCache)
+  {
+    insertInCache(sub, subId, tenant, servicePath, false, 0, 0, 0);
+  }
+
   setCondsAndInitialNotify(sub,
                            subId,
                            status,
@@ -200,11 +207,6 @@ std::string mongoCreateSubscription
     oe->fill(SccReceiverInternalError, err);
 
     return "";
-  }
-
-  if (!noCache)
-  {
-    insertInCache(sub, subId, tenant, servicePath, false, 0, 0, 0);
   }
 
   reqSemGive(__FUNCTION__, "ngsiv2 create subscription request", reqSemTaken);


### PR DESCRIPTION
Fixes #2974 

Regression work in my local Debian machine. Jenkins regression (more complete, due to it does two phases, with and without cache) is on the way right now.