### PR TITLE
[WIP] New MongoDB driver: PoC with unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@
 PROJECT(contextBroker)
 cmake_minimum_required(VERSION 2.6)
 
+# MongoC++ driver requires C++11
+set (CMAKE_CXX_STANDARD 11)
+
 #
 # DEBUG or RELEASE build ?
 #
@@ -225,6 +228,11 @@ SET (DYNAMIC_LIBS
     uuid
     crypto
     sasl2
+    # FIXME: dynamic library would be more complicated RPM deployments (as we need either include the
+    # .so files in the RPM -which has the problem of conflicting with other RPMs- or rely in an externl
+    # dependecy). However, we have find problems trying to compile with static libraries by the moment...
+    mongocxx
+    bsoncxx
 )
 
 #
@@ -243,6 +251,10 @@ endif (UNIT_TEST)
 # Common include
 #
 include_directories("/usr/include")
+
+# Needed for the new C++ driver
+include_directories("/usr/local/include/bsoncxx/v_noabi")
+include_directories("/usr/local/include/mongocxx/v_noabi")
 
 #
 # Library directories

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -66,6 +66,10 @@
 #include "mongoBackend/compoundResponses.h"
 #include "mongoBackend/MongoGlobal.h"
 
+#ifdef UNIT_TEST
+// FIXME OLD-DR: this eventually would be a global include, not only for UNIT_TEST
+#include <mongocxx/client.hpp>
+#endif
 
 
 /* ****************************************************************************
@@ -366,7 +370,10 @@ bool mongoStart
 
 #ifdef UNIT_TEST
 
-static DBClientBase* connection = NULL;
+
+// FIXME OLD-DR: eventually only connections using new driver will be used
+static DBClientBase* connection        = NULL;
+static mongocxx::client* connectionCxx = NULL;
 
 
 
@@ -377,9 +384,11 @@ static DBClientBase* connection = NULL;
 * For unit tests there is only one connection. This connection is stored right here (DBClientBase* connection) and
 * given out using the function getMongoConnection().
 */
-void setMongoConnectionForUnitTest(DBClientBase* _connection)
+void setMongoConnectionForUnitTest(DBClientBase* _connection, mongocxx::client* _connectionCxx)
 {
-  connection = _connection;
+  // FIXME OLD-DR: eventually only connections using new driver will be used
+  connection    = _connection;
+  connectionCxx = _connectionCxx;
 }
 
 
@@ -416,6 +425,22 @@ DBClientBase* getMongoConnection(void)
   return mongoPoolConnectionGet();
 #endif
 }
+
+
+
+#ifdef UNIT_TEST
+/* ****************************************************************************
+*
+* getMongoConnectionCxx -
+*
+* FIXME OLD-DR: eventually only connections using new driver will be used,
+* not only in UNIT_TEST code
+*/
+mongocxx::client* getMongoConnectionCxx(void)
+{
+  return connectionCxx;
+}
+#endif
 
 
 

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -55,6 +55,10 @@
 #include "mongoBackend/TriggeredSubscription.h"
 
 
+#ifdef UNIT_TEST
+// FIXME OLD-DR: this eventually would be a global include, not only for UNIT_TEST''
+#include <mongocxx/client.hpp>
+#endif
 
 /* ****************************************************************************
 *
@@ -111,7 +115,7 @@ extern bool mongoStart
 
 
 #ifdef UNIT_TEST
-extern void setMongoConnectionForUnitTest(mongo::DBClientBase* _connection);
+extern void setMongoConnectionForUnitTest(mongo::DBClientBase* _connection, mongocxx::client* _connectionCxx);
 #endif
 
 
@@ -141,6 +145,16 @@ extern void setNotifier(Notifier* n);
 */
 extern mongo::DBClientBase* getMongoConnection(void);
 
+#ifdef UNIT_TEST
+/* ****************************************************************************
+*
+* getMongoConnectionCxx -
+*
+* FIXME OLD-DR: eventually only connections using new driver will be used,
+* and not only in UNIT_TEST code
+*/
+extern mongocxx::client* getMongoConnectionCxx(void);
+#endif
 
 
 /* ****************************************************************************

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -224,6 +224,12 @@ include_directories("${PROJECT_SOURCE_DIR}/src/app")
 include_directories("${PROJECT_SOURCE_DIR}/test/unittests")
 include_directories("${PROJECT_SOURCE_DIR}/test")
 
+# Needed for the new C++ driver
+# FIXME OLD-DR: these includes are duplicated in top-level CMakelists.txt. Unify.
+include_directories("/usr/local/include/bsoncxx/v_noabi")
+include_directories("/usr/local/include/mongocxx/v_noabi")
+
+
 # Lib directories
 # ------------------------------------------------------------
 link_directories("/usr/local/lib/")

--- a/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
@@ -2241,7 +2241,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, mongoDbQueryFail)
 
     /* Set MongoDB connection */
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en("E3", "T3");
@@ -2266,7 +2266,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, mongoDbQueryFail)
     EXPECT_EQ(0, res.responseVector.size());
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mock */
     delete connectionMock;

--- a/test/unittests/mongoBackend/mongoQueryContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_test.cpp
@@ -3815,7 +3815,7 @@ TEST(mongoQueryContextRequest, mongoDbQueryFail)
 
     /* Set MongoDB connection */
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Forge the request (from "inside" to "outside") */
     EntityId en("E1", "T1", "false");
@@ -3839,7 +3839,7 @@ TEST(mongoQueryContextRequest, mongoDbQueryFail)
     res.contextElementResponseVector.release();
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     delete connectionMock;
     utExit();

--- a/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
@@ -897,7 +897,7 @@ TEST(mongoQueryTypes, queryAllDbException)
 
   /* Set MongoDB connection */
   DBClientBase* connectionDb = getMongoConnection();
-  setMongoConnectionForUnitTest(connectionMock);
+  setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
   /* Invoke the function in mongoBackend library */
   ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
@@ -919,7 +919,7 @@ TEST(mongoQueryTypes, queryAllDbException)
   EXPECT_EQ(0, res.entityTypeVector.size());
 
   /* Restore real DB connection */
-  setMongoConnectionForUnitTest(connectionDb);
+  setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
   /* Release mock */
   delete connectionMock;
@@ -949,7 +949,7 @@ TEST(mongoQueryTypes, queryAllGenericException)
 
   /* Set MongoDB connection */
   DBClientBase* connectionDb = getMongoConnection();
-  setMongoConnectionForUnitTest(connectionMock);
+  setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
   /* Invoke the function in mongoBackend library */
   ms = mongoEntityTypes(&res, "", servicePathVector, uriParams, V1, NULL, false);
@@ -972,7 +972,7 @@ TEST(mongoQueryTypes, queryAllGenericException)
   EXPECT_EQ(0, res.entityTypeVector.size());
 
   /* Restore real DB connection */
-  setMongoConnectionForUnitTest(connectionDb);
+  setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
   /* Release mock */
   delete connectionMock;
@@ -1453,7 +1453,7 @@ TEST(mongoQueryTypes, queryGivenTypeDbException)
 
   /* Set MongoDB connection */
   DBClientBase* connectionDb = getMongoConnection();
-  setMongoConnectionForUnitTest(connectionMock);
+  setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
   /* Invoke the function in mongoBackend library */
   ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
@@ -1477,7 +1477,7 @@ TEST(mongoQueryTypes, queryGivenTypeDbException)
   EXPECT_EQ(0, res.entityType.contextAttributeVector.size());
 
   /* Restore real DB connection */
-  setMongoConnectionForUnitTest(connectionDb);
+  setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
   /* Release mock */
   delete connectionMock;
@@ -1505,7 +1505,7 @@ TEST(mongoQueryTypes, queryGivenTypeGenericException)
 
   /* Set MongoDB connection */
   DBClientBase* connectionDb = getMongoConnection();
-  setMongoConnectionForUnitTest(connectionMock);
+  setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
   /* Invoke the function in mongoBackend library */
   ms = mongoAttributesForEntityType("Car", &res, "", servicePathVector, uriParams, false, V1);
@@ -1529,7 +1529,7 @@ TEST(mongoQueryTypes, queryGivenTypeGenericException)
   EXPECT_EQ(0, res.entityType.contextAttributeVector.size());
 
   /* Restore real DB connection */
-  setMongoConnectionForUnitTest(connectionDb);
+  setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
   /* Release mock */
   delete connectionMock;

--- a/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
@@ -2554,7 +2554,7 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
 
     /* Set MongoDB connection mock (preserving the "actual" connection for later use) */
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoRegisterContext(&req, &res, uriParams);
@@ -2587,7 +2587,7 @@ TEST(mongoRegisterContextRequest, MongoDbUpsertRegistrationFail)
               "- exception: boom!!)", s3);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mock */
     delete connectionMock;

--- a/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
@@ -763,7 +763,7 @@ TEST(mongoRegisterContext_update, MongoDbFindOneFail)
 
     /* Set MongoDB connection mock (preserving "actual" connection for later use) */
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoRegisterContext(&req, &res, uriParams);
@@ -779,7 +779,7 @@ TEST(mongoRegisterContext_update, MongoDbFindOneFail)
               "- exception: boom!!)", res.errorCode.details);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mock */
     delete connectionMock;

--- a/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
@@ -2536,7 +2536,7 @@ TEST(mongoSubscribeContextAvailability, MongoDbInsertFail)
      * The "actual" conneciton is preserved for later use */
     prepareDatabase();
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoSubscribeContextAvailability(&req, &res, uriParams);
@@ -2558,7 +2558,7 @@ TEST(mongoSubscribeContextAvailability, MongoDbInsertFail)
               "- exception: boom!!)", s2);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mocks */
     delete notifierMock;

--- a/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
@@ -4214,7 +4214,7 @@ TEST(mongoSubscribeContext, MongoDbInsertFail)
      * The "actual" conneciton is preserved for later use */
     prepareDatabase();
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoSubscribeContext(&req, &res, "", "", servicePathVector);
@@ -4239,7 +4239,7 @@ TEST(mongoSubscribeContext, MongoDbInsertFail)
               "- exception: boom!!)", s2);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mocks */
     delete notifierMock;

--- a/test/unittests/mongoBackend/mongoUnsubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoUnsubscribeContextAvailability_test.cpp
@@ -212,7 +212,7 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbFindOneFail)
      * The "actual" conneciton is preserved for later use */
     prepareDatabase();
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoUnsubscribeContextAvailability(&req, &res);
@@ -235,7 +235,7 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbFindOneFail)
     ASSERT_EQ(2, count);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mocks */
     delete notifierMock;
@@ -282,7 +282,7 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbRemoveFail)
      * The "actual" conneciton is preserved for later use */
     prepareDatabase();
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoUnsubscribeContextAvailability(&req, &res);
@@ -303,7 +303,7 @@ TEST(mongoUnsubscribeContextAvailability, MongoDbRemoveFail)
     ASSERT_EQ(2, connectionDb->count(SUBSCRIBECONTEXTAVAIL_COLL, BSONObj()));
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mocks */
     delete notifierMock;

--- a/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
@@ -2694,7 +2694,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbFindOneFail)
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoUpdateContextAvailabilitySubscription(&req, &res);
@@ -2709,7 +2709,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbFindOneFail)
               "- exception: boom!!)", res.errorCode.details);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mocks */
     delete notifierMock;
@@ -2762,7 +2762,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbUpdateFail)
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoUpdateContextAvailabilitySubscription(&req, &res);
@@ -2779,7 +2779,7 @@ TEST(mongoUpdateContextAvailabilitySubscription, MongoDbUpdateFail)
               "- exception: boom!!)", res.errorCode.details);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mocks */
     delete notifierMock;

--- a/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
@@ -4383,7 +4383,7 @@ TEST(mongoUpdateContextSubscription, MongoDbFindOneFail)
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
@@ -4398,7 +4398,7 @@ TEST(mongoUpdateContextSubscription, MongoDbFindOneFail)
               "- exception: boom!!)", res.subscribeError.errorCode.details);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mocks */
     delete notifierMock;
@@ -4455,7 +4455,7 @@ TEST(mongoUpdateContextSubscription, MongoDbUpdateFail)
     /* Set MongoDB connection (prepare database first with the "actual" connection object) */
     prepareDatabase();
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Invoke the function in mongoBackend library */
     ms = mongoUpdateContextSubscription(&req, &res, "", "", servicePathVector);
@@ -4477,7 +4477,7 @@ TEST(mongoUpdateContextSubscription, MongoDbUpdateFail)
               "- exception: boom!!)", res.subscribeError.errorCode.details);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mocks */
     delete notifierMock;

--- a/test/unittests/mongoBackend/mongoUpdateContext_2_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_2_test.cpp
@@ -3228,7 +3228,7 @@ TEST(mongoUpdateContextRequest, mongoDbUpdateFail)
 
     /* Set MongoDB connection */
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Forge the request (from "inside" to "outside") */
     Entity* eP = new Entity();
@@ -3268,7 +3268,7 @@ TEST(mongoUpdateContextRequest, mongoDbUpdateFail)
               "- exception: boom!!)", RES_CER_STATUS(0).details);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mocks */
     delete connectionMock;
@@ -3297,7 +3297,7 @@ TEST(mongoUpdateContextRequest, mongoDbQueryFail)
 
     /* Set MongoDB connection */
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Forge the request (from "inside" to "outside") */
     Entity* eP = new Entity();
@@ -3330,7 +3330,7 @@ TEST(mongoUpdateContextRequest, mongoDbQueryFail)
               "- exception: boom!!)", RES_CER_STATUS(0).details);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mock */
     delete connectionMock;

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
@@ -3262,7 +3262,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, DISABLED_MongoDbQueryF
 
     /* Set MongoDB connection */
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Forge the request (from "inside" to "outside") */
     Entity* eP = new Entity();
@@ -3295,7 +3295,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptionsNoCache, DISABLED_MongoDbQueryF
     CHECK_LAST_NOTIFICATION("51307b66f481db11bf860001", 20000000);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mock */
     delete notifierMock;

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
@@ -3319,7 +3319,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, DISABLED_MongoDbQueryFail)
 
     /* Set MongoDB connection */
     DBClientBase* connectionDb = getMongoConnection();
-    setMongoConnectionForUnitTest(connectionMock);
+    setMongoConnectionForUnitTest(connectionMock, getMongoConnectionCxx());
 
     /* Forge the request (from "inside" to "outside") */
     Entity* eP = new Entity();
@@ -3356,7 +3356,7 @@ TEST(mongoUpdateContext_withOnchangeSubscriptions, DISABLED_MongoDbQueryFail)
     EXPECT_EQ(20000000, subP->lastNotificationTime);
 
     /* Restore real DB connection */
-    setMongoConnectionForUnitTest(connectionDb);
+    setMongoConnectionForUnitTest(connectionDb, getMongoConnectionCxx());
 
     /* Release mock */
     delete notifierMock;


### PR DESCRIPTION
This PR is related with issue #3132. It implements a proof-of-concept of new driver usage in a limited part of the Orion code base. In particular, in the code of one unit test files  (mongoUnsubscribeContext_test.cpp):

* Fully adapting 2 tests cases
* Partially adapting 2 test cases (which has a part with a DB mock that cannot be converted, as it would require changes in the contextBroker code to use the new driver)

The CMakeLists.txt adaptation in the first commit of the PR (~~a03b0b7~~ bf6d983 ) is based in the feedback provided by @saurabhjangir at https://github.com/telefonicaid/fiware-orion/issues/3132#issuecomment-373478614. Thanks!

This PR it not created with the aim of be merged (in fact, it would fail CI, as the new driver has not been installed in the docker image used for CI), but providing a reference to other works in this line.

-------------

Unit test output:

```
....
[==========] 864 tests from 128 test cases ran. (31899 ms total)
[  PASSED  ] 864 tests.

  YOU HAVE 16 DISABLED TESTS
```

Check of contextBroker binary (note `git_hash` matches the 2nd one in this PR).

``` 
{
"orion" : {
  "version" : "2.3.0-next",
  "uptime" : "0 d, 0 h, 0 m, 9 s",
  "git_hash" : "448c7c5762128ca1765a748f976c79383b2f3716",
  "compile_time" : "nodate",
  "compiled_by" : "fermin",
  "compiled_in" : "menzo",
  "release_date" : "nodate",
  "doc" : "https://fiware-orion.rtfd.io/"
}
}
```

-------------

Receipt to build new MongoDB driver in Debian 9 (as reference):

Links:

* http://mongocxx.org/mongocxx-v3/installation/
* http://mongoc.org/libmongoc/current/installing.html

C driver installation (prerequirement):

```
  # wget https://github.com/mongodb/mongo-c-driver/releases/download/1.16.0/mongo-c-driver-1.16.0.tar.gz
  # tar xfvz mongo-c-driver-1.16.0.tar.gz
  # cd mongo-c-driver-1.16.0
  # mkdir cmake-build
  # cd cmake-build
  # cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF ..   
  # make
  # sudo make install
```

Installation of the new C++ driver itself:

```
  # wget https://github.com/mongodb/mongo-cxx-driver/archive/r3.4.0.tar.gz
  # tar xfvz r3.4.0.tar.gz
  # cd mongo-cxx-driver-r3.4.0/build
  # cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
  # sudo make EP_mnmlstc_core
  # make
  # sudo make install
  # sudo ldconfig
```