### PR TITLE
Default httpTimeout in documentation

### DIFF
--- a/doc/manuals/admin/cli.md
+++ b/doc/manuals/admin/cli.md
@@ -116,7 +116,7 @@ The list of available options is the following:
 -   **-pidpath <pid_file>**. Specifies the file to store the PID of the
     broker process.
 -   **-httpTimeout <interval>**. Specifies the timeout in milliseconds
-    for forwarding messages and for notifications. Default timeout (if nothing is specified)
+    for forwarding messages and for notifications. Default timeout (if this parameter is not specified)
     is 5 seconds.
 -   **-reqTimeout <interval>**. Specifies the timeout in seconds
     for REST connections. Note that the default value is zero, i.e., no timeout (wait forever).

--- a/doc/manuals/admin/cli.md
+++ b/doc/manuals/admin/cli.md
@@ -116,7 +116,8 @@ The list of available options is the following:
 -   **-pidpath <pid_file>**. Specifies the file to store the PID of the
     broker process.
 -   **-httpTimeout <interval>**. Specifies the timeout in milliseconds
-    for forwarding messages and for notifications.
+    for forwarding messages and for notifications. Default timeout (if nothing is specified)
+    is 5 seconds.
 -   **-reqTimeout <interval>**. Specifies the timeout in seconds
     for REST connections. Note that the default value is zero, i.e., no timeout (wait forever).
 -   **-cprForwardLimit**. Maximum number of forwarded requests to Context Providers for a single client request


### PR DESCRIPTION
Based in:

```
/* ****************************************************************************
*
* Default timeout - 5000 milliseconds
*/
#define DEFAULT_TIMEOUT     5000
```

Surprisingly this important default wasn't mentioned in documentation.

@fisuda it would be great if you could also incorporate to the Japanase translation. Thanks!