### PR TITLE
Mongo connection refactor to make it simpler

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
 - Fix: crash when using null character in some NGSIv1 operations
 - Hardening: NULL control in some strdup and calloc cases (very unlikely, but theoretically possible) (#3578)
 - Hardening: avoid crash in the unlikely case MongoDB get databases operations fails in csubs cache refresh logic (#3456, partly)
+- Hardening: refactor mongo connection logic at startup to make it simpler

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -87,29 +87,6 @@ void mongoInit
 
 
 
-/* ****************************************************************************
-*
-* mongoStart - 
-*/
-extern bool mongoStart
-(
-  const char* host,
-  const char* db,
-  const char* rplSet,
-  const char* username,
-  const char* passwd,
-  const char* mechanism,
-  const char* authDb,
-  bool        dbSSL,
-  bool        _multitenant,
-  double      timeout,
-  int         writeConcern = 1,
-  int         poolSize     = 10,
-  bool        semTimeStat  = false
-);
-
-
-
 #ifdef UNIT_TEST
 extern void setMongoConnectionForUnitTest(mongo::DBClientBase* _connection);
 #endif

--- a/src/lib/mongoBackend/mongoConnectionPool.cpp
+++ b/src/lib/mongoBackend/mongoConnectionPool.cpp
@@ -60,6 +60,7 @@ using mongo::BSONObj;
 using mongo::DBClientBase;
 using mongo::DBClientConnection;
 using mongo::DBClientReplicaSet;
+using mongo::client::Options;
 
 
 
@@ -132,45 +133,12 @@ static DBClientBase* mongoConnect
 
   if (strlen(rplSet) == 0)
   {
-    // Setting the first argument to true is to use autoreconnect
+    // No replica set. Setting the first argument to true is to use autoreconnect
     connection = new DBClientConnection(true);
-
-    //
-    // Not sure of how to generalize the following code,
-    // given that DBClientBase class doesn't have a common connect() method (surprisingly)
-    //
-    for (int tryNo = 0; tryNo < retries; ++tryNo)
-    {
-      try
-      {
-        connected = ((DBClientConnection*) connection)->connect(std::string(host), err);
-      }
-      catch (const std::exception &e)
-      {
-        LM_E(("Database Startup Error (exception: %s)", ((std::string) e.what()).c_str()));
-      }
-
-      if (connected)
-      {
-        break;
-      }
-
-      if (tryNo == 0)
-      {
-        LM_E(("Database Startup Error (cannot connect to mongo - doing %d retries with a %d millisecond interval)",
-              retries,
-              RECONNECT_DELAY));
-      }
-      else
-      {
-        LM_T(LmtMongo, ("Try %d connecting to mongo failed", tryNo));
-      }
-
-      usleep(RECONNECT_DELAY * 1000);  // usleep accepts microseconds
-    }
   }
   else
   {
+    // Replica set
     LM_T(LmtMongo, ("Using replica set %s", rplSet));
 
     // autoReconnect is always on for DBClientReplicaSet connections.
@@ -185,40 +153,38 @@ static DBClientBase* mongoConnect
     }
 
     connection = new DBClientReplicaSet(rplSet, rplSetHosts, timeout);
+  }
 
-    //
-    // Not sure of to generalize the following code,
-    // given that DBClientBase class hasn't a common connect() method (surprisingly)
-    //
-    for (int tryNo = 0; tryNo < retries; ++tryNo)
+  for (int tryNo = 0; tryNo < retries; ++tryNo)
+  {
+    try
     {
-      try
-      {
-        connected = ((DBClientReplicaSet*)connection)->connect();
-      }
-      catch (const std::exception &e)
-      {
-        LM_E(("Database Startup Error (exception: %s)", ((std::string) e.what()).c_str()));
-      }
-
-      if (connected)
-      {
-        break;
-      }
-
-      if (tryNo == 0)
-      {
-        LM_E(("Database Startup Error (cannot connect to mongo - doing %d retries with a %d millisecond interval)",
-              retries,
-              RECONNECT_DELAY));
-      }
-      else
-      {
-        LM_T(LmtMongo, ("Try %d connecting to mongo failed", tryNo));
-      }
-
-      usleep(RECONNECT_DELAY * 1000);  // usleep accepts microseconds
+      connected = (strlen(rplSet) == 0) ?
+            ((DBClientConnection*) connection)->connect(std::string(host), err) : // No repl set
+            ((DBClientReplicaSet*) connection)->connect();                        // Rpls set
     }
+    catch (const std::exception &e)
+    {
+      LM_E(("Database Startup Error (exception: %s)", ((std::string) e.what()).c_str()));
+    }
+
+    if (connected)
+    {
+      break;
+    }
+
+    if (tryNo == 0)
+    {
+      LM_E(("Database Startup Error (cannot connect to mongo - doing %d retries with a %d millisecond interval)",
+            retries,
+            RECONNECT_DELAY));
+    }
+    else
+    {
+      LM_T(LmtMongo, ("Try %d connecting to mongo failed", tryNo));
+    }
+
+    usleep(RECONNECT_DELAY * 1000);  // usleep accepts microseconds
   }
 
   if (connected == false)
@@ -307,6 +273,21 @@ static DBClientBase* mongoConnect
 
 /* ****************************************************************************
 *
+* shutdownClient -
+*/
+static void shutdownClient(void)
+{
+  mongo::Status status = mongo::client::shutdown();
+  if (!status.isOK())
+  {
+    LM_E(("Database Shutdown Error %s (cannot shutdown mongo client)", status.toString().c_str()));
+  }
+}
+
+
+
+/* ****************************************************************************
+*
 * mongoConnectionPoolInit -
 */
 int mongoConnectionPoolInit
@@ -318,6 +299,7 @@ int mongoConnectionPoolInit
   const char*  passwd,
   const char*  mechanism,
   const char*  authDb,
+  bool         dbSSL,
   bool         multitenant,
   double       timeout,
   int          writeConcern,
@@ -325,6 +307,29 @@ int mongoConnectionPoolInit
   bool         semTimeStat
 )
 {
+  // We cannot move status variable declaration outside the if block. That fails at compilation time
+  bool statusOk = false;
+  std::string statusString;
+  if (dbSSL)
+  {
+    mongo::Status status = mongo::client::initialize(Options().setSSLMode(Options::kSSLRequired));
+    statusOk = status.isOK();
+    statusString = status.toString();
+  }
+  else
+  {
+    mongo::Status status = mongo::client::initialize();
+    statusOk = status.isOK();
+    statusString = status.toString();
+  }
+
+  if (!statusOk)
+  {
+    LM_E(("Database Startup Error %s (cannot initialize mongo client)", statusString.c_str()));
+    return -1;
+  }
+  atexit(shutdownClient);
+
 #ifdef UNIT_TEST
   /* Basically, we are mocking all the DB pool with a single connection. The getMongoConnection() and mongoReleaseConnection() methods
    * are mocked in similar way to ensure a coherent behaviour */

--- a/src/lib/mongoBackend/mongoConnectionPool.cpp
+++ b/src/lib/mongoBackend/mongoConnectionPool.cpp
@@ -160,8 +160,8 @@ static DBClientBase* mongoConnect
     try
     {
       connected = (strlen(rplSet) == 0) ?
-            ((DBClientConnection*) connection)->connect(std::string(host), err) : // No repl set
-            ((DBClientReplicaSet*) connection)->connect();                        // Rpls set
+            ((DBClientConnection*) connection)->connect(std::string(host), err) :  // No repl set
+            ((DBClientReplicaSet*) connection)->connect();                         // Rpls set
     }
     catch (const std::exception &e)
     {

--- a/src/lib/mongoBackend/mongoConnectionPool.h
+++ b/src/lib/mongoBackend/mongoConnectionPool.h
@@ -52,11 +52,12 @@ extern int mongoConnectionPoolInit
   const char* passwd,
   const char* mechanism,
   const char* authDb,
+  bool        dbSSL,
   bool        multitenant,
   double      timeout,
-  int         writeConcern,
-  int         poolSize,
-  bool        semTimeStat
+  int         writeConcern = 1,
+  int         poolSize = 10,
+  bool        semTimeStat = false
 );
 
 

--- a/test/unittests/testInit.cpp
+++ b/test/unittests/testInit.cpp
@@ -27,6 +27,7 @@
 #include "logMsg/logMsg.h"
 
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongo/client/dbclient.h"
 
 
@@ -62,10 +63,10 @@ void setupDatabase(void)
   /* mongoStart is needed one time to create the connection pool */
   if (mongoStarted == false)
   {
-    /* In fact, the mongoStart() parameters related with the pool, e.g. pool size, are irrelevant,
+    /* In fact, the mongoConnectionPoolInit() parameters related with the pool, e.g. pool size, are irrelevant,
      * given that the connection creation is mocked under UNIT_TEST in the mongoBackend library
      */
-    mongoStart("localhost", "", "", "", "", "", "", false, false, 0, 10);
+    mongoConnectionPoolInit("localhost", "", "", "", "", "", "", false, false, 0, 10);
     mongoStarted = true;
   }
 


### PR DESCRIPTION
Two improvements:

* We have mongInit -> mongoStart -> mongoConnectionPoolInit chain. This has been simplified to mongInit -> mongoConnectionPoolInit. Driver initialization now indluded in mongoConnectionPoolInit
* Factorice common code in mongoConnect for the standalone and rplset cases

This is kind of preparation for a more profound change in the context of #3132 