### PR TITLE
FXI some test files to make them more robust

### DIFF
--- a/test/functionalTest/cases/0117_convop_using_standard_ops/getEntityTypes.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/getEntityTypes.test
@@ -348,8 +348,10 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
+#SORT_START
                 "A2",
                 "A1"
+#SORT_END
             ],
             "name": "T1"
         },
@@ -361,8 +363,10 @@ Date: REGEX(.*)
         },
         {
             "attributes": [
-                "A2",
-                "A1"
+#SORT_START
+                "A2"REGEX(,?)
+                "A1"REGEX(,?)
+#SORT_END
             ],
             "name": "T3"
         }
@@ -498,8 +502,10 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
-                "A2",
-                "A1"
+#SORT_START
+                "A2"REGEX(,?)
+                "A1"REGEX(,?)
+#SORT_END
             ],
             "name": "T1"
         },
@@ -511,8 +517,10 @@ Date: REGEX(.*)
         },
         {
             "attributes": [
-                "A2",
-                "A1"
+#SORT_START
+                "A2"REGEX(,?)
+                "A1"REGEX(,?)
+#SORT_END
             ],
             "name": "T3"
         },

--- a/test/functionalTest/cases/0519_ngsi10_entity_types_listing/contextEntityTypes.test
+++ b/test/functionalTest/cases/0519_ngsi10_entity_types_listing/contextEntityTypes.test
@@ -29,6 +29,7 @@ brokerStart CB 0-255 IPV4
 --SHELL--
 
 echo "0. Adding an entity of type 'Room', with two attributes, temperature:celsius and pressure:mmHg"
+echo "=============================================================================================="
 payload='{
   "contextElements": [
     {
@@ -57,18 +58,21 @@ echo
 
 
 echo "1. Listing of Entity Types. Response in JSON"
+echo "============================================"
 orionCurl --url '/v1/contextTypes' 
 echo
 echo
 
 
 echo "2. Listing of Entity Types. Response in JSON, with details=on"
+echo "============================================================="
 orionCurl --url '/v1/contextTypes?details=on' 
 echo
 echo
 
 
 echo "3. Listing of Entity Types. Response in JSON, with details=on and collapse=true"
+echo "==============================================================================="
 orionCurl --url '/v1/contextTypes?details=on&collapse=true'  
 echo
 echo
@@ -76,6 +80,7 @@ echo
 
 --REGEXPECT--
 0. Adding an entity of type 'Room', with two attributes, temperature:celsius and pressure:mmHg
+==============================================================================================
 HTTP/1.1 200 OK
 Content-Length: 258
 Content-Type: application/json
@@ -112,6 +117,7 @@ Date: REGEX(.*)
 
 
 1. Listing of Entity Types. Response in JSON
+============================================
 HTTP/1.1 200 OK
 Content-Length: 115
 Content-Type: application/json
@@ -126,8 +132,10 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
-                "pressure",
-                "temperature"
+#SORT_START
+                "pressure"REGEX(,?)
+                "temperature"REGEX(,?)
+#SORT_END
             ],
             "name": "Room"
         }
@@ -136,6 +144,7 @@ Date: REGEX(.*)
 
 
 2. Listing of Entity Types. Response in JSON, with details=on
+=============================================================
 HTTP/1.1 200 OK
 Content-Length: 136
 Content-Type: application/json
@@ -151,8 +160,10 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
-                "pressure",
-                "temperature"
+#SORT_START
+                "pressure"REGEX(,?)
+                "temperature"REGEX(,?)
+#SORT_END
             ],
             "name": "Room"
         }
@@ -161,6 +172,7 @@ Date: REGEX(.*)
 
 
 3. Listing of Entity Types. Response in JSON, with details=on and collapse=true
+===============================================================================
 HTTP/1.1 200 OK
 Content-Length: 96
 Content-Type: application/json

--- a/test/functionalTest/cases/0676_servicepath_context_types/servicepath_sametype.test
+++ b/test/functionalTest/cases/0676_servicepath_context_types/servicepath_sametype.test
@@ -304,8 +304,10 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
-                "b",
-                "a"
+#SORT_START
+                "b"REGEX(,?)
+                "a"REGEX(,?)
+#SORT_END
             ],
             "name": "T"
         }
@@ -359,8 +361,10 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
-                "c",
-                "b"
+#SORT_START
+                "c"REGEX(,?)
+                "b"REGEX(,?)
+#SORT_END
             ],
             "name": "T"
         }
@@ -413,8 +417,10 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
-                "d",
-                "c"
+#SORT_START
+                "d"REGEX(,?)
+                "c"REGEX(,?)
+#SORT_END
             ],
             "name": "T"
         }
@@ -438,8 +444,10 @@ Date: REGEX(.*)
     "types": [
         {
             "attributes": [
-                "d",
-                "c"
+#SORT_START
+                "d"REGEX(,?)
+                "c"REGEX(,?)
+#SORT_END
             ],
             "name": "T"
         }


### PR DESCRIPTION
The order of attributes in the get types operation may vary from MongoDB version to version (we have detected for instance between 4.0 and 4.2). This PR will make sensible .test more robust regarding this, as the order in the elements in the array doesn't have any semantic difference in the query response.