### PR TITLE
hardening/no_Werror_in_ubuntu_17_04_possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,13 @@ add_definitions(-fPIC)
 
 # Baseline compiler flags, any change here will affect all build types
 #set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror")
-set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -fno-var-tracking-assignments")
+
+
+IF (${DISTRO} STREQUAL "Ubuntu_17.04")
+  set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -fno-var-tracking-assignments")
+ELSE()
+  set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -fno-var-tracking-assignments")
+ENDIF ()
 
 #
 # Platform checks


### PR DESCRIPTION
'template<class> class std::auto_ptr' is deprecated in gcc 6.3.0 of Ubuntu 17.04, so -Werror cannot be used, at least not for now.

The *real* fix would be to rewrite the part of the code producing these warnings, but for now, disabling the `-Werror` flag makes the problem go away (warnings will still be found and give errors in other distros).