### PR TITLE
FIX removed unneded REGEX([0|1]*) in .test

### DIFF
--- a/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_deeper.test
+++ b/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_deeper.test
@@ -715,7 +715,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                                     "F": false, 
                                     "N": null, 
                                     "T": true, 
-                                    "f": 3.14REGEX([01]*), 
+                                    "f": 3.14,
                                     "i": 10, 
                                     "s": "test_string"
                                 }

--- a/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_equals_subs.test
+++ b/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_equals_subs.test
@@ -433,7 +433,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -485,7 +485,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -537,7 +537,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -589,7 +589,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -641,7 +641,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -693,7 +693,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -745,7 +745,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -797,7 +797,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -848,7 +848,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -886,7 +886,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -924,7 +924,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -962,7 +962,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -1000,7 +1000,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -1038,7 +1038,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -1076,7 +1076,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -1114,7 +1114,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }

--- a/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_lt_le_gt_ge_subs.test
+++ b/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_lt_le_gt_ge_subs.test
@@ -281,7 +281,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue", 
                         "value": {
-                            "f": 3.14REGEX([01]*), 
+                            "f": 3.14,
                             "i": 10, 
                             "modified": false, 
                             "s": "test_string"
@@ -330,7 +330,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue", 
                         "value": {
-                            "f": 3.14REGEX([01]*), 
+                            "f": 3.14,
                             "i": 10, 
                             "modified": false, 
                             "s": "test_string"
@@ -379,7 +379,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue", 
                         "value": {
-                            "f": 3.14REGEX([01]*), 
+                            "f": 3.14,
                             "i": 10, 
                             "modified": false, 
                             "s": "test_string"
@@ -428,7 +428,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue", 
                         "value": {
-                            "f": 3.14REGEX([01]*), 
+                            "f": 3.14,
                             "i": 10, 
                             "modified": false, 
                             "s": "test_string"
@@ -476,7 +476,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue", 
                         "value": {
-                            "f": 3.14REGEX([01]*), 
+                            "f": 3.14,
                             "i": 10, 
                             "modified": true, 
                             "s": "test_string"
@@ -511,7 +511,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue", 
                         "value": {
-                            "f": 3.14REGEX([01]*), 
+                            "f": 3.14,
                             "i": 10, 
                             "modified": true, 
                             "s": "test_string"
@@ -546,7 +546,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue", 
                         "value": {
-                            "f": 3.14REGEX([01]*), 
+                            "f": 3.14,
                             "i": 10, 
                             "modified": true, 
                             "s": "test_string"
@@ -581,7 +581,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue", 
                         "value": {
-                            "f": 3.14REGEX([01]*), 
+                            "f": 3.14,
                             "i": 10, 
                             "modified": true, 
                             "s": "test_string"

--- a/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_patternmatch_subs.test
+++ b/test/functionalTest/cases/1156_mqfilters_and_compounds/mqfilters_and_compounds_patternmatch_subs.test
@@ -278,7 +278,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue",
                         "value": {
-                            "f": 3.14REGEX([01]*),
+                            "f": 3.14,
                             "i": 10,
                             "modified": false,
                             "s": "test_string"
@@ -327,7 +327,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue",
                         "value": {
-                            "f": 3.14REGEX([01]*),
+                            "f": 3.14,
                             "i": 10,
                             "modified": false,
                             "s": "test_string"
@@ -376,7 +376,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue",
                         "value": {
-                            "f": 3.14REGEX([01]*),
+                            "f": 3.14,
                             "i": 10,
                             "modified": false,
                             "s": "test_string"
@@ -438,7 +438,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue",
                         "value": {
-                            "f": 3.14REGEX([01]*),
+                            "f": 3.14,
                             "i": 10,
                             "modified": true,
                             "s": "test_string"
@@ -473,7 +473,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue",
                         "value": {
-                            "f": 3.14REGEX([01]*),
+                            "f": 3.14,
                             "i": 10,
                             "modified": true,
                             "s": "test_string"
@@ -508,7 +508,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "M1": {
                         "type": "StructuredValue",
                         "value": {
-                            "f": 3.14REGEX([01]*),
+                            "f": 3.14,
                             "i": 10,
                             "modified": true,
                             "s": "test_string"

--- a/test/functionalTest/cases/1156_qfilters_and_compounds/qfilters_and_compounds_deeper.test
+++ b/test/functionalTest/cases/1156_qfilters_and_compounds/qfilters_and_compounds_deeper.test
@@ -654,7 +654,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                             "F": false, 
                             "N": null, 
                             "T": true, 
-                            "f": 3.14REGEX([01]*),
+                            "f": 3.14,
                             "i": 10, 
                             "s": "test_string"
                         }

--- a/test/functionalTest/cases/1156_qfilters_and_compounds/qfilters_and_compounds_equals_subs.test
+++ b/test/functionalTest/cases/1156_qfilters_and_compounds/qfilters_and_compounds_equals_subs.test
@@ -433,7 +433,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -485,7 +485,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -537,7 +537,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -589,7 +589,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -641,7 +641,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -693,7 +693,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -745,7 +745,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -797,7 +797,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -848,7 +848,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -886,7 +886,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -924,7 +924,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -962,7 +962,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -1000,7 +1000,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -1038,7 +1038,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -1076,7 +1076,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }
@@ -1114,7 +1114,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     "F": false, 
                     "N": null, 
                     "T": true, 
-                    "f": 3.14REGEX([01]*), 
+                    "f": 3.14,
                     "i": 10, 
                     "s": "test_string"
                 }

--- a/test/functionalTest/cases/1156_qfilters_and_compounds/qfilters_and_compounds_lt_le_gt_ge_subs.test
+++ b/test/functionalTest/cases/1156_qfilters_and_compounds/qfilters_and_compounds_lt_le_gt_ge_subs.test
@@ -270,7 +270,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": false,
                     "s": "test_string"
@@ -314,7 +314,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": false,
                     "s": "test_string"
@@ -358,7 +358,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": false,
                     "s": "test_string"
@@ -402,7 +402,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": false,
                     "s": "test_string"
@@ -445,7 +445,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": true,
                     "s": "test_string"
@@ -475,7 +475,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": true,
                     "s": "test_string"
@@ -505,7 +505,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": true,
                     "s": "test_string"
@@ -535,7 +535,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": true,
                     "s": "test_string"

--- a/test/functionalTest/cases/1156_qfilters_and_compounds/qfilters_and_compounds_patternmatch_subs.test
+++ b/test/functionalTest/cases/1156_qfilters_and_compounds/qfilters_and_compounds_patternmatch_subs.test
@@ -267,7 +267,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": false,
                     "s": "test_string"
@@ -311,7 +311,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": false,
                     "s": "test_string"
@@ -355,7 +355,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": false,
                     "s": "test_string"
@@ -412,7 +412,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": true,
                     "s": "test_string"
@@ -442,7 +442,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": true,
                     "s": "test_string"
@@ -472,7 +472,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                 "metadata": {}, 
                 "type": "StructuredValue", 
                 "value": {
-                    "f": 3.14REGEX([01]*),
+                    "f": 3.14,
                     "i": 10,
                     "modified": true,
                     "s": "test_string"

--- a/test/functionalTest/cases/2339_json_native_types_in_v1/json_native_types_in_v1.test
+++ b/test/functionalTest/cases/2339_json_native_types_in_v1/json_native_types_in_v1.test
@@ -366,7 +366,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                     {
                         "name": "Float", 
                         "type": "Number", 
-                        "value": 3.14REGEX([01]*)
+                        "value": 3.14
                     }, 
                     {
                         "name": "Integer", 
@@ -406,7 +406,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                                 false, 
                                 true
                             ], 
-                            "Float": 3.14REGEX([01]*),
+                            "Float": 3.14,
                             "Integer": 3, 
                             "Null": null, 
                             "NullVec": [
@@ -426,7 +426,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                                     false, 
                                     true
                                 ], 
-                                "Float": 3.14REGEX([01]*), 
+                                "Float": 3.14,
                                 "Integer": 3, 
                                 "Null": null, 
                                 "NullVec": [
@@ -443,7 +443,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                                     "a": "1", 
                                     "b": null, 
                                     "c": true, 
-                                    "d": 3.14REGEX([01]*)
+                                    "d": 3.14
                                 }, 
                                 "String": "string"
                             }, 
@@ -465,7 +465,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
                             {
                                 "name": "Float", 
                                 "type": "Number", 
-                                "value": 3.14REGEX([01]*)
+                                "value": 3.14
                             }, 
                             {
                                 "name": "Integer",


### PR DESCRIPTION
I don't remember why we have REGEX([0|1]) in the .test but it seems (at least in my local, i.e. Debian 8) it is no longer needed.

Let's see the Travis opinion in this matter :) If it pass the test at Travis I guess we can merge the change.