### PR TITLE
lcov command line changes in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -328,9 +328,9 @@ coverage: install_coverage
 	lcov -r coverage/broker.info "/usr/local/include/*" -o coverage/broker.info
 	lcov -r coverage/broker.info "/opt/local/include/google/*" -o coverage/broker.info
 	# Remove unit test libraries and libraries developed before contextBroker project init
-	lcov -r coverage/broker.info "test/unittests/*" -o coverage/broker.info
-	lcov -r coverage/broker.info "src/lib/logMsg/*" -o coverage/broker.info
-	lcov -r coverage/broker.info "src/lib/parseArgs/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/test/unittests/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/src/lib/logMsg/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/src/lib/parseArgs/*" -o coverage/broker.info
 	genhtml -o coverage coverage/broker.info
 
 coverage_unit_test: build_unit_test
@@ -350,11 +350,11 @@ coverage_unit_test: build_unit_test
 	lcov -r coverage/broker.info "/usr/local/include/*" -o coverage/broker.info
 	lcov -r coverage/broker.info "/opt/local/include/google/*" -o coverage/broker.info
 	# Remove unit test libraries and libraries developed before contextBroker project init
-	lcov -r coverage/broker.info "test/unittests/*" -o coverage/broker.info	
-	lcov -r coverage/broker.info "src/lib/logMsg/*" -o coverage/broker.info
-	lcov -r coverage/broker.info "src/lib/parseArgs/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/test/unittests/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/src/lib/logMsg/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/src/lib/parseArgs/*" -o coverage/broker.info
 	# app/ contains application itself, not libraries which make sense to measure unit_test coverage
-	lcov -r coverage/broker.info "src/app/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/src/app/*" -o coverage/broker.info
 	genhtml -o coverage coverage/broker.info
 
 coverage_functional_test: install_coverage
@@ -384,9 +384,9 @@ coverage_functional_test: install_coverage
 	lcov -r coverage/broker.info "/usr/local/include/*" -o coverage/broker.info
 	lcov -r coverage/broker.info "/opt/local/include/google/*" -o coverage/broker.info
 	# Remove unit test libraries and libraries developed before contextBroker project init
-	lcov -r coverage/broker.info "test/unittests/*" -o coverage/broker.info	
-	lcov -r coverage/broker.info "src/lib/logMsg/*" -o coverage/broker.info
-	lcov -r coverage/broker.info "src/lib/parseArgs/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/test/unittests/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/src/lib/logMsg/*" -o coverage/broker.info
+	lcov -r coverage/broker.info "*/src/lib/parseArgs/*" -o coverage/broker.info
 	genhtml -o coverage coverage/broker.info
 
 valgrind: install_debug


### PR DESCRIPTION
It seems the current syntax works for lcov 1.11 but not lcov 1.13 (see details in https://stackoverflow.com/questions/52512768/lcov-remove-option-is-not-removing-coverage-data-as-expected/52515497#52515497)