### PR TITLE
Modifying CMakeList.txt to make build in Debian 9 to work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ IF (${DISTRO} MATCHES "Ubuntu_17.*")
   set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -fno-var-tracking-assignments")
 ELSEIF (${DISTRO} MATCHES "Ubuntu_18.*")
   set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -fno-var-tracking-assignments")
+ELSEIF (${DISTRO} MATCHES "Debian_9.*")
+  set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -fno-var-tracking-assignments")
 ELSE()
   set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -fno-var-tracking-assignments")
 ENDIF ()
@@ -211,10 +213,10 @@ SET (BOOST_MT
 # Static libs common to contextBroker and unitTest binaries
 SET (COMMON_STATIC_LIBS
     microhttpd.a
-    mongoclient.a
 )
 
 SET (DYNAMIC_LIBS
+    mongoclient
     curl
     gnutls
     pthread

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,10 +213,10 @@ SET (BOOST_MT
 # Static libs common to contextBroker and unitTest binaries
 SET (COMMON_STATIC_LIBS
     microhttpd.a
+    mongoclient.a
 )
 
 SET (DYNAMIC_LIBS
-    mongoclient
     curl
     gnutls
     pthread

--- a/src/app/contextBroker/CMakeLists.txt
+++ b/src/app/contextBroker/CMakeLists.txt
@@ -82,7 +82,7 @@ ELSEIF(${DISTRO} STREQUAL "Fedora_20")
 # specify switch
 
 ELSE()  
-  TARGET_LINK_LIBRARIES(contextBroker ${STATIC_LIBS} -lmongoclient ${BOOST} ${DYNAMIC_LIBS})
+  TARGET_LINK_LIBRARIES(contextBroker ${STATIC_LIBS} ${BOOST} ${DYNAMIC_LIBS})
 ENDIF()
 
 IF (${DISTRO} MATCHES "Ubuntu.*")

--- a/src/app/contextBroker/CMakeLists.txt
+++ b/src/app/contextBroker/CMakeLists.txt
@@ -82,7 +82,7 @@ ELSEIF(${DISTRO} STREQUAL "Fedora_20")
 # specify switch
 
 ELSE()  
-  TARGET_LINK_LIBRARIES(contextBroker ${STATIC_LIBS} ${BOOST} ${DYNAMIC_LIBS})
+  TARGET_LINK_LIBRARIES(contextBroker ${STATIC_LIBS} -lmongoclient ${DYNAMIC_LIBS})
 ENDIF()
 
 IF (${DISTRO} MATCHES "Ubuntu.*")

--- a/src/app/contextBroker/CMakeLists.txt
+++ b/src/app/contextBroker/CMakeLists.txt
@@ -82,7 +82,7 @@ ELSEIF(${DISTRO} STREQUAL "Fedora_20")
 # specify switch
 
 ELSE()  
-  TARGET_LINK_LIBRARIES(contextBroker ${STATIC_LIBS} -lmongoclient ${DYNAMIC_LIBS})
+  TARGET_LINK_LIBRARIES(contextBroker ${STATIC_LIBS} -lmongoclient ${BOOST} ${DYNAMIC_LIBS})
 ENDIF()
 
 IF (${DISTRO} MATCHES "Ubuntu.*")

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -249,8 +249,8 @@ MESSAGE("unitTest distro: '${DISTRO}'")
 
 IF(${DISTRO} MATCHES "CentOS_6.*")
   TARGET_LINK_LIBRARIES(unitTest ${STATIC_LIBS} ${BOOST_MT} ${DYNAMIC_LIBS})
-ELSEIF(${DISTRO} MATCHES "Debian_8.*")
-  # It seems that Debian 8.x doesn't like -mt libraries for unit tests... not sure about other Debian versions
+ELSEIF((${DISTRO} MATCHES "Debian_8.*") OR (${DISTRO} MATCHES "Debian_9.*"))
+  # It seems that Debian 8.x/9.x doesn't like -mt libraries for unit tests... not sure about other Debian versions
   TARGET_LINK_LIBRARIES(unitTest ${STATIC_LIBS} ${BOOST} ${DYNAMIC_LIBS})
 ELSEIF(${DISTRO} MATCHES "Debian_.*")
   TARGET_LINK_LIBRARIES(unitTest ${STATIC_LIBS} ${BOOST_MT} ${DYNAMIC_LIBS})


### PR DESCRIPTION
This is a draft of modifications to enable the building of CB in Debian 9.x (test done in Debian 9.11 in particular, after an upgrade from Debian 8) without harming other builds.

Originally I tried to set the old gcc/g++ version in Debian 8 (gcc /g++ 4.9), following the procedures in https://unix.stackexchange.com/questions/334888/how-install-g-4-9-on-debian-stretch and https://askubuntu.com/questions/26498/how-to-choose-the-default-gcc-and-g-version, compiling both mongo driver and CB with it. Compilation step worked, but CB linking failed due to some obscure error related with boost.

Thus, I tried a different strategy: use the official Debian 9 gcc/g++ versión (gcc/g++ 6.0), after some slights modifications in the CMakeLists.txt files included in this PR. Again, I have linking problems with the mongodriver.

I finally solved it using the system libmongoclient-dev package available in Debian 9 (i.e. `apt-get install libmongoclient-dev`). That package uses the same version for the legacy driver recommended for Orion (legacy 1.1.2). With that modification I have been able to build and pass the test harness.

This PR is still WIP due to:

*  I haven't solved yet the build of unit test. It's failing. Surprisingly, in another Debian 9 instance different to the one in which I did the test yesterday (and installed from scratch) I was able (months ago) to build and run the unit test, so I need to analyze the differences.
* In order to align with the official build from sources procedure described in the documentation, it would be better to build mongoclient from sources. Again, in the other Debian 9 "fron scratch" this was solved.