### PR TITLE
Change to mongo 3.6 in docker-compose examples

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7.4.1708
+FROM centos:centos7.6.1810
 
 MAINTAINER FIWARE Orion Context Broker Team. Telefónica I+D
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,7 +24,7 @@ Follow these steps:
 2. Create a new file called `docker-compose.yml` inside your directory with the following contents:
 	
 		mongo:
-		  image: mongo:3.4
+		  image: mongo:3.6
 		  command: --nojournal
 		orion:
 		  image: fiware/orion

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@
 # as dependency and reserve the order has been found problematic in some
 # low resource hosts
 mongo:
-  image: mongo:3.4
+  image: mongo:3.6
   command: --nojournal
 
 orion:


### PR DESCRIPTION
It seems we misses updating this when Orion 2.1.0 was released.

@fisuda please take this into account to upgrade also the Japanese transaltion, pls.