### PR TITLE
Fixing broken links, whitespace & etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License badge](https://img.shields.io/github/license/telefonicaid/fiware-orion.svg)](https://opensource.org/licenses/AGPL-3.0)
 [![Docker badge](https://img.shields.io/docker/pulls/fiware/orion.svg)](https://hub.docker.com/r/fiware/orion/)
 [![SOF support badge](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/orion.svg)](http://stackoverflow.com/questions/tagged/fiware-orion)
-[![NGSI v2](https://nexus.lab.fiware.org/repository/raw/public/badges/specifications/ngsiv2.svg)](http://fiware.github.io/context.Orion/api/v2/stable/)
+[![NGSI v2](https://nexus.lab.fiware.org/repository/raw/public/badges/specifications/ngsiv2.svg)](http://fiware-ges.github.io/orion/api/v2/stable/)
 <br>
 [![Documentation badge](https://img.shields.io/readthedocs/fiware-orion.svg)](https://fiware-orion.rtfd.io)
 [![Build badge](https://img.shields.io/travis/telefonicaid/fiware-orion.svg)](https://travis-ci.org/telefonicaid/fiware-orion/)
@@ -19,8 +19,8 @@ Broker GE, providing an
 interface. Using this interface, clients can do several operations:
 
 -   Query context information. The Orion Context Broker stores context
-    information updated from applications, so queries are resolved based 
-    on that information. Context information consists on *entities* (e.g. a car) 
+    information updated from applications, so queries are resolved based
+    on that information. Context information consists on *entities* (e.g. a car)
     and their *attributes* (e.g. the speed or location of the car).
 -   Update context information, e.g. send updates of temperature
 -   Get notified when changes on context information take place (e.g. the
@@ -78,13 +78,13 @@ of the FIWARE platform.
 Orion Context Broker allows you to manage the entire lifecycle of context
 information including updates, queries, registrations and subscriptions. It is
 an NGSIv2 server implementation to manage context information and its availability.
-Context information consists on *entities* (e.g. a car) and their *attributes* 
+Context information consists on *entities* (e.g. a car) and their *attributes*
 (e.g. the speed or location of the car).
 
-Using the Orion Context Broker, you are able to create context elements and manage 
-them through updates and queries. In addition, you can subscribe to context 
-information so when some condition occurs (e.g. the context elements have changed) 
-you receive a notification. These usage scenarios and the Orion Context Broker 
+Using the Orion Context Broker, you are able to create context elements and manage
+them through updates and queries. In addition, you can subscribe to context
+information so when some condition occurs (e.g. the context elements have changed)
+you receive a notification. These usage scenarios and the Orion Context Broker
 features are described in this documentation.
 
 If this is your first contact with the Orion Context Broker, it is highly
@@ -276,18 +276,18 @@ version 3](./LICENSE).
 
 ### Are there any legal issues with AGPL 3.0? Is it safe for me to use?
 
-There is absolutely no problem in using a product licensed under AGPL 3.0. Issues with GPL 
-(or AGPL) licenses are mostly related with the fact that different people assign different 
+There is absolutely no problem in using a product licensed under AGPL 3.0. Issues with GPL
+(or AGPL) licenses are mostly related with the fact that different people assign different
 interpretations on the meaning of the term “derivate work” used in these licenses. Due to this,
 some people believe that there is a risk in just _using_ software under GPL or AGPL licenses
 (even without _modifying_ it).
 
-For the avoidance of doubt, the owners of this software licensed under an AGPL-3.0 license  
+For the avoidance of doubt, the owners of this software licensed under an AGPL-3.0 license
 wish to make a clarifying public statement as follows:
 
 > Please note that software derived as a result of modifying the source code of this
-> software in order to fix a bug or incorporate enhancements is considered a derivative 
-> work of the product. Software that merely uses or aggregates (i.e. links to) an otherwise 
+> software in order to fix a bug or incorporate enhancements is considered a derivative
+> work of the product. Software that merely uses or aggregates (i.e. links to) an otherwise
 > unmodified version of existing software is not considered a derivative work, and therefore
 > it does not need to be released as under the same license, or even released as open source.
 

--- a/doc/manuals.jp/quick_start_guide.md
+++ b/doc/manuals.jp/quick_start_guide.md
@@ -3,7 +3,7 @@
 Orion Context Broker クイックスタートガイド
 Orion Context Broker へようこそ！この簡単なガイドでは、簡単な方法で [FIWARE Lab](https://lab.fiware.org) (FIWARE Foundation が所有し、管理) の Orion Context Broker グローバルインスタンスで作業するためのいくつかの初期ステップについて説明します。
 
-Orion Context Broker は、[FIWARE NGSI バージョン2 API](http://fiware.github.io/context.Orion/api/v2/stable/) を実装しています。そのような API の良い学習リソースは、[NGSI version 2 Cookbook](http://fiware.github.io/context.Orion/api/v2/stable/cookbook/) です。
+Orion Context Broker は、[FIWARE NGSI バージョン2 API](http://fiware-ges.github.io/orion/api/v2/stable/) を実装しています。そのような API の良い学習リソースは、[NGSI version 2 Cookbook](http://fiware-ges.github.io/orion/api/v2/stable/cookbook/) です。
 
 まず、FIWARE Lab にアカウントが必要です。もし、アカウントがなければ、[次のリンク](https://account.lab.fiware.org/sign_up)で登録してください。無料ですが、有効なメールアドレスが必要です。このアカウントを使用すると、Orion への REST API コールで使用する有効な認証トークンを取得できます。そのトークンを取得するには、`token_script.sh` スクリプトを取得し、パラメータとして `orion-gi` を使用して実行します (`orion-gi` は FIWARE インフラストラクチャの Orion グローバル・インスタンスを意味します)。スクリプトで要求されたら、FIWARE Lab のユーザとパスワードを入力してください。**電子メールのドメインを含む完全なユーザ名を使用する必要があります**。例えば、電子メールが "foo@gmail.com" の場合は "foo" だけでなく、"foo@gmail.com" です :
 
@@ -18,21 +18,21 @@ Orion Context Broker は、[FIWARE NGSI バージョン2 API](http://fiware.gith
 
 取得した認証トークンが AUTH_TOKEN シェル変数にあると仮定します。次に、サンタンデールの都市センサ (特に騒音計) からリアルタイム情報を検索してみましょう :
 
-``` 
+```
 curl orion.lab.fiware.org:1026/v2/entities/urn:smartsantander:testbed:357 \
    -X GET -s -S --header 'Accept: application/json' \
    --header  "X-Auth-Token: $AUTH_TOKEN" | python -mjson.tool
-``` 
+```
 
 最後の測定時間 (TimeInstant), サウンドレベル (sound), センサバッテリ充電 (batteryCharge), センサ位置 (Latitud と Longitud ... これらの最後のものはスペイン語で申し訳ありません)の JSON ドキュメントを取得します。センサは "urn:smartsantander:testbed:357" で識別されます。
 
 道路交通に関連するもう1つのセンサをクエリしましょう :
 
-``` 
+```
 curl orion.lab.fiware.org:1026/v2/entities/urn:smartsantander:testbed:3332 \
    -X GET -s -S  --header 'Accept: application/json' \
    --header "X-Auth-Token: $AUTH_TOKEN" | python -mjson.tool
-``` 
+```
 
 "urn:smartsantander:testbed:3332" センサに関する、返された JSON のデータは次のとおりです :
 
@@ -49,7 +49,7 @@ Orion Context Broker のグローバルインスタンスは、新しいエン�
 
 次のコマンドは、Orion Context Broker に "city_location" 属性と "temperature" 属性を持つエンティティを作成します :
 
-``` 
+```
 curl orion.lab.fiware.org:1026/v2/entities -X POST -s -S \
    --header 'Content-Type: application/json' \
    --header "X-Auth-Token: $AUTH_TOKEN" -d @- <<EOF
@@ -66,15 +66,15 @@ curl orion.lab.fiware.org:1026/v2/entities -X POST -s -S \
   }
 }
 EOF
-``` 
+```
 
 エンティティが存在することを確認するには、パブリック・センサをクエリするのと同じ方法でクエリできます :
 
-``` 
+```
 curl orion.lab.fiware.org:1026/v2/entities/$ID -X GET -s -S \
     --header 'Accept: application/json'\
     --header "X-Auth-Token: $AUTH_TOKEN" | python -mjson.tool
-``` 
+```
 もちろん、温度の変更など、属性の値を変更することもできます :
 
 ```

--- a/doc/manuals/quick_start_guide.md
+++ b/doc/manuals/quick_start_guide.md
@@ -3,9 +3,9 @@
 Welcome to Orion Context Broker! In this brief guide you will find information about some initial steps to work with the
 Orion Context Broker global instance in [FIWARE Lab](https://lab.fiware.org) (owned and managed by the FIWARE Foundation) in an easy way.
 
-Orion Context Broker implements the [FIWARE NGSI version 2](http://fiware.github.io/context.Orion/api/v2/stable/) API.
+Orion Context Broker implements the [FIWARE NGSI version 2](http://fiware-ges.github.io/orion/api/v2/stable/) API.
 A good learning resource for such API is the
-[NGSI version 2 Cookbook](http://fiware.github.io/context.Orion/api/v2/stable/cookbook/).
+[NGSI version 2 Cookbook](http://fiware-ges.github.io/orion/api/v2/stable/cookbook/).
 
 First of all, you need an account in FIWARE Lab, so register for one in [the following link](https://account.lab.fiware.org/sign_up) if you don't have one (it's free, all you need is a valid email adress :). With that account you can obtain a valid authentication token to use in the REST API calls to Orion. To get that token, get and run the `token_script.sh` script using `orion-gi` as parameter (`orion-gi` means Orion global instance at FIWARE infrastructure). Introduce your FIWARE Lab user and password when the scripts ask for it (**note you have to use the complete username, including email domain**, e.g. if you email were "foo@gmail.com" you have to use "foo@gmail.com", not just "foo"):
 
@@ -20,19 +20,19 @@ First of all, you need an account in FIWARE Lab, so register for one in [the fol
 time enough to complete the rest of the steps in this guide ;)
 
 Let's assume that the authentication token you got is in the AUTH_TOKEN shell variable. Now, let's start querying some real-time information from the city sensors of Santander (in particular, a sound level meter):
-``` 
+```
 curl orion.lab.fiware.org:1026/v2/entities/urn:smartsantander:testbed:357 \
    -X GET -s -S --header 'Accept: application/json' \
    --header  "X-Auth-Token: $AUTH_TOKEN" | python -mjson.tool
-``` 
+```
 You will get a JSON document including the time of the last measure (TimeInstant), sound level (sound), sensor battery charge (batteryCharge) and sensor location (Latitud and Longitud... sorry for the Spanish in these last ones ;) for the sensor identified by "urn:smartsantander:testbed:357".
 
 Let's query another sensor, this time one related to road traffic:
-``` 
+```
 curl orion.lab.fiware.org:1026/v2/entities/urn:smartsantander:testbed:3332 \
    -X GET -s -S  --header 'Accept: application/json' \
    --header "X-Auth-Token: $AUTH_TOKEN" | python -mjson.tool
-``` 
+```
 The data you find in the returned JSON about the "urn:smartsantander:testbed:3332" sensor is:
 
 * time of measurement (TimeInstant),
@@ -48,7 +48,7 @@ The Orion Context Broker global instance can also be used to create new entities
 
 The following command creates an entity with the attributes "city_location" and "temperature" in the Orion Context Broker:
 
-``` 
+```
 curl orion.lab.fiware.org:1026/v2/entities -X POST -s -S \
    --header 'Content-Type: application/json' \
    --header "X-Auth-Token: $AUTH_TOKEN" -d @- <<EOF
@@ -65,15 +65,15 @@ curl orion.lab.fiware.org:1026/v2/entities -X POST -s -S \
   }
 }
 EOF
-``` 
+```
 
 In order to check that the entity is there, you can query it the same way you queried the public sensors:
 
-``` 
+```
 curl orion.lab.fiware.org:1026/v2/entities/$ID -X GET -s -S \
     --header 'Accept: application/json'\
     --header "X-Auth-Token: $AUTH_TOKEN" | python -mjson.tool
-``` 
+```
 And you can, of course, modify the values for the attributes, e.g. to modify the temperature:
 
 ```
@@ -97,4 +97,4 @@ curl orion.lab.fiware.org:1026/v2/entities/$ID/attrs/temperature/value \
 
 If you re-run the query command above, you will see that the temperature has changed to 18.4 ºC.
 
-This concludes this small introduction to Orion Context Broker. If you want to know more about this FIWARE enabler (including the API details, how to deploy your own private instances, how to subscribe/receive notifications, geo-localization queries and much more), please go to the [documentation home](http://github.com/telefonicaid/fiware-orion). 
+This concludes this small introduction to Orion Context Broker. If you want to know more about this FIWARE enabler (including the API details, how to deploy your own private instances, how to subscribe/receive notifications, geo-localization queries and much more), please go to the [documentation home](http://github.com/telefonicaid/fiware-orion).


### PR DESCRIPTION
 This PR replaces `fiware.github.io/context.Orion` => `fiware-ges.github.io/orion` since the location of spec has moved.