### PR TITLE
(JP) FIX improve documentation #3600

### DIFF
--- a/doc/manuals.jp/user/ngsiv2_implementation_notes.md
+++ b/doc/manuals.jp/user/ngsiv2_implementation_notes.md
@@ -270,7 +270,8 @@ NGSIv2 仕様では、サブスクリプションの対象となるエンティ�
 
 初期通知は、新しい URI パラメータオプション `skipInitialNotification`
 を使用して設定できます。
-例えば、`POST /v2/subscriptions?options=skipInitialNotification` です。
+例えば、`POST /v2/subscriptions?options=skipInitialNotification` または、
+`PATCH /v2/subscriptions/{subId}?options=skipInitialNotification` です。
 
 [初期通知](initial_notification.md) について、ドキュメントで詳細を
 確認してください。


### PR DESCRIPTION
This PR updates Japanese documentation of skipInitialNotification in ngsiv2_implementation_notes.md.