### PR TITLE
ISSUE: 3030. CORS Expose Headers.

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,6 +1,5 @@
-- Add: CORS Preflight Requests support for all NGSIv2 resources, -corsMaxAge switch (#501)
+- Add: CORS Preflight Requests support for all NGSIv2 resources, -corsMaxAge switch, CORS exposed headers (#501, #3030)
 - Fix: null not working in q/mq filter in subscriptions (#2998)
 - Fix: case-sensitive header duplication (e.g. "Content-Type" and "Content-type") in custom notifications (#2893)
 - Fix: bug in GTE and LTE operations in query filters (q/mq), both for GET operations and subscriptions (#2995)
 - Fix: Wrong "max one service-path allowed for subscriptions" in NGSIv2 subscription operation (#2948)
-- Fix: Add support for accessing response headers when making CORS requests (#3030)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
 - Fix: case-sensitive header duplication (e.g. "Content-Type" and "Content-type") in custom notifications (#2893)
 - Fix: bug in GTE and LTE operations in query filters (q/mq), both for GET operations and subscriptions (#2995)
 - Fix: Wrong "max one service-path allowed for subscriptions" in NGSIv2 subscription operation (#2948)
+- Fix: Add support for accessing response headers when making CORS requests (#3030)

--- a/doc/manuals/user/README.md
+++ b/doc/manuals/user/README.md
@@ -1,8 +1,8 @@
- 
+
 # User & Programmer's Manual
- 
+
  Orion Context Broker: User & Programmer's Manual
- 
+
 ## Table of Contents
 
   * [API Walkthrough (v2)](walkthrough_apiv2.md)
@@ -29,3 +29,4 @@
   * [Known Limitations](known_limitations.md)
   * [Considerations on NGSIv1 and NGSIv2 coexistence](v1_v2_coexistence.md)
   * [NGSIv2 Implementation Notes](ngsiv2_implementation_notes.md)
+  * [CORS](cors.md)

--- a/doc/manuals/user/cors.md
+++ b/doc/manuals/user/cors.md
@@ -1,0 +1,92 @@
+# Cross Origin Resource Sharing (CORS)
+
+[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) can be enabled
+for Orion using the `-corsOrigin` switch during startup. `-corsOrigin` takes either
+a string value of a single origin that would be allowed to make CORS requests or
+ `__ALL` for allowing any origin to make CORS requests to the context broker.
+
+The only configurable aspect of Orion's CORS mode besides the allowed origin is
+the maximum time a preflight request can be cached by the client, which is
+handled by the `-corsMaxAge` switch. It takes the maximum amount of cache time in
+seconds and defaults to `86400` (24 hours)if not used.
+
+For example:
+
+- Below command starts Orion with CORS enabled for any origin with a 10 minute
+maximum preflight cache time
+
+        contextBroker -corsOrigin __ALL -corsMaxAge 600
+
+- Start Orion with CORS enabled for only a specific origin with the default
+maximum preflight cache time
+
+        contextBroker -corsOrigin specificdomain.com
+
+CORS is available for all /v2 resources but for /v1 resources, it is only
+available for [simple GET requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests).
+
+## Access-Control-Allow-Origin
+
+If the CORS mode is enabled, Origin header is present in the request and its
+value matches Orion's allowed origin, this header will always be added to the
+response.
+
+Please note that if the above condition is not true and
+Access-Control-Allow-Origin header is not added to the response, all the CORS
+processes are stopped and no other CORS headers are added to the response.
+
+If -corsOrigin is set to a specific value, `specificdomain.com` in this case:
+
+    Access-Control-Allow-Origin: specifidomain.com
+
+If -corsOrigin is set to `__ALL`:
+
+    Access-Control-Allow-Origin: *
+
+
+## Access-Control-Allow-Methods
+
+This header should be present in Orion's response for every `OPTIONS` request
+made to `/v2` resources. Each resource has its own set of allowed methods and
+the header value is set by the `options..Only` service routines in
+[lib/serviceRoutinesV2](https://github.com/telefonicaid/fiware-orion/tree/master/src/lib/serviceRoutinesV2)
+
+## Access-Control-Allow-Headers
+
+This header should be present in Orion's response for every `OPTIONS` request
+made to `/v2` resources. Orion allows a specific set of headers in CORS requests
+and these are defined in [lib/rest/HttpHeaders.h](https://github.com/telefonicaid/fiware-orion/blob/master/src/lib/rest/HttpHeaders.h)
+
+Orion's response to a valid `OPTIONS` request would include the header and value
+below:
+
+    Access-Control-Allow-Headers: Content-Type, Fiware-Service, Fiware-Servicepath, Ngsiv2-AttrsFormat, Fiware-Correlator, X-Forwarded-For, X-Real-IP, X-Auth-Token
+
+## Access-Control-Max-Age
+
+This header should be present in Orion's response for every `OPTIONS` request
+made to `/v2` resources. The user is free to set a value for the maximum time
+(in seconds) a preflight request made to Orion can be cached by the client.
+
+If -corsMaxAge is set to a specific value, `600` in this case, Orion's response
+to a valid `OPTIONS` request would include the header and value below:
+
+    Access-Control-Max-Age: 600
+
+If -corsMaxAge is not set on startup, it will default to '86400' (24 hours) and
+Orion's response to a valid `OPTIONS` request would include the header and value
+below:
+
+    Access-Control-Max-Age: 86400
+
+## Access-Control-Expose-Headers
+
+This header should be present in Orion's response for every request made with a
+valid Origin value.Orion allows a specific set of response headers to be
+accessed by the user agent (i.e. browser) in CORS requests and these are defined
+in [lib/rest/HttpHeaders.h](https://github.com/telefonicaid/fiware-orion/blob/master/src/lib/rest/HttpHeaders.h)
+
+Orion's response to a valid CORS request would include the header and value
+below:
+
+    Access-Control-Expose-Headers: Fiware-Correlator, Fiware-Total-Count, Location

--- a/src/lib/rest/HttpHeaders.h
+++ b/src/lib/rest/HttpHeaders.h
@@ -36,18 +36,21 @@
 *
 * HTTP Headers -
 */
-#define CONTENT_TYPE                 "Content-Type"
-#define FIWARE_SERVICE               "Fiware-Service"
-#define X_AUTH_TOKEN                 "X-Auth-Token"
-#define X_REAL_IP                    "X-Real-IP"
-#define X_FORWARDED_FOR              "X-Forwarded-For"
-#define FIWARE_CORRELATOR            "Fiware-Correlator"
-#define NGSIV2_ATTRSFORMAT           "Ngsiv2-AttrsFormat"
-#define FIWARE_SERVICEPATH           "Fiware-Servicepath"
-#define ACCESS_CONTROL_ALLOW_ORIGIN  "Access-Control-Allow-Origin"
-#define ACCESS_CONTROL_ALLOW_HEADERS "Access-Control-Allow-Headers"
-#define ACCESS_CONTROL_ALLOW_METHODS "Access-Control-Allow-Methods"
-#define ACCESS_CONTROL_MAX_AGE       "Access-Control-Max-Age"
+#define ACCESS_CONTROL_ALLOW_ORIGIN   "Access-Control-Allow-Origin"
+#define ACCESS_CONTROL_ALLOW_HEADERS  "Access-Control-Allow-Headers"
+#define ACCESS_CONTROL_ALLOW_METHODS  "Access-Control-Allow-Methods"
+#define ACCESS_CONTROL_MAX_AGE        "Access-Control-Max-Age"
+#define ACCESS_CONTROL_EXPOSE_HEADERS "Access-Control-Expose-Headers"
+#define CONTENT_TYPE                  "Content-Type"
+#define FIWARE_CORRELATOR             "Fiware-Correlator"
+#define FIWARE_SERVICE                "Fiware-Service"
+#define FIWARE_SERVICEPATH            "Fiware-Servicepath"
+#define FIWARE_TOTAL_COUNT            "Fiware-Total-Count"
+#define NGSIV2_ATTRSFORMAT            "Ngsiv2-AttrsFormat"
+#define RESOURCE_LOCATION             "Location"
+#define X_AUTH_TOKEN                  "X-Auth-Token"
+#define X_REAL_IP                     "X-Real-IP"
+#define X_FORWARDED_FOR               "X-Forwarded-For"
 
 
 
@@ -55,7 +58,15 @@
 *
 * CORS Allowed Headers -
 */
-#define CORS_ALLOWED_HEADERS CONTENT_TYPE", "FIWARE_SERVICE", "FIWARE_SERVICEPATH", "NGSIV2_ATTRSFORMAT", "FIWARE_CORRELATOR", "X_FORWARDED_FOR", " X_REAL_IP", " X_AUTH_TOKEN
+#define CORS_ALLOWED_HEADERS CONTENT_TYPE", "FIWARE_SERVICE", "FIWARE_SERVICEPATH", "NGSIV2_ATTRSFORMAT", "FIWARE_CORRELATOR", "X_FORWARDED_FOR", "X_REAL_IP", "X_AUTH_TOKEN
+
+
+
+/* ****************************************************************************
+*
+* CORS Exposed Headers -
+*/
+#define CORS_EXPOSED_HEADERS FIWARE_CORRELATOR", "FIWARE_TOTAL_COUNT", "RESOURCE_LOCATION
 
 
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -816,9 +816,9 @@ void firstServicePath(const char* servicePath, char* servicePath0, int servicePa
 * isOriginAllowedForCORS - checks the Origin header of the request and returns
 * true if that Origin is allowed to make a CORS request
 */
-bool isOriginAllowedForCORS(std::string requestOrigin)
+bool isOriginAllowedForCORS(const std::string& requestOrigin)
 {
-  return ( (requestOrigin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(requestOrigin.c_str(), corsOrigin) == 0)) );
+  return ((requestOrigin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(requestOrigin.c_str(), corsOrigin) == 0)));
 }
 
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -813,6 +813,18 @@ void firstServicePath(const char* servicePath, char* servicePath0, int servicePa
 
 /* ****************************************************************************
 *
+* isOriginAllowedForCORS - checks the Origin header of the request and returns
+* true if that Origin is allowed to make a CORS request
+*/
+bool isOriginAllowedForCORS(std::string requestOrigin)
+{
+  return ( (requestOrigin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(requestOrigin.c_str(), corsOrigin) == 0)) );
+}
+
+
+
+/* ****************************************************************************
+*
 * servicePathSplit -
 */
 int servicePathSplit(ConnectionInfo* ciP)

--- a/src/lib/rest/rest.h
+++ b/src/lib/rest/rest.h
@@ -124,4 +124,13 @@ extern int servicePathCheck(ConnectionInfo* ciP, const char* servicePath);
 */
 extern void firstServicePath(const char* servicePath, char* servicePath0, int servicePath0Len);
 
+
+
+/* ****************************************************************************
+*
+* isOriginAllowedForCORS - checks the Origin header of the request and returns
+* true if that Origin is allowed to make a CORS request
+*/
+extern bool isOriginAllowedForCORS(std::string requestOrigin);
+
 #endif

--- a/src/lib/rest/rest.h
+++ b/src/lib/rest/rest.h
@@ -131,6 +131,6 @@ extern void firstServicePath(const char* servicePath, char* servicePath0, int se
 * isOriginAllowedForCORS - checks the Origin header of the request and returns
 * true if that Origin is allowed to make a CORS request
 */
-extern bool isOriginAllowedForCORS(std::string requestOrigin);
+extern bool isOriginAllowedForCORS(const std::string& requestOrigin);
 
 #endif

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -182,7 +182,8 @@ void restReply(ConnectionInfo* ciP, const std::string& _answer)
         MHD_add_response_header(response, ACCESS_CONTROL_ALLOW_ORIGIN, corsOrigin);
       }
       // If there is no match, originAllowed flag is set to false
-      else {
+      else
+      {
         originAllowed = false;
       }
 

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -163,12 +163,14 @@ void restReply(ConnectionInfo* ciP, const std::string& _answer)
     }
   }
 
-  // Check if CORS is enabled and the response is not a bad verb response
-  if ((corsEnabled == true) && (ciP->httpStatusCode != SccBadVerb))
+  // Check if CORS is enabled, the Origin header is present in the request and the response is not a bad verb response
+  if ((corsEnabled == true) && (ciP->httpHeaders.origin != "") && (ciP->httpStatusCode != SccBadVerb))
   {
-    //Only GET method is supported for V1 API
+    // Only GET method is supported for V1 API
     if ((ciP->apiVersion == V2) || (ciP->apiVersion == V1 && ciP->verb == GET))
     {
+      bool originAllowed = true;
+
       // If any origin is allowed, the header is sent always with "any" as value
       if (strcmp(corsOrigin, "__ALL") == 0)
       {
@@ -179,16 +181,27 @@ void restReply(ConnectionInfo* ciP, const std::string& _answer)
       {
         MHD_add_response_header(response, ACCESS_CONTROL_ALLOW_ORIGIN, corsOrigin);
       }
-    }
+      // If there is no match, originAllowed flag is set to false
+      else {
+        originAllowed = false;
+      }
 
-    if (ciP->verb == OPTIONS)
-    {
-      MHD_add_response_header(response, ACCESS_CONTROL_ALLOW_HEADERS, CORS_ALLOWED_HEADERS);
+      // If the origin is not allowed, no headers are added to the response
+      if (originAllowed)
+      {
+        // Add Access-Control-Expose-Headers to the response
+        MHD_add_response_header(response, ACCESS_CONTROL_EXPOSE_HEADERS, CORS_EXPOSED_HEADERS);
 
-      char maxAge[STRING_SIZE_FOR_INT];
-      snprintf(maxAge, sizeof(maxAge), "%d", corsMaxAge);
+        if (ciP->verb == OPTIONS)
+        {
+          MHD_add_response_header(response, ACCESS_CONTROL_ALLOW_HEADERS, CORS_ALLOWED_HEADERS);
 
-      MHD_add_response_header(response, ACCESS_CONTROL_MAX_AGE, maxAge);
+          char maxAge[STRING_SIZE_FOR_INT];
+          snprintf(maxAge, sizeof(maxAge), "%d", corsMaxAge);
+
+          MHD_add_response_header(response, ACCESS_CONTROL_MAX_AGE, maxAge);
+        }
+      }
     }
   }
 

--- a/src/lib/serviceRoutinesV2/optionsAllNotDelete.cpp
+++ b/src/lib/serviceRoutinesV2/optionsAllNotDelete.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/rest.h"
 #include "serviceRoutinesV2/optionsAllNotDelete.h"
 
 
@@ -45,8 +46,11 @@ std::string optionsAllNotDelete
   ParseData*                 parseDataP
 )
 {
-  ciP->httpHeader.push_back("Access-Control-Allow-Methods");
-  ciP->httpHeaderValue.push_back("GET, PATCH, POST, PUT, OPTIONS");
+  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  {
+    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeaderValue.push_back("GET, PATCH, POST, PUT, OPTIONS");
+  }
   ciP->httpStatusCode = SccOk;
 
   return "";

--- a/src/lib/serviceRoutinesV2/optionsAllNotDelete.cpp
+++ b/src/lib/serviceRoutinesV2/optionsAllNotDelete.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/HttpHeaders.h"
 #include "rest/rest.h"
 #include "serviceRoutinesV2/optionsAllNotDelete.h"
 
@@ -46,9 +47,9 @@ std::string optionsAllNotDelete
   ParseData*                 parseDataP
 )
 {
-  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
   {
-    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, PATCH, POST, PUT, OPTIONS");
   }
   ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutinesV2/optionsAllNotDelete.cpp
+++ b/src/lib/serviceRoutinesV2/optionsAllNotDelete.cpp
@@ -47,7 +47,7 @@ std::string optionsAllNotDelete
   ParseData*                 parseDataP
 )
 {
-  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
+  if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
     ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, PATCH, POST, PUT, OPTIONS");

--- a/src/lib/serviceRoutinesV2/optionsGetDeleteOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetDeleteOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetDeleteOnly.h"
 
 
@@ -45,8 +46,11 @@ std::string optionsGetDeleteOnly
   ParseData*                 parseDataP
 )
 {
-  ciP->httpHeader.push_back("Access-Control-Allow-Methods");
-  ciP->httpHeaderValue.push_back("GET, DELETE, OPTIONS");
+  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  {
+    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeaderValue.push_back("GET, DELETE, OPTIONS");
+  }
   ciP->httpStatusCode = SccOk;
 
   return "";

--- a/src/lib/serviceRoutinesV2/optionsGetDeleteOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetDeleteOnly.cpp
@@ -47,7 +47,7 @@ std::string optionsGetDeleteOnly
   ParseData*                 parseDataP
 )
 {
-  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
+  if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
     ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, DELETE, OPTIONS");

--- a/src/lib/serviceRoutinesV2/optionsGetDeleteOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetDeleteOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/HttpHeaders.h"
 #include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetDeleteOnly.h"
 
@@ -46,9 +47,9 @@ std::string optionsGetDeleteOnly
   ParseData*                 parseDataP
 )
 {
-  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
   {
-    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, DELETE, OPTIONS");
   }
   ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutinesV2/optionsGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetDeletePatchOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/HttpHeaders.h"
 #include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetDeletePatchOnly.h"
 
@@ -46,9 +47,9 @@ std::string optionsGetDeletePatchOnly
   ParseData*                 parseDataP
 )
 {
-  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
   {
-    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, DELETE, PATCH, OPTIONS");
   }
   ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutinesV2/optionsGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetDeletePatchOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetDeletePatchOnly.h"
 
 
@@ -45,8 +46,11 @@ std::string optionsGetDeletePatchOnly
   ParseData*                 parseDataP
 )
 {
-  ciP->httpHeader.push_back("Access-Control-Allow-Methods");
-  ciP->httpHeaderValue.push_back("GET, DELETE, PATCH, OPTIONS");
+  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  {
+    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeaderValue.push_back("GET, DELETE, PATCH, OPTIONS");
+  }
   ciP->httpStatusCode = SccOk;
 
   return "";

--- a/src/lib/serviceRoutinesV2/optionsGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetDeletePatchOnly.cpp
@@ -47,7 +47,7 @@ std::string optionsGetDeletePatchOnly
   ParseData*                 parseDataP
 )
 {
-  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
+  if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
     ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, DELETE, PATCH, OPTIONS");

--- a/src/lib/serviceRoutinesV2/optionsGetOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetOnly.cpp
@@ -47,7 +47,7 @@ std::string optionsGetOnly
   ParseData*                 parseDataP
 )
 {
-  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
+  if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
     ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, OPTIONS");

--- a/src/lib/serviceRoutinesV2/optionsGetOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/HttpHeaders.h"
 #include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetOnly.h"
 
@@ -46,9 +47,9 @@ std::string optionsGetOnly
   ParseData*                 parseDataP
 )
 {
-  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
   {
-    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, OPTIONS");
   }
   ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutinesV2/optionsGetOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetOnly.h"
 
 
@@ -45,8 +46,11 @@ std::string optionsGetOnly
   ParseData*                 parseDataP
 )
 {
-  ciP->httpHeader.push_back("Access-Control-Allow-Methods");
-  ciP->httpHeaderValue.push_back("GET, OPTIONS");
+  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  {
+    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeaderValue.push_back("GET, OPTIONS");
+  }
   ciP->httpStatusCode = SccOk;
 
   return "";

--- a/src/lib/serviceRoutinesV2/optionsGetPostOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPostOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetPostOnly.h"
 
 
@@ -45,8 +46,11 @@ std::string optionsGetPostOnly
   ParseData*                 parseDataP
 )
 {
-  ciP->httpHeader.push_back("Access-Control-Allow-Methods");
-  ciP->httpHeaderValue.push_back("GET, POST, OPTIONS");
+  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  {
+    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeaderValue.push_back("GET, POST, OPTIONS");
+  }
   ciP->httpStatusCode = SccOk;
 
   return "";

--- a/src/lib/serviceRoutinesV2/optionsGetPostOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPostOnly.cpp
@@ -47,7 +47,7 @@ std::string optionsGetPostOnly
   ParseData*                 parseDataP
 )
 {
-  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
+  if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
     ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, POST, OPTIONS");

--- a/src/lib/serviceRoutinesV2/optionsGetPostOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPostOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/HttpHeaders.h"
 #include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetPostOnly.h"
 
@@ -46,9 +47,9 @@ std::string optionsGetPostOnly
   ParseData*                 parseDataP
 )
 {
-  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
   {
-    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, POST, OPTIONS");
   }
   ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutinesV2/optionsGetPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPutDeleteOnly.cpp
@@ -47,7 +47,7 @@ std::string optionsGetPutDeleteOnly
   ParseData*                 parseDataP
 )
 {
-  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
+  if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
     ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, PUT, DELETE, OPTIONS");

--- a/src/lib/serviceRoutinesV2/optionsGetPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPutDeleteOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/HttpHeaders.h"
 #include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetPutDeleteOnly.h"
 
@@ -46,9 +47,9 @@ std::string optionsGetPutDeleteOnly
   ParseData*                 parseDataP
 )
 {
-  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
   {
-    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, PUT, DELETE, OPTIONS");
   }
   ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutinesV2/optionsGetPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPutDeleteOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetPutDeleteOnly.h"
 
 
@@ -45,8 +46,11 @@ std::string optionsGetPutDeleteOnly
   ParseData*                 parseDataP
 )
 {
-  ciP->httpHeader.push_back("Access-Control-Allow-Methods");
-  ciP->httpHeaderValue.push_back("GET, PUT, DELETE, OPTIONS");
+  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  {
+    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeaderValue.push_back("GET, PUT, DELETE, OPTIONS");
+  }
   ciP->httpStatusCode = SccOk;
 
   return "";

--- a/src/lib/serviceRoutinesV2/optionsGetPutOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPutOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetPutOnly.h"
 
 
@@ -45,8 +46,11 @@ std::string optionsGetPutOnly
   ParseData*                 parseDataP
 )
 {
-  ciP->httpHeader.push_back("Access-Control-Allow-Methods");
-  ciP->httpHeaderValue.push_back("GET, PUT, OPTIONS");
+  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  {
+    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeaderValue.push_back("GET, PUT, OPTIONS");
+  }
   ciP->httpStatusCode = SccOk;
 
   return "";

--- a/src/lib/serviceRoutinesV2/optionsGetPutOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPutOnly.cpp
@@ -47,7 +47,7 @@ std::string optionsGetPutOnly
   ParseData*                 parseDataP
 )
 {
-  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
+  if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
     ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, PUT, OPTIONS");

--- a/src/lib/serviceRoutinesV2/optionsGetPutOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPutOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/HttpHeaders.h"
 #include "rest/rest.h"
 #include "serviceRoutinesV2/optionsGetPutOnly.h"
 
@@ -46,9 +47,9 @@ std::string optionsGetPutOnly
   ParseData*                 parseDataP
 )
 {
-  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
   {
-    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, PUT, OPTIONS");
   }
   ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutinesV2/optionsPostOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsPostOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/rest.h"
 #include "serviceRoutinesV2/optionsPostOnly.h"
 
 
@@ -45,8 +46,11 @@ std::string optionsPostOnly
   ParseData*                 parseDataP
 )
 {
-  ciP->httpHeader.push_back("Access-Control-Allow-Methods");
-  ciP->httpHeaderValue.push_back("POST, OPTIONS");
+  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  {
+    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeaderValue.push_back("POST, OPTIONS");
+  }
   ciP->httpStatusCode = SccOk;
 
   return "";

--- a/src/lib/serviceRoutinesV2/optionsPostOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsPostOnly.cpp
@@ -27,6 +27,7 @@
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
+#include "rest/HttpHeaders.h"
 #include "rest/rest.h"
 #include "serviceRoutinesV2/optionsPostOnly.h"
 
@@ -46,9 +47,9 @@ std::string optionsPostOnly
   ParseData*                 parseDataP
 )
 {
-  if ( (ciP->httpHeaders.origin != "") && ((strcmp(corsOrigin, "__ALL") == 0) || (strcmp(ciP->httpHeaders.origin.c_str(), corsOrigin) == 0)) )
+  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
   {
-    ciP->httpHeader.push_back("Access-Control-Allow-Methods");
+    ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("POST, OPTIONS");
   }
   ciP->httpStatusCode = SccOk;

--- a/src/lib/serviceRoutinesV2/optionsPostOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsPostOnly.cpp
@@ -47,7 +47,7 @@ std::string optionsPostOnly
   ParseData*                 parseDataP
 )
 {
-  if ( isOriginAllowedForCORS(ciP->httpHeaders.origin) )
+  if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
     ciP->httpHeader.push_back(ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("POST, OPTIONS");

--- a/test/functionalTest/cases/0501_cors/allowed_headers.test
+++ b/test/functionalTest/cases/0501_cors/allowed_headers.test
@@ -21,31 +21,31 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 # CORS functionality is tested with a collection of test files in this directory.
-# This CORS test focuses on the Access-Control-Max-Age header. Other CORS
+# This CORS test focuses on the Access-Control-Allow-Headers header. Other CORS
 # related headers in this test file use REGEX(.*) as value since they are being
 # tested in their respective test files.
 
 --NAME--
-CORS Max Age
+CORS Allowed Headers
 
 --SHELL-INIT--
 dbInit CB
-brokerStart CB 0-255 IPV4 -corsOrigin __ALL -corsMaxAge 600
+brokerStart CB 0-255 IPV4 -corsOrigin __ALL
 
 --SHELL--
-echo "01. Specific Max Age Value"
-echo "=========================="
+echo "01. CORS Allowed Headers"
+echo "========================"
 orionCurl --url /v2 -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 --REGEXPECT--
-01. Specific Max Age Value
-==========================
+01. CORS Allowed Headers
+========================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 600
-Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Max-Age: REGEX([0-9]+)
+Access-Control-Allow-Headers: Content-Type, Fiware-Service, Fiware-Servicepath, Ngsiv2-AttrsFormat, Fiware-Correlator, X-Forwarded-For, X-Real-IP, X-Auth-Token
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: REGEX(.*)

--- a/test/functionalTest/cases/0501_cors/allowed_methods.test
+++ b/test/functionalTest/cases/0501_cors/allowed_methods.test
@@ -30,73 +30,73 @@ brokerStart CB 0-255 IPV4 -corsOrigin __ALL
 --SHELL--
 echo "01. Entry Points - Allowed methods: GET OPTIONS"
 echo "==============================================="
-orionCurl --url /v2 -X OPTIONS
+orionCurl --url /v2 -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "02. All Entities - Allowed methods: GET POST OPTIONS"
 echo "===================================================="
-orionCurl --url /v2/entities -X OPTIONS
+orionCurl --url /v2/entities -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "03. Entity - Allowed methods: GET DELETE OPTIONS"
 echo "================================================"
-orionCurl --url /v2/entities/testEntity -X OPTIONS
+orionCurl --url /v2/entities/testEntity -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "04. Entity Attributes - Allowed methods: GET PATCH POST PUT OPTIONS"
 echo "==================================================================="
-orionCurl --url /v2/entities/testEntity/attrs -X OPTIONS
+orionCurl --url /v2/entities/testEntity/attrs -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "05. Entity Attribute Value - Allowed methods: GET PUT OPTIONS"
 echo "============================================================="
-orionCurl --url /v2/entities/testEntity/attrs/testAttr/value -X OPTIONS
+orionCurl --url /v2/entities/testEntity/attrs/testAttr/value -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "06. Entity Attribute - Allowed methods: GET PUT DELETE OPTIONS"
 echo "=============================================================="
-orionCurl --url /v2/entities/testEntity/attrs/testAttr -X OPTIONS
+orionCurl --url /v2/entities/testEntity/attrs/testAttr -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "07. Entity Type - Allowed methods: GET OPTIONS"
 echo "=============================================="
-orionCurl --url /v2/types/testType -X OPTIONS
+orionCurl --url /v2/types/testType -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "08. All Entity Types - Allowed methods: GET OPTIONS"
 echo "==================================================="
-orionCurl --url /v2/types -X OPTIONS
+orionCurl --url /v2/types -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "09. All Subscriptions - Allowed methods: GET POST OPTIONS"
 echo "========================================================="
-orionCurl --url /v2/subscriptions -X OPTIONS
+orionCurl --url /v2/subscriptions -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "10. Specific Subscription - Allowed methods: GET DELETE PATCH OPTIONS"
 echo "====================================================================="
-orionCurl --url /v2/subscriptions/testSub -X OPTIONS
+orionCurl --url /v2/subscriptions/testSub -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "11. Batch Query - Allowed methods: POST OPTIONS"
 echo "==============================================="
-orionCurl --url /v2/op/query -X OPTIONS
+orionCurl --url /v2/op/query -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 echo "12. Batch Update - Allowed methods: POST OPTIONS"
 echo "================================================"
-orionCurl --url /v2/op/update -X OPTIONS
+orionCurl --url /v2/op/update -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
@@ -107,6 +107,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -120,6 +121,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, POST, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -133,6 +135,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, DELETE, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -146,6 +149,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, PATCH, POST, PUT, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -159,6 +163,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, PUT, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -172,6 +177,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, PUT, DELETE, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -185,6 +191,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -198,6 +205,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -211,6 +219,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, POST, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -224,6 +233,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, DELETE, PATCH, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -237,6 +247,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -250,6 +261,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: POST, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})

--- a/test/functionalTest/cases/0501_cors/allowed_methods.test
+++ b/test/functionalTest/cases/0501_cors/allowed_methods.test
@@ -20,6 +20,11 @@
 
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
+# CORS functionality is tested with a collection of test files in this directory.
+# This CORS test focuses on the Access-Control-Allow-Methods header. Other CORS 
+# related headers in this test file use REGEX(.*) as value since they are being 
+# tested in their respective test files.
+
 --NAME--
 CORS allowed methods
 
@@ -105,7 +110,7 @@ echo
 ===============================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -119,7 +124,7 @@ Date: REGEX(.*)
 ====================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -133,7 +138,7 @@ Date: REGEX(.*)
 ================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -147,7 +152,7 @@ Date: REGEX(.*)
 ===================================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -161,7 +166,7 @@ Date: REGEX(.*)
 =============================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -175,7 +180,7 @@ Date: REGEX(.*)
 ==============================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -189,7 +194,7 @@ Date: REGEX(.*)
 ==============================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -203,7 +208,7 @@ Date: REGEX(.*)
 ===================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -217,7 +222,7 @@ Date: REGEX(.*)
 =========================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -231,7 +236,7 @@ Date: REGEX(.*)
 =====================================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -245,7 +250,7 @@ Date: REGEX(.*)
 ===============================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
@@ -259,7 +264,7 @@ Date: REGEX(.*)
 ================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *

--- a/test/functionalTest/cases/0501_cors/any_origin.test
+++ b/test/functionalTest/cases/0501_cors/any_origin.test
@@ -28,23 +28,36 @@ dbInit CB
 brokerStart CB 0-255 IPV4 -corsOrigin __ALL
 
 --SHELL--
-echo "01. GET Entry Points"
-echo "===================="
+echo "01. GET Entry Points With Origin Header"
+echo "======================================="
+orionCurl --url /v2 -X GET --origin TEST_ORIGIN
+echo
+echo
+
+echo "02. OPTIONS Entry Points With Origin Header"
+echo "==========================================="
+orionCurl --url /v2 -X OPTIONS --origin TEST_ORIGIN
+echo
+echo
+
+echo "03. GET Entry Points Without Origin Header"
+echo "=========================================="
 orionCurl --url /v2 -X GET
 echo
 echo
 
-echo "02. OPTIONS Entry Points"
-echo "========================"
+echo "04. OPTIONS Entry Points Without Origin Header"
+echo "=============================================="
 orionCurl --url /v2 -X OPTIONS
 echo
 echo
 
 --REGEXPECT--
-01. GET Entry Points
-====================
+01. GET Entry Points With Origin Header
+=======================================
 HTTP/1.1 200 OK
 Content-Length: 135
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -58,14 +71,40 @@ Date: REGEX(.*)
 }
 
 
-02. OPTIONS Entry Points
-========================
+02. OPTIONS Entry Points With Origin Header
+===========================================
 HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, OPTIONS
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. GET Entry Points Without Origin Header
+==========================================
+HTTP/1.1 200 OK
+Content-Length: 135
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "entities_url": "/v2/entities",
+    "registrations_url": "/v2/registrations",
+    "subscriptions_url": "/v2/subscriptions",
+    "types_url": "/v2/types"
+}
+
+
+04. OPTIONS Entry Points Without Origin Header
+==============================================
+HTTP/1.1 200 OK
+Content-Length: 0
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0501_cors/any_origin.test
+++ b/test/functionalTest/cases/0501_cors/any_origin.test
@@ -20,6 +20,11 @@
 
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
+# CORS functionality is tested with a collection of test files in this directory.
+# This CORS test focuses on the Access-Control-Allow-Origin header. Other CORS
+# related headers in this test file use REGEX(.*) as value since they are being
+# tested in their respective test files.
+
 --NAME--
 CORS any origin
 
@@ -75,11 +80,11 @@ Date: REGEX(.*)
 ===========================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
-Access-Control-Allow-Methods: GET, OPTIONS
+Access-Control-Allow-Methods: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0501_cors/cors_bad_verbs.test
+++ b/test/functionalTest/cases/0501_cors/cors_bad_verbs.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-CORS any origin
+CORS Bad Verbs 
 
 --SHELL-INIT--
 dbInit CB

--- a/test/functionalTest/cases/0501_cors/exposed_headers.test
+++ b/test/functionalTest/cases/0501_cors/exposed_headers.test
@@ -21,32 +21,32 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 # CORS functionality is tested with a collection of test files in this directory.
-# This CORS test focuses on the Access-Control-Max-Age header. Other CORS
+# This CORS test focuses on the Access-Control-Expose-Headers header. Other CORS
 # related headers in this test file use REGEX(.*) as value since they are being
 # tested in their respective test files.
 
 --NAME--
-CORS Max Age
+CORS Exposed Headers
 
 --SHELL-INIT--
 dbInit CB
-brokerStart CB 0-255 IPV4 -corsOrigin __ALL -corsMaxAge 600
+brokerStart CB 0-255 IPV4 -corsOrigin __ALL
 
 --SHELL--
-echo "01. Specific Max Age Value"
-echo "=========================="
+echo "01. CORS Exposed Headers"
+echo "========================"
 orionCurl --url /v2 -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 --REGEXPECT--
-01. Specific Max Age Value
-==========================
+01. CORS Exposed Headers
+========================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 600
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
-Access-Control-Expose-Headers: REGEX(.*)
+Access-Control-Expose-Headers: Fiware-Correlator, Fiware-Total-Count, Location 
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})

--- a/test/functionalTest/cases/0501_cors/get_any_origin.test
+++ b/test/functionalTest/cases/0501_cors/get_any_origin.test
@@ -50,8 +50,14 @@ orionCurl --url /v1/updateContext --payload "$payload"
 echo
 echo
 
-echo "02. Query E1-T1 (Access-Control-Allow-Origin included)"
-echo "======================================================"
+echo "02. Query E1-T1 With Origin Header (Access-Control-Allow-Origin included)"
+echo "========================================================================="
+orionCurl --url /v1/contextEntities/type/T1/id/E1 -X GET --origin TEST_ORIGIN
+echo
+echo
+
+echo "03. Query E1-T1 Without Origin Header (Access-Control-Allow-Origin not included)"
+echo "================================================================================"
 orionCurl --url /v1/contextEntities/type/T1/id/E1 -X GET
 echo
 echo
@@ -89,11 +95,40 @@ Date: REGEX(.*)
 }
 
 
-02. Query E1-T1 (Access-Control-Allow-Origin included)
-======================================================
+02. Query E1-T1 With Origin Header (Access-Control-Allow-Origin included)
+=========================================================================
 HTTP/1.1 200 OK
 Content-Length: 279
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "contextElement": {
+        "attributes": [
+            {
+                "name": "A1",
+                "type": "string",
+                "value": "1"
+            }
+        ],
+        "id": "E1",
+        "isPattern": "false",
+        "type": "T1"
+    },
+    "statusCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+03. Query E1-T1 Without Origin Header (Access-Control-Allow-Origin not included)
+================================================================================
+HTTP/1.1 200 OK
+Content-Length: 279
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/functionalTest/cases/0501_cors/get_specific_origin.test
+++ b/test/functionalTest/cases/0501_cors/get_specific_origin.test
@@ -121,6 +121,7 @@ Date: REGEX(.*)
 ==================================================================================
 HTTP/1.1 200 OK
 Content-Length: 279
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: rivendel
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})

--- a/test/functionalTest/cases/0501_cors/max_age.test
+++ b/test/functionalTest/cases/0501_cors/max_age.test
@@ -30,7 +30,7 @@ brokerStart CB 0-255 IPV4 -corsOrigin __ALL -corsMaxAge 600
 --SHELL--
 echo "01. OPTIONS Entry Points"
 echo "========================"
-orionCurl --url /v2 -X OPTIONS
+orionCurl --url /v2 -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
@@ -41,6 +41,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 600
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})

--- a/test/functionalTest/cases/0501_cors/max_age_default.test
+++ b/test/functionalTest/cases/0501_cors/max_age_default.test
@@ -30,21 +30,21 @@ CORS Max Age
 
 --SHELL-INIT--
 dbInit CB
-brokerStart CB 0-255 IPV4 -corsOrigin __ALL -corsMaxAge 600
+brokerStart CB 0-255 IPV4 -corsOrigin __ALL
 
 --SHELL--
-echo "01. Specific Max Age Value"
-echo "=========================="
+echo "01. Default Max Age Value"
+echo "========================="
 orionCurl --url /v2 -X OPTIONS --origin TEST_ORIGIN
 echo
 echo
 
 --REGEXPECT--
-01. Specific Max Age Value
-==========================
+01. Default Max Age Value
+=========================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 600
+Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: *

--- a/test/functionalTest/cases/0501_cors/specific_origin.test
+++ b/test/functionalTest/cases/0501_cors/specific_origin.test
@@ -85,6 +85,7 @@ Date: REGEX(.*)
 ======================================================================================
 HTTP/1.1 200 OK
 Content-Length: 135
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: arrakis
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -118,9 +119,6 @@ Date: REGEX(.*)
 ==========================================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
-Access-Control-Allow-Headers: REGEX(.*)
-Access-Control-Allow-Methods: GET, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
@@ -132,6 +130,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Access-Control-Max-Age: 86400
 Access-Control-Allow-Headers: REGEX(.*)
+Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: arrakis
 Access-Control-Allow-Methods: GET, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -143,9 +142,6 @@ Date: REGEX(.*)
 ==============================================================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
-Access-Control-Allow-Headers: REGEX(.*)
-Access-Control-Allow-Methods: GET, OPTIONS
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0501_cors/specific_origin.test
+++ b/test/functionalTest/cases/0501_cors/specific_origin.test
@@ -20,6 +20,11 @@
 
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
+# CORS functionality is tested with a collection of test files in this directory.
+# This CORS test focuses on the Access-Control-Allow-Origin header. Other CORS
+# related headers in this test file use REGEX(.*) as value since they are being
+# tested in their respective test files.
+
 --NAME--
 CORS specific origin
 
@@ -128,11 +133,11 @@ Date: REGEX(.*)
 ==========================================================================================
 HTTP/1.1 200 OK
 Content-Length: 0
-Access-Control-Max-Age: 86400
+Access-Control-Max-Age: REGEX([0-9]+)
 Access-Control-Allow-Headers: REGEX(.*)
 Access-Control-Expose-Headers: REGEX(.*)
 Access-Control-Allow-Origin: arrakis
-Access-Control-Allow-Methods: GET, OPTIONS
+Access-Control-Allow-Methods: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 


### PR DESCRIPTION

Access-Control-Expose-Headers is now sent in the response, allowing the client to access certain response headers. 

With this PR, I took the liberty to add some improvements to our logic with respect to the CORS specification: We are no longer adding any CORS headers to the response if the client fails to add Origin to the request or the Origin value does not match the one allowed by Orion. 


