### PR TITLE
FIX forwardingMode = false using Not Implemented error messages

### DIFF
--- a/src/lib/apiTypesV2/Registration.cpp
+++ b/src/lib/apiTypesV2/Registration.cpp
@@ -129,8 +129,8 @@ std::string Provider::toJson(void)
   std::string  urlAsJson = "{\"url\": \"" + http.url + "\"}";
 
   jh.addRaw("http", urlAsJson);
-  jh.addString("supportedForwardingMode", "all");
-  jh.addBool("legacyForwarding", true);
+  jh.addString("supportedForwardingMode", forwardingModeToString(supportedForwardingMode));
+  jh.addBool("legacyForwarding", legacyForwardingMode? "true" : "false");
 
   return jh.str();
 }

--- a/src/lib/apiTypesV2/Registration.h
+++ b/src/lib/apiTypesV2/Registration.h
@@ -115,6 +115,20 @@ typedef enum ForwardingMode
 
 
 
+inline std::string forwardingModeToString(ForwardingMode f)
+{
+  switch (f)
+  {
+  case ForwardAll:     return "all";
+  case ForwardNone:    return "none";
+  case ForwardQuery:   return "query";
+  case ForwardUpdate:  return "update";
+  default:             return "Undefined";
+  }
+}
+
+
+
 /* ****************************************************************************
 *
 * Provider -
@@ -123,6 +137,7 @@ struct Provider
 {
   Http            http;
   ForwardingMode  supportedForwardingMode;
+  bool            legacyForwardingMode;
 
   std::string     toJson();
 };

--- a/src/lib/jsonParseV2/parseRegistration.cpp
+++ b/src/lib/jsonParseV2/parseRegistration.cpp
@@ -207,23 +207,19 @@ static bool providerParse(ConnectionInfo* ciP, ngsiv2::Provider* providerP, cons
   {
     const rapidjson::Value& legacyForwarding = provider["legacyForwarding"];
 
-    if (!legacyForwarding.IsBool())
+    if (legacyForwarding.IsBool())
     {
-      *errorStringP = "the field /legacyForwarding/ must be a boolean and set to /true/";
-      return false;
+      providerP->legacyForwardingMode = legacyForwarding.GetBool();
     }
-
-    bool legacyForwardingValue = legacyForwarding.GetBool();
-    if (legacyForwardingValue != true)
+    else
     {
-      *errorStringP = "the field /legacyForwarding/ must be set to /true/";
+      *errorStringP = "the field /legacyForwarding/ must be a boolean";
       return false;
     }
   }
   else
   {
-    *errorStringP = "the field /legacyForwarding/ must be present as a boolean and set to /true/";
-    return false;
+    providerP->legacyForwardingMode = false;
   }
 
   return true;

--- a/src/lib/mongoBackend/mongoRegistrationGet.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationGet.cpp
@@ -82,6 +82,11 @@ static void setDescription(ngsiv2::Registration* regP, const mongo::BSONObj& r)
 static void setProvider(ngsiv2::Registration* regP, const mongo::BSONObj& r)
 {
   regP->provider.http.url = (r.hasField(REG_PROVIDING_APPLICATION))? getStringFieldF(r, REG_PROVIDING_APPLICATION): "";
+
+  // FIXME P4: by the moment supportedForwardingMode and legacyForwardingMode are hardwired (i.e. DB is not taken
+  // into account for them)
+  regP->provider.supportedForwardingMode = ngsiv2::ForwardAll;
+  regP->provider.legacyForwardingMode = true;
 }
 
 

--- a/src/lib/serviceRoutinesV2/postRegistration.cpp
+++ b/src/lib/serviceRoutinesV2/postRegistration.cpp
@@ -66,6 +66,17 @@ std::string postRegistration
   std::string           answer;
 
   //
+  // FIXME P4: legacyForwardingMode = false to be implemented
+  //
+  if (parseDataP->reg.provider.legacyForwardingMode == false)
+  {
+    oe.fill(SccNotImplemented, "Only NGSIv1-based forwarding supported at the present moment. Set explictely legacyForwarding to true");
+    ciP->httpStatusCode = oe.code;
+    TIMED_RENDER(answer = oe.smartRender(ciP->apiVersion));
+    return answer;
+  }
+
+  //
   // FIXME P4: Forwarding modes "none", "query", and "update" to be implemented
   //
   if (parseDataP->reg.provider.supportedForwardingMode != ngsiv2::ForwardAll)

--- a/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_errors.test
+++ b/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_errors.test
@@ -833,7 +833,7 @@ payload='{
       "url": "http://localhost:'${CP1_PORT}'/v2"
     }
   },
-  "status": "green"
+  "status": "active"
 }'
 orionCurl --url /v2/registrations --payload "$payload"
 echo
@@ -859,7 +859,7 @@ payload='{
     },
     "legacyForwarding": 14
   },
-  "status": "green"
+  "status": "active"
 }'
 orionCurl --url /v2/registrations --payload "$payload"
 echo
@@ -885,7 +885,7 @@ payload='{
     },
     "legacyForwarding": false
   },
-  "status": "green"
+  "status": "active"
 }'
 orionCurl --url /v2/registrations --payload "$payload"
 echo
@@ -1561,43 +1561,43 @@ Date: REGEX(.*)
 
 43. legacyForwarding missing
 ============================
-HTTP/1.1 400 Bad Request
-Content-Length: 114
+HTTP/1.1 501 Not Implemented
+Content-Length: 144
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "the field /legacyForwarding/ must be present as a boolean and set to /true/",
-    "error": "BadRequest"
+    "description": "Only NGSIv1-based forwarding supported at the present moment. Set explictely legacyForwarding to true",
+    "error": "NotImplemented"
 }
 
 
 44. legacyForwarding not a boolean
 ==================================
 HTTP/1.1 400 Bad Request
-Content-Length: 103
+Content-Length: 85
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "the field /legacyForwarding/ must be a boolean and set to /true/",
+    "description": "the field /legacyForwarding/ must be a boolean",
     "error": "BadRequest"
 }
 
 
 45. legacyForwarding set to false
 =================================
-HTTP/1.1 400 Bad Request
-Content-Length: 89
+HTTP/1.1 501 Not Implemented
+Content-Length: 144
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "the field /legacyForwarding/ must be set to /true/",
-    "error": "BadRequest"
+    "description": "Only NGSIv1-based forwarding supported at the present moment. Set explictely legacyForwarding to true",
+    "error": "NotImplemented"
 }
 
 


### PR DESCRIPTION
Adjusting legacyForwardingMode error message, as discussed previosuly on another PR.

At the same time, I've taken the opportunity to unhardwire a couple of values from render logic (in fact the hardwire stills, but at mongoBackend level, which is better).