### PR TITLE
FIX mongo URL construction in harnessFunctions.sh

### DIFF
--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -145,7 +145,7 @@ function dbInit()
   fi
 
   dMsg "database to drop: <$db>" 
-  echo 'db.dropDatabase()' | mongo $host:$port/$db --quiet
+  echo 'db.dropDatabase()' | mongo mongodb://$host:$port/$db --quiet
 }
 
 
@@ -186,9 +186,9 @@ function dbList
 
   if [ "$name" != "" ]
   then
-    echo show dbs | mongo $host:$port --quiet | grep "$name" | awk '{ print $1 }'
+    echo show dbs | mongo mongodb://$host:$port --quiet | grep "$name" | awk '{ print $1 }'
   else
-    echo show dbs | mongo $host:$port --quiet | awk '{ print $1 }'
+    echo show dbs | mongo mongodb://$host:$port --quiet | awk '{ print $1 }'
   fi
 }
 
@@ -212,7 +212,7 @@ function dbResetAll()
     port="27017"
   fi
   
-  all=$(echo show dbs | mongo $host:$port --quiet | grep ftest | awk '{ print $1 }')
+  all=$(echo show dbs | mongo mongodb://$host:$port --quiet | grep ftest | awk '{ print $1 }')
   for db in $all
   do
     dbDrop $db
@@ -914,7 +914,7 @@ function mongoCmd()
 
   db=$1
   cmd=$2
-  echo $cmd | mongo $host:$port/$db | tail -n 2 | head -n 1
+  echo $cmd | mongo mongodb://$host:$port/$db | tail -n 2 | head -n 1
 }
 
 # ------------------------------------------------------------------------------
@@ -969,7 +969,7 @@ function dbInsertEntity()
     port="27017"
   fi
 
-  echo "$jsCode ; $ent ; $doc ; $cmd" | mongo $host:$port/$db
+  echo "$jsCode ; $ent ; $doc ; $cmd" | mongo mongodb://$host:$port/$db
 }
 
 


### PR DESCRIPTION
Maybe this error only happens with modern versions of the mongo shell. I have faced it just after upgrading my mongo package, when all test start to fail due to `dbInit` caused:

```
2018-06-11T15:40:08.988+0200 I NETWORK  [thread1] getaddrinfo("ftest") failed: Name or service not known
2018-06-11T15:40:08.989+0200 E QUERY    [thread1] Error: couldn't initialize connection to host ftest, address is invalid :
connect@src/mongo/shell/mongo.js:240:13
```

I guess that it will not hurt to people using old versions of the mongo shell but it would be a good idea to check with some other system before merging this. Any feedback?

