### PR TITLE
FIX changelog date

### DIFF
--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -952,7 +952,7 @@ fi
 - REST interface for changing log and trace levels
 - Memory leak fixes
 
-* Mon Jun 04 2013 Fermín Galán <fermin@tid.es> 0.3.0-1 (FIWARE-2.3.3-1)
+* Tue Jun 04 2013 Fermín Galán <fermin@tid.es> 0.3.0-1 (FIWARE-2.3.3-1)
 - CLI argument -logAppend
 - Handlers for SIGUSR1 and SIGUSR2 signals to stop/resume logging
 - Handlers for SIGTERM and SIGINT signals for smart exiting


### PR DESCRIPTION
I have realize of the following error in rpm build output:

```
    bogus date in %changelog: Mon Jun 04 2013 Fermín Galán <fermin@tid.es> 0.3.0-1 (FIWARE-2.3.3-1)
```

Not sure the cause, but it seems that June 4th, 2013 was Tuesday, not Monday. Let's see if this PR solves :)