### PR TITLE
FIX quick fix for the large integer wrong rendering in responses problem

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - Add: "attrs" field in POST /v2/op/query (making "attributes" obsolete) (#2604)
 - Add: "expression" field in POST /v2/op/query (#2706)
 - Remove: "scopes" field in POST /v2/op/query (#2706)
+- Fix: large integer wrong rendering in responses (#2603)

--- a/src/lib/common/string.cpp
+++ b/src/lib/common/string.cpp
@@ -1024,6 +1024,7 @@ unsigned int decimalDigits(double d)
 */
 template <> std::string toString(double f)
 {
+#if 0
   std::ostringstream ss;
 
   unsigned int digits = decimalDigits(f);
@@ -1035,6 +1036,51 @@ template <> std::string toString(double f)
   ss << f;
 
   return ss.str();
+#else
+
+  // This is a quick fix, while discussion on https://github.com/apinf/fiware-orion/pull/32 continues
+
+  char  buf[STRING_SIZE_FOR_DOUBLE];
+  int bufSize = sizeof(buf);
+
+  long long  intPart   = (long long) f;
+  double     diff      = f - intPart;
+  bool       isInteger = false;
+
+  // abs value for 'diff'
+  diff = (diff < 0)? -diff : diff;
+
+  if (diff > 0.9999999998)
+  {
+    intPart += 1;
+    isInteger = true;
+  }
+  else if (diff < 0.000000001)  // it is considered an integer
+  {
+    isInteger = true;
+  }
+
+  if (isInteger)
+  {
+    snprintf(buf, bufSize, "%lld", intPart);
+  }
+  else
+  {
+    snprintf(buf, bufSize, "%.9f", f);
+
+    // Clear out any unwanted trailing zeroes
+    char* last = &buf[strlen(buf) - 1];
+
+    while ((*last == '0') && (last != buf))
+    {
+      *last = 0;
+      --last;
+    }
+  }
+
+  return std::string(buf);
+
+#endif
 }
 
 

--- a/test/functionalTest/cases/2176_not_print_spurious_decimals/one_to_nine_decimals.test
+++ b/test/functionalTest/cases/2176_not_print_spurious_decimals/one_to_nine_decimals.test
@@ -116,14 +116,14 @@ Date: REGEX(.*)
 03. Get E1 (A10 get rounded to next integer)
 ============================================
 HTTP/1.1 200 OK
-Content-Length: 152
+Content-Length: 136
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "A1": 42.9,
-    "A10": 43.0,
+    "A10": 43,
     "A2": 42.99,
     "A3": 42.999,
     "A4": 42.9999,
@@ -138,7 +138,7 @@ Date: REGEX(.*)
 04. Get E2 (A10 get rounded to previous integer)
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 132
+Content-Length: 126
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/functionalTest/cases/2383_round_number_to_nine_digits/round_number_to_nine_digits.test
+++ b/test/functionalTest/cases/2383_round_number_to_nine_digits/round_number_to_nine_digits.test
@@ -76,7 +76,7 @@ Date: REGEX(.*)
 02. Get entity, getting the 7 digits
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 135
+Content-Length: 131
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)


### PR DESCRIPTION
This is a fix for #2603. However, this is considered a quick fix (note the `#if/#else` blocks), given there is ongoing discussion yet (see https://github.com/apinf/fiware-orion/pull/32).