### PR TITLE
Add JsonVectorHelper class and some related refactors

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Fix: metadata filter was lost during csub cache refresh (#3290)
+- Fix: NGSIv1-like error responses were used in some NGSIv2 operations
 - Remove: isDomain field in NGSIv1 registrations (it was never used)

--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -71,7 +71,7 @@ std::string Attribute::toJson
     {
       if (renderFormat == NGSI_V2_KEYVALUES)
       {
-        JsonHelper jh;
+        JsonObjectHelper jh;
         jh.addRaw(pcontextAttribute->name, pcontextAttribute->toJsonValue());
         out = jh.str();
       }

--- a/src/lib/apiTypesV2/EntID.cpp
+++ b/src/lib/apiTypesV2/EntID.cpp
@@ -37,7 +37,7 @@ namespace ngsiv2
 */
 std::string EntID::toJson()
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   if (!this->id.empty())
   {

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -303,22 +303,15 @@ std::string Entity::toJson
 */
 std::string Entity::toJsonValues(const std::vector<ContextAttribute*>& orderedAttrs)
 {
-  std::string out = "[";
+  JsonVectorHelper jh;
 
   for (unsigned int ix = 0; ix < orderedAttrs.size(); ix++)
   {
     ContextAttribute* caP = orderedAttrs[ix];
-    out += caP->toJsonValue();
-
-    if (ix != orderedAttrs.size() - 1)
-    {
-      out += ",";
-    }
+    jh.addRaw(caP->toJsonValue());
   }
 
-  out += "]";
-
-  return out;
+  return jh.str();
 }
 
 
@@ -329,7 +322,7 @@ std::string Entity::toJsonValues(const std::vector<ContextAttribute*>& orderedAt
 */
 std::string Entity::toJsonUniqueValues(const std::vector<ContextAttribute*>& orderedAttrs)
 {
-  std::string out = "[";
+  JsonVectorHelper jh;
 
   std::map<std::string, bool>  uniqueMap;
 
@@ -346,16 +339,12 @@ std::string Entity::toJsonUniqueValues(const std::vector<ContextAttribute*>& ord
     }
     else
     {
-      out += value;
+      jh.addRaw(value);
       uniqueMap[value] = true;
     }
-
-    out += ",";
   }
 
-  // The substring trick replaces final "," by "]". It is not very smart, but it saves
-  // a second pass on the vector, once the "unicity" has been calculated in the hashmap
-  return out.substr(0, out.length() - 1 ) + "]";
+  return jh.str();
 }
 
 

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -213,7 +213,7 @@ void Entity::filterAndOrderAttrs
 
 /* ****************************************************************************
 *
-* Entity::render -
+* Entity::toJsonV1 -
 *
 * This method was ported from old ContextElement class. It was name render() there
 *

--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -355,7 +355,7 @@ std::string Entity::toJsonUniqueValues(const std::vector<ContextAttribute*>& ord
 */
 std::string Entity::toJsonKeyvalues(const std::vector<ContextAttribute*>& orderedAttrs)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   if (renderId)
   {
@@ -382,7 +382,7 @@ std::string Entity::toJsonKeyvalues(const std::vector<ContextAttribute*>& ordere
 */
 std::string Entity::toJsonNormalized(const std::vector<ContextAttribute*>& orderedAttrs, const std::vector<std::string>&  metadataFilter)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   if (renderId)
   {

--- a/src/lib/apiTypesV2/EntityVector.cpp
+++ b/src/lib/apiTypesV2/EntityVector.cpp
@@ -33,6 +33,7 @@
 
 #include "common/globals.h"
 #include "common/tag.h"
+#include "common/JsonHelper.h"
 #include "alarmMgr/alarmMgr.h"
 
 #include "ngsi/Request.h"
@@ -52,23 +53,14 @@ std::string EntityVector::toJson
   const std::vector<std::string>&  metadataFilter
 )
 {
-  if (vec.size() == 0)
+  JsonVectorHelper jh;
+
+  for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    return "[]";
+    jh.addRaw(vec[ix]->toJson(renderFormat, attrsFilter, blacklist, metadataFilter));
   }
 
-  std::string out;
-
-  out += "[" + vec[0]->toJson(renderFormat, attrsFilter, blacklist, metadataFilter);
-
-  for (unsigned int ix = 1; ix < vec.size(); ++ix)
-  {
-    out += "," + vec[ix]->toJson(renderFormat, attrsFilter, blacklist, metadataFilter);
-  }
-
-  out += "]";
-
-  return out;
+  return jh.str();
 }
 
 

--- a/src/lib/apiTypesV2/HttpInfo.cpp
+++ b/src/lib/apiTypesV2/HttpInfo.cpp
@@ -72,7 +72,7 @@ HttpInfo::HttpInfo(const std::string& _url) : url(_url), verb(NOVERB), custom(fa
 */
 std::string HttpInfo::toJson()
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addString("url", this->url);
 

--- a/src/lib/apiTypesV2/Registration.cpp
+++ b/src/lib/apiTypesV2/Registration.cpp
@@ -67,7 +67,7 @@ Registration::~Registration()
 */
 std::string Registration::toJson(void)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addString("id", id);
 
@@ -101,7 +101,7 @@ std::string Registration::toJson(void)
 */
 std::string DataProvided::toJson(void)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addRaw("entities", vectorToJson(entities));
   jh.addRaw("attrs", vectorToJson(attributes));
@@ -117,10 +117,10 @@ std::string DataProvided::toJson(void)
 */
 std::string Provider::toJson(void)
 {
-  JsonHelper jhUrl;
+  JsonObjectHelper jhUrl;
   jhUrl.addString("url", http.url);
 
-  JsonHelper   jh;
+  JsonObjectHelper   jh;
   jh.addRaw("http", jhUrl.str());
   jh.addString("supportedForwardingMode", forwardingModeToString(supportedForwardingMode));
   jh.addBool("legacyForwarding", legacyForwardingMode? "true" : "false");
@@ -136,7 +136,7 @@ std::string Provider::toJson(void)
 */
 std::string ForwardingInformation::toJson()
 {
-  JsonHelper  jh;
+  JsonObjectHelper  jh;
 
   jh.addNumber("timesSent", timesSent);
 

--- a/src/lib/apiTypesV2/Registration.cpp
+++ b/src/lib/apiTypesV2/Registration.cpp
@@ -117,10 +117,11 @@ std::string DataProvided::toJson(void)
 */
 std::string Provider::toJson(void)
 {
-  JsonHelper   jh;
-  std::string  urlAsJson = "{\"url\": \"" + http.url + "\"}";
+  JsonHelper jhUrl;
+  jhUrl.addString("url", http.url);
 
-  jh.addRaw("http", urlAsJson);
+  JsonHelper   jh;
+  jh.addRaw("http", jhUrl.str());
   jh.addString("supportedForwardingMode", forwardingModeToString(supportedForwardingMode));
   jh.addBool("legacyForwarding", legacyForwardingMode? "true" : "false");
 

--- a/src/lib/apiTypesV2/Subscription.cpp
+++ b/src/lib/apiTypesV2/Subscription.cpp
@@ -63,7 +63,7 @@ Subscription::~Subscription()
 */
 std::string Subscription::toJson(void)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addString("id", this->id);
 
@@ -111,7 +111,7 @@ std::string Subscription::toJson(void)
 */
 std::string Notification::toJson(const std::string& attrsFormat)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   if (this->timesSent > 0)
   {
@@ -169,7 +169,7 @@ std::string Notification::toJson(const std::string& attrsFormat)
 */
 std::string Subject::toJson()
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addRaw("entities", vectorToJson(this->entities));
   jh.addRaw("condition", this->condition.toJson());
@@ -185,11 +185,11 @@ std::string Subject::toJson()
 */
 std::string Condition::toJson()
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addRaw("attrs", vectorToJson(this->attributes));
 
-  JsonHelper jhe;
+  JsonObjectHelper jhe;
 
   if (this->expression.q        != "")  jhe.addString("q",        this->expression.q);
   if (this->expression.mq       != "")  jhe.addString("mq",       this->expression.mq);

--- a/src/lib/common/JsonHelper.cpp
+++ b/src/lib/common/JsonHelper.cpp
@@ -119,7 +119,7 @@ std::string vectorToJson(std::vector<std::string> &list)
 */
 std::string objectToJson(std::map<std::string, std::string>& list)
 {
-  JsonHelper  jh;
+  JsonObjectHelper  jh;
 
   for (std::map<std::string, std::string>::const_iterator it = list.begin(); it != list.end(); ++it)
   {
@@ -136,9 +136,9 @@ std::string objectToJson(std::map<std::string, std::string>& list)
 
 /* ****************************************************************************
 *
-* JsonHelper -
+* JsonObjectHelper -
 */
-JsonHelper::JsonHelper(): empty(true)
+JsonObjectHelper::JsonObjectHelper(): empty(true)
 {
   ss += '{';
 }
@@ -147,9 +147,9 @@ JsonHelper::JsonHelper(): empty(true)
 
 /* ****************************************************************************
 *
-* JsonHelper::addString -
+* JsonObjectHelper::addString -
 */
-void JsonHelper::addString(const std::string& key, const std::string& value)
+void JsonObjectHelper::addString(const std::string& key, const std::string& value)
 {
   if (!empty)
   {
@@ -168,9 +168,9 @@ void JsonHelper::addString(const std::string& key, const std::string& value)
 
 /* ****************************************************************************
 *
-* JsonHelper::addRaw -
+* JsonObjectHelper::addRaw -
 */
-void JsonHelper::addRaw(const std::string& key, const std::string& value)
+void JsonObjectHelper::addRaw(const std::string& key, const std::string& value)
 {
   if (!empty)
   {
@@ -188,9 +188,9 @@ void JsonHelper::addRaw(const std::string& key, const std::string& value)
 
 /* ****************************************************************************
 *
-* JsonHelper::addNumber -
+* JsonObjectHelper::addNumber -
 */
-void JsonHelper::addNumber(const std::string& key, long long value)
+void JsonObjectHelper::addNumber(const std::string& key, long long value)
 {
   if (!empty)
   {
@@ -210,13 +210,13 @@ void JsonHelper::addNumber(const std::string& key, long long value)
 
 /* ****************************************************************************
 *
-* JsonHelper::addNumber -
+* JsonObjectHelper::addNumber -
 *
 * FIXME P4: This method is to be removed, the float version of addNumber()
 *           should be used instead.
 *           See issue #3058
 */
-void JsonHelper::addNumber(const std::string& key, double value)
+void JsonObjectHelper::addNumber(const std::string& key, double value)
 {
   if (!empty)
   {
@@ -235,9 +235,9 @@ void JsonHelper::addNumber(const std::string& key, double value)
 
 /* ****************************************************************************
 *
-* JsonHelper::addDate -
+* JsonObjectHelper::addDate -
 */
-void JsonHelper::addDate(const std::string& key, long long timestamp)
+void JsonObjectHelper::addDate(const std::string& key, long long timestamp)
 {
   if (!empty)
   {
@@ -256,9 +256,9 @@ void JsonHelper::addDate(const std::string& key, long long timestamp)
 
 /* ****************************************************************************
 *
-* JsonHelper::addBool -
+* JsonObjectHelper::addBool -
 */
-void JsonHelper::addBool(const std::string& key, bool b)
+void JsonObjectHelper::addBool(const std::string& key, bool b)
 {
   addRaw(key, b? "true" : "false");
 }
@@ -267,9 +267,9 @@ void JsonHelper::addBool(const std::string& key, bool b)
 
 /* ****************************************************************************
 *
-* JsonHelper::str -
+* JsonObjectHelper::str -
 */
-std::string JsonHelper::str()
+std::string JsonObjectHelper::str()
 {
   ss += '}';
   return ss;

--- a/src/lib/common/JsonHelper.cpp
+++ b/src/lib/common/JsonHelper.cpp
@@ -102,25 +102,14 @@ std::string toJsonString(const std::string& input)
 template <>
 std::string vectorToJson(std::vector<std::string> &list)
 {
-  switch (list.size())
+  JsonVectorHelper jh;
+
+  for (std::vector<std::string>::size_type i = 0; i != list.size(); ++i)
   {
-  case 0:
-    return "[]";
-
-  case 1:
-    return "[" + toJsonString(list[0]) + "]";
-
-  default:
-    std::string os;
-    os = '[';
-    os += toJsonString(list[0]);
-    for (std::vector<std::string>::size_type i = 1; i != list.size(); ++i)
-    {
-      os += ',' + toJsonString(list[i]);
-    }
-    os += ']';
-    return os;
+    jh.addString(list[i]);
   }
+
+  return jh.str();
 }
 
 
@@ -131,31 +120,17 @@ std::string vectorToJson(std::vector<std::string> &list)
 */
 std::string objectToJson(std::map<std::string, std::string>& list)
 {
-  std::string  os;
-  bool         firstTime = true;
-
-  os = '{';
+  JsonHelper  jh;
 
   for (std::map<std::string, std::string>::const_iterator it = list.begin(); it != list.end(); ++it)
   {
     std::string key   = it->first;
     std::string value = it->second;
 
-    if (firstTime)
-    {
-      firstTime = false;
-    }
-    else
-    {
-      os += ',';
-    }
-
-    os += toJsonString(key) + ':' + toJsonString(value);
+    jh.addString(key, value);
   }
 
-  os += '}';
-
-  return os;
+  return jh.str();
 }
 
 
@@ -281,5 +256,131 @@ void JsonHelper::addBool(const std::string& key, bool b)
 std::string JsonHelper::str()
 {
   ss += '}';
+  return ss;
+}
+
+
+
+/* ****************************************************************************
+*
+* JsonVectorHelper -
+*/
+JsonVectorHelper::JsonVectorHelper(): empty(true)
+{
+  ss += '[';
+}
+
+
+
+/* ****************************************************************************
+*
+* JsonVectorHelper::addString -
+*/
+void JsonVectorHelper::addString(const std::string& value)
+{
+  if (!empty)
+  {
+    ss += ',';
+  }
+  ss += toJsonString(value);
+
+  empty = false;
+}
+
+
+
+/* ****************************************************************************
+*
+* JsonVectorHelper::addRaw -
+*/
+void JsonVectorHelper::addRaw(const std::string& value)
+{
+  if (!empty)
+  {
+    ss += ',';
+  }
+  ss += value;
+
+  empty = false;
+}
+
+
+
+/* ****************************************************************************
+*
+* JsonVectorHelper::addNumber -
+*/
+void JsonVectorHelper::addNumber(long long value)
+{
+  if (!empty)
+  {
+    ss += ',';
+  }
+  // FIXME P7: double2str() used double as argument, but value is long long.
+  // However .test regression shows that it works... weird?
+  ss += double2string(value);
+
+  empty = false;
+}
+
+
+
+/* ****************************************************************************
+*
+* JsonVectorHelper::addNumber -
+*
+* FIXME P4: This method is to be removed, the float version of addNumber()
+*           should be used instead.
+*           See issue #3058
+*/
+void JsonVectorHelper::addNumber(double value)
+{
+  if (!empty)
+  {
+    ss += ',';
+  }
+  ss += double2string(value);
+
+  empty = false;
+
+}
+
+
+
+/* ****************************************************************************
+*
+* JsonVectorHelper::addDate -
+*/
+void JsonVectorHelper::addDate(long long timestamp)
+{
+  if (!empty)
+  {
+    ss += ',';
+  }
+  ss += toJsonString(isodate2str(timestamp));
+
+  empty = false;
+}
+
+
+
+/* ****************************************************************************
+*
+* JsonVectorHelper::addBool -
+*/
+void JsonVectorHelper::addBool(bool b)
+{
+  addRaw(b? "true" : "false");
+}
+
+
+
+/* ****************************************************************************
+*
+* JsonVectorHelper::str -
+*/
+std::string JsonVectorHelper::str()
+{
+  ss += ']';
   return ss;
 }

--- a/src/lib/common/JsonHelper.cpp
+++ b/src/lib/common/JsonHelper.cpp
@@ -42,7 +42,6 @@ std::string toJsonString(const std::string& input)
 {
   std::string ss;
 
-  ss = '"';
   for (std::string::const_iterator iter = input.begin(); iter != input.end(); ++iter)
   {
     /* FIXME P3: This function ensures that if the DB holds special characters (which are
@@ -89,8 +88,6 @@ std::string toJsonString(const std::string& input)
     }  // end-switch
 
   }  // end-for
-
-  ss += '"';
 
   return ss;
 }
@@ -158,9 +155,11 @@ void JsonHelper::addString(const std::string& key, const std::string& value)
   {
     ss += ',';
   }
+  ss += '"';
   ss += toJsonString(key);
-  ss += ':';
+  ss += "\":\"";
   ss += toJsonString(value);
+  ss += '"';
 
   empty = false;
 }
@@ -177,8 +176,9 @@ void JsonHelper::addRaw(const std::string& key, const std::string& value)
   {
     ss += ',';
   }
+  ss += '"';
   ss += toJsonString(key);
-  ss += ':';
+  ss += "\":";
   ss += value;
 
   empty = false;
@@ -198,8 +198,9 @@ void JsonHelper::addNumber(const std::string& key, long long value)
   }
   // FIXME P7: double2str() used double as argument, but value is long long.
   // However .test regression shows that it works... weird?
+  ss += '"';
   ss += toJsonString(key);
-  ss += ':';
+  ss += "\":";
   ss += double2string(value);
 
   empty = false;
@@ -221,8 +222,9 @@ void JsonHelper::addNumber(const std::string& key, double value)
   {
     ss += ',';
   }
+  ss += '"';
   ss += toJsonString(key);
-  ss += ':';
+  ss += "\":";
   ss +=  double2string(value);
 
   empty = false;
@@ -241,9 +243,11 @@ void JsonHelper::addDate(const std::string& key, long long timestamp)
   {
     ss += ',';
   }
+  ss += '"';
   ss += toJsonString(key);
-  ss += ':';
+  ss += "\":\"";
   ss += toJsonString(isodate2str(timestamp));
+  ss += '"';
 
   empty = false;
 }
@@ -294,7 +298,9 @@ void JsonVectorHelper::addString(const std::string& value)
   {
     ss += ',';
   }
+  ss += '"';
   ss += toJsonString(value);
+  ss += '"';
 
   empty = false;
 }
@@ -369,7 +375,9 @@ void JsonVectorHelper::addDate(long long timestamp)
   {
     ss += ',';
   }
+  ss += '"';
   ss += toJsonString(isodate2str(timestamp));
+  ss += '"';
 
   empty = false;
 }

--- a/src/lib/common/JsonHelper.cpp
+++ b/src/lib/common/JsonHelper.cpp
@@ -77,7 +77,9 @@ std::string toJsonString(const std::string& input)
       {
         static const char intToHex[16] =  { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' } ;
 
-        ss += "\\u00" + intToHex[(ch & 0xF0) >> 4] + intToHex[ch & 0x0F];
+        ss += "\\u00";
+        ss += intToHex[(ch & 0xF0) >> 4];
+        ss += intToHex[ch & 0x0F];
       }
       else
       {
@@ -156,7 +158,9 @@ void JsonHelper::addString(const std::string& key, const std::string& value)
   {
     ss += ',';
   }
-  ss += toJsonString(key) + ':' + toJsonString(value);
+  ss += toJsonString(key);
+  ss += ':';
+  ss += toJsonString(value);
 
   empty = false;
 }
@@ -173,7 +177,9 @@ void JsonHelper::addRaw(const std::string& key, const std::string& value)
   {
     ss += ',';
   }
-  ss += toJsonString(key) + ':' + value;
+  ss += toJsonString(key);
+  ss += ':';
+  ss += value;
 
   empty = false;
 }
@@ -192,7 +198,9 @@ void JsonHelper::addNumber(const std::string& key, long long value)
   }
   // FIXME P7: double2str() used double as argument, but value is long long.
   // However .test regression shows that it works... weird?
-  ss += toJsonString(key) + ':' + double2string(value);
+  ss += toJsonString(key);
+  ss += ':';
+  ss += double2string(value);
 
   empty = false;
 }
@@ -213,7 +221,9 @@ void JsonHelper::addNumber(const std::string& key, double value)
   {
     ss += ',';
   }
-  ss += toJsonString(key) + ':' + double2string(value);
+  ss += toJsonString(key);
+  ss += ':';
+  ss +=  double2string(value);
 
   empty = false;
 
@@ -231,7 +241,9 @@ void JsonHelper::addDate(const std::string& key, long long timestamp)
   {
     ss += ',';
   }
-  ss += toJsonString(key) + ':' + toJsonString(isodate2str(timestamp));
+  ss += toJsonString(key);
+  ss += ':';
+  ss += toJsonString(isodate2str(timestamp));
 
   empty = false;
 }

--- a/src/lib/common/JsonHelper.h
+++ b/src/lib/common/JsonHelper.h
@@ -32,11 +32,10 @@
 #include <map>
 
 
-// FIXME P10: should be renamed to JsonObjectHelper
-class JsonHelper
+class JsonObjectHelper
 {
 public:
-  JsonHelper();
+  JsonObjectHelper();
 
   void        addString(const std::string& key, const std::string& value);
   void        addRaw(const std::string& key, const std::string& value);

--- a/src/lib/common/JsonHelper.h
+++ b/src/lib/common/JsonHelper.h
@@ -31,6 +31,8 @@
 #include <vector>
 #include <map>
 
+
+// FIXME P10: should be renamed to JsonObjectHelper
 class JsonHelper
 {
 public:
@@ -42,6 +44,26 @@ public:
   void        addNumber(const std::string& key, double value);
   void        addDate(const std::string& key, long long timestamp);
   void        addBool(const std::string& key, bool b);
+
+  std::string str();
+
+private:
+ std::string  ss;
+ bool         empty;
+};
+
+
+class JsonVectorHelper
+{
+public:
+  JsonVectorHelper();
+
+  void        addString(const std::string& value);
+  void        addRaw(const std::string& value);
+  void        addNumber(long long value);
+  void        addNumber(double value);
+  void        addDate(long long timestamp);
+  void        addBool(bool b);
 
   std::string str();
 

--- a/src/lib/common/JsonHelper.h
+++ b/src/lib/common/JsonHelper.h
@@ -98,10 +98,12 @@ std::string vectorToJson(std::vector<T> &list)
 
   std::string ss;
 
-  ss += '[' + list[0].toJson();
+  ss += '[';
+  ss += list[0].toJson();
   for (size_type i = 1; i != list.size(); ++i)
   {
-    ss += ',' + list[i].toJson();
+    ss += ',';
+    ss += list[i].toJson();
   }
   ss += ']';
   return ss;

--- a/src/lib/common/statistics.cpp
+++ b/src/lib/common/statistics.cpp
@@ -224,11 +224,11 @@ std::string renderTimingStatistics(void)
     return "{}";
   }
 
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   if (acc)
   {
-    JsonHelper accJh;
+    JsonObjectHelper accJh;
 
     if (accJsonV1ParseTime)      accJh.addNumber("jsonV1Parse",      timeSpecToFloat(accTimeStat.jsonV1ParseTime));
     if (accJsonV2ParseTime)      accJh.addNumber("jsonV2Parse",      timeSpecToFloat(accTimeStat.jsonV2ParseTime));
@@ -243,7 +243,7 @@ std::string renderTimingStatistics(void)
   }
   if (last)
   {
-    JsonHelper lastJh;
+    JsonObjectHelper lastJh;
 
     if (lastJsonV1ParseTime)      lastJh.addNumber("jsonV1Parse",      timeSpecToFloat(lastTimeStat.jsonV1ParseTime));
     if (lastJsonV2ParseTime)      lastJh.addNumber("jsonV2Parse",      timeSpecToFloat(lastTimeStat.jsonV2ParseTime));

--- a/src/lib/common/tag.cpp
+++ b/src/lib/common/tag.cpp
@@ -28,6 +28,7 @@
 
 #include "logMsg/logMsg.h"
 #include "common/tag.h"
+#include "common/JsonHelper.h"
 
 
 
@@ -140,71 +141,6 @@ char* htmlEscape(const char* s)
 }
 
 
-/* ****************************************************************************
-*
-* jsonInvalidCharsTransformation -
-*
-* FIXME P5: this is a quick fix for #1172. A better fix should de developed.
-*
-* Pretty much based in JsonHelper::toJsonString(). In fact, most of the code is
-* duplicated
-*
-*/
-std::string jsonInvalidCharsTransformation(const std::string& input)
-{
-  std::string ss;
-
-  for (std::string::const_iterator iter = input.begin(); iter != input.end(); ++iter)
-  {
-    /* FIXME P3: This function ensures that if the DB holds special characters (which are
-     * not supported in JSON according to its specification), they are converted to their escaped
-     * representations. The process wouldn't be necessary if the DB couldn't hold such special characters,
-     * but as long as we support NGSIv1, it is better to have the check (e.g. a newline could be
-     * used in an attribute value using XML). Even removing NGSIv1, we have to ensure that the
-     * input parser (rapidjson) doesn't inject not supported JSON characters in the DB (this needs to be
-     * investigated in the rapidjson documentation)
-     *
-     * JSON specification is a bit obscure about the need of escaping / (what they call 'solidus'). The
-     * picture at JSON specification (http://www.json.org/) seems suggesting so, but after a careful reading of
-     * https://tools.ietf.org/html/rfc4627#section-2.5, we can conclude it is not mandatory. Online checkers
-     * such as http://jsonlint.com confirm this. Looking in some online discussions
-     * (http://andowebsit.es/blog/noteslog.com/post/the-solidus-issue/ and
-     * https://groups.google.com/forum/#!topic/opensocial-and-gadgets-spec/FkLsC-2blbo) it seems that
-     * escaping / may have sense in some situations related with JavaScript code, which is not the case of Orion.
-     *
-     */
-    switch (char ch = *iter)
-    {
-    case '\\': ss += "\\\\"; break;
-    case '"':  ss += "\\\""; break;
-    case '\b': ss += "\\b";  break;
-    case '\f': ss += "\\f";  break;
-    case '\n': ss += "\\n";  break;
-    case '\r': ss += "\\r";  break;
-    case '\t': ss += "\\t";  break;
-
-    default:
-      /* Converting the rest of special chars 0-31 to \u00xx. Note that 0x80 - 0xFF are untouched as they
-       * correspond to UTF-8 multi-byte characters */
-      if (ch >= 0 && ch <= 0x1F)
-      {
-        static const char intToHex[16] =  { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' } ;
-
-        ss += "\\u00" + intToHex[(ch & 0xF0) >> 4] + intToHex[ch & 0x0F];
-      }
-      else
-      {
-        ss += ch;
-      }
-      break;
-    }  // end-switch
-
-  }  // end-for
-
-  return ss;
-}
-
-
 
 /* ****************************************************************************
 *
@@ -295,7 +231,7 @@ std::string valueTag
     return "ERROR: no memory";
   }
 
-  std::string effectiveValue = jsonInvalidCharsTransformation(value);
+  std::string effectiveValue = toJsonString(value);
   free(value);
 
   effectiveValue = withoutQuotes ? effectiveValue : std::string("\"") + effectiveValue + "\"";

--- a/src/lib/metricsMgr/MetricsManager.cpp
+++ b/src/lib/metricsMgr/MetricsManager.cpp
@@ -339,7 +339,7 @@ static std::string metricsRender(std::map<std::string, uint64_t>* metricsMap)
   std::map<std::string, uint64_t>::iterator  it;
   uint64_t                                   incomingTransactions = 0;
   uint64_t                                   totalServiceTime     = 0;
-  JsonHelper                                 jh;
+  JsonObjectHelper                                 jh;
 
   for (it = metricsMap->begin();  it != metricsMap->end(); ++it)
   {
@@ -393,22 +393,22 @@ std::string MetricsManager::_toJson(void)
   std::map<std::string, std::map<std::string, std::map<std::string, uint64_t>*>*>::iterator  serviceIter;
   std::map<std::string, std::map<std::string, uint64_t>*>::iterator                          subServiceIter;
   std::map<std::string, uint64_t>::iterator                                                  metricIter;
-  JsonHelper                                                                                 top;
-  JsonHelper                                                                                 services;
+  JsonObjectHelper                                                                                 top;
+  JsonObjectHelper                                                                                 services;
   std::map<std::string, uint64_t>                                                            sum;
   std::map<std::string, std::map<std::string, uint64_t> >                                    subServCrossTenant;
 
   for (serviceIter = metrics.begin(); serviceIter != metrics.end(); ++serviceIter)
   {
-    JsonHelper                                                subServiceTop;
-    JsonHelper                                                jhSubService;
+    JsonObjectHelper                                                subServiceTop;
+    JsonObjectHelper                                                jhSubService;
     std::string                                               service        = serviceIter->first;
     std::map<std::string, std::map<std::string, uint64_t>*>*  servMap        = serviceIter->second;
     std::map<std::string, uint64_t>                           serviceSum;
 
     for (subServiceIter = servMap->begin(); subServiceIter != servMap->end(); ++subServiceIter)
     {
-      JsonHelper                        jhMetrics;
+      JsonObjectHelper                        jhMetrics;
       std::string                       subService           = subServiceIter->first;
       std::map<std::string, uint64_t>*  metricMap            = subServiceIter->second;
 
@@ -475,13 +475,13 @@ std::string MetricsManager::_toJson(void)
   //
   // Sum for grand total
   //
-  JsonHelper   lastSum;
-  JsonHelper   jhSubServ;
+  JsonObjectHelper   lastSum;
+  JsonObjectHelper   jhSubServ;
 
   std::map<std::string, std::map<std::string, uint64_t> >::iterator  it;
   for (it = subServCrossTenant.begin();  it != subServCrossTenant.end(); ++it)
   {
-    JsonHelper   jhSubServCross;
+    JsonObjectHelper   jhSubServCross;
     std::string  subService = it->first;
     std::string  subServiceString;
 

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -969,7 +969,10 @@ std::string ContextAttribute::toJsonValue(void)
   {
     if ((type == DATE_TYPE) || (type == DATE_TYPE_ALT))
     {
-      return toJsonString(isodate2str(numberValue));
+      std::string out = "\"";
+      out += toJsonString(isodate2str(numberValue));
+      out += '"';
+      return out;
     }
     else // regular number
     {
@@ -978,7 +981,10 @@ std::string ContextAttribute::toJsonValue(void)
   }
   else if (valueType == orion::ValueTypeString)
   {
-    return toJsonString(stringValue);
+    std::string out = "\"";
+    out += toJsonString(stringValue);
+    out += '"';
+    return out;
   }
   else if (valueType == orion::ValueTypeBoolean)
   {

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -885,7 +885,7 @@ void ContextAttribute::filterAndOrderMetadata
 */
 std::string ContextAttribute::toJson(const std::vector<std::string>&  metadataFilter)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   //
   // type

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -96,7 +96,7 @@ std::string ContextAttributeVector::toJsonTypes(void)
     std::string                 attrName  = it->first;
     std::map<std::string, int>  attrTypes = it->second;
 
-    std::string out = "[";
+    JsonVectorHelper jvh;
 
     std::map<std::string, int>::iterator jt;
     unsigned int                         jx;
@@ -117,18 +117,12 @@ std::string ContextAttributeVector::toJsonTypes(void)
       //
       if ((type != "") || (attrTypes.size() != 1))
       {
-        out += JSON_STR(type);
+        jvh.addString(type);
       }
 
-      if (jx != attrTypes.size() - 1)
-      {
-        out += ",";
-      }
     }
 
-    out += "]";
-
-    jhTypes.addRaw("types", out);
+    jhTypes.addRaw("types", jvh.str());
 
     jh.addRaw(attrName, jhTypes.str());
   }

--- a/src/lib/ngsi/ContextAttributeVector.cpp
+++ b/src/lib/ngsi/ContextAttributeVector.cpp
@@ -87,7 +87,7 @@ std::string ContextAttributeVector::toJsonTypes(void)
   }
 
   // Pass 2 - generate JSON
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   std::map<std::string, std::map<std::string, int> >::iterator it;
   unsigned int                                                 ix;
@@ -101,7 +101,7 @@ std::string ContextAttributeVector::toJsonTypes(void)
     std::map<std::string, int>::iterator jt;
     unsigned int                         jx;
 
-    JsonHelper jhTypes;
+    JsonObjectHelper jhTypes;
 
     for (jt = attrTypes.begin(), jx = 0; jt != attrTypes.end(); ++jt, ++jx)
     {

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -32,6 +32,7 @@
 #include "common/globals.h"
 #include "common/tag.h"
 #include "common/RenderFormat.h"
+#include "common/JsonHelper.h"
 #include "ngsi/ContextElementResponseVector.h"
 
 
@@ -84,19 +85,14 @@ std::string ContextElementResponseVector::toJson
   const std::vector<std::string>&  metadataFilter
 )
 {
-  std::string out;
+  JsonVectorHelper jvh;
 
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += vec[ix]->toJson(renderFormat, attrsFilter, blacklist, metadataFilter);
-
-    if (ix != vec.size() - 1)
-    {
-      out += ",";
-    }
+    jvh.addRaw(vec[ix]->toJson(renderFormat, attrsFilter, blacklist, metadataFilter));
   }
 
-  return out;
+  return jvh.str();
 }
 
 

--- a/src/lib/ngsi/EntityId.cpp
+++ b/src/lib/ngsi/EntityId.cpp
@@ -31,6 +31,7 @@
 #include "common/globals.h"
 #include "ngsi/EntityId.h"
 #include "common/tag.h"
+#include "common/JsonHelper.h"
 
 
 
@@ -118,18 +119,18 @@ std::string EntityId::toJsonV1(bool comma, bool isInVector)
 */
 std::string EntityId::toJson(void) const
 {
-  std::string  out;
-  char*        typeEscaped  = htmlEscape(type.c_str());
-  char*        idEscaped    = htmlEscape(id.c_str());
+  JsonHelper jh;
 
-  out += JSON_VALUE("id", idEscaped);
-  out += ",";
-  out += JSON_VALUE("type", typeEscaped);
+  char*  typeEscaped  = htmlEscape(type.c_str());
+  char*  idEscaped    = htmlEscape(id.c_str());
+
+  jh.addString("id", idEscaped);
+  jh.addString("type", typeEscaped);
 
   free(typeEscaped);
   free(idEscaped);
 
-  return out;
+  return jh.str();
 }
 
 

--- a/src/lib/ngsi/EntityId.cpp
+++ b/src/lib/ngsi/EntityId.cpp
@@ -119,7 +119,7 @@ std::string EntityId::toJsonV1(bool comma, bool isInVector)
 */
 std::string EntityId::toJson(void) const
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   char*  typeEscaped  = htmlEscape(type.c_str());
   char*  idEscaped    = htmlEscape(id.c_str());

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -440,7 +440,7 @@ std::string Metadata::toStringValue(void) const
 */
 std::string Metadata::toJson(void)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   /* This is needed for entities coming from NGSIv1 (which allows empty or missing types) */
   std::string defType = defaultType(valueType);

--- a/src/lib/ngsi/MetadataVector.cpp
+++ b/src/lib/ngsi/MetadataVector.cpp
@@ -108,7 +108,7 @@ bool MetadataVector::matchFilter(const std::string& mdName, const std::vector<st
 */
 std::string MetadataVector::toJson(const std::vector<Metadata*>& orderedMetadata)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   for (unsigned int ix = 0; ix < orderedMetadata.size(); ++ix)
   {

--- a/src/lib/ngsi/StatusCode.cpp
+++ b/src/lib/ngsi/StatusCode.cpp
@@ -33,6 +33,7 @@
 #include "common/globals.h"
 #include "common/string.h"
 #include "common/tag.h"
+#include "common/JsonHelper.h"
 #include "common/limits.h"
 #include "ngsi/Request.h"
 #include "ngsi/StatusCode.h"
@@ -85,7 +86,7 @@ StatusCode::StatusCode(HttpStatusCode _code, const std::string& _details, const 
 
 /* ****************************************************************************
 *
-* StatusCode::render -
+* StatusCode::toJsonV1 -
 */
 std::string StatusCode::toJsonV1(bool comma, bool showKey)
 {
@@ -127,43 +128,12 @@ std::string StatusCode::toJsonV1(bool comma, bool showKey)
 *
 * StatusCode::toJson -
 *
-* For version 2 of the API, the unnecessary 'reasonPhrase' is removed.
+* For version 2 of the API, based on OrionError.
 */
-std::string StatusCode::toJson(bool isLastElement)
+std::string StatusCode::toJson(void)
 {
-  std::string  out  = "";
-
-  if (strstr(details.c_str(), "\"") != NULL)
-  {
-    int    len = details.length() * 2;
-    char*  s    = (char*) calloc(1, len + 1);
-
-    strReplace(s, len, details.c_str(), "\"", "\\\"");
-    details = s;
-    free(s);
-  }
-
-  char codeV[STRING_SIZE_FOR_INT];
-
-  snprintf(codeV, sizeof(codeV), "%d", code);
-
-  out += "{";
-
-  out += std::string("\"code\":\"") + codeV + "\"";
-  
-  if (details != "")
-  {
-    out += ",\"details\":\"" + details + "\"";
-  }
-
-  out += "}";
-
-  if (!isLastElement)
-  {
-    out += ",";
-  }
-
-  return out;
+  OrionError oe(code, details, reasonPhrase);
+  return oe.smartRender(V2);
 }
 
 

--- a/src/lib/ngsi/StatusCode.h
+++ b/src/lib/ngsi/StatusCode.h
@@ -57,7 +57,7 @@ typedef struct StatusCode
   StatusCode(HttpStatusCode _code, const std::string& _details, const std::string& _keyName = "statusCode");
 
   std::string  toJsonV1(bool comma, bool showKey = true);
-  std::string  toJson(bool isLastElement);
+  std::string  toJson(void);
   void         fill(HttpStatusCode _code, const std::string& _details = "");
   void         fill(StatusCode* scP);
   void         fill(const StatusCode& sc);

--- a/src/lib/ngsi/SubscribeError.cpp
+++ b/src/lib/ngsi/SubscribeError.cpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "common/tag.h"
+#include "common/JsonHelper.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi/Request.h"
 #include "ngsi/SubscribeError.h"
@@ -46,37 +47,14 @@ SubscribeError::SubscribeError()
 *
 * SubscribeError::toJson -
 */
-std::string SubscribeError::toJson(RequestType requestType, bool comma)
+std::string SubscribeError::toJson(void)
 {
-  std::string  out;
+  JsonHelper jh;
 
-  out += JSON_VALUE("error", errorCode.reasonPhrase.c_str());
-  out += ",";
-  out += JSON_VALUE("description", errorCode.details.c_str());
+  jh.addString("error", errorCode.reasonPhrase);
+  jh.addString("description", errorCode.details);
 
-
-  if (requestType == UpdateContextSubscription)
-  {
-    //
-    // NOTE: the subscriptionId must have come from the request.
-    //       If the field is empty, we are in unit tests and I here set it to all zeroes
-    //
-    if (subscriptionId.get() == "")
-    {
-      subscriptionId.set("000000000000000000000000");
-    }
-    out += ",";
-    out += JSON_PROP("affectedItems") + "[" + JSON_STR(subscriptionId.toJson(requestType, true)) + "]";
-  }
-  else if ((requestType          == SubscribeContext)           &&
-           (subscriptionId.get() != "000000000000000000000000") &&
-           (subscriptionId.get() != ""))
-  {
-    out += ",";
-    out += JSON_PROP("affectedItems") + "[" + JSON_STR(subscriptionId.toJson(requestType, true)) + "]";
-  }
-
-  return out;
+  return jh.str();
 }
 
 

--- a/src/lib/ngsi/SubscribeError.cpp
+++ b/src/lib/ngsi/SubscribeError.cpp
@@ -49,7 +49,7 @@ SubscribeError::SubscribeError()
 */
 std::string SubscribeError::toJson(void)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addString("error", errorCode.reasonPhrase);
   jh.addString("description", errorCode.details);

--- a/src/lib/ngsi/SubscribeError.h
+++ b/src/lib/ngsi/SubscribeError.h
@@ -44,7 +44,7 @@ typedef struct SubscribeError
 
   SubscribeError();
   std::string toJsonV1(RequestType requestType, bool comma);
-  std::string toJson(RequestType requestType, bool comma);
+  std::string toJson(void);
   std::string check(void);
 } SubscribeError;
 

--- a/src/lib/ngsi/SubscriptionId.cpp
+++ b/src/lib/ngsi/SubscriptionId.cpp
@@ -121,40 +121,6 @@ const char* SubscriptionId::c_str(void) const
 
 /* ****************************************************************************
 *
-* SubscriptionId::toJson -
-*/
-std::string SubscriptionId::toJson(RequestType container, bool comma)
-{
-  std::string xString = string;
-
-  if (xString == "")
-  {
-    if ((container == RtSubscribeContextAvailabilityResponse)          ||
-        (container == RtUpdateContextAvailabilitySubscriptionResponse) ||
-        (container == RtUnsubscribeContextAvailabilityResponse)        ||
-        (container == NotifyContextAvailability)                       ||
-        (container == UpdateContextSubscription)                       ||
-        (container == UnsubscribeContext)                              ||
-        (container == RtUnsubscribeContextResponse)                    ||
-        (container == NotifyContext)                                   ||
-        (container == RtSubscribeResponse)                             ||
-        (container == RtSubscribeError))
-    {
-      // subscriptionId is Mandatory
-      xString = "000000000000000000000000";
-    }
-    else
-    {
-      return "";  // subscriptionId is Optional
-    }
-  }
-
-  return xString;
-}
-
-
-/* ****************************************************************************
-*
 * SubscriptionId::toJsonV1 -
 */
 std::string SubscriptionId::toJsonV1(RequestType container, bool comma)

--- a/src/lib/ngsi/SubscriptionId.h
+++ b/src/lib/ngsi/SubscriptionId.h
@@ -47,7 +47,6 @@ typedef struct SubscriptionId
   const char*   c_str(void) const;
   bool          isEmpty(void);
   std::string   toJsonV1(RequestType container, bool comma);
-  std::string   toJson(RequestType container, bool comma);
   void          release(void);
   bool          rendered(RequestType container);
 

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -27,6 +27,7 @@
 #include "common/globals.h"
 #include "common/tag.h"
 #include "common/RenderFormat.h"
+#include "common/JsonHelper.h"
 #include "ngsi10/NotifyContextRequest.h"
 #include "ngsi10/NotifyContextResponse.h"
 #include "rest/OrionError.h"
@@ -84,21 +85,14 @@ std::string NotifyContextRequest::toJson
     alarmMgr.badInput(clientIp, "Invalid notification format");
 
     return oe.toJson();
-  }
+  }  
 
-  std::string out;
+  JsonHelper jh;
 
-  out += "{";
-  out += JSON_STR("subscriptionId") + ":";
-  out += JSON_STR(subscriptionId.get());
-  out += ",";
-  out += JSON_STR("data") + ":[";
+  jh.addString("subscriptionId", subscriptionId.get());
+  jh.addRaw("data", contextElementResponseVector.toJson(renderFormat, attrsFilter, blacklist, metadataFilter));
 
-  out += contextElementResponseVector.toJson(renderFormat, attrsFilter, blacklist, metadataFilter);
-  out += "]";
-  out += "}";
-
-  return out;
+  return jh.str();
 }
 
 

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -87,7 +87,7 @@ std::string NotifyContextRequest::toJson
     return oe.toJson();
   }  
 
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addString("subscriptionId", subscriptionId.get());
   jh.addRaw("data", contextElementResponseVector.toJson(renderFormat, attrsFilter, blacklist, metadataFilter));

--- a/src/lib/ngsi10/NotifyContextResponse.cpp
+++ b/src/lib/ngsi10/NotifyContextResponse.cpp
@@ -60,7 +60,7 @@ NotifyContextResponse::NotifyContextResponse(StatusCode& sc)
 
 /* ****************************************************************************
 *
-* NotifyContextResponse::render -
+* NotifyContextResponse::toJsonV1 -
 */
 std::string NotifyContextResponse::toJsonV1(void)
 {

--- a/src/lib/ngsi10/SubscribeContextResponse.cpp
+++ b/src/lib/ngsi10/SubscribeContextResponse.cpp
@@ -27,6 +27,7 @@
 #include "logMsg/traceLevels.h"
 #include "logMsg/logMsg.h"
 #include "common/tag.h"
+#include "common/JsonHelper.h"
 #include "ngsi10/SubscribeContextResponse.h"
 
 /* ****************************************************************************
@@ -64,24 +65,21 @@ SubscribeContextResponse::SubscribeContextResponse(StatusCode& errorCode)
 */
 std::string SubscribeContextResponse::toJson(void)
 {
-  std::string out = "";
-
-  out += "{";
-
   if (subscribeError.errorCode.code == SccNone)
   {
+    std::string out;
     // FIXME P5: it is a bit weird to call a toJsonV1() method from a toJson() method. However,
     // SubscribeResponse doesn't have another option. This should be looked into detail.
+    out += "{";
     out += subscribeResponse.toJsonV1(false);
+    out += "}";
+    return out;
   }
   else
   {
-    out += subscribeError.toJson(SubscribeContext, false);
+    return subscribeError.toJson();
   }
 
-  out +=  "}";
-
-  return out;
 }
 
 /* ****************************************************************************

--- a/src/lib/ngsi9/SubscribeContextAvailabilityResponse.cpp
+++ b/src/lib/ngsi9/SubscribeContextAvailabilityResponse.cpp
@@ -80,7 +80,7 @@ SubscribeContextAvailabilityResponse::SubscribeContextAvailabilityResponse(const
 
 /* ****************************************************************************
 *
-* SubscribeContextAvailabilityResponse::render -
+* SubscribeContextAvailabilityResponse::toJsonV1 -
 */
 std::string SubscribeContextAvailabilityResponse::toJsonV1(void)
 {

--- a/src/lib/orionTypes/EntityType.cpp
+++ b/src/lib/orionTypes/EntityType.cpp
@@ -147,7 +147,7 @@ void EntityType::release(void)
 */
 std::string EntityType::toJson(bool includeType)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   if (includeType)
   {

--- a/src/lib/orionTypes/EntityTypeResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeResponse.cpp
@@ -115,7 +115,7 @@ void EntityTypeResponse::release(void)
 */
 std::string EntityTypeResponse::toJson(void)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addRaw("attrs", entityType.contextAttributeVector.toJsonTypes());
   jh.addNumber("count", entityType.count);

--- a/src/lib/orionTypes/EntityTypeVectorResponse.cpp
+++ b/src/lib/orionTypes/EntityTypeVectorResponse.cpp
@@ -31,6 +31,7 @@
 
 #include "common/globals.h"
 #include "common/tag.h"
+#include "common/JsonHelper.h"
 #include "alarmMgr/alarmMgr.h"
 
 #include "ngsi/Request.h"
@@ -117,27 +118,19 @@ void EntityTypeVectorResponse::release(void)
 */
 std::string EntityTypeVectorResponse::toJson(bool values)
 {
-  std::string  out = "[";
+  JsonVectorHelper jh;
 
   for (unsigned int ix = 0; ix < entityTypeVector.vec.size(); ++ix)
   {
     if (values)
     {
-      out += JSON_STR(entityTypeVector.vec[ix]->type);
+      jh.addString(entityTypeVector.vec[ix]->type);
     }
     else  // default
     {
-      out += entityTypeVector.vec[ix]->toJson(true);
+      jh.addRaw(entityTypeVector.vec[ix]->toJson(true));
     }
-
-    if (ix != entityTypeVector.vec.size() - 1)
-    {
-      out += ",";
-    }
-
   }
 
-  out += "]";
-
-  return out;
+  return jh.str();
 }

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -676,7 +676,9 @@ std::string CompoundValueNode::toJson(bool toplevel)
   switch (valueType)
   {
   case orion::ValueTypeString:
-    out = toJsonString(stringValue);
+    out = '"';
+    out += toJsonString(stringValue);
+    out += '"';
     break;
 
   case orion::ValueTypeNumber:
@@ -708,10 +710,12 @@ std::string CompoundValueNode::toJson(bool toplevel)
     }
     else
     {
-      out = "{" + childV[0]->toJson(false);
+      out = "{";
+      out += childV[0]->toJson(false);
       for (unsigned int ix = 1; ix < childV.size(); ix++)
       {
-        out += "," + childV[ix]->toJson(false);
+        out += ",";
+        out += childV[ix]->toJson(false);
       }
       out += "}";
     }
@@ -737,7 +741,10 @@ std::string CompoundValueNode::toJson(bool toplevel)
 
   if (parentIsObject)
   {
-    return toJsonString(name) + ":" + out;
+    std::string preOut = "\"";
+    preOut += toJsonString(name);
+    preOut += "\":";
+    return preOut + out;
   }
   else
   {

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -702,23 +702,19 @@ std::string CompoundValueNode::toJson(bool toplevel)
     break;
 
   case orion::ValueTypeObject:
-    // In thic case we cannot use JsonObjectHelper to build the object, as we don't have a
+    // In this case we cannot use JsonObjectHelper to build the object, as we don't have a
     // key-value sequence to invoke addXX() method
-    if (childV.size() == 0)
+    out = "{";
+    for (unsigned int ix = 0; ix < childV.size(); ix++)
     {
-      out = "{}";
-    }
-    else
-    {
-      out = "{";
-      out += childV[0]->toJson(false);
-      for (unsigned int ix = 1; ix < childV.size(); ix++)
+      out += childV[ix]->toJson(false);
+      if (ix != childV.size() - 1)
       {
         out += ",";
-        out += childV[ix]->toJson(false);
       }
-      out += "}";
     }
+    out += "}";
+
     // Early return in this case, to avoid getting parentIsObject as in the
     // case of root element we don't use key. Only the first call to
     // toJson() uses toplevel == true

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -702,7 +702,7 @@ std::string CompoundValueNode::toJson(bool toplevel)
     break;
 
   case orion::ValueTypeObject:
-    // In thic case we cannot use JsonHelper to build the object, as we don't have a
+    // In thic case we cannot use JsonObjectHelper to build the object, as we don't have a
     // key-value sequence to invoke addXX() method
     if (childV.size() == 0)
     {

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -744,7 +744,8 @@ std::string CompoundValueNode::toJson(bool toplevel)
     std::string preOut = "\"";
     preOut += toJsonString(name);
     preOut += "\":";
-    return preOut + out;
+    preOut += out;
+    return preOut;
   }
   else
   {

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -670,7 +670,8 @@ std::string CompoundValueNode::check(void)
 */
 std::string CompoundValueNode::toJson(bool toplevel)
 {
-  std::string out;
+  std::string      out;
+  JsonVectorHelper jh;
 
   switch (valueType)
   {
@@ -691,22 +692,16 @@ std::string CompoundValueNode::toJson(bool toplevel)
     break;
 
   case orion::ValueTypeVector:
-
-    if (childV.size() == 0)
+    for (unsigned int ix = 0; ix < childV.size(); ix++)
     {
-      out = "[]";
+      jh.addRaw(childV[ix]->toJson(false));
     }
-    else {
-      out = "[" + childV[0]->toJson(false);
-      for (unsigned int ix = 1; ix < childV.size(); ix++)
-      {
-        out += "," + childV[ix]->toJson(false);
-      }
-      out += "]";
-    }
+    out = jh.str();
     break;
 
   case orion::ValueTypeObject:
+    // In thic case we cannot use JsonHelper to build the object, as we don't have a
+    // key-value sequence to invoke addXX() method
     if (childV.size() == 0)
     {
       out = "{}";

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "common/tag.h"
+#include "common/JsonHelper.h"
 #include "rest/ConnectionInfo.h"
 #include "ngsi/StatusCode.h"
 #include "rest/OrionError.h"
@@ -138,18 +139,18 @@ std::string OrionError::setStatusCodeAndSmartRender(ApiVersion apiVersion, HttpS
 */
 std::string OrionError::toJson(void)
 {
-  std::string  out;
-  char*        reasonPhraseEscaped = htmlEscape(reasonPhrase.c_str());
-  char*        detailsEscaped = htmlEscape(details.c_str());
+  char*  reasonPhraseEscaped = htmlEscape(reasonPhrase.c_str());
+  char*  detailsEscaped      = htmlEscape(details.c_str());
 
-  out += "{" + JSON_VALUE("error", reasonPhraseEscaped);
-  out += ",";
-  out += JSON_VALUE("description", detailsEscaped) + "}";
+  JsonHelper jh;
+
+  jh.addString("error", reasonPhraseEscaped);
+  jh.addString("description", detailsEscaped);
 
   free(reasonPhraseEscaped);
   free(detailsEscaped);
 
-  return out;
+  return jh.str();
 }
 
 
@@ -186,7 +187,7 @@ std::string OrionError::toJsonV1(void)
 
 /* ****************************************************************************
 *
-* OrionError::render -
+* OrionError::shrinkReasonPhrase -
 *
 * This method removes any whitespace in the reasonPhrase field, i.e.
 * transforms "Not Found" to "NotFound".

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -142,7 +142,7 @@ std::string OrionError::toJson(void)
   char*  reasonPhraseEscaped = htmlEscape(reasonPhrase.c_str());
   char*  detailsEscaped      = htmlEscape(details.c_str());
 
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addString("error", reasonPhraseEscaped);
   jh.addString("description", detailsEscaped);

--- a/src/lib/serviceRoutines/statisticsTreat.cpp
+++ b/src/lib/serviceRoutines/statisticsTreat.cpp
@@ -151,7 +151,7 @@ static void resetStatistics(void)
 *
 * renderUsedCounter -
 */
-inline void renderUsedCounter(JsonHelper* js, const std::string& field, int counter)
+inline void renderUsedCounter(JsonObjectHelper* js, const std::string& field, int counter)
 {
   if (counter != -1)
   {
@@ -167,7 +167,7 @@ inline void renderUsedCounter(JsonHelper* js, const std::string& field, int coun
 */
 std::string renderCounterStats(void)
 {
-  JsonHelper js;
+  JsonObjectHelper js;
 
   // FIXME: try to chose names closer to the ones used in API URLs
   renderUsedCounter(&js, "jsonRequests",                              noOfJsonRequests);
@@ -246,7 +246,7 @@ std::string renderCounterStats(void)
 */
 std::string renderSemWaitStats(void)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
 
   jh.addNumber("request",           semTimeReqGet());
   jh.addNumber("dbConnectionPool",  mongoPoolConnectionSemWaitingTimeGet());
@@ -267,7 +267,7 @@ std::string renderSemWaitStats(void)
 */
 std::string renderNotifQueueStats(void)
 {
-  JsonHelper jh;
+  JsonObjectHelper jh;
   float      timeInQ = QueueStatistics::getTimeInQ();
   int        out     = QueueStatistics::getOut();
 
@@ -298,7 +298,7 @@ std::string statisticsTreat
 )
 {
 
-  JsonHelper js;
+  JsonObjectHelper js;
 
   if (ciP->method == "DELETE")
   {
@@ -355,7 +355,7 @@ std::string statisticsCacheTreat
 )
 {
 
-  JsonHelper js;
+  JsonObjectHelper js;
 
   if (ciP->method == "DELETE")
   {

--- a/src/lib/serviceRoutinesV2/getEntity.cpp
+++ b/src/lib/serviceRoutinesV2/getEntity.cpp
@@ -54,9 +54,9 @@
 *
 * URI parameters:
 *   - type=<TYPE>
-*   - options=keyValues|values|unique   (used in Entity::render)
-*   - attrs=A1,A2,...An                 (used in Entity::render)
-*   - metadata=M1,M2,...Mn              (used in Entity::render)
+*   - options=keyValues|values|unique   (used in Entity::toJson)
+*   - attrs=A1,A2,...An                 (used in Entity::toJson)
+*   - metadata=M1,M2,...Mn              (used in Entity::toJson)
 */
 std::string getEntity
 (

--- a/src/lib/serviceRoutinesV2/postEntities.cpp
+++ b/src/lib/serviceRoutinesV2/postEntities.cpp
@@ -132,7 +132,7 @@ std::string postEntities
   else if (parseDataP->upcrs.res.errorCode.code != SccOk)
   {
     ciP->httpStatusCode = parseDataP->upcrs.res.errorCode.code;
-    TIMED_RENDER(answer = parseDataP->upcrs.res.errorCode.toJson(true));
+    TIMED_RENDER(answer = parseDataP->upcrs.res.errorCode.toJson());
     ciP->answer         = answer;
   }
   else

--- a/test/functionalTest/cases/2763_postUpdateContext_error_return/postEntities_with_errors_in_service_path.test
+++ b/test/functionalTest/cases/2763_postUpdateContext_error_return/postEntities_with_errors_in_service_path.test
@@ -53,14 +53,14 @@ echo
 01. Try to create an entity with more than one service path - see error
 =======================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 79
+Content-Length: 91
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "code": "400",
-    "details": "more than one service path in context update request"
+    "description": "more than one service path in context update request",
+    "error": "BadRequest"
 }
 
 

--- a/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create.test
+++ b/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create.test
@@ -97,7 +97,7 @@ Date: REGEX(.*)
 02. GET the registration using APIv2
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 312
+Content-Length: 311
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/functionalTest/cases/3005_GET_registrations/get_registrations.test
+++ b/test/functionalTest/cases/3005_GET_registrations/get_registrations.test
@@ -220,7 +220,7 @@ Date: REGEX(.*)
 05. GET all four registration, without service path
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 1057
+Content-Length: 1053
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -335,7 +335,7 @@ Date: REGEX(.*)
 07. GET one registration using service path /a1/e2
 ==================================================
 HTTP/1.1 200 OK
-Content-Length: 265
+Content-Length: 264
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -370,7 +370,7 @@ Date: REGEX(.*)
 08. GET all four registrations (step 04) for service path /#
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 1057
+Content-Length: 1053
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/functionalTest/cases/3005_GET_registrations/get_registrations_with_pagination.test
+++ b/test/functionalTest/cases/3005_GET_registrations/get_registrations_with_pagination.test
@@ -224,7 +224,7 @@ Date: REGEX(.*)
 05. GET all four registrations, as the default result (with 'count' parameter)
 ==============================================================================
 HTTP/1.1 200 OK
-Content-Length: 1057
+Content-Length: 1053
 Content-Type: application/json
 Fiware-Total-Count: 4
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -329,7 +329,7 @@ Date: REGEX(.*)
 06. GET the first two registrations (offset: default=0, limit 2)
 ================================================================
 HTTP/1.1 200 OK
-Content-Length: 529
+Content-Length: 527
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -387,7 +387,7 @@ Date: REGEX(.*)
 07. GET second and third registrations (offset: 1, limit 2)
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 529
+Content-Length: 527
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -445,7 +445,7 @@ Date: REGEX(.*)
 08. GET only the fourth registration (offset: 3, limit: default=20)
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 265
+Content-Length: 264
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)

--- a/test/functionalTest/cases/3008_get_registration/get_reg_using_v2_created_using_v2.test
+++ b/test/functionalTest/cases/3008_get_registration/get_reg_using_v2_created_using_v2.test
@@ -98,7 +98,7 @@ Date: REGEX(.*)
 02. GET the registration using APIv2
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 263
+Content-Length: 262
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)


### PR DESCRIPTION
This PR is part of issue #1298 refactors and contains the following items:

1. Add a new class JsonVectorHelper, similar to current JsonHelper for objects
2. Ensure all NGSIv2 rendering logic (i.e. `toJson()` methods) are using the helpers. Removal of dead code and some fixes. After this change, no string concatenation is implemented in toJson() methods directly, all that is encapusulated in Json*Helper classes. Detail of the fixed methods (as far as I remember):
   * NotifyContextRequeset::toJson()
   * ContextElementResponseVector::toJson()
   * EntityID::toJson()
   * StatusCode::toJson()
   * SubscribeError::toJson()
   * SubscribeContextResponse::toJson()
   * OrionError::toJson()
3. Avoid code duplication unifying toJsonString() and jsonIvalidCharsTransformation() code
4. Avoid + for std::string in Json*Helper clases (and some other placers), according to the recommendations of https://www.thecodingdelight.com/string-cplusplus/

I'd try to coduct a test with Apache Benchmark in order to see if item 4 provides some improvement, but PR review can be done in the meanwhile.