### PR TITLE
NGSIv2 fwd details

### DIFF
--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -1935,7 +1935,7 @@ of certain subsets (entities, attributes) of the context information space, incl
 at specific geographical areas.
 
 A NGSIv2 server implementation may implement query or update forwarding to context information sources. In
-particular, some of the following forwarding mechanism could be implemented (not exahustive list):
+particular, some of the following forwarding mechanisms could be implemented (not exahustive list):
 
 * Legacy forwarding (based on NGSIv1 operations)
 * NGSI Context Source Forwarding Specification
@@ -1957,7 +1957,7 @@ Either `active` (for active registrations) or `inactive` (for inactive registrat
   As soon as the forwarding operations start working again, the status is changed back to `active`.
 + `expires` : Registration expiration date in ISO8601 format. Permanent registrations must omit this field.
 + `forwardingInformation`: Information related to the forwarding operations made against the provider.
-Automatically provided by the implementation, in the case such implementation support forwarding capabilities.
+Automatically provided by the implementation, in the case such implementation supports forwarding capabilities.
 
 The `provider` field contains the following subfields:
 + `http` : It is used to convey parameters for providers that deliver information through the HTTP protocol.

--- a/doc/apiary/v2/fiware-ngsiv2-reference.apib
+++ b/doc/apiary/v2/fiware-ngsiv2-reference.apib
@@ -1933,18 +1933,14 @@ A Context Registration allows to bind external context information sources so th
 play the role of providers
 of certain subsets (entities, attributes) of the context information space, including those located
 at specific geographical areas.
-A compliant Context Information provider shall expose an NGSIv2 interface, in particular:
 
-* Query by entity type(s), entity id(s), geoquery and attribute and/or metadata projection
-(`attrs` or `metadata` parameter). (See `GET /v2/entities`)
-* Update entity attributes (See `PATCH /v2/entities/<entityId>/attrs`)
+A NGSIv2 server implementation may implement query or update forwarding to context information sources. In
+particular, some of the following forwarding mechanism could be implemented (not exahustive list):
 
-When the entities or attributes covered by an active registered provider are subject of a query or
-update operation, and the registrations allow to forward requests, 
-implementations must forward a request to such a registered context provider so that it can provide
-the requested data or update it.
-The forwarding algorithm and precise implementation details are work to be completed
-in a future version of this specification. (*TODO*)
+* Legacy forwarding (based on NGSIv1 operations)
+* NGSI Context Source Forwarding Specification
+
+Please check the corresponding specification in order to get the details.
 
 A context registration is represented by a JSON object with the following fields:
 
@@ -1961,7 +1957,7 @@ Either `active` (for active registrations) or `inactive` (for inactive registrat
   As soon as the forwarding operations start working again, the status is changed back to `active`.
 + `expires` : Registration expiration date in ISO8601 format. Permanent registrations must omit this field.
 + `forwardingInformation`: Information related to the forwarding operations made against the provider.
-Automatically provided by the implementation. 
+Automatically provided by the implementation, in the case such implementation support forwarding capabilities.
 
 The `provider` field contains the following subfields:
 + `http` : It is used to convey parameters for providers that deliver information through the HTTP protocol.

--- a/doc/manuals/user/ngsiv2_implementation_notes.md
+++ b/doc/manuals/user/ngsiv2_implementation_notes.md
@@ -409,7 +409,7 @@ According to NGSIv2 specification:
 
 > A NGSIv2 server implementation may implement query or update forwarding to context information sources.
 
-The way in which Orion implement such forwarding is as follows:
+The way in which Orion implements such forwarding is as follows:
 
 Orion implements an additional field `legacyForwarding` (within `provider`) not included in NGSIv2
 specification. If the value of `legacyForwarding` is `true` then NGSIv1-based query/update will be used

--- a/doc/manuals/user/ngsiv2_implementation_notes.md
+++ b/doc/manuals/user/ngsiv2_implementation_notes.md
@@ -405,6 +405,12 @@ for the following aspects:
   but the registration is always active, even when the value is `inactive`. Please see
   [this issue](https://github.com/telefonicaid/fiware-orion/issues/3108) about it.
 
+According to NGSIv2 specification:
+
+> A NGSIv2 server implementation may implement query or update forwarding to context information sources.
+
+The way in which Orion implement such forwarding is as follows:
+
 Orion implements an additional field `legacyForwarding` (within `provider`) not included in NGSIv2
 specification. If the value of `legacyForwarding` is `true` then NGSIv1-based query/update will be used
 for forwarding requests associated to that registration. However, for the time being, NGSIv2-based


### PR DESCRIPTION
This PR modified the registrations part in order to delegate the forwarding aspects to external specification. At the end (given the existence of a separate "NGSI Context Source Forwarding Specification") I understand it is the proper way of dealing with this.