### PR TITLE
Fix CI retval for compliance job (and some additional polishing on the CI work)

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,12 +1,12 @@
 ## Overview
 Travis is enabled in this repository so each pull request is checked before being allowed to merge.
-The system is based on fiware/orion-ci:rpm7 which is built from master branch each time a new PR lands in master,
+The system is based on `fiware/orion-ci:rpm7` which is built from master branch each time a new PR lands in master,
 providing a clean environment with all build dependencies onboard. The Dockerfile used to build this docker is available
-in the ci/rpm7 directory.
+in the `ci/rpm7` directory.
 
-Note that fiware/orion-ci:rpm7 is *not* rebuilt due to changes in the PR branch under test. Thus, if you are developing
+Note that `fiware/orion-ci:rpm7` is *not* rebuilt due to changes in the PR branch under test. Thus, if you are developing
 a functionality that requires a new library or base system you need to do *first* a PR adding such library or base system
-to ci/rpm7/build-dep.sh and/or Dockerfile. Once that PR gets merged into master and fiware/orion-ci:rpm7 gets rebuild 
+to `ci/rpm7/build-dep.sh` and/or `Dockerfile`. Once that PR gets merged into master and `fiware/orion-ci:rpm7` gets rebuild 
 (checking progress in Dockerhub at: https://hub.docker.com/r/fiware/orion-ci/builds) your PR branch with the new 
 functionality is ready to be tested with travis. 
 
@@ -24,11 +24,11 @@ File compliance, payload and style checks are combined in one 'compliance' test.
 
 ## Changes in tests
 
-There is an special function in build.sh script named `_fix_tests()` which purpose is to do some on-the-fly adaptations
+There is an special function in `build.sh` script named `_fix_tests()` which purpose is to do some on-the-fly adaptations
 in order to make functional test to work under travis. In particular:
 
 * Test under `3000_allow_creation_transient_entities` reduce internal wait delay from 60 to 3 seconds. In addition, MongoDB
   TTL monitor thread sleep interval is changed to 3 seconds by configuration. This is needed to reduce the testing time, so
   it can fix in the 50 minutes hard limit used by travis.
 
-The work done by `_fix_tests` is rolled-back by the `_unfix_tests()` function.
+The work done by `_fix_tests()` is rolled-back by the `_unfix_tests()` function.

--- a/ci/README.md
+++ b/ci/README.md
@@ -17,6 +17,12 @@ Current version of CI supports:
 File compliance, payload and style checks are combined in one 'compliance' test.
 
 ## Changes in tests
-Special function named _fix_tests is created in build.sh to reduce the time that is spent on function tests because of travis time limits.
-This tests changed:
-* 3000_allow_creation_transient_entities
+
+There is an special function in build.sh script named `_fix_tests()` which purpose is to do some on-the-fly adaptations
+in order to make functional test to work under travis. In particular:
+
+* Test under `3000_allow_creation_transient_entities` reduce internal wait delay from 60 to 3 seconds. In addition, MongoDB
+  TTL monitor thread sleep interval is changed to 3 seconds by configuration. This is needed to reduce the testing time, so
+  it can fix in the 50 minutes hard limit used by travis.
+
+The work done by `_fix_tests` is rolled-back by the `_unfix_tests()` function.

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,8 +1,14 @@
 ## Overview
 Travis is enabled in this repository so each pull request is checked before being allowed to merge.
-The system is based on fiware/orion-ci:rpm7  which is built from master branch each time a new PR lands in master,
+The system is based on fiware/orion-ci:rpm7 which is built from master branch each time a new PR lands in master,
 providing a clean environment with all build dependencies onboard. The Dockerfile used to build this docker is available
 in the ci/rpm7 directory.
+
+Note that fiware/orion-ci:rpm7 is *not* rebuilt due to changes in the PR branch under test. Thus, if you are developing
+a functionality that requires a new library or base system you need to do *first* a PR adding such library or base system
+to ci/rpm7/build-dep.sh and/or Dockerfile. Once that PR gets merged into master and fiware/orion-ci:rpm7 gets rebuild 
+(checking progress in Dockerhub at: https://hub.docker.com/r/fiware/orion-ci/builds) your PR branch with the new 
+functionality is ready to be tested with travis. 
 
 The Travis checks are divided into stages, which are described in "Supported tests" section.
 

--- a/ci/rpm7/build-dep.sh
+++ b/ci/rpm7/build-dep.sh
@@ -69,6 +69,8 @@ curl -L https://nexus.lab.fiware.org/repository/raw/public/storage/gmock-1.5.0.t
 && make install \
 && rm -Rf /opt/gmock-1.5.0
 
+# FIXME: the MQTT notification work is yet ongoing, so this is not needed yet. It should be aligned
+# which the same procedure described in "Build from source" documentation
 #curl -L http://mosquitto.org/files/source/mosquitto-1.5.tar.gz | tar xzC /opt/ \
 #  && cd /opt/mosquitto-1.5 \
 #  && make \

--- a/ci/rpm7/build.sh
+++ b/ci/rpm7/build.sh
@@ -281,7 +281,6 @@ fi
 if [ -n "${test}" ] && [ "${stage}" = "compliance" ]; then
     echo "===================================== COMPLIANCE TESTS ================================="
 
-    status=true
     _fix
 
     make files_compliance
@@ -291,11 +290,12 @@ if [ -n "${test}" ] && [ "${stage}" = "compliance" ]; then
     if [ $? -ne 0 ]; then status=false; fi
 
     make style
-    if [ "$(cat LINT | grep 'Total errors found' | awk '{ print $4 }')" != "0" ]; then  status=false; fi
+    if [ $? -ne 0 ]; then status=false; else status=true; fi
     rm -Rf LINT*
 
-    if ! ${status}; then echo "Builder: compliance test failed"; fi
     _unfix
+
+    if ! ${status}; then echo "Builder: compliance test failed"; exit 1; fi
 
 fi
 
@@ -304,9 +304,10 @@ if [ -n "${test}" ] && [ "${stage}" = "unit" ]; then
 
     _fix
     make unit
-    if [ $? -ne 0 ]; then echo "Builder: unit test failed"; exit 1; fi
+    if [ $? -ne 0 ]; then status=false; else status=true; fi
     _unfix
 
+    if ! ${status}; then echo "Builder: unit test failed"; exit 1; fi
 fi
 
 if [ -n "${test}" ] && [ "${stage}" = "functional" ]; then

--- a/ci/rpm7/build.sh
+++ b/ci/rpm7/build.sh
@@ -281,6 +281,7 @@ fi
 if [ -n "${test}" ] && [ "${stage}" = "compliance" ]; then
     echo "===================================== COMPLIANCE TESTS ================================="
 
+    status=true
     _fix
 
     make files_compliance
@@ -290,7 +291,7 @@ if [ -n "${test}" ] && [ "${stage}" = "compliance" ]; then
     if [ $? -ne 0 ]; then status=false; fi
 
     make style
-    if [ $? -ne 0 ]; then status=false; else status=true; fi
+    if [ $? -ne 0 ]; then status=false; fi
     rm -Rf LINT*
 
     _unfix


### PR DESCRIPTION
This PR is based on the work done in https://github.com/telefonicaid/fiware-orion/pull/3192. It fix the build.sh CI script retval for the compliance tests. In addition, it includes some minor fixing and enhance README.md.

The results are:

![imagen](https://user-images.githubusercontent.com/1534240/42046635-99628494-7afe-11e8-931f-67c8deea8d69.png)

It is ok test compliance file to fail, as compliance is broken in master branch (it will be fixes soon, the PR to achieve that already exists: https://github.com/telefonicaid/fiware-orion/pull/3230).

It is not ok that functional test to fail, but looking to the log, it seems to be a glitch and I don't pay too much importance. We'll fix in a separate PR if the problem stills.

Please @caa06d9c have a look and review.
