### PR TITLE
FIX NULL control in some strdup and calloc cases

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: crash when using null character in some NGSIv1 operations
+- Hardening: NULL control in some strdup and calloc cases (very unlikely, but theoretically possible)

--- a/src/lib/jsonParse/jsonParse.cpp
+++ b/src/lib/jsonParse/jsonParse.cpp
@@ -434,6 +434,14 @@ static std::string jsonParse
 static void backslashFix(char* content)
 {
   char* newContent = strdup(content);
+  if (newContent == NULL)
+  {
+    // strdup could return NULL if we run of of memory. Very unlikely, but
+    // theoretically possible (and static code analysis tools complaint about it ;)
+    LM_E(("Runtime Error (strdup returns NULL)"));
+    return;
+  }
+
   int   nIx        = 0;
 
   for (unsigned int ix = 0; ix < strlen(content); ++ix)

--- a/src/lib/logMsg/logMsg.cpp
+++ b/src/lib/logMsg/logMsg.cpp
@@ -2766,8 +2766,12 @@ LmStatus lmReopen(int index)
 
   while (true)
   {
-    char* line = (char*) calloc(1, LINE_MAX);
     int   len;
+    char* line = (char*) calloc(1, LINE_MAX);
+    if (line == NULL)
+    {
+      break;
+    }
 
     if (fgets(line, LINE_MAX, fP) == NULL)
     {
@@ -2870,8 +2874,13 @@ int64_t lmLogLineGet
   char**    allP
 )
 {
+  char* line = (char*) calloc(1, LINE_MAX);
+  if (line == NULL)
+  {
+    return 0;
+  }
+
   static FILE*  fP     = NULL;
-  char*         line   = (char*) calloc(1, LINE_MAX);
   char*         lineP  = line;
   char*         delimiter;
   int64_t       ret;

--- a/src/lib/metricsMgr/MetricsManager.cpp
+++ b/src/lib/metricsMgr/MetricsManager.cpp
@@ -184,6 +184,14 @@ bool MetricsManager::servicePathForMetrics(const std::string& spathIn, std::stri
   }
 
   char* spath  = strdup(spathIn.c_str());
+  if (spath == NULL)
+  {
+    // strdup could return NULL if we run of of memory. Very unlikely, but
+    // theoretically possible (and static code analysis tools complaint about it ;)
+    LM_E(("Runtime Error (strdup returns NULL)"));
+    *subServiceP = "";
+    return true;
+  }
   char* toFree = spath;
 
   if (subServiceValid(spath) == false)

--- a/src/lib/parseArgs/paParse.cpp
+++ b/src/lib/parseArgs/paParse.cpp
@@ -485,13 +485,36 @@ int paParse
   if (paProgName == NULL) /* hasn't been set with paConfig */
   {
     progNameCopy = strdup(argV[0]);
+
     progName     = strdup(paProgNameSet(argV[0], level, pid, extra));
+    if (progName == NULL)
+    {
+      // strdup could return NULL if we run of of memory. Very unlikely, but
+      // theoretically possible (and static code analysis tools complaint about it ;)
+      printf("FATAL ERROR: strdup returns NULL");
+      exit(1);
+    }
+
     paProgName   = strdup(progName);
+    if (paProgName == NULL)
+    {
+      // strdup could return NULL if we run of of memory. Very unlikely, but
+      // theoretically possible (and static code analysis tools complaint about it ;)
+      printf("FATAL ERROR: strdup returns NULL");
+      exit(1);
+    }
   }
   else
   {
     progNameCopy = strdup(paProgName);
     progName     = strdup(paProgName);
+    if ((progNameCopy == NULL) || (progName == NULL))
+    {
+      // strdup could return NULL if we run of of memory. Very unlikely, but
+      // theoretically possible (and static code analysis tools complaint about it ;)
+      printf("FATAL ERROR: strdup returns NULL");
+      exit(1);
+    }
   }
 
 

--- a/src/lib/parseArgs/paUsage.cpp
+++ b/src/lib/parseArgs/paUsage.cpp
@@ -251,6 +251,14 @@ void paUsage(void)
   LM_T(LmtPaUsage, ("presenting usage"));
 
   spacePad = (char*) strdup(progName);
+  if (spacePad == NULL)
+  {
+    // strdup could return NULL if we run of of memory. Very unlikely, but
+    // theoretically possible (and static code analysis tools complaint about it ;)
+    printf("FATAL ERROR: strdup returns NULL");
+    exit(1);
+  }
+
   memset(spacePad, 0x20202020, strlen(spacePad));  /* replace progName */
 
   if (paUsageProgName != NULL)
@@ -357,6 +365,14 @@ void paExtendedUsage(void)
 
   snprintf(progNAME, sizeof(progNAME), "Extended Usage: %s ", progName);
   spacePad = (char*) strdup(progNAME);
+  spacePad = (char*) strdup(progName);
+  if (spacePad == NULL)
+  {
+    // strdup could return NULL if we run of of memory. Very unlikely, but
+    // theoretically possible (and static code analysis tools complaint about it ;)
+    printf("FATAL ERROR: strdup returns NULL");
+    exit(1);
+  }
   memset(spacePad, 0x20202020, strlen(spacePad));  /* replace progNAME */
 
   PA_M(("-------------- Preparing list for Extended usage -----------------"));


### PR DESCRIPTION
This PR address the comments done in issue https://github.com/telefonicaid/fiware-orion/issues/3578.

@Enkelmann could you do a pass with your code inspector in the PRs branch to know if the issues detected has been fixed?

@kzangeli it would be great if you could have a look to the fixes in the parseArgs and logMsg. I have tried to fix, but not sure if is right or it could be improved.