### PR TITLE
Additional Functional test for querying non-primitive data

### DIFF
--- a/test/functionalTest/cases/3162_context_providers_legacy_non_primitive/query_for_arrays.test
+++ b/test/functionalTest/cases/3162_context_providers_legacy_non_primitive/query_for_arrays.test
@@ -1,0 +1,330 @@
+# Copyright 2018 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+#
+# Uncached/Cached query
+#
+# 01. Start the contextBroker 'CB'
+# 02. Start contextProvider 'CP' (contextBroker functioning as contextProvider)
+# 03. Register an entity/attribute E1/A1 in broker, with CP as providing application
+# 04. Update/APPEND E1/A1(=CP) in CP - this is a non-primitive element e.g. an Array
+# 05. Query CP for E1/A1
+# 06. Query broker for E1/A1 (will go to CP and it will work, A1=CP is returned)
+# 07. Update/APPEND E1/A2(=broker) in broker - this is also a non-primitive element e.g. an Array
+# 08. Query broker for E1/A2 (broker's local info is returned (A2=broker))
+# 09. Query E1 in CB
+
+--NAME--
+Query Redirect Operation
+
+--SHELL-INIT--
+dbInit CB
+dbInit CP1
+brokerStart CB 0
+brokerStart CP1 0
+
+
+--SHELL--
+echo "01. contextBroker running"
+echo "02. contextProvider running (contextBroker functioning as contextProvider)"
+echo
+echo
+
+echo "03. Register an entity/attribute E1/A1 in broker, with CP as providing application"
+url3="/v2/registrations"
+payload3='{
+  "description": "Register a E1/A1 with CP as provider",
+  "dataProvided": {
+    "entities": [
+      {
+        "id": "E1",
+        "type": "E"
+      }
+    ],
+    "attrs": [
+      "A1"
+    ]
+  },
+  "provider": {
+    "http": {
+      "url": "http://localhost:'$CP1_PORT'/v1"
+    },
+     "legacyForwarding": true
+  }
+}'
+orionCurl --url "$url3" --payload "$payload3"
+echo
+echo
+
+
+echo "04. Update/APPEND E1/A1(=CP) in CP"
+url4="/v1/updateContext"
+payload6='{
+  "contextElements": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E1",
+      "attributes": [
+        {
+          "name": "A1",
+          "type": "Array",
+          "value": ["Data", "from CP"]
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --url "$url4" --payload "$payload4" --port $CP1_PORT
+echo
+echo
+
+
+echo "05. Query CP for E1/A1"
+url5="/v1/queryContext"
+payload5='{
+  "entities": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E1"
+    }
+  ],
+  "attributes": [
+    "A1"
+  ]
+}'
+orionCurl --url "$url5" --payload "$payload5" --port $CP1_PORT
+echo
+echo
+
+
+echo "06. Query broker for E1/A1 (will go to CP and it should work, A1=CP array is returned)"
+orionCurl --url /v2/entities/E1/attrs/A1/value
+echo
+echo
+
+
+echo "07. Update/APPEND E1/A2(=broker) in broker"
+url7="/v1/updateContext"
+payload7='{
+  "contextElements": [
+    {
+      "type": "E",
+      "isPattern": "false",
+      "id": "E1",
+      "attributes": [
+        {
+          "name": "A2",
+          "type": "Array",
+          "value": ["Data", "from CB"]
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --url "$url7" --payload "$payload7"
+echo
+echo
+
+
+echo "08. Query broker for E1/A2 (will go to CB and should work, A2 array is returned)"
+orionCurl --url /v2/entities/E1/attrs/A2/value
+echo
+echo
+
+
+echo "09. Query E1 in CB - expect two arrays returned"
+orionCurl --url /v2/entities/E1
+echo
+echo
+
+
+--REGEXPECT--
+01. contextBroker running
+02. contextProvider running (contextBroker functioning as contextProvider)
+
+
+03. Register an entity/attribute E1/A1 in broker, with CP as providing application
+HTTP/1.1 200 OK
+Content-Length: 64
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "duration": "PT24H",
+    "registrationId": "REGEX([0-9a-f]{24})"
+}
+
+
+04. Update/APPEND E1/A1(=CP) in CP
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "Array",
+                        "value": ["Data", "from CP"]
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "E"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+05. Query CP for E1/A1
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "Array",
+                        "value": ["Data", "from CP"]
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "E"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+06. Query broker for E1/A1 (will go to CP and it will work, A1=CP is returned)
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "metadata": {},
+    "type": "Array",
+    "value": ["Data", "from CP"]
+}
+
+
+07. Update/APPEND E1/A2(=broker) in broker
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A2",
+                        "type": "Array",
+                        "value": ["Data", "from CB"]
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "E"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+08. Query broker for E1/A2 (will go to CB and should work, A2 array is returned)
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "metadata": {},
+    "type": "Array",
+    "value": ["Data", "from CB"]
+}
+
+09. Query E1 in CB - expect two arrays returned
+HTTP/1.1 200 OK
+Content-Length: 80
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A1": {
+        "metadata": {},
+        "type": "string",
+        "value": ["Data", "from CP"]
+    },
+    "A2": {
+        "metadata": {},
+        "type": "string",
+        "value": ["Data", "from CB"]
+    },
+    "id": "E1",
+    "type": "T1"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+brokerStop CP1
+
+dbDrop CB
+dbDrop CP1


### PR DESCRIPTION
* 01. Start the contextBroker 'CB'
* 02. Start contextProvider 'CP' (contextBroker functioning as contextProvider)
* 03. Register an entity/attribute E1/A1 in broker, with CP as providing application
* 04. Update/APPEND E1/A1(=CP) in CP - this is a non-primitive element e.g. an Array
* 05. Query CP for E1/A1
* 06. Query broker for E1/A1 (will go to CP and it will work, A1=CP is returned)
* 07. Update/APPEND E1/A2(=broker) in broker - this is also a non-primitive element e.g. an Array
* 08. Query broker for E1/A2 (broker's local info is returned (A2=broker))
* 09. Query E1 in CB

This highlights the issue #3162 . It is expected that 06, 08, 09 will fail as all non-primitive data are being returned as blanks at the moment.