### PR TITLE
FIX GET /v2/subscriptions and GET /v2/subscriptions/{id} crashes for permanent subscriptions created before version 1.13.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Fix: GET /v2/subscriptions and GET /v2/subscriptions/{id} crashes for permanent subscriptions created before version 1.13.0 (#3256)
 - Hardening: Mongo driver now compiled using --use-sasl-client --ssl to enable proper DB authentication mechanisms

--- a/src/lib/apiTypesV2/Subscription.cpp
+++ b/src/lib/apiTypesV2/Subscription.cpp
@@ -72,7 +72,10 @@ std::string Subscription::toJson(void)
     jh.addString("description", this->description);
   }
 
-  if (this->expires != PERMANENT_EXPIRES_DATETIME)
+  // Orion versions previous to 1.13.0 where using (int64_t) 9e18 as expiration for permanent
+  // subscriptions. Now we use PERMANENT_EXPIRES_DATETIME, whichs is larger, but we need to be prepared
+  // for these old documents in DB (more info in issue #3256)
+  if (this->expires < (int64_t) 9e18)
   {
     jh.addDate("expires", this->expires);
   }


### PR DESCRIPTION
Fixes https://github.com/telefonicaid/fiware-orion/issues/3256