### PR TITLE
FIX upgrade Flask to 1.0.2 in ci dockerfile

### DIFF
--- a/ci/rpm7/build-dep.sh
+++ b/ci/rpm7/build-dep.sh
@@ -38,7 +38,6 @@ yum -y install \
   mongodb-org \
   mongodb-org-shell \
   nc \
-  pyOpenSSL \
   python \
   python-pip \
   rpm-build \
@@ -87,6 +86,7 @@ cd /opt \
 && virtualenv /opt/ft_env \
 && . /opt/ft_env/bin/activate \
 && pip install Flask==1.0.2 \
+&& pip install pyOpenSSL==19.0.0 \
 && deactivate
 
 ldconfig

--- a/ci/rpm7/build-dep.sh
+++ b/ci/rpm7/build-dep.sh
@@ -78,7 +78,7 @@ curl -L https://nexus.lab.fiware.org/repository/raw/public/storage/gmock-1.5.0.t
 #  && rm -Rf /opt/mosquitto-1.5
 
 # CentOS 7 installs Flask==0.10.1 which depends on Werkzeug==0.9.1. There is a bug
-# in Werkzeug which makes an empty content-length header to appear in the accumulator-server.py
+# in Werkzeug which makes an empty content-length header appear in the accumulator-server.py
 # dumps. The bug is fixed in Werkzeug==0.11.16. Thus, we override the system setting,
 # installing in the virtual env Flask==1.0.2, which depends on Werkzeug==0.15.2
 cd /opt \

--- a/ci/rpm7/build-dep.sh
+++ b/ci/rpm7/build-dep.sh
@@ -40,7 +40,7 @@ yum -y install \
   nc \
   pyOpenSSL \
   python \
-  python-flask \
+  python-pip \
   rpm-build \
   scons \
   tar \
@@ -77,6 +77,17 @@ curl -L https://nexus.lab.fiware.org/repository/raw/public/storage/gmock-1.5.0.t
 #  && make \
 #  && make install \
 #  && rm -Rf /opt/mosquitto-1.5
+
+# CentOS 7 installs Flask==0.10.1 which depends on Werkzeug==0.9.1. There is a bug
+# in Werkzeug which makes an empty content-length header to appear in the accumulator-server.py
+# dumps. The bug is fixed in Werkzeug==0.11.16. Thus, we override the system setting,
+# installing in the virtual env Flask==1.0.2, which depends on Werkzeug==0.15.2
+cd /opt \
+&& pip install virtualenv\
+&& virtualenv /opt/ft_env \
+&& . /opt/ft_env/bin/activate \
+&& pip install Flask==1.0.2 \
+&& deactivate
 
 ldconfig
 

--- a/ci/rpm7/makefile
+++ b/ci/rpm7/makefile
@@ -87,7 +87,7 @@ install_functional: install
 functional:
 	@echo '------------------------------------- make functional ----------------------------------'
 
-	# ft_env needed for accumulator-server.py. Very import to "chain" the two commands with '; \'
+	# ft_env needed for accumulator-server.py. Very important to "chain" the two commands with '; \'
 	# otherwise it seems testHarness.sh doesn't get the venv and it uses default Python in the system
 	. /opt/ft_env/bin/activate ; \
 	CB_DIFF_TOOL="diff -u" ./test/functionalTest/testHarness.sh

--- a/ci/rpm7/makefile
+++ b/ci/rpm7/makefile
@@ -90,7 +90,7 @@ functional:
 	# ft_env needed for accumulator-server.py. Very import to "chain" the two commands with '; \'
 	# otherwise it seems testHarness.sh doesn't get the venv and it uses default Python in the system
 	. /opt/ft_env/bin/activate ; \
-	./test/functionalTest/testHarness.sh --stopOnError
+	CB_DIFF_TOOL="diff -u" ./test/functionalTest/testHarness.sh
 
 style:
 	@echo '------------------------------------- make style ---------------------------------------'

--- a/ci/rpm7/makefile
+++ b/ci/rpm7/makefile
@@ -87,8 +87,9 @@ install_functional: install
 functional:
 	@echo '------------------------------------- make functional ----------------------------------'
 
-	# ft_env needed for accumulator-server.py
-	. /opt/ft_env/bin/activate
+	# ft_env needed for accumulator-server.py. Very import to "chain" the two commands with '; \'
+	# otherwise it seems testHarness.sh doesn't get the venv and it uses default Python in the system
+	. /opt/ft_env/bin/activate ; \
 	./test/functionalTest/testHarness.sh --stopOnError
 
 style:

--- a/ci/rpm7/makefile
+++ b/ci/rpm7/makefile
@@ -45,6 +45,7 @@ prepare:
 
 	./scripts/build/compileInfo.sh --release
 	. scripts/testEnv.sh
+	. /opt/ft_env/bin/activate
 
 install:
 	@echo '------------------------------------- install ------------------------------------------'

--- a/ci/rpm7/makefile
+++ b/ci/rpm7/makefile
@@ -45,7 +45,6 @@ prepare:
 
 	./scripts/build/compileInfo.sh --release
 	. scripts/testEnv.sh
-	. /opt/ft_env/bin/activate
 
 install:
 	@echo '------------------------------------- install ------------------------------------------'
@@ -88,6 +87,8 @@ install_functional: install
 functional:
 	@echo '------------------------------------- make functional ----------------------------------'
 
+	# ft_env needed for accumulator-server.py
+	. /opt/ft_env/bin/activate
 	./test/functionalTest/testHarness.sh --stopOnError
 
 style:

--- a/doc/manuals/user/walkthrough_apiv2.md
+++ b/doc/manuals/user/walkthrough_apiv2.md
@@ -123,9 +123,9 @@ command:
 # ./accumulator-server.py --port 1028 --url /accumulate --host ::1 --pretty-print -v
 ```
 
-Note this script requires Flask version 1.0.2, which can be installed using
-`pip install Flask==1.0.2`. In case of conflict with your base operating system
-Python installation, we recommend to use [virtualenv](https://virtualenv.pypa.io/en/latest/).
+Note this script requires Flask version 1.0.2 and pyOpenSSL version 19.0.0, which can be installed using
+`pip install Flask==1.0.2` and `pip install pyOpenSSL==19.0.0`. In case of conflict with your 
+base operating system Python installation, we recommend to use [virtualenv](https://virtualenv.pypa.io/en/latest/).
 
 [Top](#top)
 

--- a/doc/manuals/user/walkthrough_apiv2.md
+++ b/doc/manuals/user/walkthrough_apiv2.md
@@ -123,6 +123,10 @@ command:
 # ./accumulator-server.py --port 1028 --url /accumulate --host ::1 --pretty-print -v
 ```
 
+Note this script requires Flask version 1.0.2, which can be installed using
+`pip install Flask==1.0.2`. In case of conflict with your base operating system
+Python installation, we recommend to use [virtualenv](https://virtualenv.pypa.io/en/latest/).
+
 [Top](#top)
 
 ### Issuing commands to the broker

--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -405,7 +405,7 @@ if __name__ == '__main__':
       # We are using the new way (which is simpler) as we moved to pyOpenSSL 19.0.0. Referecence: Reference: http://stackoverflow.com/questions/28579142/attributeerror-context-object-has-no-attribute-wrap-socket/28590266
       #
       # We need to upgrade pyOpenSSL version due to problems of installing 0.13.1 inside virtualenv. Installing the module
-      # requires to compile some parts and this cause a conflict with base openssl devel libraries in CentOS 7 (solvable by hack, but we want to avoid it)
+      # requires to compile some parts and this causes a conflict with base openssl devel libraries in CentOS 7 (solvable by hack, but we want to avoid it)
       
       #context = SSL.Context(SSL.SSLv23_METHOD)
       #context.use_privatekey_file(key_file)

--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -401,13 +401,16 @@ if __name__ == '__main__':
     # makes the calle os.path.isfile(pidfile) return True, even if the file doesn't exist. Thus,
     # use debug=True below with care :)
     if (https):
-      # According to http://stackoverflow.com/questions/28579142/attributeerror-context-object-has-no-attribute-wrap-socket/28590266, the
-      # original way of using context is deprecated. New way is simpler. However, we are still testing this... some environments
-      # fail in some configurations (the current one is an attempt to make this to work at jenkins)
-      context = SSL.Context(SSL.SSLv23_METHOD)
-      context.use_privatekey_file(key_file)
-      context.use_certificate_file(cert_file)
-      #context = (cert_file, key_file)
+      # Commented lines correspond to the way of using context with pyOpenSSL 0.13.1 (the one that comes with system Python in CentOS 7).
+      # We are using the new way (which is simpler) as we moved to pyOpenSSL 19.0.0. Referecence: Reference: http://stackoverflow.com/questions/28579142/attributeerror-context-object-has-no-attribute-wrap-socket/28590266
+      #
+      # We need to upgrade pyOpenSSL version due to problems of installing 0.13.1 inside virtualenv. Installing the module
+      # requires to compile some parts and this cause a conflict with base openssl devel libraries in CentOS 7 (solvable by hack, but we want to avoid it)
+      
+      #context = SSL.Context(SSL.SSLv23_METHOD)
+      #context.use_privatekey_file(key_file)
+      #context.use_certificate_file(cert_file)
+      context = (cert_file, key_file)
       app.run(host=host, port=port, debug=False, ssl_context=context)
     else:
       app.run(host=host, port=port)

--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -37,6 +37,7 @@ __author__ = 'fermin'
 # * This script requires at least Flask 1.0.2, which comes with Werkzeug 0.15.2. There is a bug
 #   in Werkzeug < 0.11.16 that makes empty "content-length" headers to appear for some request
 #   in the accumulator dump
+# * This script also depends on pyOpenSSL 19.0.0
 
 
 from OpenSSL import SSL

--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 # Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
 #

--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -34,6 +34,10 @@ __author__ = 'fermin'
 #   in the past)
 # * Curl users: use -H "Content-Type: application/xml"  for XML payload (the default:
 #   "Content-Type: application/x-www-form-urlencoded" has been problematic in the pass)
+# * This script requires at least Flask 1.0.2, which comes with Werkzeug 0.15.2. There is a bug
+#   in Werkzeug < 0.11.16 that makes empty "content-length" headers to appear for some request
+#   in the accumulator dump
+
 
 from OpenSSL import SSL
 from flask import Flask, request, Response

--- a/test/functionalTest/README.md
+++ b/test/functionalTest/README.md
@@ -1,12 +1,12 @@
 ## How to run functional tests
 
-## Prerequisites
+### Prerequisites
 
 * The `contextBroker` binary is in execution path
 * MongoDB database is up and running
 * accumulator-server.py is correctly installed and available in the execution path (see specific section below)
 
-## How to install accumulator-server.py
+### How to install accumulator-server.py
 
 We recommend to use Python [virtualenv](https://virtualenv.pypa.io/en/latest) to install the required dependencies to avoid any potential conflict with operating system Python installation. So, first create your virtual env (named for instance `ft_env`):
 
@@ -42,7 +42,7 @@ accumulator-server.py -u
 
 **IMPORTANT:** remember to activate the virtual env (`. /path/to/ft_env/bin/activate`) before running functional tests
 
-## Run functional tests
+### Run functional tests
 
 The easiest way is running just:
 

--- a/test/functionalTest/README.md
+++ b/test/functionalTest/README.md
@@ -1,6 +1,55 @@
 ## How to run functional tests
 
-TBD
+## Prerequisites
+
+* The `contextBroker` binary is in execution path
+* MongoDB database is up and running
+* accumulator-server.py is correctly installed and available in the execution path (see specific section below)
+
+## How to install accumulator-server.py
+
+We recommend to use Python [virtualenv](https://virtualenv.pypa.io/en/latest) to install the required dependencies to avoid any potential conflict with operating system Python installation. So, first create your virtual env (named for instance `ft_env`):
+
+```
+pip install virtualenv  # if you doesn't have virtualenv itself previously installed
+virtualenv /path/to/ft_env
+```
+
+Then activate the virtual env:
+
+```
+. /path/to/ft_env/bin/activate
+```
+
+Next install accumulator-server.py depencencies:
+
+```
+pip install Flask==1.0.2
+pip install pyOpenSSL==19.0.0
+```
+
+Next, install the accumulator-server.py script itself:
+
+```
+make install_scripts  # add INSTALL_DIR=... if you need to install in an specific place
+```
+
+and check that you have it in the path:
+
+```
+accumulator-server.py -u
+```
+
+**IMPORTANT:** remember to activate the virtual env (`. /path/to/ft_env/bin/activate`) before running functional tests
+
+## Run functional tests
+
+The easiest way is running just:
+
+```
+cd test/functionalTest
+./testHarness.sh
+```
 
 ## Known issues
 

--- a/test/functionalTest/README.md
+++ b/test/functionalTest/README.md
@@ -11,7 +11,7 @@
 We recommend to use Python [virtualenv](https://virtualenv.pypa.io/en/latest) to install the required dependencies to avoid any potential conflict with operating system Python installation. So, first create your virtual env (named for instance `ft_env`):
 
 ```
-pip install virtualenv  # if you doesn't have virtualenv itself previously installed
+pip install virtualenv  # if you don't have virtualenv itself previously installed
 virtualenv /path/to/ft_env
 ```
 
@@ -31,7 +31,7 @@ pip install pyOpenSSL==19.0.0
 Next, install the accumulator-server.py script itself:
 
 ```
-make install_scripts  # add INSTALL_DIR=... if you need to install in an specific place
+make install_scripts  # add INSTALL_DIR=... if you need to install in a specific place
 ```
 
 and check that you have it in the path:

--- a/test/functionalTest/cases/2015_notification_templates/notification_templates_cache_refresh.test
+++ b/test/functionalTest/cases/2015_notification_templates/notification_templates_cache_refresh.test
@@ -130,13 +130,13 @@ Date: REGEX(.*)
 ============================================
 PATCH http://127.0.0.1:REGEX(\d+)/notify?a1=a1&a3=13&a2=a2&type=Thing&id=E1
 Fiware-Servicepath: /
-Ngsiv2-Attrsformat: custom
+A3: 13
 Entity-Id: E1
 Content-Length: 38
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
-Accept: application/json
+Ngsiv2-Attrsformat: custom
 Host: 127.0.0.1:REGEX(\d+)
-A3: 13
+Accept: application/json
 A2: a2
 A1: a1
 Entity-Type: Thing

--- a/test/functionalTest/cases/2015_notification_templates/notification_templates_many_notifications.test
+++ b/test/functionalTest/cases/2015_notification_templates/notification_templates_many_notifications.test
@@ -384,13 +384,13 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 =======================================
 PUT http://127.0.0.1:REGEX(\d+)/notify?a3=3&type=T3&id=E1
 Fiware-Servicepath: /
-Ngsiv2-Attrsformat: custom
+A3: 3
 Entity-Id: E1
 Content-Length: 33
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
-Accept: application/json
+Ngsiv2-Attrsformat: custom
 Host: 127.0.0.1:REGEX(\d+)
-A3: 3
+Accept: application/json
 Entity-Type: T3
 Content-Type: text/plain; charset=utf-8
 Fiware-Correlator: REGEX([0-9a-f\-]{36})


### PR DESCRIPTION
We have recently found a bug in default Flask version installed by default in CentOS7 which impact in the NGSIv2 query forwarding functionality (Flask is being used by the accumulator-server.py script using in functional tests). This PR upgrades Flask version to 1.0.2, which doesnt' have the bug, using virtualenv.

@caa06d9c could you have a look and provide feedback and/or LGTM, pls? Given this PR touches the ci stuff you authored, I think you are the most appropiate reviewer :)