### PR TITLE
FIX user manual ToC in markdown

### DIFF
--- a/doc/manuals/user/README.md
+++ b/doc/manuals/user/README.md
@@ -21,6 +21,7 @@
   * [Forbidden characters](forbidden_characters.md)
   * [Using regular expressions in payloads](regex_in_payload.md)
   * [Initial notification](initial_notification.md)
+  * [Onseshot subcriptions](oneshot_subscription.md)
   * [Security considerations](security.md)
   * [Known Limitations](known_limitations.md)
   * [Docker](docker.md)


### PR DESCRIPTION
CC: @fisuda just in case the modification in this PR needs some sync in the Japanese translation