### PR TITLE
NGSIv2 rendering improvements (simplification, unification and performance)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,6 @@
 - Fix: GET /v2/subscriptions and GET /v2/subscriptions/{id} crashes for permanent subscriptions created before version 1.13.0 (#3256)
 - Hardening: Mongo driver now compiled using --use-sasl-client --ssl to enable proper DB authentication mechanisms
 - Fix: correct error payload using errorCode (previously orionError was used) in POST /v1/queryContext and POST /v1/updateContext in some cases
+- Fix: bug in metadata compound value rendering in NGSIv2 (sometimes "toplevel" key was wrongly inserted in the resulting JSON object)
 - Hardening: modification of the URL parsing mechanism, making it more efficient, and the source code easier to follow (#3109, step 1)
+- Hardening: refactor NGSIv2 rendering code (throughput increase up to 33%/365% in entities/subscriptions rendering intensive scenarios) (#1298)

--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -29,6 +29,7 @@
 #include "common/errorMessages.h"
 #include "common/RenderFormat.h"
 #include "common/string.h"
+#include "common/JsonHelper.h"
 #include "ngsi10/QueryContextResponse.h"
 #include "apiTypesV2/Attribute.h"
 
@@ -48,8 +49,7 @@ std::string Attribute::render
   HttpStatusCode*     scP,                 // out parameter (pass-through)
   bool                keyValues,           // in parameter
   const std::string&  metadataList,        // in parameter
-  RequestType         requestType,         // in parameter
-  bool                comma                // in parameter
+  RequestType         requestType          // in parameter
 )
 {
   RenderFormat  renderFormat = (keyValues == true)? NGSI_V2_KEYVALUES : NGSI_V2_NORMALIZED;
@@ -76,18 +76,16 @@ std::string Attribute::render
         stringSplit(metadataList, ',', metadataFilter);
       }
 
-      out = "{";
-
-      // First parameter (isLastElement) is 'true' as it is the last and only element
-      out += pcontextAttribute->toJson(true, renderFormat, metadataFilter, requestType);
-
-      out += "}";
-    }
-
-
-    if (comma)
-    {
-      out += ",";
+      if (renderFormat == NGSI_V2_KEYVALUES)
+      {
+        JsonHelper jh;
+        jh.addRaw(pcontextAttribute->name, pcontextAttribute->toJsonValue());
+        out = jh.str();
+      }
+      else // NGSI_V2_NORMALIZED
+      {
+        out = pcontextAttribute->toJson(metadataFilter);
+      }
     }
 
     return out;

--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -82,7 +82,7 @@ std::string Attribute::render
         jh.addRaw(pcontextAttribute->name, pcontextAttribute->toJsonValue());
         out = jh.str();
       }
-      else // NGSI_V2_NORMALIZED
+      else  // NGSI_V2_NORMALIZED
       {
         out = pcontextAttribute->toJson(metadataFilter);
       }

--- a/src/lib/apiTypesV2/Attribute.h
+++ b/src/lib/apiTypesV2/Attribute.h
@@ -61,8 +61,7 @@ class Attribute
                       HttpStatusCode*     scP,
                       bool                keyValues,
                       const std::string&  metadataList,
-                      RequestType         requestType,
-                      bool                comma = false);
+                      RequestType         requestType);
   void         fill(QueryContextResponse* qcrsP, std::string attrName);
 };
 

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -179,6 +179,7 @@ void Entity::filterAttributes
   if (!includeDateExpires && ((found = attributeVector.get(DATE_EXPIRES)) != -1))
   {
     attributeVector.vec[found]->release();
+    delete attributeVector.vec[found];
     attributeVector.vec.erase(attributeVector.vec.begin() + found);
   }
 }

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -116,9 +116,9 @@ void Entity::filterAttributes
     }
     else
     {
-      // Reorder attributes in the same order they are in attrsFilter, excluding the ones
-      // note there (i.e. filtering them out) and giving special treatment to creation
-      // and modification dates
+      // Reorder attributes in the same order they are in attrsFilter (attributes not
+      // in attrsFilter are filtered out). Creation and modification dates have a special
+      // treatment
       //
       // The (attributeVector.lookup(DATE_XXXX) == -1) check is to give preference to user
       // defined attributes (see
@@ -129,13 +129,13 @@ void Entity::filterAttributes
       for (unsigned int ix = 0; ix < attrsFilter.size(); ix++)
       {
         std::string attrsFilterItem = attrsFilter[ix];
-        if ((creDate != 0) && (attrsFilterItem == DATE_CREATED) && (attributeVector.lookup(DATE_CREATED) == -1))
+        if ((creDate != 0) && (attrsFilterItem == DATE_CREATED) && (attributeVector.get(DATE_CREATED) == -1))
         {
           ContextAttribute* caP = new ContextAttribute(DATE_CREATED, DATE_TYPE, creDate);
           caNewV.push_back(caP);
           dateCreatedAdded = true;
         }
-        else if ((modDate != 0) && (attrsFilterItem == DATE_MODIFIED) && (attributeVector.lookup(DATE_MODIFIED) == -1))
+        else if ((modDate != 0) && (attrsFilterItem == DATE_MODIFIED) && (attributeVector.get(DATE_MODIFIED) == -1))
         {
           ContextAttribute* caP = new ContextAttribute(DATE_MODIFIED, DATE_TYPE, modDate);
           caNewV.push_back(caP);
@@ -144,7 +144,7 @@ void Entity::filterAttributes
         // Actual attribute filtering only takes place if '*' was not used
         else
         {
-          int found = attributeVector.lookup(attrsFilterItem);
+          int found = attributeVector.get(attrsFilterItem);
           if (found != -1)
           {
             caNewV.push_back(attributeVector.vec[found]);
@@ -153,7 +153,7 @@ void Entity::filterAttributes
         }
       }
 
-      // All the remainder elements in attributeVector need to be released,
+      // All the remaining elements in attributeVector need to be released,
       // before overriding the vector with caNewV
       attributeVector.release();
 
@@ -161,7 +161,7 @@ void Entity::filterAttributes
     }
   }
 
-  // Legacy support for options=dateCreated and opations=dateModified
+  // Legacy support for options=dateCreated and options=dateModified
   if (dateCreatedOption && !dateCreatedAdded && (creDate != 0))
   {
     ContextAttribute* caP = new ContextAttribute(DATE_CREATED, DATE_TYPE, creDate);
@@ -173,10 +173,10 @@ void Entity::filterAttributes
     attributeVector.push_back(caP);
   }
 
-  // Removing dateExpires if not explictely included in the filter
+  // Removing dateExpires if not explicitly included in the filter
   bool includeDateExpires = (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_EXPIRES) != attrsFilter.end());
   int found;
-  if (!includeDateExpires && ((found = attributeVector.lookup(DATE_EXPIRES)) != -1))
+  if (!includeDateExpires && ((found = attributeVector.get(DATE_EXPIRES)) != -1))
   {
     attributeVector.vec[found]->release();
     attributeVector.vec.erase(attributeVector.vec.begin() + found);
@@ -308,7 +308,7 @@ std::string Entity::toJsonUniqueValues(void)
     out += ",";
   }
 
-  // The substrig trick removes the final ",". It is not very smart, but it saves
+  // The substring trick replaces final "," by "]". It is not very smart, but it saves
   // a second pass on the vector, once the "unicity" has been calculated in the hashmap
   return out.substr(0, out.length() - 1 ) + "]";
 }

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -72,10 +72,19 @@ Entity::~Entity()
 * dateCreatedOption and dateModifiedOption are due to deprecated ways of requesting
 * date in response. If used, the date is added at the end.
 *
-* FIXME P3: this methods is complex. It should be refactored
-* FIXME P3: maybe dateCreated and dateModified should be pre-included in the attributes
-* vector, so all three (dateCreated, dateModified and dateExpires) could be processed in
-* a similar way.
+* FIXME P7: some comments regarding this function
+*
+* - Code should be integrated with the one on ContextElement::filterAttributes(). However,
+*   this is probable a sub-task of the more general task of changing ContextElement to use
+*   Entity class internally
+* - The function is pretty long and complex. It should be refactored to simplify it
+* - Related with this simplification maybe dateCreated and dateModified should be pre-included
+*   in the attributes vector, so all three (dateCreated, dateModified and dateExpires) could be
+*   processed in a similar way.
+* - This function shouldn't be called from toJson() code. The mongoBackend should deal with
+*   attributeVector preparation. Thus, either we leave the function heare and mongoBackend calls
+*   Entity::filterAttributes() or the logic is moved to mongoBackend (to be decided when we face
+*   this FIXME).
 */
 void Entity::filterAttributes
 (
@@ -217,9 +226,8 @@ std::string Entity::render
   }
 
   // Get the effective vector of attributes to render
-  // FIXME PR: given this is "destructive", maybe this should be done before calling render logic, no in the render itself
-  // FIXME PR: this should be moved to mongoBackend, so it returns the entity as it has to be rendered... however, note that
-  // we are adding some attributes (DATE_MODIFIED and DATE_CREATED) here. Not sure how to solve it...
+  // FIXME P7: filterAttributes will be moved and invoking it would not be needed from toJson()
+  // (see comment in filterAttributes)
   filterAttributes(attrsFilter, uriParamOptions[DATE_CREATED], uriParamOptions[DATE_MODIFIED]);
 
   std::string out;

--- a/src/lib/apiTypesV2/Entity.h
+++ b/src/lib/apiTypesV2/Entity.h
@@ -83,9 +83,9 @@ class Entity
   void         hideIdAndType(bool hide = true);
 
  private:
-  void filterAttributes (const std::vector<std::string>&  attrsFilter,
-                         bool                             dateCreatedOption,
-                         bool                             dateModifiedOption);
+  void filterAttributes(const std::vector<std::string>&  attrsFilter,
+                        bool                             dateCreatedOption,
+                        bool                             dateModifiedOption);
 
   std::string toJsonValues(void);
   std::string toJsonUniqueValues(void);

--- a/src/lib/apiTypesV2/Entity.h
+++ b/src/lib/apiTypesV2/Entity.h
@@ -67,8 +67,7 @@ class Entity
   ~Entity();
 
   std::string  render(std::map<std::string, bool>&         uriParamOptions,
-                      std::map<std::string, std::string>&  uriParam,
-                      bool                                 comma = false);
+                      std::map<std::string, std::string>&  uriParam);
 
   std::string  check(RequestType requestType);
   void         release(void);
@@ -82,6 +81,16 @@ class Entity
 
   void         fill(QueryContextResponse* qcrsP);
   void         hideIdAndType(bool hide = true);
+
+ private:
+  void filterAttributes (const std::vector<std::string>&  attrsFilter,
+                         bool                             dateCreatedOption,
+                         bool                             dateModifiedOption);
+
+  std::string toJsonValues(void);
+  std::string toJsonUniqueValues(void);
+  std::string toJsonKeyvalues(void);
+  std::string toJsonNormalized(const std::vector<std::string>&  metadataFilter);
 };
 
 #endif  // SRC_LIB_APITYPESV2_ENTITY_H_

--- a/src/lib/apiTypesV2/EntityVector.cpp
+++ b/src/lib/apiTypesV2/EntityVector.cpp
@@ -57,11 +57,11 @@ std::string EntityVector::render
 
   std::string out;
 
-  out += "[";
+  out += "[" + vec[0]->render(uriParamOptions, uriParam);
 
-  for (unsigned int ix = 0; ix < vec.size(); ++ix)
+  for (unsigned int ix = 1; ix < vec.size(); ++ix)
   {
-    out += vec[ix]->render(uriParamOptions, uriParam, ix != vec.size() - 1);
+    out += "," + vec[ix]->render(uriParamOptions, uriParam);
   }
 
   out += "]";

--- a/src/lib/common/JsonHelper.h
+++ b/src/lib/common/JsonHelper.h
@@ -39,15 +39,15 @@ public:
   void        addString(const std::string& key, const std::string& value);
   void        addRaw(const std::string& key, const std::string& value);
   void        addNumber(const std::string& key, long long value);
-  void        addNumber(const std::string& key, float value);
+  void        addNumber(const std::string& key, double value);
   void        addDate(const std::string& key, long long timestamp);
   void        addBool(const std::string& key, bool b);
 
   std::string str();
 
 private:
- std::ostringstream ss;
- bool               empty;
+ std::string  ss;
+ bool         empty;
 };
 
 
@@ -74,15 +74,15 @@ std::string vectorToJson(std::vector<T> &list)
     return "[]";
   }
 
-  std::ostringstream ss;
+  std::string ss;
 
-  ss << '[' << list[0].toJson();
+  ss += '[' + list[0].toJson();
   for (size_type i = 1; i != list.size(); ++i)
   {
-    ss << ',' << list[i].toJson();
+    ss += ',' + list[i].toJson();
   }
-  ss << ']';
-  return ss.str();
+  ss += ']';
+  return ss;
 }
 
 template <>

--- a/src/lib/common/limits.h
+++ b/src/lib/common/limits.h
@@ -211,12 +211,4 @@
 
 
 
-/* ****************************************************************************
-*
-* Precision constants -
-*/
-#define PRECISION_DIGITS  9
-#define PRECISION         0.000000001  // it corresponds to 9 digits
-
-
 #endif  // SRC_LIB_COMMON_LIMITS_H_

--- a/src/lib/common/macroSubstitute.cpp
+++ b/src/lib/common/macroSubstitute.cpp
@@ -51,7 +51,7 @@ static void attributeValue(std::string* valueP, const std::vector<ContextAttribu
     }
     else if (vec[ix]->valueType == orion::ValueTypeNumber)
     {
-      *valueP = toString(vec[ix]->numberValue);
+      *valueP = double2string(vec[ix]->numberValue);
     }
     else if (vec[ix]->valueType == orion::ValueTypeBoolean)
     {
@@ -70,19 +70,7 @@ static void attributeValue(std::string* valueP, const std::vector<ContextAttribu
     {
       if (vec[ix]->compoundValueP)
       {
-        if (vec[ix]->compoundValueP->valueType == orion::ValueTypeVector)
-        {
-          *valueP = "[" + vec[ix]->compoundValueP->toJson(true, true) + "]";
-        }
-        else if (vec[ix]->compoundValueP->valueType == orion::ValueTypeObject)
-        {
-          *valueP = "{" + vec[ix]->compoundValueP->toJson(true, true) + "}";
-        }
-        else
-        {
-          LM_E(("Runtime Error (attribute is of object type but its compound is of invalid type)"));
-          *valueP = "";
-        }
+        *valueP = vec[ix]->compoundValueP->toJson(true);
       }
       else
       {

--- a/src/lib/common/string.cpp
+++ b/src/lib/common/string.cpp
@@ -925,121 +925,11 @@ bool str2double(const char* s, double* dP)
 
 /* ****************************************************************************
 *
-* decimalDigits
-*
-* This function counts the number of decimal digits of a given float, to a maximum of
-* PRECISION_DIGITS. The algorithm is inspired in http://stackoverflow.com/a/1083316/1485926
-* but with a "cutting condition" needed due to float representation may have an infinite
-* number of decimals, e.g. 3.14 could be internally coded as 3.1399999.
-*
-* FIXME #2425: this function is not perfect and could be improved. For example,
-* considering the following
-*
-*   "A1":  42.9,
-*   "A2":  42.99,
-*   "A3":  42.999,
-*   "A4":  42.9999,
-*   "A5":  42.99999,
-*   "A6":  42.999999,
-*   "A7":  42.9999999,
-*   "A8":  42.99999999,
-*   "A9":  42.999999999,
-*   "A10": 42.9999999999,,
-*
-*   "A1":  42.1,
-*   "A2":  42.01,
-*   "A3":  42.001,
-*   "A4":  42.0001,
-*   "A5":  42.00001,
-*   "A6":  42.000001,
-*   "A7":  42.0000001,
-*   "A8":  42.00000001,
-*   "A9":  42.000000001,
-*   "A10": 42.0000000001,
-*
-* what we get is:
-*
-*   "A1":  42.9,
-*   "A2":  42.99,
-*   "A3":  42.999,
-*   "A4":  42.9999,
-*   "A5":  42.99999,
-*   "A6":  42.999999000, (fail)
-*   "A7":  42.999999900, (fail)
-*   "A8":  42.999999990, (fail)
-*   "A9":  42.999999999,
-*   "A10": 43.000000000, (fail, although probably not due to this function but the caller)
-*
-*   "A1":  42.1,
-*   "A2":  42.01,
-*   "A3":  42.001,
-*   "A4":  42.0001,
-*   "A5":  42.00001,
-*   "A6":  42.000001000, (fail)
-*   "A7":  42.000000100, (fail)
-*   "A8":  42.000000010, (fail)
-*   "A9":  42,           (fail)
-*   "A10": 42,
+* double2string
 *
 */
-unsigned int decimalDigits(double d)
+std::string double2string(double f)
 {
-  unsigned int digits = 0;
-
-  double intPart;
-  double decimalPart = fabs(modf(d, &intPart));
-
-  while (decimalPart > PRECISION)
-  {
-    digits++;
-    decimalPart *= 10;
-    decimalPart = modf(decimalPart, &intPart);
-    if (fabs(1 - decimalPart ) < PRECISION)
-    {
-      // Using a greater threshold (e.g. 0.01) would cause rounding errors,
-      // e.g. 42.9999 -> 43. This can be easily checked with the
-      // cases/2176_not_print_spurious_decimals/one_to_nine_decimals.test test
-      // (try to use PRECISION * 10 and check how the test fails).
-      //
-      break;
-    }
-  }
-
-  if (digits > PRECISION_DIGITS)
-  {
-    return PRECISION_DIGITS;
-  }
-  else
-  {
-    return digits;
-  }
-}
-
-
-/* ****************************************************************************
-*
-* toString
-*
-* Specialized version of the template for the double type
-*/
-template <> std::string toString(double f)
-{
-#if 0
-  std::ostringstream ss;
-
-  unsigned int digits = decimalDigits(f);
-  if (digits > 0)
-  {
-    ss << std::fixed << std::setprecision(digits);
-  }
-
-  ss << f;
-
-  return ss.str();
-#else
-
-  // This is a quick fix, while discussion on https://github.com/apinf/fiware-orion/pull/32 continues
-
   char  buf[STRING_SIZE_FOR_DOUBLE];
   int bufSize = sizeof(buf);
 
@@ -1079,8 +969,6 @@ template <> std::string toString(double f)
   }
 
   return std::string(buf);
-
-#endif
 }
 
 

--- a/src/lib/common/string.h
+++ b/src/lib/common/string.h
@@ -166,39 +166,12 @@ extern std::string servicePathCheck(const char* servicePath);
 extern bool str2double(const char* s, double* dP = NULL);
 
 
-
-/* ****************************************************************************
+/*****************************************************************************
 *
-* decimalDigits
-*
-*/
-extern unsigned int decimalDigits(double d);
-
-
-
-/* ****************************************************************************
-*
-* toString -
-*
-* If the generic ostringstream-based implementation would have performance
-* problems in the future, a set of per-type specialized functions could be
-* used without changing the toString() usage interface from existing callers
-*
-* In fact, we currently have an specialized function for float, although not
-* due to performance (but due to special treatment of decimal numbers in the
-* float case)
+* double2string -
 *
 */
-template <typename T> std::string toString(T t)
-{      
-  std::ostringstream ss;
-
-  ss << t;
-
-  return ss.str();
-}
-
-template <> std::string toString(float f);
+extern std::string double2string(double f);
 
 
 

--- a/src/lib/common/tag.cpp
+++ b/src/lib/common/tag.cpp
@@ -152,7 +152,7 @@ char* htmlEscape(const char* s)
 */
 std::string jsonInvalidCharsTransformation(const std::string& input)
 {
-  std::ostringstream ss;
+  std::string ss;
 
   for (std::string::const_iterator iter = input.begin(); iter != input.end(); ++iter)
   {
@@ -175,13 +175,13 @@ std::string jsonInvalidCharsTransformation(const std::string& input)
      */
     switch (char ch = *iter)
     {
-    case '\\': ss << "\\\\"; break;
-    case '"':  ss << "\\\""; break;    
-    case '\b': ss << "\\b";  break;
-    case '\f': ss << "\\f";  break;
-    case '\n': ss << "\\n";  break;
-    case '\r': ss << "\\r";  break;
-    case '\t': ss << "\\t";  break;
+    case '\\': ss += "\\\\"; break;
+    case '"':  ss += "\\\""; break;
+    case '\b': ss += "\\b";  break;
+    case '\f': ss += "\\f";  break;
+    case '\n': ss += "\\n";  break;
+    case '\r': ss += "\\r";  break;
+    case '\t': ss += "\\t";  break;
 
     default:
       /* Converting the rest of special chars 0-31 to \u00xx. Note that 0x80 - 0xFF are untouched as they
@@ -190,18 +190,18 @@ std::string jsonInvalidCharsTransformation(const std::string& input)
       {
         static const char intToHex[16] =  { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' } ;
 
-        ss << "\\u00" << intToHex[(ch & 0xF0) >> 4] << intToHex[ch & 0x0F];
+        ss += "\\u00" + intToHex[(ch & 0xF0) >> 4] + intToHex[ch & 0x0F];
       }
       else
       {
-        ss << ch;
+        ss += ch;
       }
       break;
     }  // end-switch
 
   }  // end-for
 
-  return ss.str();
+  return ss;
 }
 
 

--- a/src/lib/logMsg/time.h
+++ b/src/lib/logMsg/time.h
@@ -30,7 +30,6 @@
 #include <sys/time.h>           // struct timeval
 #include <ctime>
 #include <string>               // std::string
-#include <sstream>              // std::ostringstream
 
 
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1688,7 +1688,6 @@ static bool processOnChangeConditionForUpdateContext
   std::string                      tenant,
   const std::string&               xauthToken,
   const std::string&               fiwareCorrelator,
-  const std::vector<std::string>&  attrsOrder,
   const ngsiv2::HttpInfo&          httpInfo,
   bool                             blacklist = false
 )
@@ -1699,6 +1698,8 @@ static bool processOnChangeConditionForUpdateContext
   cer.contextElement.entityId.fill(&notifyCerP->contextElement.entityId);
 
   /* Fill NotifyContextRequest with cerP, filtering by attrL */
+  // FIXME P8: review this. Given that filterAttributes() is called on the notifyCerP in the calling
+  // method, maybe this can be simplified (or removed)
   for (unsigned int ix = 0; ix < notifyCerP->contextElement.contextAttributeVector.size(); ix++)
   {
     ContextAttribute* caP = notifyCerP->contextElement.contextAttributeVector[ix];
@@ -1746,9 +1747,7 @@ static bool processOnChangeConditionForUpdateContext
                                           xauthToken,
                                           fiwareCorrelator,
                                           renderFormat,
-                                          attrsOrder,
-                                          metadataV,
-                                          blacklist);
+                                          metadataV);
   return true;
 }
 
@@ -2052,6 +2051,8 @@ static bool processSubscriptions
       setDateModifiedMetadata(notifyCerP);
     }
 
+    // Get the effective vector of attributes to render
+    notifyCerP->contextElement.filterAttributes(tSubP->attrL.stringV, tSubP->blacklist);
 
     /* Send notification */
     LM_T(LmtSubCache, ("NOT ignored: %s", tSubP->cacheSubId.c_str()));
@@ -2066,7 +2067,6 @@ static bool processSubscriptions
                                                                 tenant,
                                                                 xauthToken,
                                                                 fiwareCorrelator,
-                                                                tSubP->attrL.stringV,
                                                                 tSubP->httpInfo,
                                                                 tSubP->blacklist);
 

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -2165,6 +2165,12 @@ static bool processOnChangeConditionForSubscription
     return false;
   }
 
+  // Get the effective vectors of attributes to render (per context element)
+  for (unsigned int ix = 0; ix < rawCerV.size() ; ix++)
+  {
+      rawCerV[ix]->contextElement.filterAttributes(attrsOrder, blacklist);
+  }
+
   /* Prune "not found" CERs */
   pruneContextElements(rawCerV, &ncr.contextElementResponseVector);
 
@@ -2230,9 +2236,7 @@ static bool processOnChangeConditionForSubscription
                                                 xauthToken,
                                                 fiwareCorrelator,
                                                 renderFormat,
-                                                attrsOrder,
-                                                metadataV,
-                                                blacklist);
+                                                metadataV);
         allCerV.release();
         ncr.contextElementResponseVector.release();
 
@@ -2249,9 +2253,8 @@ static bool processOnChangeConditionForSubscription
                                               xauthToken,
                                               fiwareCorrelator,
                                               renderFormat,
-                                              attrsOrder,
-                                              metadataV,
-                                              blacklist);
+                                              metadataV);
+
       ncr.contextElementResponseVector.release();
 
       return true;

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -903,7 +903,8 @@ std::string ContextAttribute::toJsonValue(void)
 *
 * toJsonAsValue -
 *
-* FIXME PR: given the new method toJsonValue() the name of this one should be changed
+* FIXME P7: toJsonValue() and toJsonAsValue() are very similar and may be confusing.
+* Try to find a couple of names different and meaningful enough
 */
 std::string ContextAttribute::toJsonAsValue
 (

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -33,6 +33,7 @@
 #include "common/tag.h"
 #include "common/limits.h"
 #include "common/RenderFormat.h"
+#include "common/JsonHelper.h"
 #include "alarmMgr/alarmMgr.h"
 #include "orionTypes/OrionValueType.h"
 #include "parse/forbiddenChars.h"
@@ -584,7 +585,7 @@ std::string ContextAttribute::renderAsJsonObject
         }
         else // regular number
         {
-          effectiveValue = toString(numberValue);
+          effectiveValue = double2string(numberValue);
           withoutQuotes  = true;
         }
         break;
@@ -713,7 +714,7 @@ std::string ContextAttribute::render
         }
         else // regular number
         {
-          effectiveValue = toString(numberValue);
+          effectiveValue = double2string(numberValue);
           withoutQuotes  = true;
         }
         break;
@@ -769,17 +770,9 @@ std::string ContextAttribute::render
 *
 * toJson -
 *
-* FIXME: Refactor this method in order to simplify the code paths of the rendering process
 */
-std::string ContextAttribute::toJson
-(
-  bool                             isLastElement,
-  RenderFormat                     renderFormat,
-  const std::vector<std::string>&  metadataFilter,
-  RequestType                      requestType
-)
+std::string ContextAttribute::toJson(const std::vector<std::string>&  metadataFilter)
 {
-  std::string  out;
 
   // Add special metadata representing attribute dates
   if ((creDate != 0) && (std::find(metadataFilter.begin(), metadataFilter.end(), NGSI_MD_DATECREATED) != metadataFilter.end()))
@@ -793,143 +786,124 @@ std::string ContextAttribute::toJson
     metadataVector.push_back(mdP);
   }
 
-  if ((renderFormat == NGSI_V2_VALUES) || (renderFormat == NGSI_V2_KEYVALUES) || (renderFormat == NGSI_V2_UNIQUE_VALUES))
+  JsonHelper jh;
+
+  //
+  // type
+  //
+  // This is needed for entities coming from NGSIv1 (which allows empty or missing types)
+  //
+  std::string defType = defaultType(valueType);
+
+  if (compoundValueP && compoundValueP->isVector())
   {
-    out = (renderFormat == NGSI_V2_KEYVALUES)? JSON_STR(name) + ":" : "";
-
-    if (compoundValueP != NULL)
-    {
-      if (compoundValueP->isObject())
-      {
-        out += "{" + compoundValueP->toJson(true, true) + "}";
-      }
-      else if (compoundValueP->isVector())
-      {
-        out += "[" + compoundValueP->toJson(true, true) + "]";
-      }
-    }
-    else if (valueType == orion::ValueTypeNumber)
-    {
-      if ((type == DATE_TYPE) || (type == DATE_TYPE_ALT))
-      {
-        out += JSON_STR(isodate2str(numberValue));
-      }
-      else // regular number
-      {
-        out += toString(numberValue);
-      }
-    }
-    else if (valueType == orion::ValueTypeString)
-    {
-      out += JSON_STR(stringValue);
-    }
-    else if (valueType == orion::ValueTypeBoolean)
-    {
-      out += (boolValue == true)? "true" : "false";
-    }
-    else if (valueType == orion::ValueTypeNull)
-    {
-      out += "null";
-    }
-    else if (valueType == orion::ValueTypeNotGiven)
-    {
-      LM_E(("Runtime Error (value not given in compound value)"));
-    }
-  }
-  else  // Render mode: normalized 
-  {
-    if (requestType != EntityAttributeResponse)
-    {
-      out = JSON_STR(name) + ":{";
-    }
-
-    //
-    // type
-    //
-    // This is needed for entities coming from NGSIv1 (which allows empty or missing types)
-    //
-    std::string defType = defaultType(valueType);
-
-    if (compoundValueP && compoundValueP->isVector())
-    {
-      defType = defaultType(orion::ValueTypeVector);
-    }
-
-    out += (type != "")? JSON_VALUE("type", type) : JSON_VALUE("type", defType);
-    out += ",";
-
-
-    //
-    // value
-    //
-    if (compoundValueP != NULL)
-    {
-      if (compoundValueP->isObject())
-      {
-        out += JSON_STR("value") + ":{" + compoundValueP->toJson(true, true) + "}";
-      }
-      else if (compoundValueP->isVector())
-      {
-        out += JSON_STR("value") + ":[" + compoundValueP->toJson(true, true) + "]";
-      }
-    }
-    else if (valueType == orion::ValueTypeNumber)
-    {
-      if ((type == DATE_TYPE) || (type == DATE_TYPE_ALT))
-      {
-        out += JSON_VALUE("value", isodate2str(numberValue));;
-      }
-      else // regular number
-      {
-        out += JSON_VALUE_NUMBER("value", toString(numberValue));
-      }
-    }
-    else if (valueType == orion::ValueTypeString)
-    {
-      out += JSON_VALUE("value", stringValue);
-    }
-    else if (valueType == orion::ValueTypeBoolean)
-    {
-      out += JSON_VALUE_BOOL("value", boolValue);
-    }
-    else if (valueType == orion::ValueTypeNull)
-    {
-      out += JSON_STR("value") + ":" + "null";
-    }
-    else if (valueType == orion::ValueTypeNotGiven)
-    {
-      LM_E(("Runtime Error (value not given in compound value)"));
-    }
-    else
-    {
-      out += JSON_VALUE("value", stringValue);
-    }
-    out += ",";
-
-    //
-    // metadata
-    //
-    out += JSON_STR("metadata") + ":" + "{" + metadataVector.toJson(true, metadataFilter) + "}";
-
-    if (requestType != EntityAttributeResponse)
-    {
-      out += "}";
-    }
+    defType = defaultType(orion::ValueTypeVector);
   }
 
-  if (!isLastElement)
+  jh.addString("type", type != ""? type : defType);
+
+  //
+  // value
+  //
+  if (compoundValueP != NULL)
   {
-    out += ",";
+    jh.addRaw("value", compoundValueP->toJson(true));
+  }
+  else if (valueType == orion::ValueTypeNumber)
+  {
+    if ((type == DATE_TYPE) || (type == DATE_TYPE_ALT))
+    {
+      jh.addString("value", isodate2str(numberValue));
+    }
+    else // regular number
+    {
+      jh.addNumber("value", numberValue);
+    }
+  }
+  else if (valueType == orion::ValueTypeString)
+  {
+    jh.addString("value", stringValue);
+  }
+  else if (valueType == orion::ValueTypeBoolean)
+  {
+    jh.addBool("value", boolValue);
+  }
+  else if (valueType == orion::ValueTypeNull)
+  {
+    jh.addRaw("value", "null");
+  }
+  else if (valueType == orion::ValueTypeNotGiven)
+  {
+    LM_E(("Runtime Error (value not given for attribute %s)", name.c_str()));
+  }
+  else
+  {
+    LM_E(("Runtime Error (invalid value type for attribute %s)", name.c_str()));
   }
 
-  return out;
+  //
+  // metadata
+  //
+  jh.addRaw("metadata", metadataVector.toJson(metadataFilter));
+
+  return jh.str();
 }
 
+
+/* ****************************************************************************
+*
+* toJsonValue -
+*
+* To be used by options=values and options=unique renderings
+*
+*/
+std::string ContextAttribute::toJsonValue(void)
+{
+  if (compoundValueP != NULL)
+  {
+    return compoundValueP->toJson(true);
+  }
+  else if (valueType == orion::ValueTypeNumber)
+  {
+    if ((type == DATE_TYPE) || (type == DATE_TYPE_ALT))
+    {
+      return toJsonString(isodate2str(numberValue));
+    }
+    else // regular number
+    {
+      return double2string(numberValue);
+    }
+  }
+  else if (valueType == orion::ValueTypeString)
+  {
+    return toJsonString(stringValue);
+  }
+  else if (valueType == orion::ValueTypeBoolean)
+  {
+    return boolValue ? "true" : "false";
+  }
+  else if (valueType == orion::ValueTypeNull)
+  {
+    return "null";
+  }
+  else if (valueType == orion::ValueTypeNotGiven)
+  {
+    LM_E(("Runtime Error (value not given for attribute %s)", name.c_str()));
+  }
+  else
+  {
+    LM_E(("Runtime Error (invalid value type for attribute %s)", name.c_str()));
+  }
+
+  return "";
+}
 
 
 /* ****************************************************************************
 *
 * toJsonAsValue -
+*
+* FIXME PR: given the new method toJsonValue() the name of this one should be changed
 */
 std::string ContextAttribute::toJsonAsValue
 (
@@ -971,7 +945,7 @@ std::string ContextAttribute::toJsonAsValue
         }
         else // regular number
         {
-          out = toString(numberValue);
+          out = double2string(numberValue);
         }
         break;
 
@@ -1015,14 +989,7 @@ std::string ContextAttribute::toJsonAsValue
     {
       *outMimeTypeP = outFormatSelection;
 
-      if (compoundValueP->isVector())
-      {
-        out = "[" + compoundValueP->toJson(true, true) + "]";
-      }
-      else  // Object
-      {
-        out = "{" + compoundValueP->toJson(false, true) + "}";
-      }
+      out = compoundValueP->toJson(true);
     }
   }
 
@@ -1153,7 +1120,7 @@ std::string ContextAttribute::getValue(void) const
     break;
 
   case orion::ValueTypeNumber:
-    return toString(numberValue);
+    return double2string(numberValue);
     break;
 
   case orion::ValueTypeBoolean:

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -99,16 +99,18 @@ public:
                       bool         omitValue = false);
   std::string  renderAsJsonObject(ApiVersion apiVersion, RequestType request, bool comma, bool omitValue = false);
   std::string  renderAsNameString(bool comma);
-  std::string  toJson(bool                             isLastElement,
-                      RenderFormat                     renderFormat,
-                      const std::vector<std::string>&  metadataFilter,
-                      RequestType                      requestType = NoRequest);
+
+  std::string  toJson(const std::vector<std::string>&  metadataFilter);
+
+  std::string  toJsonValue(void);
+
   std::string  toJsonAsValue(ApiVersion       apiVersion,
                              bool             acceptedTextPlain,
                              bool             acceptedJson,
                              MimeType         outFormatSelection,
                              MimeType*        outMimeTypeP,
                              HttpStatusCode*  scP);
+
   void         release(void);
   std::string  getName(void);
 

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -337,9 +337,9 @@ void ContextAttributeVector::fill(ContextAttributeVector* cavP, bool useDefaultT
 
 /* ****************************************************************************
 *
-* lookup -
+* get -
 */
-int ContextAttributeVector::lookup(const std::string& attributeName) const
+int ContextAttributeVector::get(const std::string& attributeName) const
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -34,6 +34,7 @@
 #include "common/tag.h"
 #include "common/string.h"
 #include "common/RenderFormat.h"
+#include "common/JsonHelper.h"
 #include "ngsi/ContextAttributeVector.h"
 #include "ngsi/Request.h"
 
@@ -72,6 +73,7 @@ static std::string addedLookup(const std::vector<std::string>& added, std::strin
 /* ****************************************************************************
 *
 * ContextAttributeVector::toJsonTypes -
+*
 */
 std::string ContextAttributeVector::toJsonTypes(void)
 {
@@ -85,7 +87,7 @@ std::string ContextAttributeVector::toJsonTypes(void)
   }
 
   // Pass 2 - generate JSON
-  std::string out;
+  JsonHelper jh;
 
   std::map<std::string, std::map<std::string, int> >::iterator it;
   unsigned int                                                 ix;
@@ -94,10 +96,12 @@ std::string ContextAttributeVector::toJsonTypes(void)
     std::string                 attrName  = it->first;
     std::map<std::string, int>  attrTypes = it->second;
 
-    out += JSON_STR(attrName) + ":{" + JSON_STR("types") + ":[";
+    std::string out = "[";
 
     std::map<std::string, int>::iterator jt;
     unsigned int                         jx;
+
+    JsonHelper jhTypes;
 
     for (jt = attrTypes.begin(), jx = 0; jt != attrTypes.end(); ++jt, ++jx)
     {
@@ -122,186 +126,14 @@ std::string ContextAttributeVector::toJsonTypes(void)
       }
     }
 
-    out += "]}";
+    out += "]";
 
-    if (ix != perAttrTypes.size() - 1)
-    {
-      out += ",";
-    }
+    jhTypes.addRaw("types", out);
+
+    jh.addRaw(attrName, jhTypes.str());
   }
 
-  return out;
-}
-
-
-
-/* ****************************************************************************
-*
-* ContextAttributeVector::toJson - 
-*
-* Attributes named 'id' or 'type' are not rendered in API version 2, due to the 
-* compact way in which API v2 is rendered. Attributes named 'id' or 'type' would simply
-* collide with the 'id' and 'type' of the entity itself (holder of the attribute).
-*
-* If anybody needs an attribute named 'id' or 'type', then API v1
-* will have to be used to retrieve that information.
-*/
-std::string ContextAttributeVector::toJson
-(
-  RenderFormat                     renderFormat,
-  const std::vector<std::string>&  attrsFilter,
-  const std::vector<std::string>&  metadataFilter,
-  bool                             blacklist
-) const
-{
-  if (vec.size() == 0)
-  {
-    return "";
-  }
-
-  // Check if dateExipres has to be rendered or not
-  bool includeDateExpires = (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_EXPIRES) != attrsFilter.end());
-
-  //
-  // Pass 1 - count the total number of attributes valid for rendering.
-  //
-  // Attributes named 'id' or 'type' are not rendered.
-  // This gives us a small problem in the logic here, about knowing whether the
-  // comma should be rendered or not.
-  //
-  // To fix this problem we need to do two passes over the vector, the first pass to
-  // count the number of valid attributes and the second to do the work.
-  // In the second pass, if the number of rendered attributes "so far" is less than the total
-  // number of valid attributes, then the comma must be rendered.
-  //
-  int validAttributes = 0;
-  std::map<std::string, bool>  uniqueMap;
-  if ((attrsFilter.size() == 0) || (std::find(attrsFilter.begin(), attrsFilter.end(), ALL_ATTRS) != attrsFilter.end()))
-  {
-    for (unsigned int ix = 0; ix < vec.size(); ++ix)
-    {
-      if ((vec[ix]->name == "id") || (vec[ix]->name == "type"))
-      {
-        continue;
-      }
-
-      if ((vec[ix]->name == DATE_EXPIRES) && !includeDateExpires)
-      {
-        continue;
-      }
-
-      if ((renderFormat == NGSI_V2_UNIQUE_VALUES) && (vec[ix]->valueType == orion::ValueTypeString))
-      {
-        if (uniqueMap[vec[ix]->stringValue] == true)
-        {
-          continue;
-        }
-      }
-
-      ++validAttributes;
-
-      if ((renderFormat == NGSI_V2_UNIQUE_VALUES) && (vec[ix]->valueType == orion::ValueTypeString))
-      {
-        uniqueMap[vec[ix]->stringValue] = true;
-      }
-    }
-  }
-  else if (!blacklist)
-  {
-    for (std::vector<std::string>::const_iterator it = attrsFilter.begin(); it != attrsFilter.end(); ++it)
-    {
-      if ((*it == DATE_EXPIRES) && !includeDateExpires)
-      {
-        continue;
-      }
-
-      if (lookup(*it) != NULL)
-      {
-        ++validAttributes;
-      }
-    }
-  }
-  else // attrsFilter is black list
-  {
-    for (unsigned ix = 0; ix < vec.size(); ++ix)
-    {
-      if (std::find(attrsFilter.begin(), attrsFilter.end(), vec[ix]->name) == attrsFilter.end())
-      {
-         ++validAttributes;
-      }
-    }
-  }
-
-  //
-  // Pass 2 - do the work, helped by the value of 'validAttributes'.
-  //
-  std::string  out;
-  int          renderedAttributes = 0;
-
-  uniqueMap.clear();
-
-  if (attrsFilter.size() == 0 || (std::find(attrsFilter.begin(), attrsFilter.end(), ALL_ATTRS) != attrsFilter.end()))
-  {
-    for (unsigned int ix = 0; ix < vec.size(); ++ix)
-    {
-      if ((vec[ix]->name == "id") || (vec[ix]->name == "type"))
-      {
-        continue;
-      }
-
-      if ((vec[ix]->name == DATE_EXPIRES) && !includeDateExpires)
-      {
-        continue;
-      }
-
-      ++renderedAttributes;
-
-      if ((renderFormat == NGSI_V2_UNIQUE_VALUES) && (vec[ix]->valueType == orion::ValueTypeString))
-      {
-        if (uniqueMap[vec[ix]->stringValue] == true)
-        {
-          continue;
-        }
-      }
-
-      out += vec[ix]->toJson(renderedAttributes == validAttributes, renderFormat, metadataFilter);
-
-      if ((renderFormat == NGSI_V2_UNIQUE_VALUES) && (vec[ix]->valueType == orion::ValueTypeString))
-      {
-        uniqueMap[vec[ix]->stringValue] = true;
-      }
-    }
-  }
-  else if (!blacklist)
-  {
-    for (std::vector<std::string>::const_iterator it = attrsFilter.begin(); it != attrsFilter.end(); ++it)
-    {
-      ContextAttribute* caP = lookup(*it);
-      if (caP != NULL)
-      {
-        if ((caP->name == DATE_EXPIRES) && !includeDateExpires)
-        {
-          continue;
-        }
-
-        ++renderedAttributes;
-        out += caP->toJson(renderedAttributes == validAttributes, renderFormat, metadataFilter);
-      }
-    }
-  }
-  else // attrsFilter is black list
-  {
-    for (unsigned ix = 0; ix < vec.size(); ++ix)
-    {
-      if (std::find(attrsFilter.begin(), attrsFilter.end(), vec[ix]->name) == attrsFilter.end())
-      {
-        ++renderedAttributes;
-        out += vec[ix]->toJson(renderedAttributes == validAttributes, renderFormat, metadataFilter);
-      }
-    }
-  }
-
-  return out;
+  return jh.str();
 }
 
 
@@ -507,15 +339,15 @@ void ContextAttributeVector::fill(ContextAttributeVector* cavP, bool useDefaultT
 *
 * lookup -
 */
-ContextAttribute* ContextAttributeVector::lookup(const std::string& attributeName) const
+int ContextAttributeVector::lookup(const std::string& attributeName) const
 {
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
     if (vec[ix]->name == attributeName)
     {
-      return vec[ix];
+      return ix;
     }
   }
 
-  return NULL;
+  return -1;
 }

--- a/src/lib/ngsi/ContextAttributeVector.h
+++ b/src/lib/ngsi/ContextAttributeVector.h
@@ -49,7 +49,7 @@ typedef struct ContextAttributeVector
   unsigned int             size(void) const;
   void                     release(void);
   void                     fill(struct ContextAttributeVector* cavP, bool useDefaultType = false);
-  int                      lookup(const std::string& attributeName) const;
+  int                      get(const std::string& attributeName) const;
   
   ContextAttribute*  operator[](unsigned int ix) const;
 

--- a/src/lib/ngsi/ContextAttributeVector.h
+++ b/src/lib/ngsi/ContextAttributeVector.h
@@ -49,7 +49,7 @@ typedef struct ContextAttributeVector
   unsigned int             size(void) const;
   void                     release(void);
   void                     fill(struct ContextAttributeVector* cavP, bool useDefaultType = false);
-  ContextAttribute*        lookup(const std::string& attributeName) const;
+  int                      lookup(const std::string& attributeName) const;
   
   ContextAttribute*  operator[](unsigned int ix) const;
 
@@ -63,10 +63,6 @@ typedef struct ContextAttributeVector
                             bool         omitValue   = false,
                             bool         attrsAsName = false);
 
-  std::string        toJson(RenderFormat                     renderFormat,
-                            const std::vector<std::string>&  attrsFilter,
-                            const std::vector<std::string>&  metadataV,
-                            bool                             blacklist) const;
   std::string        toJsonTypes(void);
 
 } ContextAttributeVector;

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -200,12 +200,23 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
           // Actual attribute filtering only takes place if '*' was not used
           else
           {
+#if 0
+            // FIXME #3168: to be enabled once metadata ID get removed
             int found = contextAttributeVector.get(attrsFilterItem);
             if (found != -1)
             {
               caNewV.push_back(contextAttributeVector.vec[found]);
               contextAttributeVector.vec.erase(contextAttributeVector.vec.begin() + found);
             }
+#else
+            int found = contextAttributeVector.get(attrsFilterItem);
+            while (found != -1)
+            {
+              caNewV.push_back(contextAttributeVector.vec[found]);
+              contextAttributeVector.vec.erase(contextAttributeVector.vec.begin() + found);
+              found = contextAttributeVector.get(attrsFilterItem);
+            }
+#endif
           }
         }
 
@@ -242,16 +253,9 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
 std::string ContextElement::toJson
 (
   RenderFormat                     renderFormat,
-  const std::vector<std::string>&  attrsFilter,
-  const std::vector<std::string>&  metadataFilter,
-  bool                             blacklist
+  const std::vector<std::string>&  metadataFilter
 )
 {
-  // Get the effective vector of attributes to render
-  // FIXME P7: filterAttributes will be moved and invoking it would not be needed from toJson()
-  // (see comment in filterAttributes)
-  filterAttributes(attrsFilter, blacklist);
-
   std::string out;
   switch (renderFormat)
   {

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -175,6 +175,7 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
           else
           {
             caP->release();
+            delete caP;
           }
         }
         contextAttributeVector.vec = caNewV;
@@ -224,6 +225,7 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
   if (!blacklist && !includeDateExpires && ((found = contextAttributeVector.get(DATE_EXPIRES)) != -1))
   {
     contextAttributeVector.vec[found]->release();
+    delete contextAttributeVector.vec[found];
     contextAttributeVector.vec.erase(contextAttributeVector.vec.begin() + found);
   }
 }

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -140,12 +140,12 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
 
       if (!blacklist)
       {
-        if ((entityId.creDate != 0) && (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_CREATED) != attrsFilter.end()) && (contextAttributeVector.lookup(DATE_CREATED) == -1))
+        if ((entityId.creDate != 0) && (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_CREATED) != attrsFilter.end()) && (contextAttributeVector.get(DATE_CREATED) == -1))
         {
           ContextAttribute* caP = new ContextAttribute(DATE_CREATED, DATE_TYPE, entityId.creDate);
           contextAttributeVector.push_back(caP);
         }
-        if ((entityId.modDate != 0) &&  (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_MODIFIED) != attrsFilter.end()) && (contextAttributeVector.lookup(DATE_MODIFIED) == -1))
+        if ((entityId.modDate != 0) &&  (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_MODIFIED) != attrsFilter.end()) && (contextAttributeVector.get(DATE_MODIFIED) == -1))
         {
           ContextAttribute* caP = new ContextAttribute(DATE_MODIFIED, DATE_TYPE, entityId.modDate);
           contextAttributeVector.push_back(caP);
@@ -158,9 +158,9 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
       //
       // 1. If blacklist == true, go through the contextAttributeVector, taking only its elements
       //    not in attrsFilter
-      // 2. If blacklist == false, reorder attributes in the same order they are in attrsFilter, excluding
-      //    the ones not there (i.e. filtering them out) and giving special treatment to creation
-      //    and modification dates
+      // 2. If blacklist == false, reorder attributes in the same order they are in
+      //    attrsFilter (attributes not in attrsFilter are filtered out). Creation and modification
+      //    dates have a special treatment
 
       if (blacklist)
       {
@@ -186,12 +186,12 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
         for (unsigned int ix = 0; ix < attrsFilter.size(); ix++)
         {
           std::string attrsFilterItem = attrsFilter[ix];
-          if ((entityId.creDate != 0) && (attrsFilterItem == DATE_CREATED) && (contextAttributeVector.lookup(DATE_CREATED) == -1))
+          if ((entityId.creDate != 0) && (attrsFilterItem == DATE_CREATED) && (contextAttributeVector.get(DATE_CREATED) == -1))
           {
             ContextAttribute* caP = new ContextAttribute(DATE_CREATED, DATE_TYPE, entityId.creDate);
             caNewV.push_back(caP);
           }
-          else if ((entityId.modDate != 0) && (attrsFilterItem == DATE_MODIFIED) && (contextAttributeVector.lookup(DATE_MODIFIED) == -1))
+          else if ((entityId.modDate != 0) && (attrsFilterItem == DATE_MODIFIED) && (contextAttributeVector.get(DATE_MODIFIED) == -1))
           {
             ContextAttribute* caP = new ContextAttribute(DATE_MODIFIED, DATE_TYPE, entityId.modDate);
             caNewV.push_back(caP);
@@ -199,7 +199,7 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
           // Actual attribute filtering only takes place if '*' was not used
           else
           {
-            int found = contextAttributeVector.lookup(attrsFilterItem);
+            int found = contextAttributeVector.get(attrsFilterItem);
             if (found != -1)
             {
               caNewV.push_back(contextAttributeVector.vec[found]);
@@ -208,7 +208,7 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
           }
         }
 
-        // All the remainder elements in attributeVector need to be released,
+        // All the remaining elements in attributeVector need to be released,
         // before overriding the vector with caNewV
         contextAttributeVector.release();
 
@@ -218,10 +218,10 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
     }
   }
 
-  // Removing dateExpires if not explictely included in the filter
+  // Removing dateExpires if not explicitly included in the filter
   bool includeDateExpires = (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_EXPIRES) != attrsFilter.end());
   int found;
-  if (!blacklist && !includeDateExpires && ((found = contextAttributeVector.lookup(DATE_EXPIRES)) != -1))
+  if (!blacklist && !includeDateExpires && ((found = contextAttributeVector.get(DATE_EXPIRES)) != -1))
   {
     contextAttributeVector.vec[found]->release();
     contextAttributeVector.vec.erase(contextAttributeVector.vec.begin() + found);

--- a/src/lib/ngsi/ContextElement.cpp
+++ b/src/lib/ngsi/ContextElement.cpp
@@ -121,8 +121,9 @@ std::string ContextElement::render
 * dateCreatedOption and dateModifiedOption are due to deprecated ways of requesting
 * date in response. If used, the date is added at the end.
 *
-* FIXME PR: lot of duplicated code from Entity NGSIv2 class but we don't care
-* as NGSIv1 code is deprecated. The duplication will be solved when NGSIv1 gets removed
+* FIXME P7: duplicated code in Entity::filterAttributes(). However, this
+* will be solved if ContextElement is refactored to use Entity as internal representation
+* for entities.
 */
 void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilter, bool blacklist)
 {
@@ -232,8 +233,9 @@ void ContextElement::filterAttributes(const std::vector<std::string>&  attrsFilt
 *
 * ContextElement::toJson - 
 *
-* FIXME PR: lot of duplicated code from Entity NGSIv2 class but we don't care
-* as NGSIv1 code is deprecated. The duplication will be solved when NGSIv1 gets removed
+* FIXME P7: duplicated code in Entity::toJson(). However, this
+* will be solved if ContextElement is refactored to use Entity as internal representation
+* for entities.
 */
 std::string ContextElement::toJson
 (
@@ -244,6 +246,8 @@ std::string ContextElement::toJson
 )
 {
   // Get the effective vector of attributes to render
+  // FIXME P7: filterAttributes will be moved and invoking it would not be needed from toJson()
+  // (see comment in filterAttributes)
   filterAttributes(attrsFilter, blacklist);
 
   std::string out;
@@ -271,8 +275,9 @@ std::string ContextElement::toJson
 *
 * ContextElement::toJsonValues -
 *
-* FIXME PR: lot of duplicated code from Entity NGSIv2 class but we don't care
-* as NGSIv1 code is deprecated. The duplication will be solved when NGSIv1 gets removed
+* FIXME P7: duplicated code in Entity::toJsonValues(). However, this
+* will be solved if ContextElement is refactored to use Entity as internal representation
+* for entities.
 */
 std::string ContextElement::toJsonValues(void)
 {
@@ -300,8 +305,9 @@ std::string ContextElement::toJsonValues(void)
 *
 * ContextElement::toJsonUniqueValues -
 *
-* FIXME PR: lot of duplicated code from Entity NGSIv2 class but we don't care
-* as NGSIv1 code is deprecated. The duplication will be solved when NGSIv1 gets removed
+* FIXME P7: duplicated code in toJsonUniqueValues::filterAttributes(). However, this
+* will be solved if ContextElement is refactored to use Entity as internal representation
+* for entities.
 */
 std::string ContextElement::toJsonUniqueValues(void)
 {
@@ -343,8 +349,9 @@ std::string ContextElement::toJsonUniqueValues(void)
 *
 * ContextElement::toJsonKeyvalues -
 *
-* FIXME PR: lot of duplicated code from Entity NGSIv2 class but we don't care
-* as NGSIv1 code is deprecated. The duplication will be solved when NGSIv1 gets removed
+* FIXME P7: duplicated code in Entity::toJsonKeyValues(). However, this
+* will be solved if ContextElement is refactored to use Entity as internal representation
+* for entities.
 */
 std::string ContextElement::toJsonKeyvalues(void)
 {
@@ -370,8 +377,9 @@ std::string ContextElement::toJsonKeyvalues(void)
 *
 * ContextElement::toJsonNormalized -
 *
-* FIXME PR: lot of duplicated code from Entity NGSIv2 class but we don't care
-* as NGSIv1 code is deprecated. The duplication will be solved when NGSIv1 gets removed
+* FIXME P7: duplicated code in Entity::toJsonNormalized(). However, this
+* will be solved if ContextElement is refactored to use Entity as internal representation
+* for entities.
 */
 std::string ContextElement::toJsonNormalized(const std::vector<std::string>&  metadataFilter)
 {

--- a/src/lib/ngsi/ContextElement.h
+++ b/src/lib/ngsi/ContextElement.h
@@ -55,9 +55,7 @@ typedef struct ContextElement
 
   std::string  render(ApiVersion apiVersion, bool asJsonObject, RequestType requestType, bool comma, bool omitAttributeValues = false);
   std::string  toJson(RenderFormat                     renderFormat,
-                      const std::vector<std::string>&  attrsFilter,
-                      const std::vector<std::string>&  metadataFilter,
-                      bool                             blacklist = false);
+                      const std::vector<std::string>&  metadataFilter);
   void         release(void);
   void         fill(const struct ContextElement& ce);
   void         fill(ContextElement* ceP, bool useDefaultType = false);
@@ -66,9 +64,9 @@ typedef struct ContextElement
 
   std::string  check(ApiVersion apiVersion, RequestType requestType);
 
- private:
   void filterAttributes(const std::vector<std::string>&  attrsFilter, bool blacklist);
 
+private:
   std::string toJsonValues(void);
   std::string toJsonUniqueValues(void);
   std::string toJsonKeyvalues(void);

--- a/src/lib/ngsi/ContextElement.h
+++ b/src/lib/ngsi/ContextElement.h
@@ -57,7 +57,7 @@ typedef struct ContextElement
   std::string  toJson(RenderFormat                     renderFormat,
                       const std::vector<std::string>&  attrsFilter,
                       const std::vector<std::string>&  metadataFilter,
-                      bool                             blacklist = false) const;
+                      bool                             blacklist = false);
   void         release(void);
   void         fill(const struct ContextElement& ce);
   void         fill(ContextElement* ceP, bool useDefaultType = false);
@@ -65,6 +65,14 @@ typedef struct ContextElement
   ContextAttribute* getAttribute(const std::string& attrName);
 
   std::string  check(ApiVersion apiVersion, RequestType requestType);
+
+ private:
+  void filterAttributes(const std::vector<std::string>&  attrsFilter, bool blacklist);
+
+  std::string toJsonValues(void);
+  std::string toJsonUniqueValues(void);
+  std::string toJsonKeyvalues(void);
+  std::string toJsonNormalized(const std::vector<std::string>&  metadataFilter);
 } ContextElement;
 
 #endif  // SRC_LIB_NGSI_CONTEXTELEMENT_H_

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -350,14 +350,12 @@ std::string ContextElementResponse::render
 std::string ContextElementResponse::toJson
 (
   RenderFormat                     renderFormat,
-  const std::vector<std::string>&  attrsFilter,
-  const std::vector<std::string>&  metadataFilter,
-  bool                             blacklist
+  const std::vector<std::string>&  metadataFilter
 )
 {
   std::string out;
 
-  out = contextElement.toJson(renderFormat, attrsFilter, metadataFilter, blacklist);
+  out = contextElement.toJson(renderFormat, metadataFilter);
 
   return out;
 }

--- a/src/lib/ngsi/ContextElementResponse.h
+++ b/src/lib/ngsi/ContextElementResponse.h
@@ -71,9 +71,7 @@ typedef struct ContextElementResponse
                       bool         comma               = false,
                       bool         omitAttributeValues = false);
   std::string  toJson(RenderFormat                     renderFormat,
-                      const std::vector<std::string>&  attrsFilter,
-                      const std::vector<std::string>&  metadataFilter,
-                      bool blacklist = false);
+                      const std::vector<std::string>&  metadataFilter);
   void         release(void);
 
   std::string  check(ApiVersion          apiVersion,

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -86,9 +86,7 @@ std::string ContextElementResponseVector::toJson
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += (renderFormat == NGSI_V2_VALUES)? "[": "{";
     out += vec[ix]->toJson(renderFormat, attrsFilter, metadataFilter, blacklist);
-    out += (renderFormat == NGSI_V2_VALUES)? "]": "}";
 
     if (ix != vec.size() - 1)
     {

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -77,16 +77,14 @@ std::string ContextElementResponseVector::render
 std::string ContextElementResponseVector::toJson
 (
   RenderFormat                     renderFormat,
-  const std::vector<std::string>&  attrsFilter,
-  const std::vector<std::string>&  metadataFilter,
-  bool                             blacklist
+  const std::vector<std::string>&  metadataFilter
 )
 {
   std::string out;
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += vec[ix]->toJson(renderFormat, attrsFilter, metadataFilter, blacklist);
+    out += vec[ix]->toJson(renderFormat, metadataFilter);
 
     if (ix != vec.size() - 1)
     {

--- a/src/lib/ngsi/ContextElementResponseVector.h
+++ b/src/lib/ngsi/ContextElementResponseVector.h
@@ -48,9 +48,7 @@ typedef struct ContextElementResponseVector
                                   bool         omitAttributeValues = false);
 
   std::string              toJson(RenderFormat                     renderFormat,
-                                  const std::vector<std::string>&  attrsFilter,
-                                  const std::vector<std::string>&  metadataFilter,
-                                  bool                             blacklist = false);
+                                  const std::vector<std::string>&  metadataFilter);
   void                     push_back(ContextElementResponse* item);
   unsigned int             size(void) const;
   ContextElementResponse*  lookup(EntityId* eP, HttpStatusCode code = SccNone);

--- a/src/lib/ngsi/Metadata.h
+++ b/src/lib/ngsi/Metadata.h
@@ -90,7 +90,7 @@ typedef struct Metadata
   ~Metadata();
 
   std::string  render(bool comma);
-  std::string  toJson(bool isLastElement);
+  std::string  toJson(void);
   void         release(void);
   void         fill(const struct Metadata& md);
   std::string  toStringValue(void) const;

--- a/src/lib/ngsi/MetadataVector.h
+++ b/src/lib/ngsi/MetadataVector.h
@@ -46,8 +46,7 @@ public:
   MetadataVector(void);
 
   std::string     render(bool comma);
-  std::string     toJson(bool                             isLastElement,
-                         const std::vector<std::string>&  metadataFilter);
+  std::string     toJson(const std::vector<std::string>&  metadataFilter);
   std::string     check(ApiVersion apiVersion);
 
   void            push_back(Metadata* item);

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -67,9 +67,7 @@ std::string NotifyContextRequest::render(ApiVersion apiVersion, bool asJsonObjec
 std::string NotifyContextRequest::toJson
 (
   RenderFormat                     renderFormat,
-  const std::vector<std::string>&  attrsFilter,
-  const std::vector<std::string>&  metadataFilter,
-  bool                             blacklist
+  const std::vector<std::string>&  metadataFilter
 )
 {
   if ((renderFormat != NGSI_V2_NORMALIZED) && (renderFormat != NGSI_V2_KEYVALUES) && (renderFormat != NGSI_V2_VALUES))
@@ -88,7 +86,7 @@ std::string NotifyContextRequest::toJson
   out += ",";
   out += JSON_STR("data") + ":[";
 
-  out += contextElementResponseVector.toJson(renderFormat, attrsFilter, metadataFilter, blacklist);
+  out += contextElementResponseVector.toJson(renderFormat, metadataFilter);
   out += "]";
   out += "}";
 

--- a/src/lib/ngsi10/NotifyContextRequest.h
+++ b/src/lib/ngsi10/NotifyContextRequest.h
@@ -47,9 +47,7 @@ typedef struct NotifyContextRequest
 
   std::string   render(ApiVersion apiVersion, bool asJsonObject);
   std::string   toJson(RenderFormat                     renderFormat,
-                       const std::vector<std::string>&  attrsFilter,
-                       const std::vector<std::string>&  metadataFilter,
-                       bool                             blacklist = false);
+                       const std::vector<std::string>&  metadataFilter);
   std::string   check(ApiVersion apiVersion, const std::string& predetectedError);
   void          release(void);
   NotifyContextRequest* clone(void);

--- a/src/lib/ngsiNotify/Notifier.cpp
+++ b/src/lib/ngsiNotify/Notifier.cpp
@@ -70,9 +70,7 @@ void Notifier::sendNotifyContextRequest
     const std::string&               xauthToken,
     const std::string&               fiwareCorrelator,
     RenderFormat                     renderFormat,
-    const std::vector<std::string>&  attrsOrder,
-    const std::vector<std::string>&  metadataFilter,
-    bool                             blackList
+    const std::vector<std::string>&  metadataFilter
 )
 {
   pthread_t                         tid;
@@ -82,9 +80,7 @@ void Notifier::sendNotifyContextRequest
                                                                           xauthToken,
                                                                           fiwareCorrelator,
                                                                           renderFormat,
-                                                                          attrsOrder,
-                                                                          metadataFilter,
-                                                                          blackList);
+                                                                          metadataFilter);
 
   if (!paramsV->empty()) // al least one param, an empty vector means an error occurred
   {
@@ -190,7 +186,6 @@ static std::vector<SenderThreadParams*>* buildSenderParamsCustom
     const std::string&                   xauthToken,
     const std::string&                   fiwareCorrelator,
     RenderFormat                         renderFormat,
-    const std::vector<std::string>&      attrsOrder,
     const std::vector<std::string>&      metadataFilter
 )
 {
@@ -250,7 +245,7 @@ static std::vector<SenderThreadParams*>* buildSenderParamsCustom
       }
       else
       {
-        payload  = ncr.toJson(renderFormat, attrsOrder, metadataFilter);
+        payload  = ncr.toJson(renderFormat, metadataFilter);
       }
 
       mimeType = "application/json";
@@ -395,9 +390,7 @@ std::vector<SenderThreadParams*>* Notifier::buildSenderParams
   const std::string&               xauthToken,
   const std::string&               fiwareCorrelator,
   RenderFormat                     renderFormat,
-  const std::vector<std::string>&  attrsOrder,
-  const std::vector<std::string>&  metadataFilter,
-  bool                             blackList
+  const std::vector<std::string>&  metadataFilter
 )
 {
     ConnectionInfo                    ci;
@@ -434,7 +427,6 @@ std::vector<SenderThreadParams*>* Notifier::buildSenderParams
                                      xauthToken,
                                      fiwareCorrelator,
                                      renderFormat,
-                                     attrsOrder,
                                      metadataFilter);
     }
 
@@ -483,7 +475,7 @@ std::vector<SenderThreadParams*>* Notifier::buildSenderParams
     }
     else
     {
-      payloadString = ncrP->toJson(renderFormat, attrsOrder, metadataFilter, blackList);
+      payloadString = ncrP->toJson(renderFormat, metadataFilter);
     }
 
     /* Parse URL */

--- a/src/lib/ngsiNotify/Notifier.h
+++ b/src/lib/ngsiNotify/Notifier.h
@@ -53,9 +53,7 @@ public:
                                         const std::string&                         xauthToken,
                                         const std::string&                         fiwareCorrelator,
                                         RenderFormat                               renderFormat,
-                                        const std::vector<std::string>&            attrsOrder,
-                                        const std::vector<std::string>&            metadataFilter,
-                                        bool                                       blackList);
+                                        const std::vector<std::string>&            metadataFilter);
 
   virtual void sendNotifyContextAvailabilityRequest(NotifyContextAvailabilityRequest* ncr,
                                                     const std::string&                url,
@@ -69,10 +67,7 @@ protected:
                                                              const std::string&               xauthToken,
                                                              const std::string&               fiwareCorrelator,
                                                              RenderFormat                     renderFormat,
-                                                             const std::vector<std::string>&  attrsOrder,
-                                                             const std::vector<std::string>&  metadataFilter,
-                                                             bool                             blackList
-  );
+                                                             const std::vector<std::string>&  metadataFilter);
 };
 
 #endif  // SRC_LIB_NGSINOTIFY_NOTIFIER_H_

--- a/src/lib/ngsiNotify/QueueNotifier.cpp
+++ b/src/lib/ngsiNotify/QueueNotifier.cpp
@@ -68,9 +68,7 @@ void QueueNotifier::sendNotifyContextRequest
   const std::string&               xauthToken,
   const std::string&               fiwareCorrelator,
   RenderFormat                     renderFormat,
-  const std::vector<std::string>&  attrsOrder,
-  const std::vector<std::string>&  metadataFilter,
-  bool                             blacklist
+  const std::vector<std::string>&  metadataFilter
 )
 {
   std::vector<SenderThreadParams*>* paramsV = Notifier::buildSenderParams(ncr,
@@ -79,9 +77,7 @@ void QueueNotifier::sendNotifyContextRequest
                                                                           xauthToken,
                                                                           fiwareCorrelator,
                                                                           renderFormat,
-                                                                          attrsOrder,
-                                                                          metadataFilter,
-                                                                          blacklist);
+                                                                          metadataFilter);
 
   size_t notificationsNum = paramsV->size();
   for (unsigned ix = 0; ix < notificationsNum; ix++)

--- a/src/lib/ngsiNotify/QueueNotifier.h
+++ b/src/lib/ngsiNotify/QueueNotifier.h
@@ -57,9 +57,7 @@ public:
                                 const std::string&               xauthToken,
                                 const std::string&               fiwareCorrelator,
                                 RenderFormat                     renderFormat,
-                                const std::vector<std::string>&  attrsOrder,
-                                const std::vector<std::string>&  metadataFilter,
-                                bool                             blacklist);
+                                const std::vector<std::string>&  metadataFilter);
   int start();
 
 private:

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -31,6 +31,7 @@
 
 #include "common/tag.h"
 #include "common/limits.h"
+#include "common/JsonHelper.h"
 #include "ngsi/Request.h"
 #include "orionTypes/EntityType.h"
 
@@ -143,24 +144,15 @@ void EntityType::release(void)
 */
 std::string EntityType::toJson(bool includeType)
 {
-  std::string  out = "{";
-  char         countV[STRING_SIZE_FOR_INT];
-
-  snprintf(countV, sizeof(countV), "%lld", count);
+  JsonHelper jh;
 
   if (includeType)
   {
-    out += JSON_VALUE("type", type) + ",";
+    jh.addString("type", type);
   }
 
-  out += JSON_STR("attrs") + ":";
+  jh.addRaw("attrs", contextAttributeVector.toJsonTypes());
+  jh.addNumber("count", count);
 
-  out += "{";
-  out += contextAttributeVector.toJsonTypes();
-  out += "}";
-
-  out += "," + JSON_STR("count") + ":" + countV;
-  out += "}";
-
-  return out;
+  return jh.str();
 }

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -32,6 +32,7 @@
 #include "common/globals.h"
 #include "common/tag.h"
 #include "common/limits.h"
+#include "common/JsonHelper.h"
 #include "alarmMgr/alarmMgr.h"
 
 #include "ngsi/Request.h"
@@ -115,19 +116,10 @@ void EntityTypeResponse::release(void)
 */
 std::string EntityTypeResponse::toJson(void)
 {
-  std::string  out = "{";
-  char         countV[STRING_SIZE_FOR_INT];
+  JsonHelper jh;
 
-  snprintf(countV, sizeof(countV), "%lld", entityType.count);
+  jh.addRaw("attrs", entityType.contextAttributeVector.toJsonTypes());
+  jh.addNumber("count", entityType.count);
 
-  out += JSON_STR("attrs") + ":";
-
-  out += "{";
-  out += entityType.contextAttributeVector.toJsonTypes();
-  out += "}";
-
-  out += "," + JSON_STR("count") + ":" + countV;
-  out += "}";
-
-  return out;
+  return jh.str();
 }

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -826,7 +826,7 @@ std::string CompoundValueNode::toJson(bool toplevel)
 {
   std::string out;
 
-  switch(valueType)
+  switch (valueType)
   {
   case orion::ValueTypeString:
     out = toJsonString(stringValue);

--- a/src/lib/parse/CompoundValueNode.h
+++ b/src/lib/parse/CompoundValueNode.h
@@ -161,7 +161,8 @@ class CompoundValueNode
   std::string         check(void);
   std::string         finish(void);
   std::string         render(ApiVersion apiVersion, bool noComma = false, bool noTag = false);
-  std::string         toJson(bool isLastElement, bool comma);
+
+  std::string         toJson(bool toplevel);
 
   void                shortShow(const std::string& indent);
   void                show(const std::string& indent);

--- a/src/lib/serviceRoutinesV2/getAllSubscriptions.cpp
+++ b/src/lib/serviceRoutinesV2/getAllSubscriptions.cpp
@@ -83,7 +83,7 @@ std::string getAllSubscriptions
   if ((ciP->uriParamOptions["count"]))
   {
     ciP->httpHeader.push_back(HTTP_FIWARE_TOTAL_COUNT);
-    ciP->httpHeaderValue.push_back(toString(count));
+    ciP->httpHeaderValue.push_back(double2string(count));
   }
 
   std::string out;

--- a/src/lib/serviceRoutinesV2/getEntity.cpp
+++ b/src/lib/serviceRoutinesV2/getEntity.cpp
@@ -101,7 +101,7 @@ std::string getEntity
   entity.fill(&parseDataP->qcrs.res);
 
   std::string answer;
-  TIMED_RENDER(answer = entity.render(ciP->uriParamOptions, ciP->uriParam, false));
+  TIMED_RENDER(answer = entity.render(ciP->uriParamOptions, ciP->uriParam));
 
   if (parseDataP->qcrs.res.errorCode.code == SccOk && parseDataP->qcrs.res.contextElementResponseVector.size() > 1)
   {

--- a/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
@@ -112,23 +112,13 @@ std::string getEntityAttributeValue
                                              &(ciP->httpStatusCode),
                                              ciP->uriParamOptions[OPT_KEY_VALUES],
                                              ciP->uriParam[URI_PARAM_METADATA],
-                                             EntityAttributeValueRequest,
-                                             false));
+                                             EntityAttributeValueRequest));
     }
     else
     {
       if (attribute.pcontextAttribute->compoundValueP != NULL)
       {
         TIMED_RENDER(answer = attribute.pcontextAttribute->compoundValueP->render(ciP->apiVersion));
-
-        if (attribute.pcontextAttribute->compoundValueP->isObject())
-        {
-          answer = "{" + answer + "}";
-        }
-        else if (attribute.pcontextAttribute->compoundValueP->isVector())
-        {
-          answer = "[" + answer + "]";
-        }
       }
       else
       {

--- a/src/lib/serviceRoutinesV2/getRegistrations.cpp
+++ b/src/lib/serviceRoutinesV2/getRegistrations.cpp
@@ -84,7 +84,7 @@ std::string getRegistrations
   if ((ciP->uriParamOptions["count"]))
   {
     ciP->httpHeader.push_back(HTTP_FIWARE_TOTAL_COUNT);
-    ciP->httpHeaderValue.push_back(toString(count));
+    ciP->httpHeaderValue.push_back(double2string(count));
   }
 
   TIMED_RENDER(out = vectorToJson(registrationV));

--- a/test/functionalTest/cases/0000_ipv6_support/ipv6_only.test
+++ b/test/functionalTest/cases/0000_ipv6_support/ipv6_only.test
@@ -155,4 +155,4 @@ Date: REGEX(.*)
 brokerStop CB
 accumulatorStop ${LISTENER_PORT}
 accumulatorStop ${LISTENER2_PORT}
-#dbDrop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange.test
+++ b/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange.test
@@ -38,8 +38,8 @@ payload='{
         }
     ],
     "attributes": [
-        "temperature",
-        "ligthstatus"
+        "ligthstatus",
+        "temperature"
     ],
     "reference": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
     "duration": "PT1H",

--- a/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange_nocache.test
+++ b/test/functionalTest/cases/0000_ngsi10_convenience/subscriptions_onchange_nocache.test
@@ -39,8 +39,8 @@ payload='{
         }
     ],
     "attributes": [
-        "temperature",
-        "ligthstatus"
+        "ligthstatus",
+        "temperature"
     ],
     "reference": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
     "duration": "PT1H",

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange.test
@@ -38,8 +38,8 @@ payload='{
         }
     ],
     "attributes": [
-        "temperature",
-        "lightstatus"
+        "lightstatus",
+        "temperature"
     ],
     "reference": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
     "duration": "PT1H",

--- a/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange_nocache.test
+++ b/test/functionalTest/cases/0000_ngsi10_subscriptions/subscription_sequence_onchange_nocache.test
@@ -40,8 +40,8 @@ payload='{
         }
     ],
     "attributes": [
-        "temperature",
-        "lightstatus"
+        "lightstatus",
+        "temperature"
     ],
     "reference": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
     "duration": "PT1H",

--- a/test/functionalTest/cases/0876_entity_dates/entity_dates_overridden_by_user_subs.test
+++ b/test/functionalTest/cases/0876_entity_dates/entity_dates_overridden_by_user_subs.test
@@ -432,7 +432,7 @@ Date: REGEX(.*)
 =======================================================================================================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 362
+Content-Length: 279
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -461,11 +461,6 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {},
                 "type": "Text",
                 "value": "bar"
-            },
-            "dateModified": {
-                "metadata": {},
-                "type": "DateTime",
-                "value": "REGEX(20[1|2]\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\dZ)"
             },
             "id": "E2",
             "type": "T"

--- a/test/functionalTest/cases/0876_entity_dates/entity_dates_overridden_by_user_subs.test
+++ b/test/functionalTest/cases/0876_entity_dates/entity_dates_overridden_by_user_subs.test
@@ -432,7 +432,7 @@ Date: REGEX(.*)
 =======================================================================================================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 279
+Content-Length: 362
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -461,6 +461,11 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {},
                 "type": "Text",
                 "value": "bar"
+            },
+            "dateModified": {
+                "metadata": {},
+                "type": "DateTime",
+                "value": "REGEX(20[1|2]\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\dZ)"
             },
             "id": "E2",
             "type": "T"

--- a/test/functionalTest/cases/1179_options_test/GET_v2_ent_attr_val_options_text.test
+++ b/test/functionalTest/cases/1179_options_test/GET_v2_ent_attr_val_options_text.test
@@ -58,7 +58,7 @@ echo
 echo
 
 
-echo "02. GET /v2/entities/E!/attrs/a_string/value"
+echo "02. GET /v2/entities/E1/attrs/a_string/value"
 echo "============================================"
 orionCurl --url /v2/entities/E1/attrs/a_string/value --out text
 echo
@@ -104,7 +104,7 @@ Date: REGEX(.*)
 
 
 
-02. GET /v2/entities/E!/attrs/a_string/value
+02. GET /v2/entities/E1/attrs/a_string/value
 ============================================
 HTTP/1.1 200 OK
 Content-Length: 12

--- a/test/functionalTest/cases/1367_time_measures/time_measure_stats.test
+++ b/test/functionalTest/cases/1367_time_measures/time_measure_stats.test
@@ -217,7 +217,7 @@ echo
 01. Second call to GET /statistics (gives time stat of FIRST request for /statistics)
 =====================================================================================
 HTTP/1.1 200 OK
-Content-Length: 127
+Content-Length: REGEX(.*)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -326,7 +326,7 @@ Date: REGEX(.*)
 03. GET /statistics
 ===================
 HTTP/1.1 200 OK
-Content-Length: 451
+Content-Length: REGEX(.*)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -370,7 +370,7 @@ Date: REGEX(.*)
 05. GET /statistics
 ===================
 HTTP/1.1 200 OK
-Content-Length: 477
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -435,7 +435,7 @@ Date: REGEX(.*)
 07. GET /statistics
 ===================
 HTTP/1.1 200 OK
-Content-Length: 422
+Content-Length: REGEX(.*)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/functionalTest/cases/2507_csub_metadata_field/previous_value_with_compounds.test
+++ b/test/functionalTest/cases/2507_csub_metadata_field/previous_value_with_compounds.test
@@ -265,7 +265,7 @@ Date: REGEX(.*)
 ==============================================================================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 220
+Content-Length: 217
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -279,13 +279,13 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
             "A": {
                 "metadata": {
                     "previousValue": {
-                        "toplevel": [
+                        "type": "ComplexVector",
+                        "value": [
                             1,
                             {
                                 "b": "foo"
                             }
-                        ],
-                        "type": "ComplexVector"
+                        ]
                     }
                 },
                 "type": "ComplexObject",

--- a/test/functionalTest/cases/2750_common_metrics/2750_complex_service_path.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_complex_service_path.test
@@ -125,7 +125,7 @@ Date: REGEX(.*)
 05. Ask for Metrics, see A1 and A2 as service paths, as well as two 'root service path'
 =======================================================================================
 HTTP/1.1 200 OK
-Content-Length: REGEX((842|850))
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/functionalTest/cases/2750_common_metrics/2750_forwards.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_forwards.test
@@ -304,7 +304,7 @@ Date: REGEX(.*)
 09. Ask for metrics, see 1 error in outgoing transactions
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 1908
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/functionalTest/cases/2750_common_metrics/2750_reset_metrics.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_reset_metrics.test
@@ -146,7 +146,7 @@ Date: REGEX(.*)
 04. Ask for Metrics, see 1 Incoming Transaction (the reset-request in step 03 :-)
 =================================================================================
 HTTP/1.1 200 OK
-Content-Length: 332
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -184,7 +184,7 @@ Date: REGEX(.*)
 05. Ask for Metrics, with ?reset=true to reset after responding
 ===============================================================
 HTTP/1.1 200 OK
-Content-Length: 620
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -198,13 +198,13 @@ Date: REGEX(.*)
                     "serviceTime": REGEX(.*)
                 },
                 "root-subserv": {
-                    "incomingTransactionResponseSize": 332,
+                    "incomingTransactionResponseSize": 320,
                     "incomingTransactions": 1,
                     "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
-                "incomingTransactionResponseSize": 332,
+                "incomingTransactionResponseSize": 320,
                 "incomingTransactions": 2,
                 "serviceTime": REGEX(.*)
             }
@@ -217,13 +217,13 @@ Date: REGEX(.*)
                 "serviceTime": REGEX(.*)
             },
             "root-subserv": {
-                "incomingTransactionResponseSize": 332,
+                "incomingTransactionResponseSize": 320,
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             }
         },
         "sum": {
-            "incomingTransactionResponseSize": 332,
+            "incomingTransactionResponseSize": 320,
             "incomingTransactions": 2,
             "serviceTime": REGEX(.*)
         }
@@ -234,7 +234,7 @@ Date: REGEX(.*)
 06. Ask for Metrics, see 1 Incoming Transaction (step 05)
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 456
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -244,13 +244,13 @@ Date: REGEX(.*)
         "default-service": {
             "subservs": {
                 "SP5": {
-                    "incomingTransactionResponseSize": 620,
+                    "incomingTransactionResponseSize": REGEX(\d+),
                     "incomingTransactions": 1,
                     "serviceTime": REGEX(.*)
                 }
             },
             "sum": {
-                "incomingTransactionResponseSize": 620,
+                "incomingTransactionResponseSize": REGEX(\d+),
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             }
@@ -259,13 +259,13 @@ Date: REGEX(.*)
     "sum": {
         "subservs": {
             "SP5": {
-                "incomingTransactionResponseSize": 620,
+                "incomingTransactionResponseSize": REGEX(\d+),
                 "incomingTransactions": 1,
                 "serviceTime": REGEX(.*)
             }
         },
         "sum": {
-            "incomingTransactionResponseSize": 620,
+            "incomingTransactionResponseSize": REGEX(\d+),
             "incomingTransactions": 1,
             "serviceTime": REGEX(.*)
         }

--- a/test/functionalTest/cases/2750_common_metrics/2750_totalPayloadAsMetric.test
+++ b/test/functionalTest/cases/2750_common_metrics/2750_totalPayloadAsMetric.test
@@ -241,7 +241,7 @@ Date: REGEX(.*)
 06. Ask for Metrics, see 6 Incoming Transactions, and 150 bytes in incomingTransactionRequestSize
 =================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 931
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -317,7 +317,7 @@ Date: REGEX(.*)
 08. Ask for Metrics, see 8, and see incomingTransactionResponseSize
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 1145
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/functionalTest/cases/2846_empty_maps_in_metrics/empty_maps_in_metrics.test
+++ b/test/functionalTest/cases/2846_empty_maps_in_metrics/empty_maps_in_metrics.test
@@ -94,7 +94,7 @@ Date: REGEX(.*)
 03. GET metrics and reset metrics at the same time
 ==================================================
 HTTP/1.1 200 OK
-Content-Length: 678
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -150,7 +150,7 @@ Date: REGEX(.*)
 04. GET metrics, see no 'emptied reported items'
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 461
+Content-Length: REGEX(\d+)
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/unittests/commonMocks.h
+++ b/test/unittests/commonMocks.h
@@ -223,15 +223,13 @@ class NotifierMock : public Notifier
      */
   }
 
-  MOCK_METHOD9(sendNotifyContextRequest, void(NotifyContextRequest*            ncr,
+  MOCK_METHOD7(sendNotifyContextRequest, void(NotifyContextRequest*            ncr,
                                               const ngsiv2::HttpInfo&          httpInfo,
                                               const std::string&               tenant,
                                               const std::string&               xauthToken,
                                               const std::string&               fiwareCorrelator,
                                               RenderFormat                     renderFormat,
-                                              const std::vector<std::string>&  attrsFilter,
-                                              const std::vector<std::string>&  metadataFilter,
-                                              bool                             blacklist));
+                                              const std::vector<std::string>&  metadataFilter));
 
     MOCK_METHOD5(sendNotifyContextAvailabilityRequest, void(NotifyContextAvailabilityRequest*  ncar,
                                                             const std::string&                 url,
@@ -246,11 +244,9 @@ class NotifierMock : public Notifier
                                          const std::string&               xauthToken,
                                          const std::string&               fiwareCorrelator,
                                          RenderFormat                     renderFormat,
-                                         const std::vector<std::string>&  attrsFilter,
-                                         const std::vector<std::string>&  metadataFilter,
-                                         bool                             blacklist = false)
+                                         const std::vector<std::string>&  metadataFilter)
     {
-      Notifier::sendNotifyContextRequest(ncr, httpInfo, tenant, xauthToken, fiwareCorrelator, renderFormat, attrsFilter, metadataFilter, blacklist);
+      Notifier::sendNotifyContextRequest(ncr, httpInfo, tenant, xauthToken, fiwareCorrelator, renderFormat, metadataFilter);
     }
 
     void parent_sendNotifyContextAvailabilityRequest(NotifyContextAvailabilityRequest*  ncar,

--- a/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
@@ -2518,7 +2518,7 @@ TEST(mongoSubscribeContextAvailability, MongoDbInsertFail)
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     TimerMock* timerMock = new TimerMock();

--- a/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
@@ -2774,7 +2774,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_disjoint)
 
     NotifierMock*                notifierMock = new NotifierMock();
     std::vector<std::string>     metadataFilter;
-    ngsiv2::HttpInfo             httpInfo("http://notify.me");    
+    ngsiv2::HttpInfo             httpInfo("http://notify.me");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3198,7 +3198,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN)
 
     NotifierMock*                notifierMock = new NotifierMock();
     std::vector<std::string>     metadataFilter;
-    ngsiv2::HttpInfo             httpInfo("http://notify.me");    
+    ngsiv2::HttpInfo             httpInfo("http://notify.me");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),

--- a/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
@@ -292,7 +292,7 @@ TEST(mongoSubscribeContext, Ent1_Attr0_C1)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -372,7 +372,7 @@ TEST(mongoSubscribeContext, Ent1_AttrN_C1)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -456,7 +456,7 @@ TEST(mongoSubscribeContext, Ent1_Attr0_CN)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -540,7 +540,7 @@ TEST(mongoSubscribeContext, Ent1_Attr0_CNbis)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -622,7 +622,7 @@ TEST(mongoSubscribeContext, Ent1_AttrN_CN)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -713,7 +713,7 @@ TEST(mongoSubscribeContext, Ent1_AttrN_CNbis)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -802,7 +802,7 @@ TEST(mongoSubscribeContext, EntN_Attr0_C1)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -888,7 +888,7 @@ TEST(mongoSubscribeContext, EntN_AttrN_C1)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -978,7 +978,7 @@ TEST(mongoSubscribeContext, EntN_Attr0_CN)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1068,7 +1068,7 @@ TEST(mongoSubscribeContext, EntN_Attr0_CNbis)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1156,7 +1156,7 @@ TEST(mongoSubscribeContext, EntN_AttrN_CN)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1250,7 +1250,7 @@ TEST(mongoSubscribeContext, EntN_AttrN_CNbis)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1356,7 +1356,6 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_C1)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
 
@@ -1366,9 +1365,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
 
     setNotifier(notifierMock);
 
@@ -1460,7 +1457,6 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_C1_JSON)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*               notifierMock = new NotifierMock();
-    std::vector<std::string>    attrsFilter;
     std::vector<std::string>    metadataFilter;
     ngsiv2::HttpInfo            httpInfo("http://notify.me");
 
@@ -1470,9 +1466,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_C1_JSON)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1561,12 +1555,8 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*               notifierMock = new NotifierMock();
-    std::vector<std::string>    attrsFilter;
     std::vector<std::string>    metadataFilter;
     ngsiv2::HttpInfo            httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1574,9 +1564,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1669,12 +1657,8 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_C1_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1682,9 +1666,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_C1_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1793,12 +1775,8 @@ TEST(mongoSubscribeContext, matchEnt1NoType_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cer3P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1806,9 +1784,7 @@ TEST(mongoSubscribeContext, matchEnt1NoType_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1917,12 +1893,8 @@ TEST(mongoSubscribeContext, matchEnt1NoType_AttrN_C1_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cer3P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1930,9 +1902,7 @@ TEST(mongoSubscribeContext, matchEnt1NoType_AttrN_C1_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2033,12 +2003,8 @@ TEST(mongoSubscribeContext, matchEnt1Pattern_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2046,9 +2012,7 @@ TEST(mongoSubscribeContext, matchEnt1Pattern_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2149,12 +2113,8 @@ TEST(mongoSubscribeContext, matchEnt1Pattern_AttrN_C1_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2162,9 +2122,7 @@ TEST(mongoSubscribeContext, matchEnt1Pattern_AttrN_C1_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2279,12 +2237,8 @@ TEST(mongoSubscribeContext, matchEnt1PatternNoType_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cer4P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2292,9 +2246,7 @@ TEST(mongoSubscribeContext, matchEnt1PatternNoType_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2409,12 +2361,8 @@ TEST(mongoSubscribeContext, matchEnt1PatternNoType_AttrN_C1_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cer4P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2422,9 +2370,7 @@ TEST(mongoSubscribeContext, matchEnt1PatternNoType_AttrN_C1_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2519,7 +2465,6 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_CN)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
 
@@ -2529,9 +2474,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_CN)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2626,7 +2569,6 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_CN_partial)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
 
@@ -2636,9 +2578,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_CN_partial)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2734,7 +2674,6 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_CNbis)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
 
@@ -2744,9 +2683,7 @@ TEST(mongoSubscribeContext, matchEnt1_Attr0_CNbis)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2836,12 +2773,8 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
-    ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
+    ngsiv2::HttpInfo             httpInfo("http://notify.me");    
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2849,9 +2782,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2948,12 +2879,8 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_partial)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2961,9 +2888,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_partial)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3060,12 +2985,8 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_partial_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3073,9 +2994,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN_partial_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3172,12 +3091,8 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CNbis)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3185,9 +3100,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CNbis)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3284,12 +3197,8 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
-    ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
+    ngsiv2::HttpInfo             httpInfo("http://notify.me");    
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3297,9 +3206,7 @@ TEST(mongoSubscribeContext, matchEnt1_AttrN_CN)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3410,7 +3317,6 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_C1)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
 
@@ -3420,9 +3326,7 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3524,12 +3428,8 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3537,9 +3437,7 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3649,7 +3547,6 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_CN)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
 
@@ -3659,9 +3556,7 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_CN)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3772,7 +3667,6 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_CNbis)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
 
@@ -3782,9 +3676,7 @@ TEST(mongoSubscribeContext, matchEntN_Attr0_CNbis)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3888,12 +3780,8 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_CN)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3901,9 +3789,7 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_CN)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -4011,12 +3897,8 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_CNbis)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -4024,9 +3906,7 @@ TEST(mongoSubscribeContext, matchEntN_AttrN_CNbis)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -4119,7 +3999,7 @@ TEST(mongoSubscribeContext, defaultDuration)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -4204,7 +4084,7 @@ TEST(mongoSubscribeContext, MongoDbInsertFail)
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 

--- a/test/unittests/mongoBackend/mongoUnsubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUnsubscribeContext_test.cpp
@@ -116,7 +116,7 @@ TEST(mongoUnsubscribeContext, subscriptionNotFound)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -156,7 +156,7 @@ TEST(mongoUnsubscribeContext, unsubscribe)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -205,7 +205,7 @@ TEST(mongoUnsubscribeContext, MongoDbFindOneFail)
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -277,7 +277,7 @@ TEST(mongoUnsubscribeContext, MongoDbRemoveFail)
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 

--- a/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
@@ -432,7 +432,7 @@ TEST(mongoUpdateContextSubscription, subscriptionNotFound)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -475,7 +475,7 @@ TEST(mongoUpdateContextSubscription, updateDuration)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -567,7 +567,7 @@ TEST(mongoUpdateContextSubscription, updateThrottling)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -641,7 +641,7 @@ TEST(mongoUpdateContextSubscription, clearThrottling)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -717,7 +717,7 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_C1)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -796,7 +796,7 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_C1)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -876,7 +876,7 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_CN)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -958,7 +958,7 @@ TEST(mongoUpdateContextSubscription, Ent1_Attr0_CNbis)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1038,7 +1038,7 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_CN)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1123,7 +1123,7 @@ TEST(mongoUpdateContextSubscription, Ent1_AttrN_CNbis)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1207,7 +1207,7 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_C1)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1289,7 +1289,7 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_C1)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1373,7 +1373,7 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_CN)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1461,7 +1461,7 @@ TEST(mongoUpdateContextSubscription, EntN_Attr0_CNbis)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1543,7 +1543,7 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_CN)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1629,7 +1629,7 @@ TEST(mongoUpdateContextSubscription, EntN_AttrN_CNbis)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -1727,7 +1727,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_C1)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
@@ -1737,9 +1736,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1826,7 +1823,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_C1_JSON)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
@@ -1836,9 +1832,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_C1_JSON)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1923,7 +1917,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -1933,9 +1926,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2023,7 +2014,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_C1_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2033,9 +2023,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_C1_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2138,7 +2126,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1NoType_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cer3P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2148,9 +2135,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1NoType_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2253,7 +2238,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1NoType_AttrN_C1_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cer3P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2263,9 +2247,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1NoType_AttrN_C1_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2360,7 +2342,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1Pattern_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2370,9 +2351,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1Pattern_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2467,7 +2446,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1Pattern_AttrN_C1_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2477,9 +2455,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1Pattern_AttrN_C1_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2588,7 +2564,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1PatternNoType_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cer4P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2598,9 +2573,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1PatternNoType_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2709,7 +2682,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1PatternNoType_AttrN_C1_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cer4P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2719,9 +2691,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1PatternNoType_AttrN_C1_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2811,7 +2781,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_CN)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
@@ -2821,9 +2790,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_CN)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2915,7 +2882,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_CN_partial)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
@@ -2925,9 +2891,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_CN_partial)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3020,7 +2984,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_CNbis)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
@@ -3030,9 +2993,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_Attr0_CNbis)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3120,7 +3081,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -3130,9 +3090,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3224,7 +3182,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN_partial)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -3234,9 +3191,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN_partial)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3328,7 +3283,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN_partial_disjoint)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -3338,9 +3292,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN_partial_disjoint)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3432,7 +3384,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CNbis)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -3442,9 +3393,7 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CNbis)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3536,7 +3485,6 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN)
     expectedNcr.contextElementResponseVector.push_back(cerP);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -3546,13 +3494,8 @@ TEST(mongoUpdateContextSubscription, matchEnt1_AttrN_CN)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A2");
 
     /* Forge the request (from "inside" to "outside") */
     req.subscriptionId.set("51307b66f481db11bf860002");
@@ -3656,7 +3599,6 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_C1)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify3.me");
 
@@ -3666,9 +3608,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3765,7 +3705,6 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_C1)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify4.me");
 
@@ -3775,9 +3714,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_C1)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3880,7 +3817,6 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_CN)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify3.me");
 
@@ -3890,9 +3826,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_CN)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3997,7 +3931,6 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_CNbis)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify3.me");
 
@@ -4007,9 +3940,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_Attr0_CNbis)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -4108,7 +4039,6 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_CN)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify4.me");
 
@@ -4118,9 +4048,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_CN)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -4221,7 +4149,6 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_CNbis)
     expectedNcr.contextElementResponseVector.push_back(cer2P);
 
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify4.me");
 
@@ -4231,9 +4158,7 @@ TEST(mongoUpdateContextSubscription, matchEntN_AttrN_CNbis)
                                                         "",
                                                         "no correlator",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -4318,7 +4243,7 @@ TEST(mongoUpdateContextSubscription, updateDurationAndNotifyConditions)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -4399,7 +4324,7 @@ TEST(mongoUpdateContextSubscription, MongoDbFindOneFail)
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 
@@ -4465,7 +4390,7 @@ TEST(mongoUpdateContextSubscription, MongoDbUpdateFail)
             .WillByDefault(Return(fakeSub));
 
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
@@ -393,9 +393,9 @@ static void prepareDatabaseWithNoTypeSubscriptions(void)
 */
 #define CHECK_LAST_NOTIFICATION(subId, timestamp)                                      \
 {                                                                                      \
-  DBClientBase* connection = getMongoConnection();                                     \
-  BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID(subId))); \
-  EXPECT_EQ(timestamp, sub.getIntField("lastNotification"));                           \
+  DBClientBase* connection = getMongoConnection();
+  BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID(subId)));
+  EXPECT_EQ(timestamp, sub.getIntField("lastNotification"));
 }
 
 
@@ -1690,7 +1690,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMixMatchNo
     expectedNcr.contextElementResponseVector.push_back(cerP);
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
-    ngsiv2::HttpInfo          httpInfo("http://notify1.me");  
+    ngsiv2::HttpInfo          httpInfo("http://notify1.me");
     std::vector<std::string>  metadataFilter;
 
     NotifierMock* notifierMock = new NotifierMock();
@@ -2206,7 +2206,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_deleteMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  metadataFilter;   
+    std::vector<std::string>  metadataFilter;
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2329,7 +2329,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_appendMatchDisjo
     expectedNcr.contextElementResponseVector.push_back(cerP);
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
-    ngsiv2::HttpInfo          httpInfo("http://notify2.me");    
+    ngsiv2::HttpInfo          httpInfo("http://notify2.me");
     std::vector<std::string>  metadataFilter;
 
     NotifierMock* notifierMock = new NotifierMock();

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
@@ -393,9 +393,9 @@ static void prepareDatabaseWithNoTypeSubscriptions(void)
 */
 #define CHECK_LAST_NOTIFICATION(subId, timestamp)                                      \
 {                                                                                      \
-  DBClientBase* connection = getMongoConnection();
-  BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID(subId)));
-  EXPECT_EQ(timestamp, sub.getIntField("lastNotification"));
+  DBClientBase* connection = getMongoConnection();                                     \
+  BSONObj sub = connection->findOne(SUBSCRIBECONTEXT_COLL, BSON("_id" << OID(subId))); \
+  EXPECT_EQ(timestamp, sub.getIntField("lastNotification"));                           \
 }
 
 

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
@@ -425,11 +425,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -438,9 +434,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -497,11 +491,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -510,9 +500,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -566,9 +554,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_type
     ngsiv2::HttpInfo          httpInfo("http://notify10.me");
     std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -577,9 +562,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_type
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -631,11 +614,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_idAn
     expectedNcr.subscriptionId.set("51307b66f481db11bf860011");
 
     ngsiv2::HttpInfo          httpInfo("http://notify11.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -644,9 +623,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_idAn
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -698,11 +675,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -711,9 +684,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -770,14 +741,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatch_noTy
     expectedNcr1.subscriptionId.set("51307b66f481db11bf860001");
     expectedNcr2.subscriptionId.set("51307b66f481db11bf860004");
 
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo1("http://notify1.me");
     ngsiv2::HttpInfo             httpInfo4("http://notify4.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr1),
@@ -786,9 +752,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatch_noTy
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr2),
                                                         MatchHttpInfo(&httpInfo4),
@@ -796,9 +760,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatch_noTy
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -859,11 +821,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_noTy
 
     ngsiv2::HttpInfo          httpInfo1("http://notify1.me");
     ngsiv2::HttpInfo          httpInfo4("http://notify4.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr1),
@@ -872,9 +830,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_noTy
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr2),
                                                         MatchHttpInfo(&httpInfo4),
@@ -882,9 +838,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_noTy
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -940,11 +894,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatch_noTy
 
     ngsiv2::HttpInfo          httpInfo1("http://notify1.me");
     ngsiv2::HttpInfo          httpInfo4("http://notify4.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr1),
@@ -953,9 +903,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatch_noTy
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr2),
                                                         MatchHttpInfo(&httpInfo4),
@@ -963,9 +911,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatch_noTy
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1019,11 +965,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatch_patt
     expectedNcr.subscriptionId.set("51307b66f481db11bf860003");
 
     ngsiv2::HttpInfo          httpInfo("http://notify3.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1032,9 +974,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatch_patt
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1089,11 +1029,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_patt
     expectedNcr.subscriptionId.set("51307b66f481db11bf860003");
 
     ngsiv2::HttpInfo          httpInfo("http://notify3.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1102,9 +1038,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_patt
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1155,11 +1089,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatch_patt
     expectedNcr.subscriptionId.set("51307b66f481db11bf860003");
 
     ngsiv2::HttpInfo          httpInfo("http://notify3.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1168,9 +1098,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatch_patt
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1223,11 +1151,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatch_patt
     expectedNcr.subscriptionId.set("51307b66f481db11bf860005");
 
     ngsiv2::HttpInfo          httpInfo("http://notify5.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1236,9 +1160,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatch_patt
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1293,11 +1215,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_patt
     expectedNcr.subscriptionId.set("51307b66f481db11bf860005");
 
     ngsiv2::HttpInfo          httpInfo("http://notify5.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1306,9 +1224,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatch_patt
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1359,11 +1275,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatch_patt
     expectedNcr.subscriptionId.set("51307b66f481db11bf860005");
 
     ngsiv2::HttpInfo          httpInfo("http://notify5.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1372,9 +1284,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatch_patt
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1427,11 +1337,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatchDisjo
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1440,9 +1346,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatchDisjo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1495,11 +1399,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatchDisjo
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1508,9 +1408,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMatchDisjo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1563,11 +1461,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatchDisjo
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1576,9 +1470,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMatchDisjo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1620,7 +1512,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1662,7 +1554,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1704,7 +1596,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1746,7 +1638,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMatchWitho
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1798,12 +1690,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMixMatchNo
     expectedNcr.contextElementResponseVector.push_back(cerP);
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
-    ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
+    ngsiv2::HttpInfo          httpInfo("http://notify1.me");  
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1812,9 +1700,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_updateMixMatchNo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1884,9 +1770,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_appendMixMatchNo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1939,11 +1823,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMixMatchNo
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -1952,9 +1832,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_deleteMixMatchNo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2022,9 +1900,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_update2Matches1N
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2081,11 +1957,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_append2Matches1N
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2094,9 +1966,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_append2Matches1N
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2149,11 +2019,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_delete2Matches1N
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     ngsiv2::HttpInfo          httpInfo("http://notify1.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2162,9 +2028,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, Cond1_delete2Matches1N
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2217,11 +2081,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_updateMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2230,9 +2090,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_updateMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2288,11 +2146,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_appendMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2301,9 +2155,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_appendMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2354,11 +2206,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_deleteMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
-    std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
+    std::vector<std::string>  metadataFilter;   
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2367,9 +2215,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_deleteMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2422,11 +2268,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_updateMatchDisjo
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2435,9 +2277,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_updateMatchDisjo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2489,12 +2329,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_appendMatchDisjo
     expectedNcr.contextElementResponseVector.push_back(cerP);
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
-    ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
+    ngsiv2::HttpInfo          httpInfo("http://notify2.me");    
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2503,9 +2339,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_appendMatchDisjo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2558,11 +2392,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_deleteMatchDisjo
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2571,9 +2401,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_deleteMatchDisjo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2615,7 +2443,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_updateNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2657,7 +2485,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_appendNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2699,7 +2527,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_deleteNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2741,7 +2569,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_updateMatchWitho
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2794,11 +2622,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_updateMixMatchNo
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2807,9 +2631,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_updateMixMatchNo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2866,11 +2688,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_appendMixMatchNo
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2879,9 +2697,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_appendMixMatchNo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2934,11 +2750,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_deleteMixMatchNo
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -2947,9 +2759,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_deleteMixMatchNo
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3004,11 +2814,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_update2Matches1N
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -3017,9 +2823,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_update2Matches1N
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3076,11 +2880,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_append2Matches1N
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -3089,9 +2889,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_append2Matches1N
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3144,11 +2942,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_delete2Matches1N
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     ngsiv2::HttpInfo          httpInfo("http://notify2.me");
-    std::vector<std::string>  attrsFilter;
     std::vector<std::string>  metadataFilter;
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     NotifierMock* notifierMock = new NotifierMock();
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
@@ -3157,9 +2951,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, CondN_delete2Matches1N
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3215,7 +3007,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, DISABLED_MongoDbQueryF
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _)).Times(0);
     setNotifier(notifierMock);
 
     /* Set MongoDB connection */

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
@@ -1645,7 +1645,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMixMatchNoMatch)
 
     NotifierMock* notifierMock = new NotifierMock();
     std::vector<std::string>     metadataFilter;
-    ngsiv2::HttpInfo             httpInfo("http://notify1.me");    
+    ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
@@ -391,19 +391,13 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch)
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
-
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
                                                         "",
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -461,13 +455,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -475,9 +464,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -530,13 +517,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -544,9 +526,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -605,14 +585,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_noType)
     expectedNcr2.subscriptionId.set("51307b66f481db11bf860004");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
     ngsiv2::HttpInfo             httpInfo2("http://notify4.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr1),
                                                         MatchHttpInfo(&httpInfo),
@@ -620,9 +595,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_noType)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr2),
                                                         MatchHttpInfo(&httpInfo2),
@@ -630,9 +603,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_noType)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -699,14 +670,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_noType)
     expectedNcr2.subscriptionId.set("51307b66f481db11bf860004");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
     ngsiv2::HttpInfo             httpInfo2("http://notify4.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr1),
                                                         MatchHttpInfo(&httpInfo),
@@ -714,9 +680,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_noType)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr2),
                                                         MatchHttpInfo(&httpInfo2),
@@ -724,9 +688,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_noType)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -789,15 +751,9 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_noType)
     expectedNcr2.subscriptionId.set("51307b66f481db11bf860004");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
     ngsiv2::HttpInfo             httpInfo2("http://notify4.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
-
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr1),
                                                         MatchHttpInfo(&httpInfo),
@@ -805,9 +761,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_noType)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr2),
                                                         MatchHttpInfo(&httpInfo2),
@@ -815,9 +769,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_noType)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
 
     setNotifier(notifierMock);
 
@@ -879,14 +831,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_pattern)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860003");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify3.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
-
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -894,9 +840,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_pattern)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
 
     setNotifier(notifierMock);
 
@@ -957,13 +901,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_pattern)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860003");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify3.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -971,9 +910,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_pattern)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1028,13 +965,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_pattern)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860003");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify3.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1042,9 +974,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_pattern)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1101,13 +1031,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_pattern_noT
     expectedNcr.subscriptionId.set("51307b66f481db11bf860005");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify5.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1115,9 +1040,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatch_pattern_noT
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1176,13 +1099,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_pattern_noT
     expectedNcr.subscriptionId.set("51307b66f481db11bf860005");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify5.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1190,9 +1108,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatch_pattern_noT
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1247,13 +1163,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_pattern_noT
     expectedNcr.subscriptionId.set("51307b66f481db11bf860005");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify5.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1261,9 +1172,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatch_pattern_noT
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1320,13 +1229,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatchDisjoint)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1334,9 +1238,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatchDisjoint)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1393,13 +1295,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatchDisjoint)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1407,9 +1304,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMatchDisjoint)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1466,13 +1361,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatchDisjoint)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1480,9 +1370,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMatchDisjoint)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1528,7 +1416,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
@@ -1538,9 +1425,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(0);
+                                                        metadataFilter)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1586,7 +1471,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
@@ -1596,9 +1480,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(0);
+                                                        metadataFilter)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1643,7 +1525,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
@@ -1653,9 +1534,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(0);
+                                                        metadataFilter)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1700,7 +1579,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatchWithoutChang
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
 
@@ -1710,9 +1588,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMatchWithoutChang
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(0);
+                                                        metadataFilter)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1768,13 +1644,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMixMatchNoMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
-    ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
+    ngsiv2::HttpInfo             httpInfo("http://notify1.me");    
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1782,9 +1653,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_updateMixMatchNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1845,13 +1714,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMixMatchNoMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1859,9 +1723,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_appendMixMatchNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1918,13 +1780,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMixMatchNoMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -1932,9 +1789,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_deleteMixMatchNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -1994,13 +1849,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_update2Matches1Notifica
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2008,9 +1858,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_update2Matches1Notifica
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2073,13 +1921,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_append2Matches1Notifica
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2087,9 +1930,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_append2Matches1Notifica
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2147,13 +1988,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_delete2Matches1Notifica
     expectedNcr.subscriptionId.set("51307b66f481db11bf860001");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify1.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2161,9 +1997,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, Cond1_delete2Matches1Notifica
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2220,13 +2054,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2234,9 +2063,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2296,13 +2123,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2310,9 +2132,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2367,13 +2187,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2381,9 +2196,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2440,13 +2253,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatchDisjoint)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2454,9 +2262,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatchDisjoint)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2514,13 +2320,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMatchDisjoint)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2528,9 +2329,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMatchDisjoint)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2587,13 +2386,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMatchDisjoint)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2601,9 +2395,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMatchDisjoint)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2649,7 +2441,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateNoMatch)
 
     /* Prepare mock */
     NotifierMock*                notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2659,9 +2450,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(0);
+                                                        metadataFilter)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2706,7 +2495,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2716,9 +2504,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(0);
+                                                        metadataFilter)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2763,7 +2549,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteNoMatch)
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2773,9 +2558,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(0);
+                                                        metadataFilter)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2820,7 +2603,6 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatchWithoutChang
 
     /* Prepare mock */
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
 
@@ -2830,9 +2612,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMatchWithoutChang
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(0);
+                                                        metadataFilter)).Times(0);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2888,13 +2668,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMixMatchNoMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2902,9 +2677,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_updateMixMatchNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -2965,13 +2738,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMixMatchNoMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -2979,9 +2747,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_appendMixMatchNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3038,13 +2804,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMixMatchNoMatch)
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3052,9 +2813,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_deleteMixMatchNoMatch)
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3113,13 +2872,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_update2Matches1Notifica
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3127,9 +2881,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_update2Matches1Notifica
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3191,13 +2943,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_append2Matches1Notifica
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3205,9 +2952,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_append2Matches1Notifica
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3265,13 +3010,8 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_delete2Matches1Notifica
     expectedNcr.subscriptionId.set("51307b66f481db11bf860002");
 
     NotifierMock* notifierMock = new NotifierMock();
-    std::vector<std::string>     attrsFilter;
     std::vector<std::string>     metadataFilter;
     ngsiv2::HttpInfo             httpInfo("http://notify2.me");
-
-    attrsFilter.push_back("A1");
-    attrsFilter.push_back("A3");
-    attrsFilter.push_back("A4");
 
     EXPECT_CALL(*notifierMock, sendNotifyContextRequest(MatchNcr(&expectedNcr),
                                                         MatchHttpInfo(&httpInfo),
@@ -3279,9 +3019,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, CondN_delete2Matches1Notifica
                                                         "",
                                                         "",
                                                         NGSI_V1_LEGACY,
-                                                        attrsFilter,
-                                                        metadataFilter,
-                                                        false)).Times(1);
+                                                        metadataFilter)).Times(1);
     setNotifier(notifierMock);
 
     /* Forge the request (from "inside" to "outside") */
@@ -3341,7 +3079,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, DISABLED_MongoDbQueryFail)
             .WillByDefault(Throw(e));
 
     NotifierMock* notifierMock = new NotifierMock();
-    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _, _, _))
+    EXPECT_CALL(*notifierMock, sendNotifyContextRequest(_, _, _, _, _, _, _))
             .Times(0);
     setNotifier(notifierMock);
 


### PR DESCRIPTION
This PR is motivated by https://github.com/telefonicaid/fiware-orion/issues/1298#issuecomment-417659196 and introduces improvements in NGSIv2 rendering logic in both simplfication/unification and peformance aspects. A summary of changes follow.

With regards to simplification/unification:

* Extend JsonHelper utilization along NGSIv2 rendering logic
* Simplification in several methods, mainly:
   * CompoundValueNode::toJson()
   * Entity::toJson() (spliting in several other methods)
   * ContextAttribute::toJson()
   * ContextAttributeVector:.toJson() (removed)
   * MetadataVector::toJson() (the usage of JsonHelper removes the need of double-pass)
* Simplification in argument passing. In particular, `bool comma` removed whenever possible
* Removing stale code.

With regards to peformance:

* JsonHelper implemention changed from std::ostringstream to std::string concatenation (as in previous NGSIv2 renderind code for entities). After the changes in this PR, I think std::ostringstream is no longer used in any part of the CB code.
* Logic in the toJson() methods has been simplified.
* I have done some basic `ab` testing with render intenstive operations (GET /v2/entities?limit=1000 and GET /v2/subscriptions?limit=1000, which 500 bytes entities/subscription, i.e. ~50KB in each GET response). The details of the test are [here for master](https://gist.github.com/fgalan/cdde23007ed7b34b566be72c67121907) and [here for this branch](https://gist.github.com/fgalan/d84d75ec0a66f53672257c860525c2df), but, in summary the result is pretty good:
    * Entities rendering test: from 77.22 tps to 103.06 tps **(33.46% gain)**
    * Subscriptions renderint test: 25.73 tps from to 119.75 tps **(365.4% gain)**

(The script used to populate the database can be found [here](https://gist.github.com/fgalan/e65be5ea398f8553b6a331885f2872e4). Eventually, it would be added to the repository for future usage)

From my point of view, this PR doesn't completes #1298 and more could to be done with regards to simplification and unification (for instance, ContextElement should use Entity internally and this will simplify a lot removing all the specific ContextElement rendering code) and peformance (other implementation alternatives for JsonHelper.cpp could be explored) but I think is an important step ahead.

Note, there are some changes in .test but all there seem to be ok. See specific comments in .test files.