### PR TITLE
REFACTOR related with #1298

### DIFF
--- a/src/lib/common/tag.h
+++ b/src/lib/common/tag.h
@@ -39,13 +39,6 @@
 * Macros for JSON rendering
 */
 #define JSON_STR(value)                std::string("\"" + std::string(value) + "\"")
-#define JSON_NUMBER(value)             std::string(value)
-#define JSON_BOOL(bvalue)              std::string((bvalue == true)? "true" : "false") 
-
-#define JSON_PROP(name)                std::string("\"" + std::string(name) + "\":")
-#define JSON_VALUE(name, value)        std::string(JSON_PROP(name) + JSON_STR(value))
-#define JSON_VALUE_NUMBER(name, value) std::string(JSON_PROP(name) + JSON_NUMBER(value))
-#define JSON_VALUE_BOOL(name, value)   std::string(JSON_PROP(name) + ((value == true)? "true" : "false"))
 
 
 

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -245,11 +245,6 @@ std::string Metadata::toJsonV1(bool comma)
 
   if (compoundValueP != NULL)
   {
-    // FIXME P8: We need to to this to avoid repeat the "value" keyword. I don't
-    // understand why (if you look to the similar code in Metadata::toJson(), it
-    // is not used there). It comes from the old implementation
-    compoundValueP->container = compoundValueP;
-
     out += JSON_STR("value") + ":" + compoundValueP->toJson(true);
   }
   else if (valueType == orion::ValueTypeString)

--- a/src/lib/serviceRoutinesV2/entryPointsTreat.cpp
+++ b/src/lib/serviceRoutinesV2/entryPointsTreat.cpp
@@ -31,6 +31,7 @@
 #include "common/string.h"
 #include "common/globals.h"
 #include "common/tag.h"
+#include "common/JsonHelper.h"
 
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
@@ -49,15 +50,13 @@ std::string entryPointsTreat
   ParseData*                 parseDataP
 )
 {
-  std::string out = "{";
+  JsonObjectHelper jh;
 
-  out += JSON_VALUE("entities_url",      ENTITIES_URL)      + ",";
-  out += JSON_VALUE("types_url",         TYPES_URL)         + ",";
-  out += JSON_VALUE("subscriptions_url", SUBSCRIPTIONS_URL) + ",";
-  out += JSON_VALUE("registrations_url", REGISTRATIONS_URL);
-
-  out += "}";
+  jh.addString("entities_url",      ENTITIES_URL);
+  jh.addString("types_url",         TYPES_URL);
+  jh.addString("subscriptions_url", SUBSCRIPTIONS_URL);
+  jh.addString("registrations_url", REGISTRATIONS_URL);
 
   ciP->httpStatusCode = SccOk;
-  return out;
+  return jh.str();
 }


### PR DESCRIPTION
Related with #1298 

This PR ensures that old JSON_ macros are using only in the NGSIv1 renderint part. In fact, it seems that only JSON_STR is used at the end, the rest is not used and has been removed.