### PR TITLE
Bug/2948 wrong max one service path response

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - Add: CORS Preflight Requests support for /v2 and /v2/entities, -corsMaxAge switch (#501)
 - Fix: case-sensitive header duplication (e.g. "Content-Type" and "Content-type") in custom notifications (#2893)
 - Fix: bug in GTE and LTE operations in query filters (q/mq), both for GET operations and subscriptions (#2995)
+- Fix: Wrong "max one service-path allowed for subscriptions" in NGSIv2 subscription operation (#2948)

--- a/src/lib/ngsi/SubscribeError.cpp
+++ b/src/lib/ngsi/SubscribeError.cpp
@@ -67,12 +67,12 @@ std::string SubscribeError::toJson(RequestType requestType, bool comma)
     }
     out += ",";
     out += JSON_PROP("affectedItems") + "[" + JSON_STR(subscriptionId.toJson(requestType, true)) + "]";
- }
+  }
   else if ((requestType          == SubscribeContext)           &&
            (subscriptionId.get() != "000000000000000000000000") &&
            (subscriptionId.get() != ""))
   {
-	out += ",";
+    out += ",";
     out += JSON_PROP("affectedItems") + "[" + JSON_STR(subscriptionId.toJson(requestType, true)) + "]";
   }
 

--- a/src/lib/ngsi/SubscribeError.cpp
+++ b/src/lib/ngsi/SubscribeError.cpp
@@ -44,6 +44,45 @@ SubscribeError::SubscribeError()
 
 /* ****************************************************************************
 *
+* SubscribeError::toJson -
+*/
+std::string SubscribeError::toJson(RequestType requestType, bool comma)
+{
+  std::string  out;
+
+  out += JSON_VALUE("error", errorCode.reasonPhrase.c_str());
+  out += ",";
+  out += JSON_VALUE("description", errorCode.details.c_str());
+
+
+  if (requestType == UpdateContextSubscription)
+  {
+    //
+    // NOTE: the subscriptionId must have come from the request.
+    //       If the field is empty, we are in unit tests and I here set it to all zeroes
+    //
+    if (subscriptionId.get() == "")
+    {
+      subscriptionId.set("000000000000000000000000");
+    }
+    out += ",";
+    out += JSON_PROP("affectedItems") + "[" + JSON_STR(subscriptionId.toJson(requestType, true)) + "]";
+ }
+  else if ((requestType          == SubscribeContext)           &&
+           (subscriptionId.get() != "000000000000000000000000") &&
+           (subscriptionId.get() != ""))
+  {
+	out += ",";
+    out += JSON_PROP("affectedItems") + "[" + JSON_STR(subscriptionId.toJson(requestType, true)) + "]";
+  }
+
+  return out;
+}
+
+
+
+/* ****************************************************************************
+*
 * SubscribeError::render -
 */
 std::string SubscribeError::render(RequestType requestType, bool comma)

--- a/src/lib/ngsi/SubscribeError.h
+++ b/src/lib/ngsi/SubscribeError.h
@@ -44,7 +44,7 @@ typedef struct SubscribeError
 
   SubscribeError();
   std::string render(RequestType requestType, bool comma);
-
+  std::string toJson(RequestType requestType, bool comma);
   std::string check(void);
 } SubscribeError;
 

--- a/src/lib/ngsi/SubscriptionId.cpp
+++ b/src/lib/ngsi/SubscriptionId.cpp
@@ -141,6 +141,40 @@ void SubscriptionId::present(const std::string& indent)
 
 /* ****************************************************************************
 *
+* SubscriptionId::toJson -
+*/
+std::string SubscriptionId::toJson(RequestType container, bool comma)
+{
+  std::string xString = string;
+
+  if (xString == "")
+  {
+    if ((container == RtSubscribeContextAvailabilityResponse)          ||
+        (container == RtUpdateContextAvailabilitySubscriptionResponse) ||
+        (container == RtUnsubscribeContextAvailabilityResponse)        ||
+        (container == NotifyContextAvailability)                       ||
+        (container == UpdateContextSubscription)                       ||
+        (container == UnsubscribeContext)                              ||
+        (container == RtUnsubscribeContextResponse)                    ||
+        (container == NotifyContext)                                   ||
+        (container == RtSubscribeResponse)                             ||
+        (container == RtSubscribeError))
+    {
+      // subscriptionId is Mandatory
+      xString = "000000000000000000000000";
+    }
+    else
+    {
+      return "";  // subscriptionId is Optional
+    }
+  }
+
+  return xString;
+}
+
+
+/* ****************************************************************************
+*
 * SubscriptionId::render -
 */
 std::string SubscriptionId::render(RequestType container, bool comma)

--- a/src/lib/ngsi/SubscriptionId.h
+++ b/src/lib/ngsi/SubscriptionId.h
@@ -47,6 +47,7 @@ typedef struct SubscriptionId
   const char*   c_str(void) const;
   bool          isEmpty(void);
   std::string   render(RequestType container,bool comma);
+  std::string   toJson(RequestType container,bool comma);
   void          present(const std::string& indent);
   void          release(void);
   bool          rendered(RequestType container);

--- a/src/lib/ngsi/SubscriptionId.h
+++ b/src/lib/ngsi/SubscriptionId.h
@@ -46,8 +46,8 @@ typedef struct SubscriptionId
   std::string   get(void) const;
   const char*   c_str(void) const;
   bool          isEmpty(void);
-  std::string   render(RequestType container,bool comma);
-  std::string   toJson(RequestType container,bool comma);
+  std::string   render(RequestType container, bool comma);
+  std::string   toJson(RequestType container, bool comma);
   void          present(const std::string& indent);
   void          release(void);
   bool          rendered(RequestType container);

--- a/src/lib/ngsi10/SubscribeContextResponse.cpp
+++ b/src/lib/ngsi10/SubscribeContextResponse.cpp
@@ -60,6 +60,30 @@ SubscribeContextResponse::SubscribeContextResponse(StatusCode& errorCode)
 
 /* ****************************************************************************
 *
+* SubscribeContextResponse::toJson -
+*/
+std::string SubscribeContextResponse::toJson(void)
+{
+  std::string out     = "";
+
+  out += "{" ;
+
+  if (subscribeError.errorCode.code == SccNone)
+  {
+    out += subscribeResponse.render(false);
+  }
+  else
+  {
+    out += subscribeError.toJson(SubscribeContext, false);
+  }
+
+  out +=  "}";
+
+  return out;
+}
+
+/* ****************************************************************************
+*
 * SubscribeContextResponse::render - 
 */
 std::string SubscribeContextResponse::render(void)

--- a/src/lib/ngsi10/SubscribeContextResponse.cpp
+++ b/src/lib/ngsi10/SubscribeContextResponse.cpp
@@ -64,9 +64,9 @@ SubscribeContextResponse::SubscribeContextResponse(StatusCode& errorCode)
 */
 std::string SubscribeContextResponse::toJson(void)
 {
-  std::string out     = "";
+  std::string out = "";
 
-  out += "{" ;
+  out += "{";
 
   if (subscribeError.errorCode.code == SccNone)
   {

--- a/src/lib/ngsi10/SubscribeContextResponse.h
+++ b/src/lib/ngsi10/SubscribeContextResponse.h
@@ -47,6 +47,7 @@ typedef struct SubscribeContextResponse
   ~SubscribeContextResponse();
 
   std::string render(void);
+  std::string toJson(void);
 } SubscribeContextResponse;
 
 #endif  // SRC_LIB_NGSI10_SUBSCRIBECONTEXTRESPONSE_H_

--- a/src/lib/serviceRoutines/postSubscribeContext.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContext.cpp
@@ -71,7 +71,8 @@ std::string postSubscribeContext
   {
     char  noOfV[STRING_SIZE_FOR_INT];
     snprintf(noOfV, sizeof(noOfV), "%lu", ciP->servicePathV.size());
-    std::string details = std::string("max *one* service-path allowed for subscriptions (") + noOfV + " given";
+    ciP->httpStatusCode           = SccBadRequest;
+    std::string details           = std::string("max *one* service-path allowed for subscriptions (") + noOfV + " given";
 
     alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutinesV2/postSubscriptions.cpp
+++ b/src/lib/serviceRoutinesV2/postSubscriptions.cpp
@@ -56,6 +56,7 @@ extern std::string postSubscriptions
   {
     const size_t  MSG_SIZE        = 96;  // strlen(msg) + enough room for digits
     char          errMsg[MSG_SIZE];
+    ciP->httpStatusCode           = SccBadRequest;
 
     snprintf(errMsg, MSG_SIZE, "max *one* service-path allowed for subscriptions (%lu given)",
              (unsigned long) ciP->servicePathV.size());

--- a/src/lib/serviceRoutinesV2/postSubscriptions.cpp
+++ b/src/lib/serviceRoutinesV2/postSubscriptions.cpp
@@ -62,7 +62,7 @@ extern std::string postSubscriptions
     alarmMgr.badInput(clientIp, errMsg);
     scr.subscribeError.errorCode.fill(SccBadRequest, "max one service-path allowed for subscriptions");
 
-    TIMED_RENDER(answer = scr.render());
+    TIMED_RENDER(answer = scr.toJson());
     return answer;
   }
 

--- a/test/functionalTest/cases/2948_wrong_max_one_service_path_response/wrong_max_one_service_path_response.test
+++ b/test/functionalTest/cases/2948_wrong_max_one_service_path_response/wrong_max_one_service_path_response.test
@@ -1,0 +1,78 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Wrong "max one service-path allowed for subscriptions" in NGSIv2 subscription operation
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create subscription for E1 with multiple service paths header
+
+#
+
+echo "01. Create subscription for E1 with multiple service paths header"
+echo "=============================================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id" : "E1"
+      }
+    ],
+    "condition": {
+      "attrs": []
+    }
+  },
+  "notification": {
+    "httpCustom": {
+      "url":     "http://localhost:1028/accumulate"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload" --header "Fiware-ServicePath:/Madrid/Gardens/ParqueNorte, /Madrid/Gardens/ParqueOeste"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create subscription for E1 with multiple service paths header
+==============================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 86
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "max one service-path allowed for subscriptions", 
+    "error": "Bad Request"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/2948_wrong_max_one_service_path_response/wrong_max_one_service_path_response.test
+++ b/test/functionalTest/cases/2948_wrong_max_one_service_path_response/wrong_max_one_service_path_response.test
@@ -30,12 +30,11 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. Create subscription for E1 with multiple service paths header
-
+# 01. Attempt to create subscription for E1 with multiple service paths header, and see it fail
 #
 
-echo "01. Create subscription for E1 with multiple service paths header"
-echo "=============================================================="
+echo "01. Attempt to create subscription for E1 with multiple service paths header, and see it fail"
+echo "============================================================================================="
 payload='{
   "subject": {
     "entities": [
@@ -59,8 +58,8 @@ echo
 
 
 --REGEXPECT--
-01. Create subscription for E1 with multiple service paths header
-==============================================================
+01. Attempt to create subscription for E1 with multiple service paths header, and see it fail
+=============================================================================================
 HTTP/1.1 400 Bad Request
 Content-Length: 86
 Content-Type: application/json


### PR DESCRIPTION
This PR fixes #2948 Issue

- It was implemented a new **toJson()** method in SubscriberError, in order to correctly print out the error response, depending on which serviceRoutine version calls either render() or toJson() method.
- Fixed 400 httpStatusCode in both serviceRoutines 