### PR TITLE
FIX direct_https_notifications_no_accept_selfsigned.test to cover both CB_THREADPOOL posibilities

### DIFF
--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
@@ -89,7 +89,13 @@ echo
 
 echo "04. Look in the CB log for the warning about cert not accepted"
 echo "=============================================================="
-grep "Peer certificate cannot be authenticated" /tmp/contextBroker.log | grep "notification failure" | awk -F 'notification failure for queue worker: ' '{print $2}'
+
+LINE1=$(grep "Peer certificate cannot be authenticated" /tmp/contextBroker.log | grep "notification failure" | awk -F 'notification failure for queue worker: ' '{print $2}')
+LINE2=$(grep "Peer certificate cannot be authenticated" /tmp/contextBroker.log | grep "notification failure" | awk -F 'notification failure for sender-thread: ' '{print $2}')
+
+# Depending CB_THREADPOOL=ON|OFF, either LINE1 or LINE2 has the text we are looking for but not both at the same time
+echo $LINE1$LINE2
+
 echo
 echo
 


### PR DESCRIPTION
Current .test works ok with normal run of test harness (i.e. just `testHarness.sh`), which is the one done by travis for instance.

However, one of our jenkins instances does two passes, one with just `testHarness.sh` and another adding CB_NO_CACHE=ON CB_THREADPOOL=OFF. The latter (CB_THREADPOOL=OFF) makes this .test to fail.

I don't like the fix too much (it's a kind of hack) so any other suggestion fixing the problem is welcome.