### PR TITLE
ADD dateExpires as builtin attribute

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,5 +1,5 @@
 - Add: upsert option for the POST /v2/entities operation (#3215)
-- Add: transient entities functionality (new reserved attribute: dateExpires) (#3000)
+- Add: transient entities functionality (new NGSIv2 builtin attribute: dateExpires) (#3000)
 - Add: "attrs" field in POST /v2/op/query (making "attributes" obsolete) (#2604)
 - Add: "expression" field in POST /v2/op/query (#2706)
 - Fix: large integer wrong rendering in responses (#2603)

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -105,6 +105,7 @@ std::string Entity::render
   }
 
   // Add special attributes representing entity dates
+  // Note 'uriParamOptions[DATE_CREATED/DATE_MODIFIED] ||' is needed due to backward compability
   if ((creDate != 0) && (uriParamOptions[DATE_CREATED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_CREATED) != attrsFilter.end())))
   {
     ContextAttribute* caP = new ContextAttribute(DATE_CREATED, DATE_TYPE, creDate);

--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -96,19 +96,12 @@
 
 /* ****************************************************************************
 *
-* virtual attributes
+* NGSIv2 builtin attributes
 */
 #define DATE_CREATED    "dateCreated"
 #define DATE_MODIFIED   "dateModified"
+#define DATE_EXPIRES    "dateExpires"
 #define ALL_ATTRS       "*"
-
-
-
-/* ****************************************************************************
-*
-* Transient entity attribute -
-*/
-#define DATE_EXPIRES "dateExpires"
 
 
 

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -159,6 +159,8 @@ std::string ContextAttributeVector::toJson
     return "";
   }
 
+  // Check if dateExipres has to be rendered or not
+  bool includeDateExpires = (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_EXPIRES) != attrsFilter.end());
 
   //
   // Pass 1 - count the total number of attributes valid for rendering.
@@ -183,6 +185,11 @@ std::string ContextAttributeVector::toJson
         continue;
       }
 
+      if ((vec[ix]->name == DATE_EXPIRES) && !includeDateExpires)
+      {
+        continue;
+      }
+
       if ((renderFormat == NGSI_V2_UNIQUE_VALUES) && (vec[ix]->valueType == orion::ValueTypeString))
       {
         if (uniqueMap[vec[ix]->stringValue] == true)
@@ -203,6 +210,11 @@ std::string ContextAttributeVector::toJson
   {
     for (std::vector<std::string>::const_iterator it = attrsFilter.begin(); it != attrsFilter.end(); ++it)
     {
+      if ((*it == DATE_EXPIRES) && !includeDateExpires)
+      {
+        continue;
+      }
+
       if (lookup(*it) != NULL)
       {
         ++validAttributes;
@@ -237,6 +249,11 @@ std::string ContextAttributeVector::toJson
         continue;
       }
 
+      if ((vec[ix]->name == DATE_EXPIRES) && !includeDateExpires)
+      {
+        continue;
+      }
+
       ++renderedAttributes;
 
       if ((renderFormat == NGSI_V2_UNIQUE_VALUES) && (vec[ix]->valueType == orion::ValueTypeString))
@@ -262,6 +279,11 @@ std::string ContextAttributeVector::toJson
       ContextAttribute* caP = lookup(*it);
       if (caP != NULL)
       {
+        if ((caP->name == DATE_EXPIRES) && !includeDateExpires)
+        {
+          continue;
+        }
+
         ++renderedAttributes;
         out += caP->toJson(renderedAttributes == validAttributes, renderFormat, metadataFilter);
       }

--- a/test/functionalTest/cases/3000_allow_creation_transient_entities/create_transient_entity.test
+++ b/test/functionalTest/cases/3000_allow_creation_transient_entities/create_transient_entity.test
@@ -80,18 +80,13 @@ Date: REGEX(.*)
 02. GET /v2/entities (see if entity is still present, expired but not yet removed)
 ==================================================================================
 HTTP/1.1 200 OK
-Content-Length: 107
+Content-Length: 25
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 [
     {
-        "dateExpires": {
-            "metadata": {},
-            "type": "DateTime",
-            "value": "2010-01-01T00:00:00.00Z"
-        },
         "id": "E1",
         "type": "T1"
     }

--- a/test/functionalTest/cases/3000_allow_creation_transient_entities/filter_by_date_expires.test
+++ b/test/functionalTest/cases/3000_allow_creation_transient_entities/filter_by_date_expires.test
@@ -78,18 +78,13 @@ Date: REGEX(.*)
 02. GET /v2/entities q=dateExpires>2010-01-01T00:00:00Z and get the entity
 ==========================================================================
 HTTP/1.1 200 OK
-Content-Length: 107
+Content-Length: 25
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 [
     {
-        "dateExpires": {
-            "metadata": {},
-            "type": "DateTime",
-            "value": "2028-01-01T00:00:00.00Z"
-        },
         "id": "E1",
         "type": "T1"
     }

--- a/test/functionalTest/cases/3000_allow_creation_transient_entities/filtering_in_out_date_expires.test
+++ b/test/functionalTest/cases/3000_allow_creation_transient_entities/filtering_in_out_date_expires.test
@@ -1,0 +1,371 @@
+# Copyright 2018 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Filtering in and out dateExpires builtin attribute
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity with attributes A, B and dateExpires
+# 02. GET /v2/entities/E and get A and B
+# 03. GET /v2/entities/E?attrs=dateExpires and get dateExpires
+# 04. GET /v2/entities/E?attrs=dateExpires,A and get dateExpires and A
+# 05. GET /v2/entities/E?attrs=dateExpires,* and get dateExpires, A and B
+# 06. POST /v2/op/query on E and get A and B
+# 07. POST /v2/op/query on E with attrs: [ dateExpires ] and get dateExpires
+# 08. POST /v2/op/query on E with attrs: [ dateExpires, A ] and get dateExpires and A
+# 09. POST /v2/op/query on E with attrs: [ dateExpires, * ] and get dateExpires, A and B
+#
+
+echo "01. Create entity with attributes A, B and dateExpires"
+echo "======================================================"
+payload='{
+    "id": "E",
+    "type": "T",
+    "dateExpires":{
+      "type": "DateTime",
+      "value": "2050-01-01T00:00:00Z"
+    },
+    "A": {
+      "type": "Text",
+      "value": "foo"
+    },
+    "B": {
+      "type": "Text",
+      "value": "bar"
+    }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. GET /v2/entities/E and get A and B"
+echo "======================================"
+orionCurl --url '/v2/entities/E'
+echo
+echo
+
+
+echo "03. GET /v2/entities/E?attrs=dateExpires and get dateExpires"
+echo "============================================================"
+orionCurl --url '/v2/entities/E?attrs=dateExpires'
+echo
+echo
+
+
+echo "04. GET /v2/entities/E?attrs=dateExpires,A and get dateExpires and A"
+echo "===================================================================="
+orionCurl --url '/v2/entities/E?attrs=dateExpires,A'
+echo
+echo
+
+
+echo "05. GET /v2/entities/E?attrs=dateExpires,* and get dateExpires, A and B"
+echo "======================================================================="
+orionCurl --url '/v2/entities/E?attrs=dateExpires,*'
+echo
+echo
+
+
+echo "06. POST /v2/op/query on E and get A and B"
+echo "=========================================="
+payload='{
+  "entities": [
+    {
+      "id": "E",
+      "type": "T"
+    }
+  ]
+}'
+orionCurl --url /v2/op/query --payload "$payload"
+echo
+echo
+
+
+echo "07. POST /v2/op/query on E with attrs: [ dateExpires ] and get dateExpires"
+echo "=========================================================================="
+payload='{
+  "entities": [
+    {
+      "id": "E",
+      "type": "T"
+    }
+  ],
+  "attrs": [ "dateExpires" ]
+}'
+orionCurl --url /v2/op/query --payload "$payload"
+echo
+echo
+
+
+echo "08. POST /v2/op/query on E with attrs: [ dateExpires, A ] and get dateExpires and A"
+echo "==================================================================================="
+payload='{
+  "entities": [
+    {
+      "id": "E",
+      "type": "T"
+    }
+  ],
+  "attrs": [ "dateExpires", "A" ]
+}'
+orionCurl --url /v2/op/query --payload "$payload"
+echo
+echo
+
+
+echo "09. POST /v2/op/query on E with attrs: [ dateExpires, * ] and get dateExpires, A and B"
+echo "======================================================================================"
+payload='{
+  "entities": [
+    {
+      "id": "E",
+      "type": "T"
+    }
+  ],
+  "attrs": [ "dateExpires", "*" ]
+}'
+orionCurl --url /v2/op/query --payload "$payload"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity with attributes A, B and dateExpires
+======================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. GET /v2/entities/E and get A and B
+======================================
+HTTP/1.1 200 OK
+Content-Length: 117
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Text",
+        "value": "foo"
+    },
+    "B": {
+        "metadata": {},
+        "type": "Text",
+        "value": "bar"
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+03. GET /v2/entities/E?attrs=dateExpires and get dateExpires
+============================================================
+HTTP/1.1 200 OK
+Content-Length: 103
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "dateExpires": {
+        "metadata": {},
+        "type": "DateTime",
+        "value": "2050-01-01T00:00:00.00Z"
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+04. GET /v2/entities/E?attrs=dateExpires,A and get dateExpires and A
+====================================================================
+HTTP/1.1 200 OK
+Content-Length: 151
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Text",
+        "value": "foo"
+    },
+    "dateExpires": {
+        "metadata": {},
+        "type": "DateTime",
+        "value": "2050-01-01T00:00:00.00Z"
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+05. GET /v2/entities/E?attrs=dateExpires,* and get dateExpires, A and B
+=======================================================================
+HTTP/1.1 200 OK
+Content-Length: 199
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Text",
+        "value": "foo"
+    },
+    "B": {
+        "metadata": {},
+        "type": "Text",
+        "value": "bar"
+    },
+    "dateExpires": {
+        "metadata": {},
+        "type": "DateTime",
+        "value": "2050-01-01T00:00:00.00Z"
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+06. POST /v2/op/query on E and get A and B
+==========================================
+HTTP/1.1 200 OK
+Content-Length: 119
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A": {
+            "metadata": {},
+            "type": "Text",
+            "value": "foo"
+        },
+        "B": {
+            "metadata": {},
+            "type": "Text",
+            "value": "bar"
+        },
+        "id": "E",
+        "type": "T"
+    }
+]
+
+
+07. POST /v2/op/query on E with attrs: [ dateExpires ] and get dateExpires
+==========================================================================
+HTTP/1.1 200 OK
+Content-Length: 105
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "dateExpires": {
+            "metadata": {},
+            "type": "DateTime",
+            "value": "2050-01-01T00:00:00.00Z"
+        },
+        "id": "E",
+        "type": "T"
+    }
+]
+
+
+08. POST /v2/op/query on E with attrs: [ dateExpires, A ] and get dateExpires and A
+===================================================================================
+HTTP/1.1 200 OK
+Content-Length: 153
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A": {
+            "metadata": {},
+            "type": "Text",
+            "value": "foo"
+        },
+        "dateExpires": {
+            "metadata": {},
+            "type": "DateTime",
+            "value": "2050-01-01T00:00:00.00Z"
+        },
+        "id": "E",
+        "type": "T"
+    }
+]
+
+
+09. POST /v2/op/query on E with attrs: [ dateExpires, * ] and get dateExpires, A and B
+======================================================================================
+HTTP/1.1 200 OK
+Content-Length: 201
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A": {
+            "metadata": {},
+            "type": "Text",
+            "value": "foo"
+        },
+        "B": {
+            "metadata": {},
+            "type": "Text",
+            "value": "bar"
+        },
+        "dateExpires": {
+            "metadata": {},
+            "type": "DateTime",
+            "value": "2050-01-01T00:00:00.00Z"
+        },
+        "id": "E",
+        "type": "T"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3000_allow_creation_transient_entities/filtering_in_out_date_expires_in_notifications.test
+++ b/test/functionalTest/cases/3000_allow_creation_transient_entities/filtering_in_out_date_expires_in_notifications.test
@@ -1,0 +1,479 @@
+# Copyright 2018 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Filtering in and out dateExpires builtin attribute in notifications
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create sub1 on E1 without attrs
+# 02. Create sub2 on E2 with attrs: [ dateExpires ]
+# 03. Create sub3 on E3 with attrs [ dateExpires, A ]
+# 04. Create sub4 on E4 with attrs: [ dateExpires, * ]
+# 05. Create E1 with attrs A, B and dateExpires
+# 06. Dump & reset accumulator: see E1 with A and B
+# 07. Create E2 with attrs A, B and dateExpires
+# 08. Dump & reset accumulator: see E2 with dateExpires
+# 09. Create E3 with attrs A, B and dateExpires
+# 10. Dump & reset accumulator: see E3 with dateExpires and A
+# 11. Create E4 with attrs A, B and dateExpires
+# 12. Dump & reset accumulator: see E4 with dateExpires and B
+#
+
+echo "01. Create sub1 on E1 without attrs"
+echo "==================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E1"
+      }
+    ]
+  },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create sub2 on E2 with attrs: [ dateExpires ]"
+echo "================================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E2"
+      }
+    ]
+  },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    },
+    "attrs": [ "dateExpires" ]
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "03. Create sub3 on E3 with attrs [ dateExpires, A ]"
+echo "==================================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E3"
+      }
+    ]
+  },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    },
+    "attrs": [ "dateExpires", "A" ]
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "04. Create sub4 on E4 with attrs: [ dateExpires, * ]"
+echo "===================================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E4"
+      }
+    ]
+  },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    },
+    "attrs": [ "dateExpires", "*" ]
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "05. Create E1 with attrs A, B and dateExpires"
+echo "============================================="
+payload='{
+    "id": "E1",
+    "type": "T",
+    "dateExpires":{
+      "type": "DateTime",
+      "value": "2050-01-01T00:00:00Z"
+    },
+    "A": {
+      "type": "Text",
+      "value": "foo"
+    },
+    "B": {
+      "type": "Text",
+      "value": "bar"
+    }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "06. Dump & reset accumulator: see E1 with A and B"
+echo "================================================="
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "07. Create E2 with attrs A, B and dateExpires"
+echo "============================================="
+payload='{
+    "id": "E2",
+    "type": "T",
+    "dateExpires":{
+      "type": "DateTime",
+      "value": "2050-01-01T00:00:00Z"
+    },
+    "A": {
+      "type": "Text",
+      "value": "foo"
+    },
+    "B": {
+      "type": "Text",
+      "value": "bar"
+    }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "08. Dump & reset accumulator: see E2 with dateExpires"
+echo "====================================================="
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "09. Create E3 with attrs A, B and dateExpires"
+echo "=============================================="
+payload='{
+    "id": "E3",
+    "type": "T",
+    "dateExpires":{
+      "type": "DateTime",
+      "value": "2050-01-01T00:00:00Z"
+    },
+    "A": {
+      "type": "Text",
+      "value": "foo"
+    },
+    "B": {
+      "type": "Text",
+      "value": "bar"
+    }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "10. Dump & reset accumulator: see E3 with dateExpires and A"
+echo "==========================================================="
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "11. Create E4 with attrs A, B and dateExpires"
+echo "============================================="
+payload='{
+    "id": "E4",
+    "type": "T",
+    "dateExpires":{
+      "type": "DateTime",
+      "value": "2050-01-01T00:00:00Z"
+    },
+    "A": {
+      "type": "Text",
+      "value": "foo"
+    },
+    "B": {
+      "type": "Text",
+      "value": "bar"
+    }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "12. Dump & reset accumulator: see E4 with dateExpires and B"
+echo "==========================================================="
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+--REGEXPECT--
+01. Create sub1 on E1 without attrs
+===================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub2 on E2 with attrs: [ dateExpires ]
+=================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Create sub3 on E3 with attrs [ dateExpires, A ]
+===================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Create sub4 on E4 with attrs: [ dateExpires, * ]
+====================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Create E1 with attrs A, B and dateExpires
+=============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. Dump & reset accumulator: see E1 with A and B
+=================================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 173
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Text",
+                "value": "foo"
+            },
+            "B": {
+                "metadata": {},
+                "type": "Text",
+                "value": "bar"
+            },
+            "id": "E1",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
+}
+=======================================
+
+
+07. Create E2 with attrs A, B and dateExpires
+=============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E2?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+08. Dump & reset accumulator: see E2 with dateExpires
+=====================================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 159
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+
+{
+    "data": [
+        {
+            "dateExpires": {
+                "metadata": {},
+                "type": "DateTime",
+                "value": "2050-01-01T00:00:00.00Z"
+            },
+            "id": "E2",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
+}
+=======================================
+
+
+09. Create E3 with attrs A, B and dateExpires
+==============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E3?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+10. Dump & reset accumulator: see E3 with dateExpires and A
+===========================================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 207
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Text",
+                "value": "foo"
+            },
+            "dateExpires": {
+                "metadata": {},
+                "type": "DateTime",
+                "value": "2050-01-01T00:00:00.00Z"
+            },
+            "id": "E3",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
+}
+=======================================
+
+
+11. Create E4 with attrs A, B and dateExpires
+=============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E4?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+12. Dump & reset accumulator: see E4 with dateExpires and B
+===========================================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 255
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Text",
+                "value": "foo"
+            },
+            "B": {
+                "metadata": {},
+                "type": "Text",
+                "value": "bar"
+            },
+            "dateExpires": {
+                "metadata": {},
+                "type": "DateTime",
+                "value": "2050-01-01T00:00:00.00Z"
+            },
+            "id": "E4",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+accumulatorStop


### PR DESCRIPTION
Finally it was decided to have `dateExpires` as NGSIv2 builtin attribute (see https://github.com/telefonicaid/fiware-orion/pull/3220). This involves some changes in the implementation.

@arigliano as author of the original implementation it would be great if you could review this PR and provide feedback/aproval. The changes are small, only in the rendering part (which check if dateExpires is in the `attrs` filter, omitting it in negative case). Thanks!