### PR TITLE
FIX broken 0675 test

### DIFF
--- a/src/lib/serviceRoutines/postSubscribeContext.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContext.cpp
@@ -71,7 +71,7 @@ std::string postSubscribeContext
   {
     char  noOfV[STRING_SIZE_FOR_INT];
     snprintf(noOfV, sizeof(noOfV), "%lu", ciP->servicePathV.size());
-    ciP->httpStatusCode           = SccBadRequest;
+    ciP->httpStatusCode           = SccOk;  // NGSIv1 is weird... it uses 200 OK at HTTP level for errors
     std::string details           = std::string("max *one* service-path allowed for subscriptions (") + noOfV + " given";
 
     alarmMgr.badInput(clientIp, details);


### PR DESCRIPTION
This PR solves this problem found in .test in last night regression:

```
-----  Erroneous simple NGSI10 subscription with service path of two items  -----
(0675_servicePath_in_ngsi10_subscriptions/erroneous_ngsi10_subscription_with_two_service_paths.test) output not as expected
VALIDATION ERROR: input line:
   HTTP/1.1 400 Bad Request
does not match ref line:
   HTTP/1.1 200 OK
```

This problem seems to be cause by this particular line change in recent PR: https://github.com/telefonicaid/fiware-orion/pull/3034/files#diff-d1f63b595203e4a4cba617e43167a5ccR74

I don't understand how this has survived to the `make test` done in that PR (https://github.com/telefonicaid/fiware-orion/pull/3034#issuecomment-344567601). Which exact command did yo execute @arigliano ?
