### PR TITLE
FIX documentation regaring lowercase actionTypes for NGSIv2

### DIFF
--- a/doc/manuals/deprecated.md
+++ b/doc/manuals/deprecated.md
@@ -15,7 +15,8 @@ not mantained or evolved any longer. In particular:
 
 A list of deprecated features and the version in which they were deprecated follows:
 
-
+* Usage of that is `APPEND`, `APPEND_STRICT`, `UPDATE`, `DELETE` and `REPLACE` in `POST /v2/op/update` is
+  deprecated in Orion 1.14.0. Use `append`, `appendStrict`, `update`, `delete` and `replace` counterparts.
 * Metadata ID is deprecated in Orion 1.13.0. On the one hand, this functionality is not compatible with the
   NGSIv2 JSON representation format (attribute names are used as keys in a JSON object, so names cannot be
   duplicated). On the other hand, IDs can easily be implemented using prefixes/suffixes in attribute names,
@@ -70,6 +71,7 @@ The following table provides information about the last Orion version supporting
 
 | **Removed feature**                                                        | **Last Orion version supporting feature** | **That version release date**   |
 |----------------------------------------------------------------------------|-------------------------------------------|---------------------------------|
+| `APPEND`, `UPDATE`, etc. action types in `POST /v2/op/update`              | Not yet defined                           | Not yet defined                 |
 | `dateCreated` and `dateModified` in `options` URI parameter                | Not yet defined                           | Not yet defined                 |
 | `/ngsi10` and `/ngsi9` URL prefixes                                        | Not yet defined                           | Not yet defined                 |
 | `location` metadata to specify entity location                             | Not yet defined                           | Not yet defined                 |

--- a/doc/manuals/devel/cookbook.md
+++ b/doc/manuals/devel/cookbook.md
@@ -161,7 +161,7 @@ The `entity id`, `attribute name`, and `metadata name` (all part of the URL path
 All service routines that modify/create entities/attributes/metadata rely on the NGSIv1 service routine `postUpdateContext()`, and `putMetadata()` is no exception. So, what needs to be done in `putMetadata()` is to build a `UpdateContextRequest` object using the parameters of `putMetadata()` and call `postUpdateContext()`. Something like this:
 
 ```
-  parseDataP->upcr.res.fill(entityId, attributeName, metadataName, "APPEND");  
+  parseDataP->upcr.res.fill(entityId, attributeName, metadataName, ActionTypeAppend);
   postUpdateContext(ciP, components, compV, parseDataP, NGSIV2_FLAVOUR_ONAPPEND);    
 ```
 

--- a/doc/manuals/user/update_action_types.md
+++ b/doc/manuals/user/update_action_types.md
@@ -1,13 +1,13 @@
 # Update action types
 
 Both `POST /v1/updateContext` (NGSIv1) and `POST /v2/op/update` use an `actionType` field.
-This field allows the following values:
+Its value is as follows:
 
-* [APPEND](#append)
-* [APPEND_STRICT](#append_strict)
-* [UPDATE](#update)
-* [DELETE](#delete)
-* [REPLACE](#replace)
+* [`append`](#append) (NGSIv2) or `APPEND` (NGSIv1)
+* [`appendStrict`](#appendstrict) (NGSIv2) or `APPEND_STRICT` (NGSIv1)
+* [`update`](#update) (NGSIv2) or `UPDATE` (NGSIv1)
+* [`delete`](#delete) (NGSIv2) or `DELETE` (NGSIv1)
+* [`replace`](#replace) (NGSIv2) or `REPLACE` (NGSIv1)
 
 The actionType values are described in following subsections. 
 In the case of NGSIv2, equivalences to RESTful operations are described as well
@@ -15,30 +15,30 @@ In the case of NGSIv2, equivalences to RESTful operations are described as well
 Similar equivalences exist as convenicence operations in the case of NGSIv1 (the 
 [final example](#example-about-creation-and-removal-of-attributes-in-ngsiv1) illustrates them).
 
-## APPEND
+## `append`
 
 This action type is used for creation of entities, creation of attributes in existing entities
-and for updating existing attributes in existing entities. In the latter case, it is equal to UPDATE.
+and for updating existing attributes in existing entities. In the latter case, it is equal to `update`.
 
 In NGSIv2 it maps to `POST /v2/entities` (if the entity does not already exist)
 or `POST /v2/entities/<id>/attrs` (if the entity already exists).
 
-## APPEND_STRICT
+## `appendStrict`
 
 This action type is used for creation of entities or attributes in existing entities.
-Attempts to use it to update already existing attributes (as APPEND allows) will result in an error.
+Attempts to use it to update already existing attributes (as  `append` allows) will result in an error.
 
 In NGSIv2 it maps to `POST /v2/entities` (if the entity does not already exist)
 or `POST /v2/entities/<id>/attrs?options=append` (if the entity already exists).
 
-## UPDATE
+## `update`
 
 This action type is used for modification of already existing attributes. Attempts to use it to create
-new entities or attributes (as APPEND or APPEND_STRICT allow) will result in an error.
+new entities or attributes (as `append` or `appendStrict` allow) will result in an error.
 
 In NGSIv2 it maps to `PATCH /v2/entities/<id>/attrs`.
 
-## DELETE
+## `delete`
 
 This action type is used for removal of attributes in existing entities (but without removing the
 entity itself) or for deletion of entities.
@@ -46,7 +46,7 @@ entity itself) or for deletion of entities.
 In NGSIv2 it maps to `DELETE /v2/entities/<id>/attrs/<attrName>` on every attribute included
 in the entity or to `DELETE /v2/entities/<id>` if the entity has no attributes.
 
-## REPLACE
+## `replace`
 
 This action type is used for replacement of attributes in existing entities, i.e. all the existing attributes are
 removed and the ones included in the request are added.

--- a/doc/manuals/user/walkthrough_apiv2.md
+++ b/doc/manuals/user/walkthrough_apiv2.md
@@ -955,7 +955,7 @@ For example, to create Room3 (temperature 21.2 and pressure 722) and Room4
 ```
 curl -v localhost:1026/v2/op/update -s -S -H 'Content-Type: application/json' -d @- <<EOF
 {
-  "actionType": "APPEND",
+  "actionType": "append",
   "entities": [
     {
       "type": "Room",
@@ -987,14 +987,14 @@ EOF
 ```
 
 The response uses HTTP response code 204 No Content. In this case we are using
-APPEND `actionType`, which is for adding entities and attribute. We can also use
-UPDATE to change an attribute in one entity (temperature in Room3) and another
+`append` `actionType`, which is for adding entities and attribute. We can also use
+`update` to change an attribute in one entity (temperature in Room3) and another
 attribute in other (pressure in Room4), leaving the other attributes untouched.
 
 ```
 curl -v localhost:1026/v2/op/update -s -S -H 'Content-Type: application/json' -d @- <<EOF
 {
-  "actionType": "UPDATE",
+  "actionType": "udpate",
   "entities": [
     {
       "type": "Room",
@@ -1017,7 +1017,7 @@ curl -v localhost:1026/v2/op/update -s -S -H 'Content-Type: application/json' -d
 EOF
 ```
 
-Apart from APPEND and UPDATE, there are other action types: DELETE, APPEND_STRICT, etc. Check out
+Apart from `append` and `update`, there are other action types: `delete`, `appendStrict`, etc. Check out
 [this section](update_action_types.md) for details.
 
 Finally, the `POST /v2/op/query` allows to retrieve entities matching a query condition


### PR DESCRIPTION
This was done in Orion 1.14.0 but I have found some issues in the documentation that this PR tries to solve.