### PR TITLE
FIX error reported by valgrind

### DIFF
--- a/src/lib/rest/ConnectionInfo.h
+++ b/src/lib/rest/ConnectionInfo.h
@@ -120,6 +120,7 @@ public:
     port                   (0),
     ip                     (""),
     apiVersion             (V1),
+    requestType            (NoRequest),
     inCompoundValue        (false),
     compoundValueP         (NULL),
     compoundValueRoot      (NULL),


### PR DESCRIPTION
Solves the folllowing errors reported by valgrind check:

```
6 test cases show valgrind errors:
  1033: fwd_v2_query_with_contextElement_providingApplicationList shows 21 valgrind errors
  1044: fwd_v2_ngsiv2_query_double_forward shows 7 valgrind errors
  1054: fwd_v2_ngsiv2_query_one_forward_query shows 7 valgrind errors
  1055: fwd_v2_ngsiv2_query_shadowed_attribute shows 7 valgrind errors
  1069: forwards_with_providers shows 49 valgrind errors
  1070: fwd_ngsv1_ngsv2_interoperability shows 7 valgrind errors
```