### PR TITLE
Prepare introductory presentations for Orion 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ recommended to have a look to the brief
 ### Introductory presentations
 
 -   Orion Context Broker
-    [(en)](https://www.slideshare.net/fermingalan/orion-context-broker-20181218)
+    [(en)](https://www.slideshare.net/fermingalan/orion-context-broker-20190214)
     [(jp)](https://www.slideshare.net/fisuda/orion-context-broker-ja-20181219)
 -   NGSIv2 Overview for Developers That Already Know NGSIv1
-    [(en)](https://www.slideshare.net/fermingalan/ngsiv2-overview-for-developers-that-already-know-ngsiv1-20181218)
+    [(en)](https://www.slideshare.net/fermingalan/ngsiv2overviewfordevelopersthatalreadyknowngsiv120190214)
     [(jp)](https://www.slideshare.net/fisuda/ngsiv2-overview-for-developers-that-already-know-ngsiv1-ja-20181219)
 
 [Top](#top)

--- a/doc/manuals.jp/devel/README.md
+++ b/doc/manuals.jp/devel/README.md
@@ -1,6 +1,6 @@
 # <a name="top"></a>開発マニュアル
 
-*注 : このドキュメントでは、リリース 2.1.x の Orion Context Broker について説明しています。*
+*注 : このドキュメントでは、リリース 2.2.x の Orion Context Broker について説明しています。*
 
 ## 対象読者
 

--- a/doc/manuals/devel/README.md
+++ b/doc/manuals/devel/README.md
@@ -1,6 +1,6 @@
 # <a name="top"></a>Development Manual
 
-*Note: This document describes Orion Context Broker as of release 2.1.x.*
+*Note: This document describes Orion Context Broker as of release 2.2.x.*
 
 ## Intended audience
 The intended audience of this manual is developers that need to understand the internals of the Orion Context Broker


### PR DESCRIPTION
This PR change the links for introductory presentations for version 2.2.0. In addition, I have updated the reference version in devel manual.

@fisuda please have a look as I have touched one of the documents in the Japanese translation and provide LGTM if it is ok.