### PR TITLE
Simplification of CompoundValueNode class

### DIFF
--- a/src/lib/jsonParse/jsonParse.cpp
+++ b/src/lib/jsonParse/jsonParse.cpp
@@ -286,10 +286,9 @@ void eatCompound
       }
 
       containerP->add(orion::ValueTypeString, nodeName, nodeValue);
-      LM_T(LmtCompoundValue, ("Added string '%s' (value: '%s') under '%s'",
+      LM_T(LmtCompoundValue, ("Added string '%s' (value: '%s')",
                               nodeName.c_str(),
-                              nodeValue.c_str(),
-                              containerP->cpath()));
+                              nodeValue.c_str()));
     }
     else if ((nodeName == "") && (nodeValue == "") && (noOfChildren == 0))  // Unnamed String with EMPTY VALUE
     {
@@ -298,30 +297,31 @@ void eatCompound
     }
     else if ((nodeName != "") && (nodeValue == "") && (noOfChildren == 0))  // Named Empty string
     {
-      LM_T(LmtCompoundValue, ("Adding container '%s' under '%s'", nodeName.c_str(), containerP->cpath()));
+      LM_T(LmtCompoundValue, ("Adding container '%s'", nodeName.c_str()));
       containerP = containerP->add(ValueTypeString, nodeName, "");
     }
     else if ((nodeName != "") && (nodeValue == ""))  // Named Container
     {
-      LM_T(LmtCompoundValue, ("Adding container '%s' under '%s'", nodeName.c_str(), containerP->cpath()));
+      LM_T(LmtCompoundValue, ("Adding container '%s'", nodeName.c_str()));
       containerP = containerP->add(ValueTypeObject, nodeName, "");
     }
     else if ((nodeName == "") && (nodeValue == ""))  // Name-Less container
     {
-      LM_T(LmtCompoundValue, ("Adding name-less container under '%s' (parent may be a Vector!)", containerP->cpath()));
+      LM_T(LmtCompoundValue, ("Adding name-less container (parent may be a Vector!)"));
       containerP->valueType = ValueTypeVector;
       containerP = containerP->add(ValueTypeObject, "item", "");
     }
     else if ((nodeName == "") && (nodeValue != ""))  // Name-Less String + its container is a vector
     {
       containerP->valueType = ValueTypeVector;
-      LM_T(LmtCompoundValue, ("Set '%s' to be a vector", containerP->cpath()));
+      LM_T(LmtCompoundValue, ("Set to be a vector"));
       containerP->add(orion::ValueTypeString, "item", nodeValue);
-      LM_T(LmtCompoundValue, ("Added a name-less string (value: '%s') under '%s'",
-                              nodeValue.c_str(), containerP->cpath()));
+      LM_T(LmtCompoundValue, ("Added a name-less string (value: '%s')", nodeValue.c_str()));
     }
     else
-      LM_T(LmtCompoundValue, ("IMPOSSIBLE !!!"));
+    {
+      LM_E(("Runtime Error (impossible siutation)"));
+    }
   }
 
   boost::property_tree::ptree subtree = (boost::property_tree::ptree) v.second;

--- a/src/lib/jsonParseV2/parseAttributeValue.cpp
+++ b/src/lib/jsonParseV2/parseAttributeValue.cpp
@@ -66,7 +66,7 @@ std::string parseAttributeValue(ConnectionInfo* ciP, ContextAttribute* caP)
   }
 
   caP->valueType  = (document.IsObject())? orion::ValueTypeObject : orion::ValueTypeVector;
-  parseContextAttributeCompoundValueStandAlone(document, caP, caP->valueType);
+  parseContextAttributeCompoundValueStandAlone(document, caP);
 
   return "OK";
 }

--- a/src/lib/jsonParseV2/parseContextAttributeCompoundValue.cpp
+++ b/src/lib/jsonParseV2/parseContextAttributeCompoundValue.cpp
@@ -67,8 +67,6 @@ std::string parseContextAttributeCompoundValue
 {
   if (node->IsObject())
   {
-    int counter  = 0;
-
     for (rapidjson::Value::ConstMemberIterator iter = node->MemberBegin(); iter != node->MemberEnd(); ++iter)
     {
       std::string                nodeType = jsonParseTypeNames[iter->value.GetType()];
@@ -77,11 +75,6 @@ std::string parseContextAttributeCompoundValue
       cvnP->valueType  = stringToCompoundType(nodeType);
 
       cvnP->name       = iter->name.GetString();
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + cvnP->name;
 
       if (nodeType == "String")
       {
@@ -101,12 +94,10 @@ std::string parseContextAttributeCompoundValue
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -119,29 +110,16 @@ std::string parseContextAttributeCompoundValue
       {
         parseContextAttributeCompoundValue(iter, caP, cvnP);
       }
-
-      ++counter;
     }
   }
   else if (node->IsArray())
   {
-    int counter  = 0;
-
     for (rapidjson::Value::ConstValueIterator iter = node->Begin(); iter != node->End(); ++iter)
     {
       std::string                nodeType  = jsonParseTypeNames[iter->GetType()];
       orion::CompoundValueNode*  cvnP      = new orion::CompoundValueNode();
-      char                       itemNo[STRING_SIZE_FOR_INT];
-
-      snprintf(itemNo, sizeof(itemNo), "%03d", counter);
 
       cvnP->valueType  = stringToCompoundType(nodeType);
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + "[" + itemNo + "]";
-
 
       if (nodeType == "String")
       {
@@ -161,12 +139,10 @@ std::string parseContextAttributeCompoundValue
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -179,11 +155,8 @@ std::string parseContextAttributeCompoundValue
       {
         parseContextAttributeCompoundValue(iter, caP, cvnP);
       }
-
-      ++counter;
     }
   }
-
 
   return "OK";
 }
@@ -206,13 +179,8 @@ std::string parseContextAttributeCompoundValue
   if (caP->compoundValueP == NULL)
   {
     caP->compoundValueP            = new orion::CompoundValueNode();
-    caP->compoundValueP->name      = "TOP";
-    caP->compoundValueP->container = caP->compoundValueP;
+    caP->compoundValueP->name      = "";
     caP->compoundValueP->valueType = stringToCompoundType(type);
-    caP->compoundValueP->path      = "/";
-    caP->compoundValueP->rootP     = caP->compoundValueP;
-    caP->compoundValueP->level     = 0;
-    caP->compoundValueP->siblingNo = 0;
 
     parent = caP->compoundValueP;
 
@@ -228,23 +196,12 @@ std::string parseContextAttributeCompoundValue
   //
   if (type == "Array")
   {
-    int counter  = 0;
-
     for (rapidjson::Value::ConstValueIterator iter = node->value.Begin(); iter != node->value.End(); ++iter)
     {
       std::string                nodeType  = jsonParseTypeNames[iter->GetType()];
       orion::CompoundValueNode*  cvnP      = new orion::CompoundValueNode();
-      char                       itemNo[STRING_SIZE_FOR_INT];
-
-      snprintf(itemNo, sizeof(itemNo), "%03d", counter);
 
       cvnP->valueType  = stringToCompoundType(nodeType);
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + "[" + itemNo + "]";
-
 
       if (nodeType == "String")
       {
@@ -260,12 +217,10 @@ std::string parseContextAttributeCompoundValue
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -278,14 +233,10 @@ std::string parseContextAttributeCompoundValue
       {
         parseContextAttributeCompoundValue(iter, caP, cvnP);
       }
-
-      ++counter;
     }
   }
   else if (type == "Object")
   {
-    int counter  = 0;
-
     rapidjson::Value::ConstMemberIterator iter;
     for (iter = node->value.MemberBegin(); iter != node->value.MemberEnd(); ++iter)
     {
@@ -294,11 +245,6 @@ std::string parseContextAttributeCompoundValue
 
       cvnP->name       = iter->name.GetString();
       cvnP->valueType  = stringToCompoundType(nodeType);
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + cvnP->name;
 
       if (nodeType == "String")
       {
@@ -314,12 +260,10 @@ std::string parseContextAttributeCompoundValue
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -332,8 +276,6 @@ std::string parseContextAttributeCompoundValue
       {
         parseContextAttributeCompoundValue(iter, caP, cvnP);
       }
-
-      ++counter;
     }
   }
 
@@ -349,18 +291,12 @@ std::string parseContextAttributeCompoundValue
 std::string parseContextAttributeCompoundValueStandAlone
 (
   rapidjson::Document&  document,
-  ContextAttribute*     caP,
-  orion::ValueType      valueType
+  ContextAttribute*     caP
 )
 {
   caP->compoundValueP            = new orion::CompoundValueNode();
-  caP->compoundValueP->name      = "TOP";
-  caP->compoundValueP->container = caP->compoundValueP;
+  caP->compoundValueP->name      = "";
   caP->compoundValueP->valueType = caP->valueType;  // Convert to other type?
-  caP->compoundValueP->path      = "/";
-  caP->compoundValueP->rootP     = caP->compoundValueP;
-  caP->compoundValueP->level     = 0;
-  caP->compoundValueP->siblingNo = 0;
 
   orion::CompoundValueNode*   parent  = caP->compoundValueP;
 
@@ -370,23 +306,12 @@ std::string parseContextAttributeCompoundValueStandAlone
   //
   if (caP->valueType == orion::ValueTypeVector)
   {
-    int counter  = 0;
-
     for (rapidjson::Value::ConstValueIterator iter = document.Begin(); iter != document.End(); ++iter)
     {
       std::string                nodeType  = jsonParseTypeNames[iter->GetType()];
       orion::CompoundValueNode*  cvnP      = new orion::CompoundValueNode();
-      char                       itemNo[STRING_SIZE_FOR_INT];
-
-      snprintf(itemNo, sizeof(itemNo), "%03d", counter);
 
       cvnP->valueType  = stringToCompoundType(nodeType);
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + "[" + itemNo + "]";
-
 
       if (nodeType == "String")
       {
@@ -406,12 +331,10 @@ std::string parseContextAttributeCompoundValueStandAlone
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -428,14 +351,10 @@ std::string parseContextAttributeCompoundValueStandAlone
       {
         caP->type = defaultType(caP->valueType);
       }
-
-      ++counter;
     }
   }
   else if (caP->valueType == orion::ValueTypeObject)
   {
-    int counter  = 0;
-
     for (rapidjson::Value::ConstMemberIterator iter = document.MemberBegin(); iter != document.MemberEnd(); ++iter)
     {
       std::string                nodeType = jsonParseTypeNames[iter->value.GetType()];
@@ -443,11 +362,6 @@ std::string parseContextAttributeCompoundValueStandAlone
 
       cvnP->name       = iter->name.GetString();
       cvnP->valueType  = stringToCompoundType(nodeType);
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + cvnP->name;
 
       if (nodeType == "String")
       {
@@ -467,12 +381,10 @@ std::string parseContextAttributeCompoundValueStandAlone
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -489,8 +401,6 @@ std::string parseContextAttributeCompoundValueStandAlone
       {
         caP->type = defaultType(caP->valueType);
       }
-
-      ++counter;
     }
   }
 

--- a/src/lib/jsonParseV2/parseContextAttributeCompoundValue.h
+++ b/src/lib/jsonParseV2/parseContextAttributeCompoundValue.h
@@ -53,8 +53,7 @@ extern std::string parseContextAttributeCompoundValue
 extern std::string parseContextAttributeCompoundValueStandAlone
 (
   rapidjson::Document&  document,
-  ContextAttribute*     caP,
-  orion::ValueType      valueType
+  ContextAttribute*     caP
 );
 
 #endif  // SRC_LIB_JSONPARSEV2_PARSECONTEXTATTRIBUTECOMPOUNDVALUE_H_

--- a/src/lib/jsonParseV2/parseMetadataCompoundValue.cpp
+++ b/src/lib/jsonParseV2/parseMetadataCompoundValue.cpp
@@ -68,8 +68,6 @@ std::string parseMetadataCompoundValue
 {
   if (node->IsObject())
   {
-    int counter  = 0;
-
     for (rapidjson::Value::ConstMemberIterator iter = node->MemberBegin(); iter != node->MemberEnd(); ++iter)
     {
       std::string                nodeType = jsonParseTypeNames[iter->value.GetType()];
@@ -78,11 +76,6 @@ std::string parseMetadataCompoundValue
       cvnP->valueType  = stringToCompoundType(nodeType);
 
       cvnP->name       = iter->name.GetString();
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + cvnP->name;
 
       if (nodeType == "String")
       {
@@ -102,12 +95,10 @@ std::string parseMetadataCompoundValue
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -120,28 +111,16 @@ std::string parseMetadataCompoundValue
       {
         parseMetadataCompoundValue(iter, mdP, cvnP);
       }
-
-      ++counter;
     }
   }
   else if (node->IsArray())
   {
-    int counter  = 0;
-
     for (rapidjson::Value::ConstValueIterator iter = node->Begin(); iter != node->End(); ++iter)
     {
       std::string                nodeType  = jsonParseTypeNames[iter->GetType()];
       orion::CompoundValueNode*  cvnP      = new orion::CompoundValueNode();
-      char                       itemNo[STRING_SIZE_FOR_INT];
-
-      snprintf(itemNo, sizeof(itemNo), "%03d", counter);
 
       cvnP->valueType  = stringToCompoundType(nodeType);
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + "[" + itemNo + "]";
 
       if (nodeType == "String")
       {
@@ -161,12 +140,10 @@ std::string parseMetadataCompoundValue
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -179,8 +156,6 @@ std::string parseMetadataCompoundValue
       {
         parseMetadataCompoundValue(iter, mdP, cvnP);
       }
-
-      ++counter;
     }
   }
 
@@ -205,13 +180,8 @@ std::string parseMetadataCompoundValue
   if (mdP->compoundValueP == NULL)
   {
     mdP->compoundValueP            = new orion::CompoundValueNode();
-    mdP->compoundValueP->name      = "TOP";
-    mdP->compoundValueP->container = mdP->compoundValueP;
+    mdP->compoundValueP->name      = "";
     mdP->compoundValueP->valueType = stringToCompoundType(type);
-    mdP->compoundValueP->path      = "/";
-    mdP->compoundValueP->rootP     = mdP->compoundValueP;
-    mdP->compoundValueP->level     = 0;
-    mdP->compoundValueP->siblingNo = 0;
 
     parent = mdP->compoundValueP;
   }
@@ -222,22 +192,12 @@ std::string parseMetadataCompoundValue
   //
   if (type == "Array")
   {
-    int counter  = 0;
-
     for (rapidjson::Value::ConstValueIterator iter = node->value.Begin(); iter != node->value.End(); ++iter)
     {
       std::string                nodeType  = jsonParseTypeNames[iter->GetType()];
       orion::CompoundValueNode*  cvnP      = new orion::CompoundValueNode();
-      char                       itemNo[STRING_SIZE_FOR_INT];
-
-      snprintf(itemNo, sizeof(itemNo), "%03d", counter);
 
       cvnP->valueType  = stringToCompoundType(nodeType);
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + "[" + itemNo + "]";
 
       if (nodeType == "String")
       {
@@ -253,12 +213,10 @@ std::string parseMetadataCompoundValue
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -271,13 +229,10 @@ std::string parseMetadataCompoundValue
       {
         parseMetadataCompoundValue(iter, mdP, cvnP);
       }
-
-      ++counter;
     }
   }
   else if (type == "Object")
   {
-    int                                    counter  = 0;
     rapidjson::Value::ConstMemberIterator  iter;
 
     for (iter = node->value.MemberBegin(); iter != node->value.MemberEnd(); ++iter)
@@ -287,11 +242,6 @@ std::string parseMetadataCompoundValue
 
       cvnP->name       = iter->name.GetString();
       cvnP->valueType  = stringToCompoundType(nodeType);
-      cvnP->container  = parent;
-      cvnP->rootP      = parent->rootP;
-      cvnP->level      = parent->level + 1;
-      cvnP->siblingNo  = counter;
-      cvnP->path       = parent->path + cvnP->name;
 
       if (nodeType == "String")
       {
@@ -307,12 +257,10 @@ std::string parseMetadataCompoundValue
       }
       else if (nodeType == "Object")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeObject;
       }
       else if (nodeType == "Array")
       {
-        cvnP->path += "/";
         cvnP->valueType = orion::ValueTypeVector;
       }
 
@@ -325,8 +273,6 @@ std::string parseMetadataCompoundValue
       {
         parseMetadataCompoundValue(iter, mdP, cvnP);
       }
-
-      ++counter;
     }
   }
 

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -1164,7 +1164,7 @@ std::string ContextAttribute::check(ApiVersion apiVersion, RequestType requestTy
 
   if ((compoundValueP != NULL) && (compoundValueP->childV.size() != 0))
   {
-    return compoundValueP->check();
+    return compoundValueP->check("");
   }
 
   if (valueType == orion::ValueTypeString)

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -197,10 +197,7 @@ ContextElementResponse::ContextElementResponse
       case Array:
         caP = new ContextAttribute(ca.name, ca.type, "");
         caP->compoundValueP = new orion::CompoundValueNode(orion::ValueTypeVector);
-        // FIXME P7: next line is counterintuitive. If the object is a vector, why
-        // we need to use ValueTypeObject here? Because otherwise Metadata::toJson()
-        // method doesn't work. A littely crazy... it should be fixed.
-        caP->valueType = orion::ValueTypeObject;
+        caP->valueType = orion::ValueTypeVector;
         compoundVectorResponse(caP->compoundValueP, getFieldF(attr, ENT_ATTRS_VALUE));
         break;
 

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -211,17 +211,18 @@ Metadata::Metadata(const std::string& _name, const BSONObj& mdB)
     valueType = orion::ValueTypeNull;
     break;
 
-  // FIXME P7: why don't have a case for Object (valueType = orion::ValueTypeObject)
-  // and other for Array (valueType = orion::ValueTypeVector)? This is confusing, probably
-  // from the days when valueType wasn't already invented...
   case Object:
-  case Array:
     valueType      = orion::ValueTypeObject;
     compoundValueP = new orion::CompoundValueNode();
     compoundObjectResponse(compoundValueP, getFieldF(mdB, ENT_ATTRS_VALUE));
-    compoundValueP->container = compoundValueP;
-    compoundValueP->name      = "value";
-    compoundValueP->valueType = (bsonType == Object)? orion::ValueTypeObject : orion::ValueTypeVector;
+    compoundValueP->valueType = orion::ValueTypeObject;
+    break;
+
+  case Array:
+    valueType      = orion::ValueTypeVector;
+    compoundValueP = new orion::CompoundValueNode();
+    compoundVectorResponse(compoundValueP, getFieldF(mdB, ENT_ATTRS_VALUE));
+    compoundValueP->valueType = orion::ValueTypeVector;
     break;
 
   default:

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -49,13 +49,7 @@ CompoundValueNode::CompoundValueNode():
   name        ("Unset"),
   valueType   (orion::ValueTypeNotGiven),
   numberValue (0.0),
-  boolValue   (false),
-  container   (NULL),
-  rootP       (NULL),
-  siblingNo   (0),
-  renderName  (false),
-  path        ("Unset"),
-  level       (0)
+  boolValue   (false)
 {
   LM_T(LmtCompoundValue, ("Created EMPTY compound node at %p", this));
 }
@@ -67,16 +61,10 @@ CompoundValueNode::CompoundValueNode():
 * CompoundValueNode - constructor for toplevel 'node'
 */
 CompoundValueNode::CompoundValueNode(orion::ValueType _type):
-  name        ("toplevel"),
+  name        (""),
   valueType   (_type),
   numberValue (0.0),
-  boolValue   (false),
-  container   (this),
-  rootP       (this),
-  siblingNo   (0),
-  renderName  (false),
-  path        ("/"),
-  level       (0)
+  boolValue   (false)
 {
   LM_T(LmtCompoundValue, ("Created TOPLEVEL compound node (a %s) at %p", (valueType == orion::ValueTypeVector)? "Vector" : "Object", this));
 }
@@ -89,30 +77,18 @@ CompoundValueNode::CompoundValueNode(orion::ValueType _type):
 */
 CompoundValueNode::CompoundValueNode
 (
-  CompoundValueNode*  _container,
-  const std::string&  _path,
   const std::string&  _name,
   const std::string&  _value,
-  int                 _siblingNo,
-  orion::ValueType    _type,
-  int                 _level
+  orion::ValueType    _type
 ):
   name        (_name),
   valueType   (_type),
   stringValue (_value),
   numberValue (0.0),
-  boolValue   (false),
-  container   (_container),
-  rootP       (container->rootP),
-  siblingNo   (_siblingNo),
-  renderName  (false),
-  path        (_path),
-  level       (container->level + 1)
+  boolValue   (false)
 {
-  LM_T(LmtCompoundValue, ("Created compound node '%s' at level %d, sibling number %d, type %s at %p",
+  LM_T(LmtCompoundValue, ("Created compound node '%s', type %s at %p",
                           name.c_str(),
-                          level,
-                          siblingNo,
                           orion::valueTypeName(valueType),
                           this));
 }
@@ -125,30 +101,18 @@ CompoundValueNode::CompoundValueNode
 */
 CompoundValueNode::CompoundValueNode
 (
-  CompoundValueNode*  _container,
-  const std::string&  _path,
   const std::string&  _name,
   const char*         _value,
-  int                 _siblingNo,
-  orion::ValueType    _type,
-  int                 _level
+  orion::ValueType    _type
 ):
   name        (_name),
   valueType   (_type),
   stringValue (std::string(_value)),
   numberValue (0.0),
-  boolValue   (false),
-  container   (_container),
-  rootP       (container->rootP),
-  siblingNo   (_siblingNo),
-  renderName  (false),
-  path        (_path),
-  level       (container->level + 1)
+  boolValue   (false)
 {
-  LM_T(LmtCompoundValue, ("Created compound node '%s' at level %d, sibling number %d, type %s at %p",
+  LM_T(LmtCompoundValue, ("Created compound node '%s', type %s at %p",
                           name.c_str(),
-                          level,
-                          siblingNo,
                           orion::valueTypeName(valueType),
                           this));
 }
@@ -161,30 +125,18 @@ CompoundValueNode::CompoundValueNode
 */
 CompoundValueNode::CompoundValueNode
 (
-  CompoundValueNode*  _container,
-  const std::string&  _path,
   const std::string&  _name,
   double              _value,
-  int                 _siblingNo,
-  orion::ValueType    _type,
-  int                 _level
+  orion::ValueType    _type
 ):
   name        (_name),
   valueType   (_type),
   stringValue (),
   numberValue (_value),
-  boolValue   (false),
-  container   (_container),
-  rootP       (container->rootP),
-  siblingNo   (_siblingNo),
-  renderName  (false),
-  path        (_path),
-  level       (container->level + 1)
+  boolValue   (false)
 {
-  LM_T(LmtCompoundValue, ("Created compound node '%s' at level %d, sibling number %d, type %s at %p",
+  LM_T(LmtCompoundValue, ("Created compound node '%s', type %s at %p",
                           name.c_str(),
-                          level,
-                          siblingNo,
                           orion::valueTypeName(valueType),
                           this));
 }
@@ -197,30 +149,18 @@ CompoundValueNode::CompoundValueNode
 */
 CompoundValueNode::CompoundValueNode
 (
-  CompoundValueNode*  _container,
-  const std::string&  _path,
   const std::string&  _name,
   bool                _value,
-  int                 _siblingNo,
-  orion::ValueType    _type,
-  int                 _level
+  orion::ValueType    _type
 ):
   name        (_name),
   valueType   (_type),
   stringValue (""),
   numberValue (0.0),
-  boolValue   (_value),
-  container   (_container),
-  rootP       (container->rootP),
-  siblingNo   (_siblingNo),
-  renderName  (false),
-  path        (_path),
-  level       (container->level + 1)
+  boolValue   (_value)
 {
-  LM_T(LmtCompoundValue, ("Created compound node '%s' at level %d, sibling number %d, type %s at %p",
+  LM_T(LmtCompoundValue, ("Created compound node '%s', type %s at %p",
                           name.c_str(),
-                          level,
-                          siblingNo,
                           orion::valueTypeName(valueType),
                           this));
 }
@@ -233,7 +173,7 @@ CompoundValueNode::CompoundValueNode
 */
 CompoundValueNode::~CompoundValueNode()
 {
-  LM_T(LmtCompoundValue, ("Destroying node %p: name: '%s', path '%s' at %p (with %d children)", this, name.c_str(), path.c_str(), this, childV.size()));
+  LM_T(LmtCompoundValue, ("Destroying node %p: name: '%s' at %p (with %d children)", this, name.c_str(), this, childV.size()));
 
   for (uint64_t ix = 0; ix < childV.size(); ++ix)
   {
@@ -258,10 +198,11 @@ CompoundValueNode::~CompoundValueNode()
 /* ****************************************************************************
 *
 * finish -
+*
 */
 std::string CompoundValueNode::finish(void)
 {
-  error = "OK";
+  std::string error = "OK";
 
   LM_T(LmtCompoundValue, ("Finishing a compound"));
 
@@ -270,7 +211,7 @@ std::string CompoundValueNode::finish(void)
     show("");
   }
 
-  check();  // sets 'error' for toplevel node
+  error = check("");  // sets 'error' for toplevel node
 
   return error;
 }
@@ -283,21 +224,16 @@ std::string CompoundValueNode::finish(void)
 */
 CompoundValueNode* CompoundValueNode::add(CompoundValueNode* node)
 {
-  node->container = this;
-  node->level     = level + 1;
-  node->siblingNo = childV.size();
-  node->rootP     = rootP;
-
   if (node->valueType == orion::ValueTypeString)
-    LM_T(LmtCompoundValueAdd, ("Adding String '%s', with value '%s' under '%s' (%s)",
+  {
+    LM_T(LmtCompoundValueAdd, ("Adding String '%s', with value '%s'",
                                node->name.c_str(),
-                               node->stringValue.c_str(),
-                               node->container->path.c_str(),
-                               node->container->name.c_str()));
+                               node->stringValue.c_str()));
+  }
   else
-    LM_T(LmtCompoundValueAdd, ("Adding %s '%s' under '%s' (%s)", orion::valueTypeName(node->valueType), node->name.c_str(),
-                               node->container->path.c_str(),
-                               node->container->name.c_str()));
+  {
+    LM_T(LmtCompoundValueAdd, ("Adding %s '%s')", orion::valueTypeName(node->valueType), node->name.c_str()));
+  }
 
   childV.push_back(node);
   return node;
@@ -316,18 +252,7 @@ CompoundValueNode* CompoundValueNode::add
   const std::string&      _value
 )
 {
-  std::string newPath = path;
-
-  if (newPath == "/")
-  {
-    newPath += _name;
-  }
-  else
-  {
-    newPath += "/" + _name;
-  }
-
-  CompoundValueNode* node = new CompoundValueNode(this, newPath, _name, _value, childV.size(), _type, level + 1);
+  CompoundValueNode* node = new CompoundValueNode(_name, _value, _type);
 
   return add(node);
 }
@@ -345,18 +270,7 @@ CompoundValueNode* CompoundValueNode::add
   const char*             _value
 )
 {
-  std::string newPath = path;
-
-  if (newPath == "/")
-  {
-    newPath += _name;
-  }
-  else
-  {
-    newPath += "/" + _name;
-  }
-
-  CompoundValueNode* node = new CompoundValueNode(this, newPath, _name, _value, childV.size(), _type, level + 1);
+  CompoundValueNode* node = new CompoundValueNode(_name, _value, _type);
 
   return add(node);
 }
@@ -374,18 +288,7 @@ CompoundValueNode* CompoundValueNode::add
   double                  _value
 )
 {
-  std::string newPath = path;
-
-  if (newPath == "/")
-  {
-    newPath += _name;
-  }
-  else
-  {
-    newPath += "/" + _name;
-  }
-
-  CompoundValueNode* node = new CompoundValueNode(this, newPath, _name, _value, childV.size(), _type, level + 1);
+  CompoundValueNode* node = new CompoundValueNode(_name, _value, _type);
 
   return add(node);
 }
@@ -403,18 +306,7 @@ CompoundValueNode* CompoundValueNode::add
   bool                    _value
 )
 {
-  std::string newPath = path;
-
-  if (newPath == "/")
-  {
-    newPath += _name;
-  }
-  else
-  {
-    newPath += "/" + _name;
-  }
-
-  CompoundValueNode* node = new CompoundValueNode(this, newPath, _name, _value, childV.size(), _type, level + 1);
+  CompoundValueNode* node = new CompoundValueNode(_name, _value, _type);
 
   return add(node);
 }
@@ -427,19 +319,7 @@ CompoundValueNode* CompoundValueNode::add
 */
 void CompoundValueNode::shortShow(const std::string& indent)
 {
-  if ((rootP == this) && (valueType == orion::ValueTypeVector))
-  {
-    LM_T(LmtCompoundValue,      ("%s%s (toplevel vector)",
-                                 indent.c_str(),
-                                 name.c_str()));
-  }
-  else if (rootP == this)
-  {
-    LM_T(LmtCompoundValue,      ("%s%s (toplevel object)",
-                                 indent.c_str(),
-                                 name.c_str()));
-  }
-  else if (valueType == orion::ValueTypeVector)
+  if (valueType == orion::ValueTypeVector)
   {
     LM_T(LmtCompoundValue,      ("%s%s (vector)",
                                  indent.c_str(),
@@ -511,24 +391,9 @@ void CompoundValueNode::show(const std::string& indent)
                                 name.c_str()));
   }
 
-  LM_T(LmtCompoundValueShow, ("%scontainer: %s",
-                              indent.c_str(),
-                              container->name.c_str()));
-  LM_T(LmtCompoundValueShow, ("%slevel:     %d",
-                              indent.c_str(),
-                              level));
-  LM_T(LmtCompoundValueShow, ("%ssibling:   %d",
-                              indent.c_str(),
-                              siblingNo));
   LM_T(LmtCompoundValueShow, ("%stype:      %s",
                               indent.c_str(),
                               orion::valueTypeName(valueType)));
-  LM_T(LmtCompoundValueShow, ("%spath:      %s",
-                              indent.c_str(),
-                              path.c_str()));
-  LM_T(LmtCompoundValueShow, ("%srootP:     %s",
-                              indent.c_str(),
-                              rootP->name.c_str()));
 
   if (valueType == orion::ValueTypeString)
   {
@@ -594,9 +459,8 @@ void CompoundValueNode::show(const std::string& indent)
 * A vector must have all its children with the same name.
 * An object cannot have two children with the same name.
 *
-* Encountered errors are saved in the 'error' field of the root of the tree (rootP->error).
 */
-std::string CompoundValueNode::check(void)
+std::string CompoundValueNode::check(const std::string& path)
 {
   if (valueType == orion::ValueTypeVector)
   {
@@ -609,11 +473,9 @@ std::string CompoundValueNode::check(void)
     {
       if (childV[ix]->name != childV[0]->name)
       {
-        rootP->error =
-          std::string("bad tag-name of vector item: /") + childV[ix]->name + "/, should be /" + childV[0]->name + "/";
-
-        alarmMgr.badInput(clientIp, rootP->error);
-        return rootP->error;
+        std::string error = "bad tag-name of vector item: /" + childV[ix]->name + "/, should be /" + childV[0]->name + "/";
+        alarmMgr.badInput(clientIp, error);
+        return error;
       }
     }
   }
@@ -630,10 +492,11 @@ std::string CompoundValueNode::check(void)
       {
         if (childV[ix]->name == childV[ix2]->name)
         {
-          rootP->error = std::string("duplicated tag-name: /") + childV[ix]->name + "/ in path: " + path;
-          alarmMgr.badInput(clientIp, rootP->error);
+          std::string fullPath = (path == "" ? "/" : path + name);
+          std::string error = "duplicated tag-name: /" + childV[ix]->name + "/ in path: " + fullPath;
+          alarmMgr.badInput(clientIp, error);
 
-          return rootP->error;
+          return error;
         }
       }
     }
@@ -652,7 +515,7 @@ std::string CompoundValueNode::check(void)
 
   for (uint64_t ix = 0; ix < childV.size(); ++ix)
   {
-    res = childV[ix]->check();
+    res = childV[ix]->check(path + name + "/");
     if (res !="OK")
     {
       return res;
@@ -727,42 +590,35 @@ CompoundValueNode* CompoundValueNode::clone(void)
 
   LM_T(LmtCompoundValue, ("cloning '%s'", name.c_str()));
 
-  if (rootP == this)
+  switch (valueType)
   {
-    me = new CompoundValueNode(valueType);
-  }
-  else
-  {
-    switch (valueType)
-    {
-    case orion::ValueTypeString:
-    case orion::ValueTypeObject:
-    case orion::ValueTypeVector:
-      me = new CompoundValueNode(container, path, name, stringValue, siblingNo, valueType, level);
-      break;
+  case orion::ValueTypeString:
+  case orion::ValueTypeObject:
+  case orion::ValueTypeVector:
+    me = new CompoundValueNode(name, stringValue, valueType);
+    break;
 
-    case orion::ValueTypeNumber:
-      me = new CompoundValueNode(container, path, name, numberValue, siblingNo, valueType, level);
-      break;
+  case orion::ValueTypeNumber:
+    me = new CompoundValueNode(name, numberValue, valueType);
+    break;
 
-    case orion::ValueTypeBoolean:
-      me = new CompoundValueNode(container, path, name, boolValue, siblingNo, valueType, level);
-      break;
+  case orion::ValueTypeBoolean:
+    me = new CompoundValueNode(name, boolValue, valueType);
+    break;
 
-    case orion::ValueTypeNull:
-      me = new CompoundValueNode(container, path, name, stringValue, siblingNo, valueType, level);
-      me->valueType = orion::ValueTypeNull;
-      break;
+  case orion::ValueTypeNull:
+    me = new CompoundValueNode(name, stringValue, valueType);
+    me->valueType = orion::ValueTypeNull;
+    break;
 
-    case orion::ValueTypeNotGiven:
-      me = NULL;
-      LM_E(("Runtime Error (value not given in compound node value)"));
-      break;
+  case orion::ValueTypeNotGiven:
+    me = NULL;
+    LM_E(("Runtime Error (value not given in compound node value)"));
+    break;
 
-    default:
-      me = NULL;
-      LM_E(("Runtime Error (unknown compound node value type: %d)", valueType));
-    }
+  default:
+    me = NULL;
+    LM_E(("Runtime Error (unknown compound node value type: %d)", valueType));
   }
 
   for (unsigned int ix = 0; ix < childV.size(); ++ix)
@@ -816,16 +672,5 @@ bool CompoundValueNode::isString(void)
 const char* CompoundValueNode::cname(void)
 {
   return name.c_str();
-}
-
-
-
-/* ****************************************************************************
-*
-* cpath -
-*/
-const char* CompoundValueNode::cpath(void)
-{
-  return path.c_str();
 }
 }

--- a/src/lib/parse/CompoundValueNode.cpp
+++ b/src/lib/parse/CompoundValueNode.cpp
@@ -61,7 +61,6 @@ CompoundValueNode::CompoundValueNode():
 * CompoundValueNode - constructor for toplevel 'node'
 */
 CompoundValueNode::CompoundValueNode(orion::ValueType _type):
-  name        (""),
   valueType   (_type),
   numberValue (0.0),
   boolValue   (false)
@@ -202,8 +201,6 @@ CompoundValueNode::~CompoundValueNode()
 */
 std::string CompoundValueNode::finish(void)
 {
-  std::string error = "OK";
-
   LM_T(LmtCompoundValue, ("Finishing a compound"));
 
   if (lmTraceIsSet(LmtCompoundValueShow))
@@ -211,9 +208,7 @@ std::string CompoundValueNode::finish(void)
     show("");
   }
 
-  error = check("");  // sets 'error' for toplevel node
-
-  return error;
+  return check("");
 }
 
 
@@ -492,7 +487,7 @@ std::string CompoundValueNode::check(const std::string& path)
       {
         if (childV[ix]->name == childV[ix2]->name)
         {
-          std::string fullPath = (path == "" ? "/" : path + name);
+          std::string fullPath = (path == "" ? "/" : path + name + "/");
           std::string error = "duplicated tag-name: /" + childV[ix]->name + "/ in path: " + fullPath;
           alarmMgr.badInput(clientIp, error);
 

--- a/src/lib/parse/CompoundValueNode.h
+++ b/src/lib/parse/CompoundValueNode.h
@@ -56,23 +56,6 @@ namespace orion
 * o childV       A vector of the children of a Vector or Object.
 *                Contains pointers to CompoundValueNode.
 *
-* o container    A pointer to the father of the node. The father is the Object/Vector node
-*                that owns this node.
-*
-* o rootP        A pointer to the owner of the entire tree
-*
-* o error        This string is used by the 'check' function to save any errors detected during
-*                the 'check' phase.
-*                FIXME P1: May be removed if the check function is modified.
-*
-* o path         Absolute path of the node in the tree.
-*                Used for error messages, e.g. duplicated tag-name in a struct.
-*
-* o level        The depth or nesting level in which this node lives.
-*
-* o siblingNo:   This field is used for rendering JSON. It tells us whether a comma should
-*                be added after a field (a comma is added unless the sibling number is
-*                equal to the number of siblings (the size of the containers child vector).
 */
 class CompoundValueNode
 {
@@ -85,69 +68,38 @@ class CompoundValueNode
   bool                               boolValue;
   std::vector<CompoundValueNode*>    childV;
 
-
-  // Auxiliar fields for creation of the tree
-  CompoundValueNode*                 container;
-  CompoundValueNode*                 rootP;
-  std::string                        error;
-
-  // Needed for JSON rendering
-  int                                siblingNo;
-  bool                               renderName;
-
-  // Fields that may not be necessary
-  // FIXME P4: when finally sure, remove the unnecessary fields
-  std::string                        path;
-  int                                level;
-
   // Constructors/Destructors
   CompoundValueNode();
   explicit CompoundValueNode(orion::ValueType _type);
 
   CompoundValueNode
   (
-    CompoundValueNode*  _container,
-    const std::string&  _path,
     const std::string&  _name,
     const std::string&  _value,
-    int                 _siblingNo,
-    orion::ValueType    _type,
-    int                 _level = -1
+    orion::ValueType    _type
   );
 
 
   CompoundValueNode
   (
-    CompoundValueNode*  _container,
-    const std::string&  _path,
     const std::string&  _name,
     const char*         _value,
-    int                 _siblingNo,
-    orion::ValueType    _type,
-    int                 _level = -1
+    orion::ValueType    _type
   );
 
 
   CompoundValueNode
   (
-    CompoundValueNode*  _container,
-    const std::string&  _path,
     const std::string&  _name,
     double              _value,
-    int                 _siblingNo,
-    orion::ValueType    _type,
-    int                 _level = -1
+    orion::ValueType    _type
   );
 
   CompoundValueNode
   (
-    CompoundValueNode*  _container,
-    const std::string&  _path,
     const std::string&  _name,
     bool                 _value,
-    int                 _siblingNo,
-    orion::ValueType    _type,
-    int                 _level = -1
+    orion::ValueType    _type
   );
 
   ~CompoundValueNode();
@@ -158,7 +110,7 @@ class CompoundValueNode
   CompoundValueNode*  add(const orion::ValueType _type, const std::string& _name, const char* _value);
   CompoundValueNode*  add(const orion::ValueType _type, const std::string& _name, double _value);
   CompoundValueNode*  add(const orion::ValueType _type, const std::string& _name, bool _value);
-  std::string         check(void);
+  std::string         check(const std::string& path);
   std::string         finish(void);
 
   std::string         toJson(void);
@@ -171,7 +123,6 @@ class CompoundValueNode
   bool                isString(void);
 
   const char*         cname(void);
-  const char*         cpath(void);
 };
 
 }  // namespace orion

--- a/src/lib/parse/compoundValue.cpp
+++ b/src/lib/parse/compoundValue.cpp
@@ -42,58 +42,6 @@ namespace orion
 {
 /* ****************************************************************************
 *
-* compoundValueStart - 
-*
-* This function is called when the first compound node is encountered, so not
-* only must the root be created, but also the first node of the compound tree
-* must be taken care of. This is done by calling compoundValueMiddle.
-*/
-void compoundValueStart
-(
-    ConnectionInfo*     ciP,
-    const std::string&  path,
-    const std::string&  name,
-    const std::string&  value,
-    const std::string&  rest,
-    orion::ValueType    type,
-    bool                fatherIsVector
-)
-{
-  ciP->inCompoundValue   = true;
-  ciP->compoundValueP    = new orion::CompoundValueNode(orion::ValueTypeObject);
-  ciP->compoundValueRoot = ciP->compoundValueP;
-
-  LM_T(LmtCompoundValueContainer, ("Set current container to '%s' (%s)",
-                                   ciP->compoundValueP->path.c_str(),
-                                   ciP->compoundValueP->name.c_str()));
-
-
-  if (fatherIsVector)
-  {
-    ciP->compoundValueP->valueType = orion::ValueTypeVector;
-  }
-
-  //
-  // In the parsing routines, in all context attributes that can accept Compound values,
-  // a pointer to the one where we are right now is saved in ParseData.
-  //
-  // If this pointer is not set, it is a fatal error and the broker dies, because of the
-  // following LM_X, that does an exit
-  // It is better to exit here and clearly see the error, than to continue and get strange
-  // outputs that will be difficult to trace back to here.
-  //
-  if (ciP->parseDataP->lastContextAttribute == NULL)
-    orionExitFunction(1, "No pointer to last ContextAttribute");
-
-  ciP->compoundValueVector.push_back(ciP->compoundValueP);
-  LM_T(LmtCompoundValueAdd, ("Created new toplevel element"));
-  compoundValueMiddle(ciP, rest, name, value, type);
-}
-
-
-
-/* ****************************************************************************
-*
 * compoundValueMiddle - 
 *
 * containerType: vector/object/string
@@ -119,9 +67,7 @@ void compoundValueMiddle
     // ciP->compoundValueP points to the current compound container
     ciP->compoundValueP = ciP->compoundValueP->add(type, name, "");
 
-    LM_T(LmtCompoundValueContainer, ("Set current container to '%s' (%s)",
-                                     ciP->compoundValueP->path.c_str(),
-                                     ciP->compoundValueP->name.c_str()));
+    LM_T(LmtCompoundValueContainer, ("Set current container to '%s'", ciP->compoundValueP->name.c_str()));
   }
   else
   {

--- a/src/lib/parse/compoundValue.h
+++ b/src/lib/parse/compoundValue.h
@@ -36,23 +36,6 @@ namespace orion
 {
 /* ****************************************************************************
 *
-* compoundValueStart - 
-*/
-extern void compoundValueStart
-(
-  ConnectionInfo*     ciP,
-  const std::string&  path,
-  const std::string&  name,
-  const std::string&  value,
-  const std::string&  rest,
-  orion::ValueType    type,
-  bool                fatherIsVector
-);
-
-
-
-/* ****************************************************************************
-*
 * compoundValueMiddle - 
 */
 extern void compoundValueMiddle

--- a/test/functionalTest/cases/2457_json_tags_with_same_name/json_tags_with_same_name.test
+++ b/test/functionalTest/cases/2457_json_tags_with_same_name/json_tags_with_same_name.test
@@ -296,13 +296,13 @@ Date: REGEX(.*)
 07. V2: Try to create an entity E7 with attr A1 with compound value { "a": 1, "b": { "a": 1, "a": 2} } - see error
 ==================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 75
+Content-Length: 76
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "duplicated tag-name: /a/ in path: /b",
+    "description": "duplicated tag-name: /a/ in path: /b/",
     "error": "BadRequest"
 }
 
@@ -310,7 +310,7 @@ Date: REGEX(.*)
 08. V1: Try to create an entity E7 with attr A1 with compound value { "a": 1, "b": { "a": 1, "a": 2} } - see error
 ==================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 128
+Content-Length: 129
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -318,7 +318,7 @@ Date: REGEX(.*)
 {
     "errorCode": {
         "code": "400",
-        "details": "compound value error: duplicated tag-name: /a/ in path: /b",
+        "details": "compound value error: duplicated tag-name: /a/ in path: /b/",
         "reasonPhrase": "Bad Request"
     }
 }

--- a/test/functionalTest/cases/2457_json_tags_with_same_name/json_tags_with_same_name.test
+++ b/test/functionalTest/cases/2457_json_tags_with_same_name/json_tags_with_same_name.test
@@ -296,13 +296,13 @@ Date: REGEX(.*)
 07. V2: Try to create an entity E7 with attr A1 with compound value { "a": 1, "b": { "a": 1, "a": 2} } - see error
 ==================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 76
+Content-Length: 75
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "duplicated tag-name: /a/ in path: /b/",
+    "description": "duplicated tag-name: /a/ in path: /b",
     "error": "BadRequest"
 }
 

--- a/test/unittests/parse/CompoundValueNode_test.cpp
+++ b/test/unittests/parse/CompoundValueNode_test.cpp
@@ -50,7 +50,7 @@ TEST(CompoundValueNode, tree)
 
   for (int ix = 0; ix < 5; ++ix)
   {
-    vecItem = new orion::CompoundValueNode(vec, std::string("/vec/") + name, name, "a", ix, orion::ValueTypeString, 2);
+    vecItem = new orion::CompoundValueNode(name, "a", orion::ValueTypeString);
     vec->add(vecItem);
   }
 
@@ -64,8 +64,6 @@ TEST(CompoundValueNode, tree)
   ASSERT_EQ(1, copy->childV.size());
   ASSERT_EQ(6, copy->childV[0]->childV.size());
   ASSERT_STREQ("vecItem", copy->childV[0]->childV[0]->name.c_str());
-  ASSERT_EQ(3, copy->childV[0]->childV[3]->siblingNo);
-  ASSERT_EQ(2, copy->childV[0]->childV[3]->level);
 
   delete tree;
   delete copy;
@@ -108,8 +106,8 @@ TEST(CompoundValueNode, vectorInvalidAndOk)
   lmTraceLevelSet(LmtCompoundValueAdd, true);
 
   orion::CompoundValueNode*  tree     = new orion::CompoundValueNode(orion::ValueTypeObject);
-  orion::CompoundValueNode*  vec      = new orion::CompoundValueNode(tree, "/vec", "vec", "", 0, orion::ValueTypeVector, 1);
-  orion::CompoundValueNode*  item1    = new orion::CompoundValueNode(vec, std::string("/vec/vecitem1"), "vecitem1",  "a", 0, orion::ValueTypeString, 2);
+  orion::CompoundValueNode*  vec      = new orion::CompoundValueNode("vec", "", orion::ValueTypeVector);
+  orion::CompoundValueNode*  item1    = new orion::CompoundValueNode("vecitem1", "a", orion::ValueTypeString);
   const char*                outFile  = "ngsi.compoundValue.vector.invalid.json";
 
   utInit();
@@ -118,17 +116,17 @@ TEST(CompoundValueNode, vectorInvalidAndOk)
   vec->add(item1);
   vec->add(orion::ValueTypeString, "vecitem", "a");
 
-  tree->finish();
-  EXPECT_STREQ("bad tag-name of vector item: /vecitem/, should be /vecitem1/", tree->error.c_str());
+  std::string error = tree->finish();
+  EXPECT_STREQ("bad tag-name of vector item: /vecitem/, should be /vecitem1/", error.c_str());
 
   item1->name = "vecitem";
-  tree->finish();
-  EXPECT_STREQ("OK", tree->error.c_str());
+  error = tree->finish();
+  EXPECT_STREQ("OK", error.c_str());
 
   std::string rendered;
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile)) << "Error getting test data from '" << outFile << "'";
-  rendered = tree->toJson(true);
+  rendered = tree->toJson();
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   tree->shortShow("");
@@ -153,9 +151,9 @@ TEST(CompoundValueNode, structInvalidAndOk)
   lmTraceLevelSet(LmtCompoundValueAdd, true);
 
   orion::CompoundValueNode*  tree     = new orion::CompoundValueNode(orion::ValueTypeObject);
-  orion::CompoundValueNode*  str      = new orion::CompoundValueNode(tree, "/struct", "struct", "", 0, orion::ValueTypeObject, 1);
-  orion::CompoundValueNode*  item1    = new orion::CompoundValueNode(str, std::string("/struct/structitem"), "structitem", "a", 0, orion::ValueTypeString, 2);
-  orion::CompoundValueNode*  item2    = new orion::CompoundValueNode(str, std::string("/struct/structitem"), "structitem", "a", 1, orion::ValueTypeString, 2);
+  orion::CompoundValueNode*  str      = new orion::CompoundValueNode("struct", "", orion::ValueTypeObject);
+  orion::CompoundValueNode*  item1    = new orion::CompoundValueNode("structitem", "a", orion::ValueTypeString);
+  orion::CompoundValueNode*  item2    = new orion::CompoundValueNode("structitem", "a", orion::ValueTypeString);
   const char*                outFile  = "ngsi.compoundValue.struct.invalid.json";
 
   utInit();
@@ -164,17 +162,17 @@ TEST(CompoundValueNode, structInvalidAndOk)
   str->add(item1);
   str->add(item2);
 
-  tree->finish();
-  EXPECT_STREQ("duplicated tag-name: /structitem/ in path: /struct", tree->error.c_str());
+  std::string error = tree->finish();
+  EXPECT_STREQ("duplicated tag-name: /structitem/ in path: /struct", error.c_str());
 
   item2->name = "structitem2";
-  tree->finish();
-  EXPECT_STREQ("OK", tree->error.c_str());
+  error = tree->finish();
+  EXPECT_STREQ("OK", error.c_str());
 
   std::string rendered;
 
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outFile)) << "Error getting test data from '" << outFile << "'";
-  rendered = tree->toJson(true);
+  rendered = tree->toJson();
   EXPECT_STREQ(expectedBuf, rendered.c_str());
 
   tree->shortShow("");

--- a/test/unittests/parse/CompoundValueNode_test.cpp
+++ b/test/unittests/parse/CompoundValueNode_test.cpp
@@ -163,7 +163,7 @@ TEST(CompoundValueNode, structInvalidAndOk)
   str->add(item2);
 
   std::string error = tree->finish();
-  EXPECT_STREQ("duplicated tag-name: /structitem/ in path: /struct", error.c_str());
+  EXPECT_STREQ("duplicated tag-name: /structitem/ in path: /struct/", error.c_str());
 
   item2->name = "structitem2";
   error = tree->finish();

--- a/test/unittests/parse/compoundValue_test.cpp
+++ b/test/unittests/parse/compoundValue_test.cpp
@@ -123,18 +123,11 @@ TEST(compoundValue, updateOneStringJson)
   // Get root of compound value
   cvnRootP = caP->compoundValueP;
 
-  // The root pointer of the root must be the root itself
-  EXPECT_EQ(cvnRootP, cvnRootP->rootP);
-
   // The root should be a struct in this test case
   EXPECT_EQ(orion::ValueTypeObject, cvnRootP->valueType);
 
   // The root should have exactly one child
   EXPECT_EQ(1, cvnRootP->childV.size());
-
-  EXPECT_EQ(0, cvnRootP->level);
-  EXPECT_EQ(0, cvnRootP->siblingNo);
-  EXPECT_EQ("/", cvnRootP->path);
 
   // The child
   childP = cvnRootP->childV[0];
@@ -143,13 +136,6 @@ TEST(compoundValue, updateOneStringJson)
   EXPECT_EQ(orion::ValueTypeString,  childP->valueType);
   EXPECT_EQ("STRING",                          childP->stringValue);
   EXPECT_EQ(0,                                 childP->childV.size());
-
-  EXPECT_EQ(cvnRootP,                          childP->container);
-  EXPECT_EQ(cvnRootP,                          childP->rootP);
-
-  EXPECT_EQ("/s1",                             childP->path);
-  EXPECT_EQ(1,                                 childP->level);
-  EXPECT_EQ(0,                                 childP->siblingNo);
 
   utExit();
 }
@@ -189,18 +175,11 @@ TEST(compoundValue, updateTwoStringsJson)
   // Get root of compound value
   cvnRootP = caP->compoundValueP;
 
-  // The root pointer of the root must be the root itself
-  EXPECT_EQ(cvnRootP, cvnRootP->rootP);
-
   // The root should be a struct in this test case
   EXPECT_EQ(orion::ValueTypeObject, cvnRootP->valueType);
 
   // The root should have exactly two children
   EXPECT_EQ(2, cvnRootP->childV.size());
-
-  EXPECT_EQ(0, cvnRootP->level);
-  EXPECT_EQ(0, cvnRootP->siblingNo);
-  EXPECT_EQ("/", cvnRootP->path);
 
   // child 1
   childP = cvnRootP->childV[0];
@@ -210,13 +189,6 @@ TEST(compoundValue, updateTwoStringsJson)
   EXPECT_EQ("STRING",                          childP->stringValue);
   EXPECT_EQ(0,                                 childP->childV.size());
 
-  EXPECT_EQ(cvnRootP,                          childP->container);
-  EXPECT_EQ(cvnRootP,                          childP->rootP);
-
-  EXPECT_EQ("/s1",                             childP->path);
-  EXPECT_EQ(1,                                 childP->level);
-  EXPECT_EQ(0,                                 childP->siblingNo);
-
   // child 2
   childP = cvnRootP->childV[1];
 
@@ -224,13 +196,6 @@ TEST(compoundValue, updateTwoStringsJson)
   EXPECT_EQ(orion::ValueTypeString,  childP->valueType);
   EXPECT_EQ("STRING",                          childP->stringValue);
   EXPECT_EQ(0,                                 childP->childV.size());
-
-  EXPECT_EQ(cvnRootP,                          childP->container);
-  EXPECT_EQ(cvnRootP,                          childP->rootP);
-
-  EXPECT_EQ("/s2",                             childP->path);
-  EXPECT_EQ(1,                                 childP->level);
-  EXPECT_EQ(1,                                 childP->siblingNo);
 
   utExit();
 }
@@ -300,18 +265,11 @@ TEST(compoundValue, updateContextValueVectorOneItemJson)
   // Get root of compound value
   cvnRootP = caP->compoundValueP;
 
-  // The root pointer of the root must be the root itself
-  EXPECT_EQ(cvnRootP, cvnRootP->rootP);
-
   // The root should be a 'vector' in this test case
   EXPECT_EQ(orion::ValueTypeVector, cvnRootP->valueType);
 
   // The root should have exactly one child
   EXPECT_EQ(1, cvnRootP->childV.size());
-
-  EXPECT_EQ(0, cvnRootP->level);
-  EXPECT_EQ(0, cvnRootP->siblingNo);
-  EXPECT_EQ("/", cvnRootP->path);
 
   // The child
   childP = cvnRootP->childV[0];
@@ -320,13 +278,6 @@ TEST(compoundValue, updateContextValueVectorOneItemJson)
   EXPECT_EQ(orion::ValueTypeString,  childP->valueType);
   EXPECT_EQ("1",                               childP->stringValue);
   EXPECT_EQ(0,                                 childP->childV.size());
-
-  EXPECT_EQ(cvnRootP,                          childP->container);
-  EXPECT_EQ(cvnRootP,                          childP->rootP);
-
-  EXPECT_EQ("/item",                           childP->path);
-  EXPECT_EQ(1,                                 childP->level);
-  EXPECT_EQ(0,                                 childP->siblingNo);
 
   utExit();
 }
@@ -366,18 +317,11 @@ TEST(compoundValue, updateContextValueVectorFiveItemsJson)
   // Get root of compound value
   cvnRootP = caP->compoundValueP;
 
-  // The root pointer of the root must be the root itself
-  EXPECT_EQ(cvnRootP, cvnRootP->rootP);
-
   // The root should be a 'vector' in this test case
   EXPECT_EQ(orion::ValueTypeVector, cvnRootP->valueType);
 
   // The root should have five children
   EXPECT_EQ(5, cvnRootP->childV.size());
-
-  EXPECT_EQ(0, cvnRootP->level);
-  EXPECT_EQ(0, cvnRootP->siblingNo);
-  EXPECT_EQ("/", cvnRootP->path);
 
   // Child 1-5
   std::string value[] = { "1", "2", "3", "4", "5" };
@@ -389,13 +333,6 @@ TEST(compoundValue, updateContextValueVectorFiveItemsJson)
     EXPECT_EQ(orion::ValueTypeString,  childP->valueType);
     EXPECT_EQ(value[childIx],                    childP->stringValue);
     EXPECT_EQ(0,                                 childP->childV.size());
-
-    EXPECT_EQ(cvnRootP,                          childP->container);
-    EXPECT_EQ(cvnRootP,                          childP->rootP);
-
-    EXPECT_EQ("/item",                           childP->path);
-    EXPECT_EQ(1,                                 childP->level);
-    EXPECT_EQ(childIx,                           childP->siblingNo);
   }
 
   utExit();
@@ -448,18 +385,11 @@ TEST(compoundValue, updateTwoStructsJson)
   // Get root of compound value
   cvnRootP = caP->compoundValueP;
 
-  // The root pointer of the root must be the root itself
-  EXPECT_EQ(cvnRootP, cvnRootP->rootP);
-
   // The root should be a 'struct' in this test case
   EXPECT_EQ(orion::ValueTypeObject, cvnRootP->valueType);
 
   // The root should have two children
   EXPECT_EQ(2, cvnRootP->childV.size());
-
-  EXPECT_EQ(0, cvnRootP->level);
-  EXPECT_EQ(0, cvnRootP->siblingNo);
-  EXPECT_EQ("/", cvnRootP->path);
 
   // Now, child struct 1
   structP = cvnRootP->childV[0];
@@ -468,27 +398,13 @@ TEST(compoundValue, updateTwoStructsJson)
   EXPECT_EQ(orion::ValueTypeObject,  structP->valueType);
   EXPECT_EQ(2,                                 structP->childV.size());
 
-  EXPECT_EQ(cvnRootP,                          structP->container);
-  EXPECT_EQ(cvnRootP,                          structP->rootP);
-
-  EXPECT_EQ("/struct1",                        structP->path);
-  EXPECT_EQ(1,                                 structP->level);
-  EXPECT_EQ(0,                                 structP->siblingNo);
-
   // Child 1 of struct1
   childP = structP->childV[0];
 
   EXPECT_EQ("s1-1",                              childP->name);
   EXPECT_EQ(orion::ValueTypeString,    childP->valueType);
   EXPECT_EQ("1-1",                               childP->stringValue);
-  EXPECT_EQ(0,                                   childP->childV.size());
-
-  EXPECT_EQ(structP,                             childP->container);
-  EXPECT_EQ(cvnRootP,                            childP->rootP);
-
-  EXPECT_EQ("/struct1/s1-1",                     childP->path);
-  EXPECT_EQ(2,                                   childP->level);
-  EXPECT_EQ(0,                                   childP->siblingNo);
+  EXPECT_EQ(0,                                   childP->childV.size()); 
 
 
   // Child 2 of struct1
@@ -499,13 +415,6 @@ TEST(compoundValue, updateTwoStructsJson)
   EXPECT_EQ("1-2",                               childP->stringValue);
   EXPECT_EQ(0,                                   childP->childV.size());
 
-  EXPECT_EQ(structP,                             childP->container);
-  EXPECT_EQ(cvnRootP,                            childP->rootP);
-
-  EXPECT_EQ("/struct1/s1-2",                     childP->path);
-  EXPECT_EQ(2,                                   childP->level);
-  EXPECT_EQ(1,                                   childP->siblingNo);
-
 
 
   // child struct 2
@@ -515,13 +424,6 @@ TEST(compoundValue, updateTwoStructsJson)
   EXPECT_EQ(orion::ValueTypeObject,  structP->valueType);
   EXPECT_EQ(2,                                 structP->childV.size());
 
-  EXPECT_EQ(cvnRootP,                          structP->container);
-  EXPECT_EQ(cvnRootP,                          structP->rootP);
-
-  EXPECT_EQ("/struct2",                        structP->path);
-  EXPECT_EQ(1,                                 structP->level);
-  EXPECT_EQ(1,                                 structP->siblingNo);
-
   // Child 1 of struct2
   childP = cvnRootP->childV[1]->childV[0];
 
@@ -529,13 +431,6 @@ TEST(compoundValue, updateTwoStructsJson)
   EXPECT_EQ(orion::ValueTypeString,    childP->valueType);
   EXPECT_EQ("2-1",                               childP->stringValue);
   EXPECT_EQ(0,                                   childP->childV.size());
-
-  EXPECT_EQ(structP,                             childP->container);
-  EXPECT_EQ(cvnRootP,                            childP->rootP);
-
-  EXPECT_EQ("/struct2/s2-1",                     childP->path);
-  EXPECT_EQ(2,                                   childP->level);
-  EXPECT_EQ(0,                                   childP->siblingNo);
 
 
   // Child 2 of struct2
@@ -545,13 +440,6 @@ TEST(compoundValue, updateTwoStructsJson)
   EXPECT_EQ(orion::ValueTypeString,    childP->valueType);
   EXPECT_EQ("2-2",                               childP->stringValue);
   EXPECT_EQ(0,                                   childP->childV.size());
-
-  EXPECT_EQ(structP,                             childP->container);
-  EXPECT_EQ(cvnRootP,                            childP->rootP);
-
-  EXPECT_EQ("/struct2/s2-2",                     childP->path);
-  EXPECT_EQ(2,                                   childP->level);
-  EXPECT_EQ(1,                                   childP->siblingNo);
 
   utExit();
 }
@@ -607,18 +495,11 @@ TEST(compoundValue, sixLevelsJson)
   cvnRootP = caP->compoundValueP;
   EXPECT_TRUE(cvnRootP != NULL);
 
-  // The root pointer of the root must be the root itself
-  EXPECT_EQ(cvnRootP, cvnRootP->rootP);
-
   // The root should be a 'struct' in this test case
   EXPECT_EQ(orion::ValueTypeObject, cvnRootP->valueType);
 
   // The root should have one child
   EXPECT_EQ(1, cvnRootP->childV.size());
-
-  EXPECT_EQ(0, cvnRootP->level);
-  EXPECT_EQ(0, cvnRootP->siblingNo);
-  EXPECT_EQ("/", cvnRootP->path);
 
 
   // Now, child 1: level1
@@ -629,13 +510,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("",                                level1->stringValue);
   EXPECT_EQ(2,                                 level1->childV.size());
 
-  EXPECT_EQ(cvnRootP,                          level1->container);
-  EXPECT_EQ(cvnRootP,                          level1->rootP);
-
-  EXPECT_EQ("/level1",                         level1->path);
-  EXPECT_EQ(1,                                 level1->level);
-  EXPECT_EQ(0,                                 level1->siblingNo);
-
   // /level1/level == 1
   childP = level1->childV[0];
 
@@ -644,13 +518,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("2",                               childP->stringValue);
   EXPECT_EQ(0,                                 childP->childV.size());
 
-  EXPECT_EQ(level1,                            childP->container);
-  EXPECT_EQ(cvnRootP,                          childP->rootP);
-
-  EXPECT_EQ("/level1/level",                   childP->path);
-  EXPECT_EQ(2,                                 childP->level);
-  EXPECT_EQ(0,                                 childP->siblingNo);
-
 
   // /level1/level2 == Struct
   level2 = level1->childV[1];
@@ -658,13 +525,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("level2",                          level2->name);
   EXPECT_EQ(orion::ValueTypeObject,  level2->valueType);
   EXPECT_EQ(2,                                 level2->childV.size());
-
-  EXPECT_EQ(level1,                            level2->container);
-  EXPECT_EQ(cvnRootP,                          level2->rootP);
-
-  EXPECT_EQ("/level1/level2",                  level2->path);
-  EXPECT_EQ(2,                                 level2->level);
-  EXPECT_EQ(1,                                 level2->siblingNo);
 
 
   // /level1/level2/level == 2
@@ -675,13 +535,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("3",                               childP->stringValue);
   EXPECT_EQ(0,                                 childP->childV.size());
 
-  EXPECT_EQ(level2,                            childP->container);
-  EXPECT_EQ(cvnRootP,                          childP->rootP);
-
-  EXPECT_EQ("/level1/level2/level",            childP->path);
-  EXPECT_EQ(3,                                 childP->level);
-  EXPECT_EQ(0,                                 childP->siblingNo);
-
   // /level1/level2/level3 == Vector
   level3 = level2->childV[1];
 
@@ -689,26 +542,12 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ(orion::ValueTypeVector,  level3->valueType);
   EXPECT_EQ(2,                                 level3->childV.size());
 
-  EXPECT_EQ(level2,                            level3->container);
-  EXPECT_EQ(cvnRootP,                          level3->rootP);
-
-  EXPECT_EQ("/level1/level2/level3",           level3->path);
-  EXPECT_EQ(3,                                 level3->level);
-  EXPECT_EQ(1,                                 level3->siblingNo);
-
   // /level1/level2/level3/level4item[0]
   vitemP = level3->childV[0];
 
   EXPECT_EQ("item",                             vitemP->name);
   EXPECT_EQ(orion::ValueTypeObject,   vitemP->valueType);
   EXPECT_EQ(2,                                  vitemP->childV.size());
-
-  EXPECT_EQ(level3,                             vitemP->container);
-  EXPECT_EQ(cvnRootP,                           vitemP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item",       vitemP->path);
-  EXPECT_EQ(4,                                  vitemP->level);
-  EXPECT_EQ(0,                                  vitemP->siblingNo);
 
   // /level1/level2/level3/item[0]/level
   childP = vitemP->childV[0];
@@ -718,26 +557,12 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("5",                                      childP->stringValue);
   EXPECT_EQ(0,                                        childP->childV.size());
 
-  EXPECT_EQ(vitemP,                                   childP->container);
-  EXPECT_EQ(cvnRootP,                                 childP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/level",       childP->path);
-  EXPECT_EQ(5,                                        childP->level);
-  EXPECT_EQ(0,                                        childP->siblingNo);
-
   // /level1/level2/level3/item[0]/struct1
   structP = vitemP->childV[1];
 
   EXPECT_EQ("struct1",                                  structP->name);
   EXPECT_EQ(orion::ValueTypeObject,           structP->valueType);
   EXPECT_EQ(3,                                          structP->childV.size());
-
-  EXPECT_EQ(vitemP,                                     structP->container);
-  EXPECT_EQ(cvnRootP,                                   structP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/struct1",       structP->path);
-  EXPECT_EQ(5,                                          structP->level);
-  EXPECT_EQ(1,                                          structP->siblingNo);
 
   // /level1/level2/level3/item[0]/struct1/level
   childP = structP->childV[0];
@@ -747,13 +572,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("6",                                              childP->stringValue);
   EXPECT_EQ(0,                                                childP->childV.size());
 
-  EXPECT_EQ(structP,                                          childP->container);
-  EXPECT_EQ(cvnRootP,                                         childP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/struct1/level",       childP->path);
-  EXPECT_EQ(6,                                                childP->level);
-  EXPECT_EQ(0,                                                childP->siblingNo);
-
   // /level1/level2/level3/item[0]/struct1/s1-1
   childP = structP->childV[1];
 
@@ -761,13 +579,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ(orion::ValueTypeString,                 childP->valueType);
   EXPECT_EQ("1-1",                                            childP->stringValue);
   EXPECT_EQ(0,                                                childP->childV.size());
-
-  EXPECT_EQ(structP,                                          childP->container);
-  EXPECT_EQ(cvnRootP,                                         childP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/struct1/s1-1",        childP->path);
-  EXPECT_EQ(6,                                                childP->level);
-  EXPECT_EQ(1,                                                childP->siblingNo);
 
   // /level1/level2/level3/item[0]/struct1/s1-2
   childP = structP->childV[2];
@@ -777,13 +588,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("1-2",                                            childP->stringValue);
   EXPECT_EQ(0,                                                childP->childV.size());
 
-  EXPECT_EQ(structP,                                          childP->container);
-  EXPECT_EQ(cvnRootP,                                         childP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/struct1/s1-2",        childP->path);
-  EXPECT_EQ(6,                                                childP->level);
-  EXPECT_EQ(2,                                                childP->siblingNo);
-
 
   // /level1/level2/level3/item[1]
   vitemP = level3->childV[1];
@@ -791,13 +595,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("item",                             vitemP->name);
   EXPECT_EQ(orion::ValueTypeObject,   vitemP->valueType);
   EXPECT_EQ(2,                                  vitemP->childV.size());
-
-  EXPECT_EQ(level3,                             vitemP->container);
-  EXPECT_EQ(cvnRootP,                           vitemP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item",       vitemP->path);
-  EXPECT_EQ(4,                                  vitemP->level);
-  EXPECT_EQ(1,                                  vitemP->siblingNo);
 
   // /level1/level2/level3/item[1]/level
   childP = vitemP->childV[0];
@@ -807,26 +604,12 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("5",                                      childP->stringValue);
   EXPECT_EQ(0,                                        childP->childV.size());
 
-  EXPECT_EQ(vitemP,                                   childP->container);
-  EXPECT_EQ(cvnRootP,                                 childP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/level",       childP->path);
-  EXPECT_EQ(5,                                        childP->level);
-  EXPECT_EQ(0,                                        childP->siblingNo);
-
   // /level1/level2/level3/item[1]/struct2
   structP = vitemP->childV[1];
 
   EXPECT_EQ("struct2",                                  structP->name);
   EXPECT_EQ(orion::ValueTypeObject,           structP->valueType);
   EXPECT_EQ(3,                                          structP->childV.size());
-
-  EXPECT_EQ(vitemP,                                     structP->container);
-  EXPECT_EQ(cvnRootP,                                   structP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/struct2",       structP->path);
-  EXPECT_EQ(5,                                          structP->level);
-  EXPECT_EQ(1,                                          structP->siblingNo);
 
   // /level1/level2/level3/item[1]/struct2/level
   childP = structP->childV[0];
@@ -836,13 +619,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("6",                                              childP->stringValue);
   EXPECT_EQ(0,                                                childP->childV.size());
 
-  EXPECT_EQ(structP,                                          childP->container);
-  EXPECT_EQ(cvnRootP,                                         childP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/struct2/level",       childP->path);
-  EXPECT_EQ(6,                                                childP->level);
-  EXPECT_EQ(0,                                                childP->siblingNo);
-
   // /level1/level2/level3/item[1]/struct2/s2-1
   childP = structP->childV[1];
 
@@ -851,13 +627,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ("2-1",                                            childP->stringValue);
   EXPECT_EQ(0,                                                childP->childV.size());
 
-  EXPECT_EQ(structP,                                          childP->container);
-  EXPECT_EQ(cvnRootP,                                         childP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/struct2/s2-1",        childP->path);
-  EXPECT_EQ(6,                                                childP->level);
-  EXPECT_EQ(1,                                                childP->siblingNo);
-
   // /level1/level2/level3/item[1]/struct2/s2-2
   childP = structP->childV[2];
 
@@ -865,13 +634,6 @@ TEST(compoundValue, sixLevelsJson)
   EXPECT_EQ(orion::ValueTypeString,                 childP->valueType);
   EXPECT_EQ("2-2",                                            childP->stringValue);
   EXPECT_EQ(0,                                                childP->childV.size());
-
-  EXPECT_EQ(structP,                                          childP->container);
-  EXPECT_EQ(cvnRootP,                                         childP->rootP);
-
-  EXPECT_EQ("/level1/level2/level3/item/struct2/s2-2",        childP->path);
-  EXPECT_EQ(6,                                                childP->level);
-  EXPECT_EQ(2,                                                childP->siblingNo);
 
   utExit();
 }
@@ -911,18 +673,11 @@ TEST(compoundValue, updateOneStringAndOneVectorInSeparateContextValuesJson)
   // Get root of compound value
   cvnRootP = caP->compoundValueP;
 
-  // The root pointer of the root must be the root itself
-  EXPECT_EQ(cvnRootP, cvnRootP->rootP);
-
   // The root should be a struct in this test case
   EXPECT_EQ(orion::ValueTypeObject, cvnRootP->valueType);
 
   // The root should have exactly one child
   EXPECT_EQ(1, cvnRootP->childV.size());
-
-  EXPECT_EQ(0, cvnRootP->level);
-  EXPECT_EQ(0, cvnRootP->siblingNo);
-  EXPECT_EQ("/", cvnRootP->path);
 
   // The child
   childP = cvnRootP->childV[0];
@@ -931,13 +686,6 @@ TEST(compoundValue, updateOneStringAndOneVectorInSeparateContextValuesJson)
   EXPECT_EQ(orion::ValueTypeString,  childP->valueType);
   EXPECT_EQ("STRING",                          childP->stringValue);
   EXPECT_EQ(0,                                 childP->childV.size());
-
-  EXPECT_EQ(cvnRootP,                          childP->container);
-  EXPECT_EQ(cvnRootP,                          childP->rootP);
-
-  EXPECT_EQ("/s1",                             childP->path);
-  EXPECT_EQ(1,                                 childP->level);
-  EXPECT_EQ(0,                                 childP->siblingNo);
 
 
   //
@@ -951,18 +699,11 @@ TEST(compoundValue, updateOneStringAndOneVectorInSeparateContextValuesJson)
   // Get root of compound value
   cvnRootP = caP->compoundValueP;
 
-  // The root pointer of the root must be the root itself
-  EXPECT_EQ(cvnRootP, cvnRootP->rootP);
-
   // The root should be a vector in this test case
   EXPECT_EQ(orion::ValueTypeVector, cvnRootP->valueType);
 
   // The root should have four children
   EXPECT_EQ(4, cvnRootP->childV.size());
-
-  EXPECT_EQ(0, cvnRootP->level);
-  EXPECT_EQ(0, cvnRootP->siblingNo);
-  EXPECT_EQ("/", cvnRootP->path);
 
   // The children
   const char* value[] = { "I-0", "I-1", "I-2", "I-3" };
@@ -975,12 +716,6 @@ TEST(compoundValue, updateOneStringAndOneVectorInSeparateContextValuesJson)
     EXPECT_EQ(value[ix],               childP->stringValue);
     EXPECT_EQ(0,                       childP->childV.size());
 
-    EXPECT_EQ(cvnRootP,                childP->container);
-    EXPECT_EQ(cvnRootP,                childP->rootP);
-
-    EXPECT_EQ("/item",                 childP->path);
-    EXPECT_EQ(1,                       childP->level);
-    EXPECT_EQ(ix,                      childP->siblingNo);
   }
 
   utExit();


### PR DESCRIPTION
CompoundValuesNode class is simplified removing a bunch of extra fields not actually used (maybe there were useful when this class was developed, but now it is mature and there is no need for them).

The simplification has allowed to address easyly a couple of pending FIXME P7 issues:

```
// FIXME P7: next line is counterintuitive. If the object is a vector, why [...]
// FIXME P7: why don't have a case for Object (valueType = orion::ValueTypeObject) [...]
```