### PR TITLE
Bug/3458 legacy forwarding with idpattern

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: idPattern '.*' is now allowed in NGSIv2 registrations (#3458)
+- Add: Forwarded queries work for registrations using idPattern == '.*', but only for simple cases (#3458)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+o Wildcards can now be used as Entity Id in registrations (#3458)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-o Wildcards can now be used as Entity Id in registrations (#3458)
+- Fix: idPattern '.*' is now allowed in NGSIv2 registrations (#3458)

--- a/doc/manuals/devel/cookbook.md
+++ b/doc/manuals/devel/cookbook.md
@@ -394,7 +394,12 @@ function call stack and variables etc., as the program logic is executed.
 For this end, the functional test suite has a CLI that tells the suite to *not* start the contextBroker itself, but assume
 that the contextBroker is started already, and just run the tests against that "external contextBroker".
 This CLI option is called `--xbroker`.
-It is only supported for a **single test case**, i.e., you have to run `testHarness.sh` with a test file as parameter.
+
+Please take into account a couple of remarks regarding the `--xbroker` switch:
+
+* It is only supported for a **single test case**, i.e., you have to run `testHarness.sh` with a test file as parameter.
+* It doesn't start **any** of the contextBrokers involved in the tests (main context broker and brokers serving as context providers). In some cases, you may need to debug only one of the brokers, letting the other brokers be started by the functional test suite. In such a case, `--xbroker` should **not** be used - instead edit the .test file and comment out the `brokerStart` (and corresopnding`brokerStop` lines) you need to disable (amd remember to revert the changes afterwards!).
+
 Before running `testHarness.sh` you must start your "external contextBroker", running under gdb, valgrind or whatever program you prefer
 for debugging.
 

--- a/doc/manuals/devel/cookbook.md
+++ b/doc/manuals/devel/cookbook.md
@@ -384,21 +384,25 @@ Note that `t1` is used and not `T1`. This is because Orion converts tenants to a
 ## Debug a Functional Test Case
 
 Sometimes you have the need of debugging a test case (i.e., a .test file). Maybe is an existing .test
-that has started to fail due to some modification in the code. Or maybe is a bug that has been reported
+that has started to fail due to some modification in the code. Or maybe it is a bug that has been reported
 as a new .test (the preferred way to report new bugs! :)
 
-Whatever the case, it may be useful to run Orion under a debugger (e.g. [`gdb`](https://www.gnu.org/software/gdb) or any of its [graphical front-ends](https://sourceware.org/gdb/wiki/GDB%20Front%20Ends))
-with that test as "input". In this way you can set breakpoints, use step-by-step execution, inspects 
-function call stack and variables, etc. as the program logic is executed.
+Whatever the case, it may be useful to run Orion in a debugger (e.g. [`gdb`](https://www.gnu.org/software/gdb) or any of its [graphical front-ends](https://sourceware.org/gdb/wiki/GDB%20Front%20Ends)),
+with that test as "input". That way you can set breakpoints, use step-by-step execution, inspect
+function call stack and variables etc., as the program logic is executed.
 
-The procedure is easy. Let's assume your test is `test_to_debug.test`. First, edit that file in order 
-to comment out any `brokerStart` and `brokerStop` line. In some cases it is also a good idea to
-comment out `dbDrop` lines, so you can have a look to the DB after .test ends.
+For this end, the functional test suite has a CLI that tells the suite to *not* start the contextBroker itself, but assume
+that the contextBroker is started already, and just run the tests against that "external contextBroker".
+This CLI option is called `--xbroker`.
+It is only supported for a **single test case**, i.e., you have to run `testHarness.sh` with a test file as parameter.
+Before running `testHarness.sh` you must start your "external contextBroker", running under gdb, valgrind or whatever program you prefer
+for debugging.
 
-Next, start contextBroker process under your debugger. The exact procedure depends on the particular
-debugger or debugger front-end being used, so we are not going into the details here. However, it is
-important to use the following CLI parameters for contextBroker, as they correspond to the port and 
-database used by the function test framework:
+*In some cases it may be a good idea to comment out `dbDrop` lines, so you can have a look at the DB after the test finalizes.
+Once you have finished debugging, remember to restore any `dbDrop` lines in the .test file (just revert the test file with `git checkout`).*
+
+It is crucial to use the following CLI parameters when starting the "external contextBroker", as they correspond to the port and 
+database used by the functional test framework:
 
 ```
 -db ftest -port 9999
@@ -420,11 +424,9 @@ Finally, execute the functional test for `test_to_debug.test`:
 CB_MAX_TRIES=1 /path/to/testHarness.sh /path/to/test_to_debug.test
 ```
 
-The test will start execution using the contextBroker process under debugger. For instance, if you
-have set a breakpoint in a place traversed by the .test cases, the execution will stop there.
-
-Once you have ended, remember to restore the `brokerStart`, `brokerStop` and (maybe) `dbDrop` lines
-in the .test file.
+The test will start execution against the contextBroker process running in the debugger.
+So, if you have set a breakpoint in a place traversed by the .test cases, the execution will stop there, and you
+can step etc, as always when in GDB.
 
 [Top](#top)
 

--- a/doc/manuals/devel/cookbook.md
+++ b/doc/manuals/devel/cookbook.md
@@ -398,7 +398,7 @@ This CLI option is called `--xbroker`.
 Please take into account a couple of remarks regarding the `--xbroker` switch:
 
 * It is only supported for a **single test case**, i.e., you have to run `testHarness.sh` with a test file as parameter.
-* It doesn't start **any** of the contextBrokers involved in the tests (main context broker and brokers serving as context providers). In some cases, you may need to debug only one of the brokers, letting the other brokers be started by the functional test suite. In such a case, `--xbroker` should **not** be used - instead edit the .test file and comment out the `brokerStart` (and corresopnding`brokerStop` lines) you need to disable (amd remember to revert the changes afterwards!).
+* It doesn't start **any** of the contextBrokers involved in the tests (main context broker and brokers serving as context providers). In some cases, you may need to debug only one of the brokers, letting the other brokers be started by the functional test suite. In such a case, `--xbroker` should **not** be used - instead edit the .test file and comment out the `brokerStart` (and corresponding`brokerStop` lines) you need to disable (and remember to revert the changes afterwards!).
 
 Before running `testHarness.sh` you must start your "external contextBroker", running under gdb, valgrind or whatever program you prefer
 for debugging.

--- a/doc/manuals/user/ngsiv2_implementation_notes.md
+++ b/doc/manuals/user/ngsiv2_implementation_notes.md
@@ -334,7 +334,8 @@ for the following aspects:
 * `PATCH /v2/registration/<id>` is not implemented. Thus, registrations cannot be updated
   directly. I.e., updates must be done deleting and re-creating the registration. Please
   see [this issue](https://github.com/telefonicaid/fiware-orion/issues/3007) about this.
-* `idPattern` and `typePattern` are not implemented.
+* `idPattern` is supported but only for the exact regular expression `.*`
+* `typePattern` is not implemented.
 * The only valid `supportedForwardingMode` is `all`. Trying to use any other value will end
   in a 501 Not Implemented error response. Please
   see [this issue](https://github.com/telefonicaid/fiware-orion/issues/3106) about this.

--- a/doc/manuals/user/ngsiv2_implementation_notes.md
+++ b/doc/manuals/user/ngsiv2_implementation_notes.md
@@ -335,6 +335,8 @@ for the following aspects:
   directly. I.e., updates must be done deleting and re-creating the registration. Please
   see [this issue](https://github.com/telefonicaid/fiware-orion/issues/3007) about this.
 * `idPattern` is supported but only for the exact regular expression `.*`
+  And, right now (2019-03-21), only forwarding of queries is working for registrations with idPatterns.
+  forwarded updates do not work for registrations with idPattern (the plan is to fix this asap). 
 * `typePattern` is not implemented.
 * The only valid `supportedForwardingMode` is `all`. Trying to use any other value will end
   in a 501 Not Implemented error response. Please

--- a/src/lib/common/errorMessages.h
+++ b/src/lib/common/errorMessages.h
@@ -98,4 +98,9 @@
 
 #define ERROR_DESC_BAD_VERB                           "method not allowed"
 
+
+#define ERROR_NOTIMPLEMENTED                          "NotImplemented"
+#define ERROR_IDPATTERN_NOTSUPPORTED                  "Unsupported idPattern"
+#define ERROR_TYPEPATTERN_NOTIMPLEMENTED              "typePattern is not supported"
+
 #endif  // SRC_LIB_COMMON_ERRORMESSAGES_H_

--- a/src/lib/common/errorMessages.h
+++ b/src/lib/common/errorMessages.h
@@ -100,7 +100,7 @@
 
 
 #define ERROR_NOTIMPLEMENTED                          "NotImplemented"
-#define ERROR_IDPATTERN_NOTSUPPORTED                  "Unsupported idPattern"
-#define ERROR_TYPEPATTERN_NOTIMPLEMENTED              "typePattern is not supported"
+#define ERROR_DESC_IDPATTERN_NOTSUPPORTED             "Unsupported idPattern"
+#define ERROR_DESC_TYPEPATTERN_NOTIMPLEMENTED         "typePattern is not supported"
 
 #endif  // SRC_LIB_COMMON_ERRORMESSAGES_H_

--- a/src/lib/jsonParseV2/parseRegistration.cpp
+++ b/src/lib/jsonParseV2/parseRegistration.cpp
@@ -88,7 +88,8 @@ static bool dataProvidedParse
   }
 
   //
-  // If idPattern is used, it MUST be ".*", else: Error
+  // If idPattern is used, it MUST be ".*", else: Error 501
+  // If any type-pattern is used: Error 501
   //
   for (unsigned int eIx = 0; eIx < dataProvidedP->entities.size(); ++eIx)
   {
@@ -98,8 +99,18 @@ static bool dataProvidedParse
     {
       ciP->httpStatusCode = SccNotImplemented;
       oeP->code           = SccNotImplemented;
-      oeP->reasonPhrase   = "NotImplemented";
-      oeP->details        = "Unsupported idPattern";
+      oeP->reasonPhrase   = ERROR_NOTIMPLEMENTED;
+      oeP->details        = ERROR_IDPATTERN_NOTSUPPORTED;
+
+      return false;
+    }
+
+    if (eP->typePattern != "")
+    {
+      ciP->httpStatusCode = SccNotImplemented;
+      oeP->code           = SccNotImplemented;
+      oeP->reasonPhrase   = ERROR_NOTIMPLEMENTED;
+      oeP->details        = ERROR_TYPEPATTERN_NOTIMPLEMENTED;
 
       return false;
     }

--- a/src/lib/jsonParseV2/parseRegistration.cpp
+++ b/src/lib/jsonParseV2/parseRegistration.cpp
@@ -100,7 +100,7 @@ static bool dataProvidedParse
       ciP->httpStatusCode = SccNotImplemented;
       oeP->code           = SccNotImplemented;
       oeP->reasonPhrase   = ERROR_NOTIMPLEMENTED;
-      oeP->details        = ERROR_IDPATTERN_NOTSUPPORTED;
+      oeP->details        = ERROR_DESC_IDPATTERN_NOTSUPPORTED;
 
       return false;
     }
@@ -110,7 +110,7 @@ static bool dataProvidedParse
       ciP->httpStatusCode = SccNotImplemented;
       oeP->code           = SccNotImplemented;
       oeP->reasonPhrase   = ERROR_NOTIMPLEMENTED;
-      oeP->details        = ERROR_TYPEPATTERN_NOTIMPLEMENTED;
+      oeP->details        = ERROR_DESC_TYPEPATTERN_NOTIMPLEMENTED;
 
       return false;
     }

--- a/src/lib/logMsg/traceLevels.h
+++ b/src/lib/logMsg/traceLevels.h
@@ -127,6 +127,7 @@ typedef enum TraceLevels
   LmtSoftError,
   LmtNotImplemented,
   LmtCurlContext,
+  LmtForward = 235,
 
   LmtBug = 250
 } TraceLevels;

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1882,19 +1882,9 @@ static void processEntity(ContextRegistrationResponse* crr, const EntityIdVector
 {
   EntityId en;
 
-  en.id   = getStringFieldF(entity, REG_ENTITY_ID);
-  en.type = entity.hasField(REG_ENTITY_TYPE) ? getStringFieldF(entity, REG_ENTITY_TYPE) : "";
-
-  /*
-   * Old Comment:
-   *   isPattern = true is not allowed in registrations so it is not in the
-   *   document retrieved with the query; however we will set it to be formally correct with NGSI spec
-   *
-   * New Comment:
-   *   isPattern = true is allowed as APIv2 registrations support entity ID as wildcard.
-   *   See issue #3458
-   */
-  en.isPattern = entity.hasField(REG_ENTITY_ISPATTERN) ? getStringFieldF(entity, REG_ENTITY_ISPATTERN) : "false";
+  en.id        = getStringFieldF(entity, REG_ENTITY_ID);
+  en.type      = entity.hasField(REG_ENTITY_TYPE)?      getStringFieldF(entity, REG_ENTITY_TYPE)      : "";
+  en.isPattern = entity.hasField(REG_ENTITY_ISPATTERN)? getStringFieldF(entity, REG_ENTITY_ISPATTERN) : "false";
 
   if (includedEntity(en, enV))
   {
@@ -2127,6 +2117,8 @@ bool registrationsQuery
       continue;
     }
     docs++;
+
+    LM_T(LmtMongo, ("retrieved document [%d]: '%s'", docs, r.toString().c_str()));
     LM_T(LmtForward, ("retrieved document [%d]: '%s'", docs, r.toString().c_str()));
 
     MimeType                  mimeType = JSON;

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1894,7 +1894,7 @@ static void processEntity(ContextRegistrationResponse* crr, const EntityIdVector
    *   isPattern = true is allowed as APIv2 registrations support entity ID as wildcard.
    *   See issue #3458
    */
-  en.isPattern = entity.hasField(REG_ENTITY_ISPATTERN) ? getStringFieldF(entity, REG_ENTITY_ISPATTERN) : "";
+  en.isPattern = entity.hasField(REG_ENTITY_ISPATTERN) ? getStringFieldF(entity, REG_ENTITY_ISPATTERN) : "false";
 
   if (includedEntity(en, enV))
   {

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1885,11 +1885,16 @@ static void processEntity(ContextRegistrationResponse* crr, const EntityIdVector
   en.id   = getStringFieldF(entity, REG_ENTITY_ID);
   en.type = entity.hasField(REG_ENTITY_TYPE) ? getStringFieldF(entity, REG_ENTITY_TYPE) : "";
 
-  /* isPattern = true is not allowed in registrations so it is not in the
-   * document retrieved with the query; however we will set it to be formally correct
-   * with NGSI spec
+  /*
+   * Old Comment:
+   *   isPattern = true is not allowed in registrations so it is not in the
+   *   document retrieved with the query; however we will set it to be formally correct with NGSI spec
+   *
+   * New Comment:
+   *   isPattern = true is allowed as APIv2 registrations support entity ID as wildcard.
+   *   See issue #3458
    */
-  en.isPattern = std::string("false");
+  en.isPattern = entity.hasField(REG_ENTITY_ISPATTERN) ? getStringFieldF(entity, REG_ENTITY_ISPATTERN) : "";
 
   if (includedEntity(en, enV))
   {

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -2046,8 +2046,8 @@ bool registrationsQuery
       }
       else
       {
-        /* We have detected that sometimes mongo stores { id: ..., type ...} and others { type: ..., id: ...},
-           so we have to take both them into account
+        /* We have detected that sometimes mongo stores { id: ..., type ...} and sometimes { type: ..., id: ...},
+           so we have to take both of them into account
         */
         entitiesWithType.append(BSON(REG_ENTITY_ID << en->id << REG_ENTITY_TYPE << en->type));
         entitiesWithType.append(BSON(REG_ENTITY_TYPE << en->type << REG_ENTITY_ID << en->id));
@@ -2066,8 +2066,8 @@ bool registrationsQuery
     LM_T(LmtMongo, ("Attribute discovery: '%s'", attrName.c_str()));
   }
 
-  entityOr.append(BSON(contextRegistrationEntities << BSON("$in" << entitiesWithType.arr())));
-  entityOr.append(BSON(contextRegistrationEntitiesId << BSON("$in" <<entitiesWithoutType.arr())));
+  entityOr.append(BSON(contextRegistrationEntities   << BSON("$in" << entitiesWithType.arr())));
+  entityOr.append(BSON(contextRegistrationEntitiesId << BSON("$in" << entitiesWithoutType.arr())));
 
   BSONObjBuilder queryBuilder;
 
@@ -2079,9 +2079,7 @@ bool registrationsQuery
 
   if (attrs.arrSize() > 0)
   {
-    /* If we don't do this checking, the {$in: [] } in the attribute name part will
-     * make the query fail
-     */
+    /* If we don't do this check, the {$in: [] } of the attribute name part makes the query fail */
     queryBuilder.append(contextRegistrationAttrsNames, BSON("$in" << attrs.arr()));
   }
 
@@ -2129,7 +2127,7 @@ bool registrationsQuery
       continue;
     }
     docs++;
-    LM_T(LmtMongo, ("retrieved document [%d]: '%s'", docs, r.toString().c_str()));
+    LM_T(LmtForward, ("retrieved document [%d]: '%s'", docs, r.toString().c_str()));
 
     MimeType                  mimeType = JSON;
     std::vector<BSONElement>  queryContextRegistrationV = getFieldF(r, REG_CONTEXT_REGISTRATION).Array();
@@ -2821,7 +2819,7 @@ bool someContextElementNotFound(const ContextElementResponse& cer)
 *
 * cprLookupByAttribute -
 *
-* Search for the CPr, given the entity/attribute as argument. Actually, two CPrs can be returned
+* Search for the CPr, given the entity/attribute as argument. Actually, two CPrs can be returned -
 * the "general" one at entity level or the "specific" one at attribute level
 */
 void cprLookupByAttribute
@@ -2859,7 +2857,7 @@ void cprLookupByAttribute
         *perEntPa         = crr->contextRegistration.providingApplication.get();
         *perEntPaMimeType = crr->contextRegistration.providingApplication.getMimeType();
 
-        break; /* enIx */
+        break;  /* enIx */
       }
 
       /* Is there a matching entity or the absence of attributes? */
@@ -2868,7 +2866,7 @@ void cprLookupByAttribute
         std::string regAttrName = crr->contextRegistration.contextRegistrationAttributeVector[attrIx]->name;
         if (regAttrName == attrName)
         {
-          /* We cannot "improve" this result keep searching in CRR vector, so we return */
+          /* We cannot "improve" this result by keep searching the CRR vector, so we return */
           *perAttrPa         = crr->contextRegistration.providingApplication.get();
           *perAttrPaMimeType = crr->contextRegistration.providingApplication.getMimeType();
 

--- a/src/lib/mongoBackend/mongoQueryContext.cpp
+++ b/src/lib/mongoBackend/mongoQueryContext.cpp
@@ -292,6 +292,8 @@ static void processGenericEntities
 /* ****************************************************************************
 *
 * cerVectorPresent -
+*
+* FIXME: temporal debugging routine to be removed once forwarding works 100% ok
 */
 void cerVectorPresent(const char* what, const ContextElementResponseVector& cerV)
 {
@@ -321,6 +323,8 @@ void cerVectorPresent(const char* what, const ContextElementResponseVector& cerV
 /* ****************************************************************************
 *
 * crrVectorPresent -
+*
+* FIXME: temporal debugging routine to be removed once forwarding works 100% ok
 */
 void crrVectorPresent(const char* what, const ContextRegistrationResponseVector& crrV)
 {
@@ -430,6 +434,7 @@ HttpStatusCode mongoQueryContext
     LM_T(LmtForward, ("Calling registrationsQuery I"));
     if (registrationsQuery(requestP->entityIdVector, requestP->attributeList, &crrV, &err, tenant, servicePathV, 0, 0, false))
     {
+      // FIXME: call to crrVectorPresent to be removed once forwarding works
       // crrVectorPresent("registrationsQuery I", crrV);
       if (crrV.size() > 0)
       {
@@ -446,6 +451,7 @@ HttpStatusCode mongoQueryContext
     LM_T(LmtForward, ("Calling registrationsQuery II"));
     if (registrationsQuery(requestP->entityIdVector, requestP->attributeList, &crrV, &err, tenant, servicePathV, 0, 0, false))
     {
+      // FIXME: call to crrVectorPresent to be removed once forwarding works
       // crrVectorPresent("registrationsQuery II", crrV);
       if (crrV.size() > 0)
       {
@@ -465,6 +471,7 @@ HttpStatusCode mongoQueryContext
     LM_T(LmtForward, ("Calling registrationsQuery III"));
     if (registrationsQuery(requestP->entityIdVector, attrNullList, &crrV, &err, tenant, servicePathV, 0, 0, false))
     {
+      // FIXME: call to crrVectorPresent to be removed once forwarding works
       // crrVectorPresent("registrationsQuery III", crrV);
       if (crrV.size() > 0)
       {
@@ -484,6 +491,7 @@ HttpStatusCode mongoQueryContext
     LM_T(LmtForward, ("Calling registrationsQuery IV"));
     if (registrationsQuery(requestP->entityIdVector, requestP->attributeList, &crrV, &err, tenant, servicePathV, 0, 0, false))
     {
+      // FIXME: call to crrVectorPresent to be removed once forwarding works
       // crrVectorPresent("registrationsQuery IV", crrV);
       if (crrV.size() > 0)
       {
@@ -496,8 +504,10 @@ HttpStatusCode mongoQueryContext
 
   /* Prune "not found" CERs */
   LM_T(LmtForward, ("Before pruning, we have %d elements in rawCerV", rawCerV.size()));
+  // FIXME: call to cerVectorPresent to be removed once forwarding works
   // cerVectorPresent("Before pruning", rawCerV);
   pruneContextElements(rawCerV, &responseP->contextElementResponseVector);
+  // FIXME: call to cerVectorPresent to be removed once forwarding works
   // cerVectorPresent("After pruning", rawCerV);
   LM_T(LmtForward, ("After pruning, we have %d elements in contextElementResponseVector", responseP->contextElementResponseVector.size()));
 

--- a/src/lib/mongoBackend/mongoQueryContext.cpp
+++ b/src/lib/mongoBackend/mongoQueryContext.cpp
@@ -293,7 +293,7 @@ static void processGenericEntities
 *
 * cerVectorPresent -
 */
-void cerVectorPresent(const char* what, ContextElementResponseVector& cerV)
+void cerVectorPresent(const char* what, const ContextElementResponseVector& cerV)
 {
   LM_T(LmtForward, ("%s: got a CER vector of %d items", what, cerV.size()));
   LM_T(LmtForward, ("-------------------------------------------------------------"));
@@ -322,7 +322,7 @@ void cerVectorPresent(const char* what, ContextElementResponseVector& cerV)
 *
 * crrVectorPresent -
 */
-void crrVectorPresent(const char* what, ContextRegistrationResponseVector& crrV)
+void crrVectorPresent(const char* what, const ContextRegistrationResponseVector& crrV)
 {
   LM_T(LmtForward, ("%s: got a CRR vector of %d items", what, crrV.size()));
   LM_T(LmtForward, ("-------------------------------------------------------------"));

--- a/src/lib/mongoBackend/mongoQueryContext.cpp
+++ b/src/lib/mongoBackend/mongoQueryContext.cpp
@@ -160,7 +160,7 @@ static void addContextProviderAttribute
     /* Reached this point, it means that the cerV doesn't contain a proper CER, so we create it */
     ContextElementResponse* cerP            = new ContextElementResponse();
 
-    cerP->entity.fill(enP->id, enP->type, "false");
+    cerP->entity.fill(enP->id, enP->type, enP->isPattern);
     cerP->statusCode.fill(SccOk);
 
     ContextAttribute* caP = new ContextAttribute(craP->name, "", "");
@@ -333,6 +333,7 @@ HttpStatusCode mongoQueryContext
   ContextElementResponseVector rawCerV;
 
   reqSemTake(__FUNCTION__, "ngsi10 query request", SemReadOp, &reqSemTaken);
+
   ok = entitiesQuery(requestP->entityIdVector,
                      requestP->attributeList,
                      requestP->restriction,
@@ -388,7 +389,7 @@ HttpStatusCode mongoQueryContext
     crrV.release();
   }
 
-  /* Second CPr lookup (in the case some element stills not being found): looking in E-<null> registrations */
+  /* Second CPr lookup (in the case some elements still not being found): looking in E-<null> registrations */
   StringList attrNullList;
 
   if (someContextElementNotFound(rawCerV))
@@ -405,7 +406,7 @@ HttpStatusCode mongoQueryContext
   }
 
   /* Special case: request with <null> attributes. In that case, entitiesQuery() may have captured some local attribute, but
-   * the list need to be completed. Note that in the case of having this request someContextElementNotFound() is always false
+   * the list needs to be completed. Note that in the case of having this request someContextElementNotFound() is always false
    * so we efficient not invoking registrationQuery() too much times
    */
   if (requestP->attributeList.size() == 0)

--- a/src/lib/mongoBackend/mongoRegistrationCreate.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationCreate.cpp
@@ -116,7 +116,7 @@ static void setContextRegistrationVector(ngsiv2::Registration* regP, mongo::BSON
   {
     ngsiv2::EntID* eP = &regP->dataProvided.entities[eIx];
 
-    if (eP->idPattern == "false")
+    if (eP->idPattern == "")
     {
       if (eP->type == "")
       {

--- a/src/lib/mongoBackend/mongoRegistrationCreate.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationCreate.cpp
@@ -114,33 +114,29 @@ static void setContextRegistrationVector(ngsiv2::Registration* regP, mongo::BSON
 
   for (unsigned int eIx = 0; eIx < regP->dataProvided.entities.size(); ++eIx)
   {
-    ngsiv2::EntID* eP                  = &regP->dataProvided.entities[eIx];
-    std::string    entityId            = (eP->id          != "")? eP->id : eP->idPattern;
-    std::string    entityIsPattern     = (eP->idPattern   != "")? "true" : "false";
-    std::string    entityType          = (eP->type        != "")? eP->type : eP->typePattern;
-    bool           entityTypeIsPattern = (eP->typePattern != "")? true : false;
+    ngsiv2::EntID* eP = &regP->dataProvided.entities[eIx];
 
-    if (entityType == "")  // No entity type given - all types match
+    if (eP->idPattern == "false")
     {
-      entityType = ".*";
-      entityTypeIsPattern = true;
-    }
-
-    if ((entityIsPattern == "false") && (entityTypeIsPattern == false))
-    {
-      entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_TYPE << entityType));
-    }
-    else if (entityIsPattern == "false")
-    {
-      entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_TYPE << entityType << REG_ENTITY_ISTYPEPATTERN << entityTypeIsPattern));
-    }
-    else if (entityTypeIsPattern == false)
-    {
-      entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_ISPATTERN << entityIsPattern << REG_ENTITY_TYPE << entityType));
+      if (eP->type == "")
+      {
+        entities.append(BSON(REG_ENTITY_ID << eP->id));
+      }
+      else
+      {
+        entities.append(BSON(REG_ENTITY_ID << eP->id << REG_ENTITY_TYPE << eP->type));
+      }
     }
     else
     {
-      entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_ISPATTERN << entityIsPattern << REG_ENTITY_TYPE << entityType << REG_ENTITY_ISTYPEPATTERN << entityTypeIsPattern));
+      if (eP->type == "")
+      {
+        entities.append(BSON(REG_ENTITY_ID << eP->idPattern << REG_ENTITY_ISPATTERN << "true"));
+      }
+      else
+      {
+        entities.append(BSON(REG_ENTITY_ID << eP->idPattern << REG_ENTITY_ISPATTERN << "true" << REG_ENTITY_TYPE << eP->type));
+      }
     }
   }
 

--- a/src/lib/mongoBackend/mongoRegistrationCreate.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationCreate.cpp
@@ -127,13 +127,21 @@ static void setContextRegistrationVector(ngsiv2::Registration* regP, mongo::BSON
     }
 
     if ((entityIsPattern == "false") && (entityTypeIsPattern == false))
+    {
       entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_TYPE << entityType));
+    }
     else if (entityIsPattern == "false")
+    {
       entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_TYPE << entityType << REG_ENTITY_ISTYPEPATTERN << entityTypeIsPattern));
+    }
     else if (entityTypeIsPattern == false)
+    {
       entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_ISPATTERN << entityIsPattern << REG_ENTITY_TYPE << entityType));
+    }
     else
+    {
       entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_ISPATTERN << entityIsPattern << REG_ENTITY_TYPE << entityType << REG_ENTITY_ISTYPEPATTERN << entityTypeIsPattern));
+    }
   }
 
   for (unsigned int aIx = 0; aIx < regP->dataProvided.attributes.size(); ++aIx)

--- a/src/lib/mongoBackend/mongoRegistrationCreate.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationCreate.cpp
@@ -126,7 +126,14 @@ static void setContextRegistrationVector(ngsiv2::Registration* regP, mongo::BSON
       entityTypeIsPattern = true;
     }
 
-    entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_ISPATTERN << entityIsPattern << REG_ENTITY_TYPE << entityType << REG_ENTITY_ISTYPEPATTERN << entityTypeIsPattern));
+    if ((entityIsPattern == "false") && (entityTypeIsPattern == false))
+      entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_TYPE << entityType));
+    else if (entityIsPattern == "false")
+      entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_TYPE << entityType << REG_ENTITY_ISTYPEPATTERN << entityTypeIsPattern));
+    else if (entityTypeIsPattern == false)
+      entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_ISPATTERN << entityIsPattern << REG_ENTITY_TYPE << entityType));
+    else
+      entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_ISPATTERN << entityIsPattern << REG_ENTITY_TYPE << entityType << REG_ENTITY_ISTYPEPATTERN << entityTypeIsPattern));
   }
 
   for (unsigned int aIx = 0; aIx < regP->dataProvided.attributes.size(); ++aIx)

--- a/src/lib/mongoBackend/mongoRegistrationCreate.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationCreate.cpp
@@ -114,16 +114,19 @@ static void setContextRegistrationVector(ngsiv2::Registration* regP, mongo::BSON
 
   for (unsigned int eIx = 0; eIx < regP->dataProvided.entities.size(); ++eIx)
   {
-    ngsiv2::EntID* eP = &regP->dataProvided.entities[eIx];
+    ngsiv2::EntID* eP                  = &regP->dataProvided.entities[eIx];
+    std::string    entityId            = (eP->id          != "")? eP->id : eP->idPattern;
+    std::string    entityIsPattern     = (eP->idPattern   != "")? "true" : "false";
+    std::string    entityType          = (eP->type        != "")? eP->type : eP->typePattern;
+    bool           entityTypeIsPattern = (eP->typePattern != "")? true : false;
 
-    if (eP->type == "")  // No type provided => all types
+    if (entityType == "")  // No entity type given - all types match
     {
-      entities.append(BSON(REG_ENTITY_ID << eP->id));
+      entityType = ".*";
+      entityTypeIsPattern = true;
     }
-    else
-    {
-      entities.append(BSON(REG_ENTITY_ID << eP->id << REG_ENTITY_TYPE << eP->type));
-    }
+
+    entities.append(BSON(REG_ENTITY_ID << entityId << REG_ENTITY_ISPATTERN << entityIsPattern << REG_ENTITY_TYPE << entityType << REG_ENTITY_ISTYPEPATTERN << entityTypeIsPattern));
   }
 
   for (unsigned int aIx = 0; aIx < regP->dataProvided.attributes.size(); ++aIx)

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -150,7 +150,7 @@ static bool queryForward(ConnectionInfo* ciP, QueryContextRequest* qcrP, QueryCo
     return false;
   }
 
-  LM_T(LmtCPrForwardRequestPayload, ("forward queryContext response payload: %s", out.c_str()));
+  LM_T(LmtCPrForwardResponsePayload, ("forward queryContext response payload: %s", out.c_str()));
 
 
   //
@@ -272,7 +272,7 @@ std::string postQueryContext
   ParseData*                 parseDataP
 )
 {
-  LM_T(LmtCPrForwardRequestPayload, ("In postQueryContext: Forwarding ... ?"));
+  LM_T(LmtForward, ("In postQueryContext: Forwarding ... ?"));
 
   //
   // Convops calling this routine may need the response in digital
@@ -337,19 +337,19 @@ std::string postQueryContext
   //
   // <DEBUG>
   //
-  LM_T(LmtCPrForwardRequestPayload, ("Forward: Response from mongoQueryContext:"));
-  LM_T(LmtCPrForwardRequestPayload, ("Forward: --------------------------------"));
+  LM_T(LmtForward, ("Response from mongoQueryContext:"));
+  LM_T(LmtForward, ("--------------------------------"));
 
   for (unsigned int ix = 0; ix < qcrsP->contextElementResponseVector.size(); ++ix)
   {
     Entity* eP = &qcrsP->contextElementResponseVector[ix]->entity;
 
-    LM_T(LmtCPrForwardRequestPayload, ("Forward: Entity: '%s'/'%s'/'%s'/'%s'", eP->id.c_str(), eP->isPattern.c_str(), eP->type.c_str(), FT(eP->isTypePattern)));
+    LM_T(LmtForward, ("Entity: '%s'/'%s'/'%s'/'%s'", eP->id.c_str(), eP->isPattern.c_str(), eP->type.c_str(), FT(eP->isTypePattern)));
 
     if (eP->providingApplicationList.size() != 0)
     {
       for (unsigned int paIx = 0; paIx < eP->providingApplicationList.size(); paIx++)
-        LM_T(LmtCPrForwardRequestPayload, ("Forward: Entity PA: %s", eP->providingApplicationList[paIx].string.c_str()));
+        LM_T(LmtForward, ("Entity PA: %s", eP->providingApplicationList[paIx].string.c_str()));
     }
 
     for (unsigned int aIx = 0; aIx < eP->attributeVector.size(); aIx++)
@@ -357,9 +357,9 @@ std::string postQueryContext
       ContextAttribute* aP = eP->attributeVector[aIx];
 
       if (aP->providingApplication.string != "")
-        LM_T(LmtCPrForwardRequestPayload, ("Forward: Attribute %d: %s (Providing Application: %s)", aIx, aP->name.c_str(), aP->providingApplication.string.c_str()));
+        LM_T(LmtForward, ("Attribute %d: %s (Providing Application: %s)", aIx, aP->name.c_str(), aP->providingApplication.string.c_str()));
       else
-        LM_T(LmtCPrForwardRequestPayload, ("Forward: Attribute %d: %s (No Providing Application)", aIx, aP->name.c_str()));
+        LM_T(LmtForward, ("Attribute %d: %s (No Providing Application)", aIx, aP->name.c_str()));
     }
   }
   //
@@ -394,13 +394,13 @@ std::string postQueryContext
   //
   if (forwardsPending(qcrsP) == false)
   {
-    LM_T(LmtCPrForwardRequestPayload, ("No Forwarding necessary"));
+    LM_T(LmtForward, ("No Forwarding necessary"));
     TIMED_RENDER(answer = qcrsP->toJsonV1(asJsonObject));
 
     qcrP->release();
     return answer;
   }
-  LM_T(LmtCPrForwardRequestPayload, ("Requests to be Forwarded"));
+  LM_T(LmtForward, ("Requests to be Forwarded"));
 
   //
   // 03. Complex case (queries to be forwarded)

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -337,6 +337,8 @@ std::string postQueryContext
   //
   // <DEBUG>
   //
+  // FIXME: This debug block should be removed once forwards works the way it should.
+  //
   LM_T(LmtForward, ("Response from mongoQueryContext:"));
   LM_T(LmtForward, ("--------------------------------"));
 

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -191,7 +191,7 @@ static void updateForward(ConnectionInfo* ciP, UpdateContextRequest* upcrP, Upda
     return;
   }
 
-  LM_T(LmtCPrForwardRequestPayload, ("forward updateContext response payload: %s", out.c_str()));
+  LM_T(LmtCPrForwardResponsePayload, ("forward updateContext response payload: %s", out.c_str()));
 
 
   //

--- a/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_errors.test
+++ b/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_errors.test
@@ -77,6 +77,7 @@ brokerStart CB 0-255 IPv4 -statCounters
 # 46. supportedForwardingMode set to 'none'
 # 47. supportedForwardingMode set to 'query'
 # 48. supportedForwardingMode set to 'update'
+# 49. dataProvided:entities:entity:idPattern too complex
 #
 
 
@@ -970,6 +971,31 @@ echo
 echo
 
 
+echo "49. dataProvided:entities:entity:idPattern too complex"
+echo "======================================================"
+payload='{
+  "description": "DESC",
+  "dataProvided": {
+    "entities": [
+      {
+        "idPattern": "E.*",
+        "type": "T1"
+      }
+    ],
+    "attrs": [ "A1", "A2" ]
+  },
+  "provider": {
+    "http": {
+      "url": "http://localhost:'${CP1_PORT}'/v2"
+    },
+    "legacyForwarding": true
+  }
+}'
+orionCurl --url /v2/registrations --payload "$payload"
+echo
+echo
+
+
 --REGEXPECT--
 01. Invalid JSON in payload
 ===========================
@@ -1639,6 +1665,20 @@ Date: REGEX(.*)
 
 {
     "description": "non-supported Forwarding Mode",
+    "error": "NotImplemented"
+}
+
+
+49. dataProvided:entities:entity:idPattern too complex
+======================================================
+HTTP/1.1 501 Not Implemented
+Content-Length: 64
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Unsupported idPattern",
     "error": "NotImplemented"
 }
 

--- a/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_errors.test
+++ b/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_errors.test
@@ -78,6 +78,7 @@ brokerStart CB 0-255 IPv4 -statCounters
 # 47. supportedForwardingMode set to 'query'
 # 48. supportedForwardingMode set to 'update'
 # 49. dataProvided:entities:entity:idPattern too complex
+# 50. dataProvided:entities:entity:typePattern is used (it's not supported)
 #
 
 
@@ -996,6 +997,31 @@ echo
 echo
 
 
+echo "50. dataProvided:entities:entity:typePattern is used (it's not supported)"
+echo "========================================================================="
+payload='{
+  "description": "DESC",
+  "dataProvided": {
+    "entities": [
+      {
+        "id": "E1",
+        "typePattern": ".*"
+      }
+    ],
+    "attrs": [ "A1", "A2" ]
+  },
+  "provider": {
+    "http": {
+      "url": "http://localhost:'${CP1_PORT}'/v2"
+    },
+    "legacyForwarding": true
+  }
+}'
+orionCurl --url /v2/registrations --payload "$payload"
+echo
+echo
+
+
 --REGEXPECT--
 01. Invalid JSON in payload
 ===========================
@@ -1679,6 +1705,20 @@ Date: REGEX(.*)
 
 {
     "description": "Unsupported idPattern",
+    "error": "NotImplemented"
+}
+
+
+50. dataProvided:entities:entity:typePattern is used (it's not supported)
+=========================================================================
+HTTP/1.1 501 Not Implemented
+Content-Length: 71
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "typePattern is not supported", 
     "error": "NotImplemented"
 }
 

--- a/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_v1_forward.test
+++ b/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_v1_forward.test
@@ -26,17 +26,18 @@ Create registration using APIv2 and provoke v1 forwards
 --SHELL-INIT--
 dbInit CB
 dbInit CP1
-brokerStart CB
+brokerStart CB 100,186 IPV4
 brokerStart CP1
 
 --SHELL--
 
 #
 # 01. Register entity E1/A1 (using APIv2) for CP1
-# 02. Create E1/A1 in CP1
-# 03. GET E1/A1 from main broker (forward made to CP1)
-# 04. UPDATE E1/A1 in main broker (forward made to CP1)
-# 05. GET E1/A1 directly from CP1, make sure updates are there
+# 02. See the registration in mongo
+# 03. Create E1/A1 in CP1
+# 04. GET E1/A1 from main broker (forward made to CP1)
+# 05. UPDATE E1/A1 in main broker (forward made to CP1)
+# 06. GET E1/A1 directly from CP1, make sure updates are there
 #
 # FIXME: Add test case for v2 forwarding once v2 forwarding is implemented
 #
@@ -67,7 +68,14 @@ echo
 echo
 
 
-echo "02. Create E1/A1 in CP1"
+echo "02. See the registration in mongo"
+echo "================================="
+mongoCmdLong ${CB_DB_NAME} "db.registrations.findOne()"
+echo
+echo
+
+
+echo "03. Create E1/A1 in CP1"
 echo "======================="
 payload='{
   "id": "E1",
@@ -81,14 +89,14 @@ echo
 echo
 
 
-echo "03. GET E1/A1 from main broker (forward made to CP1)"
+echo "04. GET E1/A1 from main broker (forward made to CP1)"
 echo "===================================================="
 orionCurl --url '/v2/entities/E1?type=T1'
 echo
 echo
 
 
-echo "04. UPDATE E1/A1 in main broker (forward made to CP1)"
+echo "05. UPDATE E1/A1 in main broker (forward made to CP1)"
 echo "====================================================="
 payload='{
   "A1": {
@@ -100,7 +108,7 @@ echo
 echo
 
 
-echo "05. GET E1/A1 directly from CP1, make sure updates are there"
+echo "06. GET E1/A1 directly from CP1, make sure updates are there"
 echo "============================================================"
 orionCurl --url /v2/entities/E1 --port $CP1_PORT
 echo
@@ -118,7 +126,40 @@ Date: REGEX(.*)
 
 
 
-02. Create E1/A1 in CP1
+02. See the registration in mongo
+=================================
+MongoDB shell version REGEX(.*)
+connecting to: mongodb://localhost:27017/ftest
+MongoDB server version: REGEX(.*)
+{
+	"_id" : REGEX(.*),
+	"description" : "located in CP1",
+	"expiration" : REGEX(.*),
+	"servicePath" : "/",
+	"contextRegistration" : [
+		{
+			"entities" : [
+				{
+					"id" : "E1",
+					"type" : "T1"
+				}
+			],
+			"attrs" : [
+				{
+					"name" : "A1",
+					"type" : ""
+				}
+			],
+			"providingApplication" : "http://localhost:REGEX(\d+)/v1"
+		}
+	],
+	"status" : "active",
+	"format" : "JSON"
+}
+bye
+
+
+03. Create E1/A1 in CP1
 =======================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -128,7 +169,7 @@ Date: REGEX(.*)
 
 
 
-03. GET E1/A1 from main broker (forward made to CP1)
+04. GET E1/A1 from main broker (forward made to CP1)
 ====================================================
 HTTP/1.1 200 OK
 Content-Length: 78
@@ -147,7 +188,7 @@ Date: REGEX(.*)
 }
 
 
-04. UPDATE E1/A1 in main broker (forward made to CP1)
+05. UPDATE E1/A1 in main broker (forward made to CP1)
 =====================================================
 HTTP/1.1 204 No Content
 Content-Length: 0
@@ -156,7 +197,7 @@ Date: REGEX(.*)
 
 
 
-05. GET E1/A1 directly from CP1, make sure updates are there
+06. GET E1/A1 directly from CP1, make sure updates are there
 ============================================================
 HTTP/1.1 200 OK
 Content-Length: 76

--- a/test/functionalTest/cases/3458_legacy-forwarding-with-idpattern/legacy-forwarding-with-idpattern.test
+++ b/test/functionalTest/cases/3458_legacy-forwarding-with-idpattern/legacy-forwarding-with-idpattern.test
@@ -1,0 +1,240 @@
+# Copyright 2019 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Entity ID and ID Pattern must not be lost in forwarded queries (issue #3458)
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Register entities of type Weather|OffStreetParking, with ID .*, and three attributes
+# 02. See the registration in mongo
+# 03. GET the registration to check it's correct
+# 04. Query all the Weather entities - only to provoke the query being forwarded to the accumulator
+# 05. Dump accumulator requests
+#
+
+echo "01. Register entities of type Weather|OffStreetParking, with ID .*, and three attributes"
+echo "========================================================================================"
+payload='{
+  "dataProvided": {
+    "entities": [
+      {
+        "type": "Weather",
+        "idPattern": ".*"
+      },
+      {
+        "type": "OffStreetParking",
+        "idPattern": ".*"
+      }
+    ],
+    "attrs": [
+      "temperature",
+      "humidity",
+      "availableSpotNumber"
+    ]
+  },
+  "provider": {
+    "http": {
+      "url": "http://localhost:'${LISTENER_PORT}'/v1"
+    },
+    "legacyForwarding": true
+  }
+}'
+orionCurl --url /v2/registrations --payload "$payload"
+echo
+echo
+
+
+echo "02. See the registration in mongo"
+echo "================================="
+mongoCmd2 ${CB_DB_NAME} "db.registrations.findOne()"
+echo
+echo
+
+
+echo "03. GET the registration to check it's correct"
+echo "=============================================="
+orionCurl --url /v2/registrations
+echo
+echo
+
+
+echo "04. Query all the Weather entities - only to provoke the query being forwarded to the accumulator"
+echo "================================================================================================="
+orionCurl --url '/v2/entities?type=Weather'
+echo
+echo
+
+
+echo "05. Dump accumulator requests"
+echo "============================="
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Register entities of type Weather|OffStreetParking, with ID .*, and three attributes
+========================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/registrations/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. See the registration in mongo
+=================================
+MongoDB shell version REGEX(.*)
+connecting to: mongodb://localhost:27017/ftest
+MongoDB server version: REGEX(.*)
+{
+	"_id" : REGEX(.*),
+	"expiration" : REGEX(.*),
+	"servicePath" : "/",
+	"contextRegistration" : [
+		{
+			"entities" : [
+				{
+					"id" : ".*",
+					"isPattern" : "true",
+					"type" : "Weather",
+					"isTypePattern" : false
+				},
+				{
+					"id" : ".*",
+					"isPattern" : "true",
+					"type" : "OffStreetParking",
+					"isTypePattern" : false
+				}
+			],
+			"attrs" : [
+				{
+					"name" : "temperature",
+					"type" : ""
+				},
+				{
+					"name" : "humidity",
+					"type" : ""
+				},
+				{
+					"name" : "availableSpotNumber",
+					"type" : ""
+				}
+			],
+			"providingApplication" : "http://localhost:9997/v1"
+		}
+	],
+	"format" : "JSON"
+}
+bye
+
+
+03. GET the registration to check it's correct
+==============================================
+HTTP/1.1 200 OK
+Content-Length: 332
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "dataProvided": {
+            "attrs": [
+                "temperature", 
+                "humidity", 
+                "availableSpotNumber"
+            ], 
+            "entities": [
+                {
+                    "idPattern": ".*", 
+                    "type": "Weather"
+                }, 
+                {
+                    "idPattern": ".*", 
+                    "type": "OffStreetParking"
+                }
+            ]
+        }, 
+        "id": "REGEX([0-9a-f]{24})",
+        "provider": {
+            "http": {
+                "url": "http://localhost:9997/v1"
+            }, 
+            "legacyForwarding": true, 
+            "supportedForwardingMode": "all"
+        }, 
+        "status": "active"
+    }
+]
+
+
+04. Query all the Weather entities - only to provoke the query being forwarded to the accumulator
+=================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
+
+
+05. Dump accumulator requests
+=============================
+POST http://localhost:REGEX(\d+)/v1/queryContext
+Fiware-Servicepath: /
+Content-Length: 124
+User-Agent: REGEX(.*)
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+
+{
+    "attributes": [
+        "temperature", 
+        "humidity", 
+        "availableSpotNumber"
+    ], 
+    "entities": [
+        {
+            "id": ".*", 
+            "isPattern": "true", 
+            "type": "Weather"
+        }
+    ]
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3458_legacy-forwarding-with-idpattern/legacy-forwarding-with-idpattern.test
+++ b/test/functionalTest/cases/3458_legacy-forwarding-with-idpattern/legacy-forwarding-with-idpattern.test
@@ -25,7 +25,9 @@ Entity ID and ID Pattern must not be lost in forwarded queries (issue #3458)
 
 --SHELL-INIT--
 dbInit CB
+dbInit CP1
 brokerStart CB
+brokerStart CP1
 accumulatorStart --pretty-print
 
 --SHELL--
@@ -36,6 +38,11 @@ accumulatorStart --pretty-print
 # 03. GET the registration to check it's correct
 # 04. Query all the Weather entities - only to provoke the query being forwarded to the accumulator
 # 05. Dump accumulator requests
+# 06. Register entities of type Weather2|OffStreetParking2, with ID .*, and three attributes, for CPr1
+# 07. Create Weather2 entity with availableSpotNumber in CPr1
+# 08. Create OffStreetParking2 entity with temperature and humidity in CPr1
+# 09. Query all the Weather2 entities, and see the one from CPr1
+# 10. Query all the OffStreetParking2 entities, and see the one from CPr1
 #
 
 echo "01. Register entities of type Weather|OffStreetParking, with ID .*, and three attributes"
@@ -94,6 +101,83 @@ echo
 echo "05. Dump accumulator requests"
 echo "============================="
 accumulatorDump
+echo
+echo
+
+
+echo "06. Register entities of type Weather2|OffStreetParking2, with ID .*, and three attributes, for CPr1"
+echo "===================================================================================================="
+payload='{
+  "dataProvided": {
+    "entities": [
+      {
+        "type": "Weather2",
+        "idPattern": ".*"
+      },
+      {
+        "type": "OffStreetParking2",
+        "idPattern": ".*"
+      }
+    ],
+    "attrs": [
+      "temperature",
+      "humidity",
+      "availableSpotNumber"
+    ]
+  },
+  "provider": {
+    "http": {
+      "url": "http://localhost:'${CP1_PORT}'/v1"
+    },
+    "legacyForwarding": true
+  }
+}'
+orionCurl --url /v2/registrations --payload "$payload"
+echo
+echo
+
+
+echo "07. Create Weather2 entity with availableSpotNumber in CPr1"
+echo "==========================================================="
+payload='{
+  "id": "w2",
+  "type": "Weather2",
+  "availableSpotNumber": {
+    "value": 5
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload" --port $CP1_PORT
+echo
+echo
+
+
+echo "08. Create OffStreetParking2 entity with temperature and humidity in CPr1"
+echo "========================================================================="
+payload='{
+  "id": "op2",
+  "type": "OffStreetParking2",
+  "temperature": {
+    "value": 28
+  },
+  "humidity": {
+    "value": 55
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload" --port $CP1_PORT
+echo
+echo
+
+
+echo "09. Query all the Weather2 entities, and see the one from CPr1"
+echo "=============================================================="
+orionCurl --url /v2/entities?type=Weather2
+echo
+echo
+
+
+echo "10. Query all the OffStreetParking2 entities, and see the one from CPr1"
+echo "======================================================================="
+orionCurl --url /v2/entities?type=OffStreetParking2
 echo
 echo
 
@@ -233,6 +317,84 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 =======================================
 
 
+06. Register entities of type Weather2|OffStreetParking2, with ID .*, and three attributes, for CPr1
+====================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/registrations/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+07. Create Weather2 entity with availableSpotNumber in CPr1
+===========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/w2?type=Weather2
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+08. Create OffStreetParking2 entity with temperature and humidity in CPr1
+=========================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/op2?type=OffStreetParking2
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+09. Query all the Weather2 entities, and see the one from CPr1
+==============================================================
+HTTP/1.1 200 OK
+Content-Length: 97
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "availableSpotNumber": {
+            "metadata": {}, 
+            "type": "Number", 
+            "value": "5"
+        }, 
+        "id": "w2", 
+        "type": "Weather2"
+    }
+]
+
+
+10. Query all the OffStreetParking2 entities, and see the one from CPr1
+=======================================================================
+HTTP/1.1 200 OK
+Content-Length: 156
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "humidity": {
+            "metadata": {}, 
+            "type": "Number", 
+            "value": "55"
+        }, 
+        "id": "op2", 
+        "temperature": {
+            "metadata": {}, 
+            "type": "Number", 
+            "value": "28"
+        }, 
+        "type": "OffStreetParking2"
+    }
+]
+
+
 --TEARDOWN--
 brokerStop CB
 dbDrop CB
+dbDrop CP1

--- a/test/functionalTest/cases/3458_legacy-forwarding-with-idpattern/legacy-forwarding-with-idpattern.test
+++ b/test/functionalTest/cases/3458_legacy-forwarding-with-idpattern/legacy-forwarding-with-idpattern.test
@@ -72,7 +72,7 @@ echo
 
 echo "02. See the registration in mongo"
 echo "================================="
-mongoCmd2 ${CB_DB_NAME} "db.registrations.findOne()"
+mongoCmdLong ${CB_DB_NAME} "db.registrations.findOne()"
 echo
 echo
 

--- a/test/functionalTest/cases/3458_legacy-forwarding-with-idpattern/legacy-forwarding-with-idpattern.test
+++ b/test/functionalTest/cases/3458_legacy-forwarding-with-idpattern/legacy-forwarding-with-idpattern.test
@@ -124,14 +124,12 @@ MongoDB server version: REGEX(.*)
 				{
 					"id" : ".*",
 					"isPattern" : "true",
-					"type" : "Weather",
-					"isTypePattern" : false
+					"type" : "Weather"
 				},
 				{
 					"id" : ".*",
 					"isPattern" : "true",
-					"type" : "OffStreetParking",
-					"isTypePattern" : false
+					"type" : "OffStreetParking"
 				}
 			],
 			"attrs" : [

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -925,6 +925,32 @@ function mongoCmd()
 
 # ------------------------------------------------------------------------------
 #
+# mongoCmd2 - like mongoCmd but showing all the output, not just the last line.
+#             Meant to be used in conjunction with 'grep'
+#
+function mongoCmd2()
+{
+  host="${CB_DATABASE_HOST}"
+  if [ "$host" == "" ]
+  then
+    host="localhost"
+  fi
+
+  port="${CB_DATABASE_PORT}"
+  if [ "$port" == "" ]
+  then
+    port="27017"
+  fi
+
+  db=$1
+  cmd=$2
+  echo $cmd | mongo mongodb://$host:$port/$db
+}
+
+
+
+# ------------------------------------------------------------------------------
+#
 # dbInsertEntity -
 #
 # Insert a crafted entity with an "inflated" attribute. The database is passed
@@ -1239,6 +1265,7 @@ export -f accumulatorReset
 export -f orionCurl
 export -f dbInsertEntity
 export -f mongoCmd
+export -f mongoCmd2
 export -f vMsg
 export -f dMsg
 export -f valgrindSleep

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -520,6 +520,11 @@ function localBrokerStop
 #
 function brokerStart()
 {
+  if [ "$CB_WITH_EXTERNAL_BROKER" == 1 ]
+  then
+    return
+  fi
+
   role=$1
   traceLevels=$2
   ipVersion=$3

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -925,10 +925,10 @@ function mongoCmd()
 
 # ------------------------------------------------------------------------------
 #
-# mongoCmd2 - like mongoCmd but showing all the output, not just the last line.
-#             Meant to be used in conjunction with 'grep'
+# mongoCmdLong - like mongoCmd but showing all the output, not just the last line.
+#                Meant to be used in conjunction with 'grep'
 #
-function mongoCmd2()
+function mongoCmdLong()
 {
   host="${CB_DATABASE_HOST}"
   if [ "$host" == "" ]
@@ -1265,7 +1265,7 @@ export -f accumulatorReset
 export -f orionCurl
 export -f dbInsertEntity
 export -f mongoCmd
-export -f mongoCmd2
+export -f mongoCmdLong
 export -f vMsg
 export -f dMsg
 export -f valgrindSleep

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -139,7 +139,7 @@ function usage()
   echo "$empty [--noCache (force broker to be started with the option --noCache)]"
   echo "$empty [--cache (force broker to be started without the option --noCache)]"
   echo "$empty [--noThreadpool (do not use a threadpool, unless specified by a test case. If not set, a thread pool of 200:20 is used by default in test cases which do not set notificationMode options)]"
-  echo "$empty [--xbroker (use an external broker)]"
+  echo "$empty [--xbroker (use external brokers, i.e. this script will *not* start any brokers, including context providers)]"
   echo "$empty [ <directory or file> ]*"
   echo
   echo "* Please note that if a directory is passed as parameter, its entire path must be given, not only the directory-name"

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -139,6 +139,7 @@ function usage()
   echo "$empty [--noCache (force broker to be started with the option --noCache)]"
   echo "$empty [--cache (force broker to be started without the option --noCache)]"
   echo "$empty [--noThreadpool (do not use a threadpool, unless specified by a test case. If not set, a thread pool of 200:20 is used by default in test cases which do not set notificationMode options)]"
+  echo "$empty [--xbroker (use an external broker)]"
   echo "$empty [ <directory or file> ]*"
   echo
   echo "* Please note that if a directory is passed as parameter, its entire path must be given, not only the directory-name"
@@ -244,6 +245,7 @@ toIx=0
 ixList=""
 noCache=""
 threadpool=ON
+xbroker=off
 
 vMsg "parsing options"
 while [ "$#" != 0 ]
@@ -264,6 +266,7 @@ do
   elif [ "$1" == "--noCache" ];      then noCache=ON;
   elif [ "$1" == "--cache" ];        then noCache=OFF;
   elif [ "$1" == "--noThreadpool" ]; then threadpool=OFF;
+  elif [ "$1" == "--xbroker" ];      then xbroker=ON;
   else
     if [ "$dirOrFile" == "" ]
     then
@@ -302,6 +305,8 @@ then
   export CB_THREADPOOL=$threadpool
 fi
 
+
+
 # ------------------------------------------------------------------------------
 #
 # Check unmatching --dir and 'parameter that is a directory' AND
@@ -311,6 +316,7 @@ fi
 # 2. Else, it must be a file, or a filter.
 #    If the 
 #
+singleFile=No
 if [ "$dirOrFile" != "" ]
 then
   vMsg dirOrFile: $dirOrFile
@@ -334,6 +340,7 @@ then
       exit 1
     fi
 
+    singleFile=Yes
     #
     # If just a filename is given, keep the directory as is.
     # If a whole path is given, use the directory-part as directory and the file-part as filter
@@ -360,6 +367,20 @@ then
   fi
 fi
 
+#
+# The option of running against an external broker "--xbroker" only works (for now, at least) with a single test case.
+# Strange things may happen (due to the state inside the broker) if more that one test case are launched.
+# This check avoid this situation.
+#
+# If in the future we want to be able to run more than one test case against an external broker, we'd need to make sure
+# that each test case undoes all internal state inside the external broker. E.g. delete subscriptions, entities, etc.
+#
+if [ "$singleFile" == "No" ] && [ "$xbroker" == "ON" ]
+then
+    echo "External broker can only be used with individual test cases"
+    exit 1
+fi
+
 vMsg directory: $dir
 vMsg testFilter: $testFilter
 vMsg "Script in $SCRIPT_HOME"
@@ -371,6 +392,18 @@ vMsg "Script in $SCRIPT_HOME"
 # Other global variables
 #
 toBeStopped=false
+
+
+
+# ------------------------------------------------------------------------------
+#
+# xbroker - if this CLI is set, then the broker is not to be started as part of
+#           the test suite - another broker is assumed to be running already
+#
+if [ "$xbroker" == "ON" ]
+then
+    export CB_WITH_EXTERNAL_BROKER=1
+fi
 
 
 


### PR DESCRIPTION
Two issues in this PR, one small one:
- Made the functional test suite able to run single test cases against an external broker

And the bigger one, allowing for storing registrations with wildcard in entity id in the database.
For some strange reason this was not implemented when POST /v2/registrations was introduced.

One simple functest supplied to verify that a registration with entity id as wildcard is correctly stored in the DB + correctly returned by GET /v2/registrations.
