### PR TITLE
Fix afiliations in NGSIv2 spec

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -18,14 +18,17 @@ and subscriptions.
 
 ## Editors
 
-José Manuel Cantera Fonseca (FIWARE Foundation e.V., formerly with Telefónica I+D), Fermín Galán Márquez (Telefónica I+D),
+José Manuel Cantera Fonseca (FIWARE Foundation e.V., formerly with Telefónica I+D), 
+Fermín Galán Márquez (Telefónica España, formerly with Telefónica I+D),
 Tobias Jacobs (NEC).
   
 ## Acknowledgements
 
 The editors would like to express their gratitude to the following people who actively
 contributed to this specification:
-Juan José Hierro (Telefónica I+D), Marcos Reyes (Telefónica I+D), Ken Zangelin (Telefónica I+D),
+Juan José Hierro (FIWARE Foundation e.V., formerly with Telefónica I+D), 
+Marcos Reyes (Telefónica España, formerly with Telefónica I+D), 
+Ken Zangelin (APInf, formerly with Telefónica I+D),
 Iván Arias León (Telefónica I+D), Carlos Romero Brox (Telefónica I+D),
 Antonio José López Navarro (Telefónica I+D),  Marc Capdevielle (Orange), Gilles Privat (Orange), 
 Sergio García Gómez (Telefónica I+D), Martin Bauer (NEC).


### PR DESCRIPTION
Now that we are close to release a new RC (by the end of November) of NGSIv2 stable, it is a good time to do a little fixing in authors and editors affiliations.

@kzangeli @mrutid @jmcanterafonseca 