### PR TITLE
UPDATE reference Orion version in developers manual

### DIFF
--- a/doc/manuals/devel/README.md
+++ b/doc/manuals/devel/README.md
@@ -1,6 +1,6 @@
 # <a name="top"></a>Development Manual
 
-*Note: This document describes Orion Context Broker as of release 1.7.x.*
+*Note: This document describes Orion Context Broker as of release 1.10.x.*
 
 ## Intended audience
 The intended audience of this manual is developers that need to understand the internals of the Orion Context Broker


### PR DESCRIPTION
We have recently released three Orion versions, but I think they have no impact on the developers documentation, so I think the version number could be moved forward.

However, I'd like to have a second opition, so I cast this PR to get @kzangeli 's feedback :)

The detail of changes corresponding to these versions, in the case it helps is:

https://github.com/telefonicaid/fiware-orion/releases/tag/1.10.0
https://github.com/telefonicaid/fiware-orion/releases/tag/1.9.0
https://github.com/telefonicaid/fiware-orion/releases/tag/1.8.0
