### PR TITLE
Standardize Endpoint titles within the Apiary Definition.

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-rc-2018_04_30.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2018_04_30.apib
@@ -993,7 +993,7 @@ to keep your client decoupled from implementation details.
 
 # Group Entities
 
-### List entities [GET /v2/entities{?limit,offset,options,type,id,idPattern,typePattern,q,mq,georel,geometry,coords,attrs,metadata,orderBy}]
+### List Entities [GET /v2/entities{?limit,offset,options,type,id,idPattern,typePattern,q,mq,georel,geometry,coords,attrs,metadata,orderBy}]
 
 Retrieves a list of entities that match different criteria by id, type, pattern matching (either id or type)
 and/or those which match a query or geographical query (see [Simple Query Language](#simple_query_language) and 
@@ -1113,7 +1113,7 @@ Response code:
          }
         ]
 
-### Create entity [POST /v2/entities{?options}]
+### Create Entity [POST /v2/entities{?options}]
 
 The payload is an object representing the entity to be created. The object follows
 the JSON entity representation format (described in a "JSON Entity Representation" section).
@@ -1162,7 +1162,7 @@ Response:
 
 ## Entity by ID [/v2/entities/{entityId}{?type,attrs,options}]
 
-### Retrieve entity [GET /v2/entities/{entityId}{?type,attrs,metadata,options}]
+### Retrieve Entity [GET /v2/entities/{entityId}{?type,attrs,metadata,options}]
 
 The response is an object representing the entity identified by the ID. The object follows
 the JSON entity representation format (described in "JSON Entity Representation" section).
@@ -1222,7 +1222,7 @@ Response:
           }
         }
 
-### Retrieve entity attributes [GET /v2/entities/{entityId}/attrs{?type,attrs,metadata,options}]
+### Retrieve Entity Attributes [GET /v2/entities/{entityId}/attrs{?type,attrs,metadata,options}]
 
 This request is similar to retreiving the whole entity, however this one omits the `id` and `type`
 fields.
@@ -1283,7 +1283,7 @@ Response:
           }
         }
 
-### Update or append entity attributes [POST /v2/entities/{entityId}/attrs{?type,options}]
+### Update or Append Entity Attributes [POST /v2/entities/{entityId}/attrs{?type,options}]
 
 The request payload is an object representing the attributes to append or update. The object follows
 the JSON entity representation format (described in "JSON Entity Representation" section), except
@@ -1326,7 +1326,7 @@ Response:
 
 + Response 204
 
-### Update existing entity attributes [PATCH /v2/entities/{entityId}/attrs{?type,options}]
+### Update Existing Entity Attributes [PATCH /v2/entities/{entityId}/attrs{?type,options}]
 
 The request payload is an object representing the attributes to update. The object follows
 the JSON entity representation format (described in "JSON Entity Representation" section), except
@@ -1400,7 +1400,7 @@ Response:
 
 + Response 204
 
-### Remove entity [DELETE /v2/entities/{entityId}{?type}]
+### Remove Entity [DELETE /v2/entities/{entityId}{?type}]
 
 Delete the entity.
 
@@ -1449,7 +1449,7 @@ Response:
           "metadata": {}
         }
 
-### Update attribute data [PUT /v2/entities/{entityId}/attrs/{attrName}{?type}]
+### Update Attribute Data [PUT /v2/entities/{entityId}/attrs/{attrName}{?type}]
 
 The request payload is an object representing the new attribute data. Previous attribute data
 is replaced by the one in the request. The object follows the JSON representation for attributes
@@ -1481,7 +1481,7 @@ Response:
 + Response 200
 
 
-### Remove a single attribute [DELETE /v2/entities/{entityId}/attrs/{attrName}{?type}]
+### Remove a Single Attribute [DELETE /v2/entities/{entityId}/attrs/{attrName}{?type}]
 
 Removes an entity attribute.
 
@@ -1504,7 +1504,7 @@ Response:
 
 ## By Entity ID [/v2/entities/{entityId}/attrs/{attrName}/value?{type}]
 
-### Get attribute value [GET /v2/entities/{entityId}/attrs/{attrName}/value{?type}]
+### Get Attribute Value [GET /v2/entities/{entityId}/attrs/{attrName}/value{?type}]
 
 This operation returns the `value` property with the value of the attribute.
 
@@ -1539,7 +1539,7 @@ Response:
           "country": "Spain"
         }
 
-### Update attribute value [PUT /v2/entities/{entityId}/attrs/{attrName}/value{?type}]
+### Update Attribute Value [PUT /v2/entities/{entityId}/attrs/{attrName}/value{?type}]
 
 The request payload is the new attribute value.
 
@@ -1584,7 +1584,7 @@ Response:
 
 ## Entity types [/v2/types{?limit,offset,options}]
 
-### List entity types [GET /v2/types/{?limit,offset,options}]
+### List Entity Types [GET /v2/types/{?limit,offset,options}]
 
 If the `values` option is not in use, this operation returns a JSON array with the entity types.
 Each element is a JSON object with information about the type:
@@ -1780,7 +1780,7 @@ Notification rules are as follow:
 
 ## Subscription List [/v2/subscriptions]
 
-### List subscriptions [GET /v2/subscriptions{?limit,offset,options}]
+### List Subscriptions [GET /v2/subscriptions{?limit,offset,options}]
 
 Returns a list of all the subscriptions present in the system.
 
@@ -1889,7 +1889,7 @@ Response:
 
 ## Subscription By ID [/v2/subscriptions/{subscriptionId}]
 
-### Retrieve subscription [GET /v2/subscriptions/{subscriptionId}]
+### Retrieve Subscription [GET /v2/subscriptions/{subscriptionId}]
 
 The response is the subscription represented by a JSON object as described at the beginning of this
 section.
@@ -2040,7 +2040,7 @@ Not present if registration has never had a successful notification.
 
 ## Registration list [/v2/registrations]
 
-### List registrations [GET /v2/registrations{?limit,offset,options}]
+### List Registrations [GET /v2/registrations{?limit,offset,options}]
 
 Lists all the context provider registrations present in the system.
 

--- a/doc/apiary/v2/fiware-ngsiv2-rc-2018_04_30.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-rc-2018_04_30.apib
@@ -1584,7 +1584,7 @@ Response:
 
 ## Entity types [/v2/types{?limit,offset,options}]
 
-### Retrieve entity types [GET /v2/types/{?limit,offset,options}]
+### List entity types [GET /v2/types/{?limit,offset,options}]
 
 If the `values` option is not in use, this operation returns a JSON array with the entity types.
 Each element is a JSON object with information about the type:
@@ -1780,7 +1780,7 @@ Notification rules are as follow:
 
 ## Subscription List [/v2/subscriptions]
 
-### Retrieve subscriptions [GET /v2/subscriptions{?limit,offset,options}]
+### List subscriptions [GET /v2/subscriptions{?limit,offset,options}]
 
 Returns a list of all the subscriptions present in the system.
 
@@ -1841,7 +1841,7 @@ Response:
         ]
 
 
-### Create a new subscription [POST /v2/subscriptions]
+### Create Subscription [POST /v2/subscriptions]
 
 Creates a new subscription.
 The subscription is represented by a JSON object as described at the beginning of this section.
@@ -1937,7 +1937,7 @@ Response:
         }
 
 
-### Update subscription [PATCH /v2/subscriptions/{subscriptionId}]
+### Update Subscription [PATCH /v2/subscriptions/{subscriptionId}]
 
 Only the fields included in the request are updated in the subscription.
 
@@ -2040,9 +2040,9 @@ Not present if registration has never had a successful notification.
 
 ## Registration list [/v2/registrations]
 
-### Retrieve registrations [GET /v2/registrations{?limit,offset,options}]
+### List registrations [GET /v2/registrations{?limit,offset,options}]
 
-Lists all the registrations present in the system.
+Lists all the context provider registrations present in the system.
 
 + Parameters
     + limit: 10 (optional, number) - Limit the number of registrations to be retrieved
@@ -2092,9 +2092,9 @@ Response:
           }
         ]
 
-### Create a new context provider registration [POST /v2/registrations]
+### Create Registration [POST /v2/registrations]
 
-Creates a new registration. This is typically used for binding context sources
+Creates a new context provider registration. This is typically used for binding context sources
 as providers of certain data.
 The registration is represented by a JSON object as described at the beginning of this section.
 
@@ -2134,7 +2134,7 @@ Response:
 
 ## Registration By ID [/v2/registrations/{registrationId}]
 
-### Retrieve context provider registration [GET /v2/registrations/{registrationId}]
+### Retrieve Registration [GET /v2/registrations/{registrationId}]
 
 The response is the registration represented by a JSON object as described at the beginning of this
 section.
@@ -2180,7 +2180,7 @@ Response:
             }
       }      
 
-### Update context provider registration [PATCH /v2/registrations/{registrationId}]
+### Update Registration [PATCH /v2/registrations/{registrationId}]
 
 Only the fields included in the request are updated in the registration.
 
@@ -2201,9 +2201,9 @@ Response:
 
 + Response 204
 
-### Delete context provider registration [DELETE /v2/registrations/{registrationId}]
+### Delete Registration [DELETE /v2/registrations/{registrationId}]
 
-Cancels registration.
+Cancels a context provider registration.
 
 Response:
 


### PR DESCRIPTION
This is a very minor documentation fix, but will help third-party developers down the line. Currently the titles for the endpoint names within the Apiary definition are inconsistent: for example list/retrieve are not used consistently. Without standard naming conventions Developers using `swagger-code-gen `can generate a simple NGSI proxy library, but this will be stuck  with inconsistent function names, making the generated library difficult to  use.

This PR amends the following: 

* Use list + Plural  for  GET calls that retrieve multiple entities
* Use get + Singular for GET calls that retrieve single entities
* Use create + Singular for POST calls that create single entities
* Use verb + Registration for all registration endpoints 

The reason for suggesting this standardization here is as follows:

* The Apiary definition is the ultimate source of truth - it is used to create the Swagger file for the NGSI specification hosted elsewhere.
* The third level headings defined within the Apiary file are copied over to the summary field in the Swagger definition
* swagger-code-gen uses the summary field to generate the names of its functions in each language.

I assume this change needs to be made to the April 2018 file first, before it can be copied over to the stable standard.



