### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Fiware-Orion
 site_url: https://fiware-orion.readthedocs.org
-repo_url: https://github.com/telefonicaid/fiware-orion.git
+repo_url: https://github.com/telefonicaid/fiware-orion
 site_description: Orion Context Broker Documentation
 docs_dir: doc/manuals
 site_dir: html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Fiware-Orion
 site_url: https://fiware-orion.readthedocs.org
 repo_url: https://github.com/telefonicaid/fiware-orion
 site_description: Orion Context Broker Documentation
-docs_dir: docs
+docs_dir: doc
 site_dir: html
 markdown_extensions: [toc,fenced_code]
 use_directory_urls: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,9 @@ site_name: Fiware-Orion
 site_url: https://fiware-orion.readthedocs.org
 repo_url: https://github.com/telefonicaid/fiware-orion
 site_description: Orion Context Broker Documentation
-docs_dir: doc
+docs_dir: doc/manuals
 site_dir: html
+edit_uri: edit/master/doc/manuals
 markdown_extensions: [toc,fenced_code]
 use_directory_urls: false
 theme: readthedocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Fiware-Orion
 site_url: https://fiware-orion.readthedocs.org
 repo_url: https://github.com/telefonicaid/fiware-orion
 site_description: Orion Context Broker Documentation
-docs_dir: doc/manuals
+docs_dir: docs
 site_dir: html
 markdown_extensions: [toc,fenced_code]
 use_directory_urls: false


### PR DESCRIPTION
As in this repo "telefonicaid/fiware-cygnus" there is a mistake in yml file, for more info look at the pull request:
https://github.com/telefonicaid/fiware-cygnus/pull/1639
Links to GitHub in https://fiware-orion.readthedocs.io are broken for this reason.
Repo URL must be:
repo_url: https://github.com/telefonicaid/fiware-orion
Instead of
repo_url: https://github.com/telefonicaid/fiware-orion.git