### PR TITLE
FIX refactor mongo logic

### DIFF
--- a/src/lib/mongoBackend/MongoCommonRegister.cpp
+++ b/src/lib/mongoBackend/MongoCommonRegister.cpp
@@ -42,6 +42,7 @@
 #include "mongoBackend/MongoGlobal.h"
 #include "mongoBackend/TriggeredSubscription.h"
 #include "mongoBackend/connectionOperations.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/safeMongo.h"
 #include "mongoBackend/dbConstants.h"
 #include "mongoBackend/MongoCommonRegister.h"

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -51,6 +51,7 @@
 #include "rest/uriParamNames.h"
 
 #include "mongoBackend/connectionOperations.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/safeMongo.h"
 #include "mongoBackend/dbConstants.h"
 #include "mongoBackend/dbFieldEncoding.h"

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -87,12 +87,6 @@ void mongoInit
 
 
 
-#ifdef UNIT_TEST
-extern void setMongoConnectionForUnitTest(mongo::DBClientBase* _connection);
-#endif
-
-
-
 /* ****************************************************************************
 *
 * getNotifier -
@@ -106,25 +100,6 @@ extern Notifier* getNotifier(void);
 * setNotifier -
 */
 extern void setNotifier(Notifier* n);
-
-
-
-/* ****************************************************************************
-*
-* getMongoConnection -
-*
-* I would prefer to have per-collection methods, to have a better encapsulation, but
-* the Mongo C++ API seems not to work that way
-*/
-extern mongo::DBClientBase* getMongoConnection(void);
-
-
-
-/* ****************************************************************************
-*
-* releaseMongoConnection - 
-*/
-extern void releaseMongoConnection(mongo::DBClientBase* connection);
 
 
 

--- a/src/lib/mongoBackend/connectionOperations.h
+++ b/src/lib/mongoBackend/connectionOperations.h
@@ -54,7 +54,8 @@ extern bool collectionRangedQuery
 (
   mongo::DBClientBase*                   connection,
   const std::string&                     col,
-  const mongo::Query&                    q,
+  const mongo::BSONObj&                  q,
+  const mongo::BSONObj&                  sort,
   int                                    limit,
   int                                    offset,
   std::auto_ptr<mongo::DBClientCursor>*  cursor,

--- a/src/lib/mongoBackend/mongoConnectionPool.cpp
+++ b/src/lib/mongoBackend/mongoConnectionPool.cpp
@@ -543,3 +543,78 @@ const char* mongoConnectionSemGet(void)
 
   return "free";
 }
+
+
+
+#ifdef UNIT_TEST
+
+static DBClientBase* connection = NULL;
+
+
+
+/* ****************************************************************************
+*
+* setMongoConnectionForUnitTest -
+*
+* For unit tests there is only one connection. This connection is stored right here (DBClientBase* connection) and
+* given out using the function getMongoConnection().
+*/
+void setMongoConnectionForUnitTest(DBClientBase* _connection)
+{
+  connection = _connection;
+}
+
+
+
+/* ****************************************************************************
+*
+* mongoInitialConnectionGetForUnitTest -
+*
+* This function is meant to be used by unit tests, to get a connection from the pool
+* and then use that connection, setting it with the function 'setMongoConnectionForUnitTest'.
+* This will set the static variable 'connection' in MongoGlobal.cpp and later 'getMongoConnection'
+* returns that variable (getMongoConnection is used by the entire mongo backend).
+*/
+DBClientBase* mongoInitialConnectionGetForUnitTest(void)
+{
+  return mongoPoolConnectionGet();
+}
+#endif
+
+
+
+/* ****************************************************************************
+*
+* getMongoConnection -
+*
+* I would prefer to have per-collection methods, to have a better encapsulation, but
+* the Mongo C++ API doesn't seem to work that way
+*/
+DBClientBase* getMongoConnection(void)
+{
+#ifdef UNIT_TEST
+  return connection;
+#else
+  return mongoPoolConnectionGet();
+#endif
+}
+
+
+
+/* ****************************************************************************
+*
+* releaseMongoConnection - give back mongo connection to connection pool
+*
+* Older versions of this function planned to use a std::auto_ptr<DBClientCursor>* parameter
+* in order to invoke kill() on it for a "safer" connection releasing. However, at the end
+* it seems that kill() will not help at all (see deetails in https://github.com/telefonicaid/fiware-orion/issues/1568)
+* and after some testing we have checked that the current solution is stable.
+*/
+void releaseMongoConnection(DBClientBase* connection)
+{
+#ifdef UNIT_TEST
+  return;
+#else
+  return mongoPoolConnectionRelease(connection);
+#endif  // UNIT_TEST
+}

--- a/src/lib/mongoBackend/mongoConnectionPool.h
+++ b/src/lib/mongoBackend/mongoConnectionPool.h
@@ -108,4 +108,31 @@ extern const char* mongoConnectionPoolSemGet(void);
 */
 extern const char* mongoConnectionSemGet(void);
 
+
+
+// Higher level functions (previously in MongoGlobal)
+
+#ifdef UNIT_TEST
+extern void setMongoConnectionForUnitTest(mongo::DBClientBase* _connection);
+#endif
+
+
+/* ****************************************************************************
+*
+* getMongoConnection -
+*
+* I would prefer to have per-collection methods, to have a better encapsulation, but
+* the Mongo C++ API seems not to work that way
+*/
+extern mongo::DBClientBase* getMongoConnection(void);
+
+
+
+/* ****************************************************************************
+*
+* releaseMongoConnection -
+*/
+extern void releaseMongoConnection(mongo::DBClientBase* connection);
+
+
 #endif  // SRC_LIB_MONGOBACKEND_MONGOCONNECTIONPOOL_H_

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -35,6 +35,7 @@
 
 #include "mongoBackend/MongoGlobal.h"
 #include "mongoBackend/connectionOperations.h"
+#include "mongoConnectionPool.h"
 #include "mongoBackend/dbFieldEncoding.h"
 #include "mongoBackend/safeMongo.h"
 #include "mongoBackend/mongoQueryTypes.h"

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -35,7 +35,7 @@
 
 #include "mongoBackend/MongoGlobal.h"
 #include "mongoBackend/connectionOperations.h"
-#include "mongoConnectionPool.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/dbFieldEncoding.h"
 #include "mongoBackend/safeMongo.h"
 #include "mongoBackend/mongoQueryTypes.h"

--- a/src/lib/mongoBackend/mongoRegistrationDelete.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationDelete.cpp
@@ -40,6 +40,7 @@
 #include "mongoBackend/safeMongo.h"
 #include "mongoBackend/MongoGlobal.h"
 #include "mongoBackend/connectionOperations.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoRegistrationDelete.h"
 
 

--- a/src/lib/mongoBackend/mongoRegistrationGet.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationGet.cpp
@@ -40,6 +40,7 @@
 #include "mongoBackend/safeMongo.h"
 #include "mongoBackend/MongoGlobal.h"
 #include "mongoBackend/connectionOperations.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoRegistrationGet.h"
 
 
@@ -363,7 +364,7 @@ void mongoRegistrationsGet
   LM_T(LmtMongo, ("Mongo Get Registrations"));
 
   std::auto_ptr<mongo::DBClientCursor>  cursor;
-  mongo::Query                          q;
+  mongo::BSONObj                        q;
 
   // FIXME P6: This here is a bug ... See #3099 for more info
   if (!servicePath.empty() && (servicePath != "/#"))
@@ -371,11 +372,9 @@ void mongoRegistrationsGet
     q = BSON(REG_SERVICE_PATH << servicePathV[0]);
   }
 
-  q.sort(BSON("_id" << 1));
-
   TIME_STAT_MONGO_READ_WAIT_START();
   mongo::DBClientBase* connection = getMongoConnection();
-  if (!collectionRangedQuery(connection, getRegistrationsCollectionName(tenant), q, limit, offset, &cursor, countP, &err))
+  if (!collectionRangedQuery(connection, getRegistrationsCollectionName(tenant), q, BSON("_id" << 1), limit, offset, &cursor, countP, &err))
   {
     releaseMongoConnection(connection);
     TIME_STAT_MONGO_READ_WAIT_STOP();

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -41,6 +41,7 @@
 
 #include "mongoBackend/MongoGlobal.h"
 #include "mongoBackend/connectionOperations.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/safeMongo.h"
 #include "mongoBackend/dbConstants.h"
 #include "mongoBackend/mongoSubCache.h"

--- a/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersQuery_test.cpp
@@ -28,6 +28,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoQueryContext.h"
 #include "ngsi10/QueryContextRequest.h"
 #include "ngsi10/QueryContextResponse.h"

--- a/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
+++ b/test/unittests/mongoBackend/mongoContextProvidersUpdate_test.cpp
@@ -31,6 +31,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUpdateContext.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi/EntityId.h"

--- a/test/unittests/mongoBackend/mongoCreateSubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoCreateSubscription_test.cpp
@@ -33,6 +33,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoCreateSubscription.h"
 
 #include "unittests/testInit.h"

--- a/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
@@ -28,6 +28,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoDiscoverContextAvailability.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi/EntityId.h"

--- a/test/unittests/mongoBackend/mongoGetSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoGetSubscriptions_test.cpp
@@ -32,6 +32,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoGetSubscriptions.h"
 
 #include "unittests/testInit.h"

--- a/test/unittests/mongoBackend/mongoNotifyContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoNotifyContextAvailability_test.cpp
@@ -34,6 +34,7 @@
 
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoNotifyContextAvailability.h"
 
 #include "unittests/commonMocks.h"

--- a/test/unittests/mongoBackend/mongoNotifyContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoNotifyContext_test.cpp
@@ -33,6 +33,7 @@
 #include "common/globals.h"
 #include "apiTypesV2/HttpInfo.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoNotifyContext.h"
 #include "ngsi10/NotifyContextRequest.h"
 

--- a/test/unittests/mongoBackend/mongoQueryContextCompoundValues_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContextCompoundValues_test.cpp
@@ -31,6 +31,7 @@
 #include "common/globals.h"
 #include "orionTypes/OrionValueType.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoQueryContext.h"
 #include "ngsi/EntityId.h"
 #include "ngsi10/QueryContextRequest.h"

--- a/test/unittests/mongoBackend/mongoQueryContextFilterExistEntity_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContextFilterExistEntity_test.cpp
@@ -29,6 +29,7 @@
 
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoQueryContext.h"
 #include "ngsi/EntityId.h"
 #include "ngsi10/QueryContextRequest.h"

--- a/test/unittests/mongoBackend/mongoQueryContextGeo_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContextGeo_test.cpp
@@ -31,6 +31,7 @@
 
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoQueryContext.h"
 #include "ngsi/EntityId.h"
 #include "ngsi10/QueryContextRequest.h"

--- a/test/unittests/mongoBackend/mongoQueryContext_filters_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_filters_test.cpp
@@ -32,6 +32,7 @@
 #include "common/globals.h"
 #include "orionTypes/OrionValueType.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoQueryContext.h"
 #include "ngsi/EntityId.h"
 #include "ngsi10/QueryContextRequest.h"

--- a/test/unittests/mongoBackend/mongoQueryContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryContext_test.cpp
@@ -32,6 +32,7 @@
 #include "common/globals.h"
 #include "orionTypes/OrionValueType.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoQueryContext.h"
 #include "ngsi/EntityId.h"
 #include "ngsi10/QueryContextRequest.h"

--- a/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
+++ b/test/unittests/mongoBackend/mongoQueryTypes_test.cpp
@@ -31,6 +31,7 @@
 
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoQueryTypes.h"
 #include "orionTypes/EntityTypeVectorResponse.h"
 #include "orionTypes/EntityTypeResponse.h"

--- a/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_test.cpp
@@ -33,6 +33,7 @@
 
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoRegisterContext.h"
 #include "ngsi/StatusCode.h"
 #include "ngsi/ContextRegistration.h"

--- a/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
+++ b/test/unittests/mongoBackend/mongoRegisterContext_update_test.cpp
@@ -32,6 +32,7 @@
 
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoRegisterContext.h"
 #include "ngsi/ContextRegistration.h"
 #include "ngsi/EntityId.h"

--- a/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContextAvailability_test.cpp
@@ -32,6 +32,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoSubscribeContextAvailability.h"
 #include "ngsi9/SubscribeContextAvailabilityRequest.h"
 #include "ngsi9/SubscribeContextAvailabilityResponse.h"

--- a/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoSubscribeContext_test.cpp
@@ -30,6 +30,7 @@
 
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoSubscribeContext.h"
 #include "ngsi10/SubscribeContextRequest.h"
 #include "ngsi10/SubscribeContextResponse.h"

--- a/test/unittests/mongoBackend/mongoUnsubscribeContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoUnsubscribeContextAvailability_test.cpp
@@ -29,6 +29,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUnsubscribeContextAvailability.h"
 #include "ngsi9/UnsubscribeContextAvailabilityRequest.h"
 #include "ngsi9/UnsubscribeContextAvailabilityResponse.h"

--- a/test/unittests/mongoBackend/mongoUnsubscribeContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUnsubscribeContext_test.cpp
@@ -29,6 +29,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUnsubscribeContext.h"
 #include "ngsi10/UnsubscribeContextRequest.h"
 #include "ngsi10/UnsubscribeContextResponse.h"

--- a/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextAvailabilitySubscription_test.cpp
@@ -31,6 +31,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUpdateContextAvailabilitySubscription.h"
 #include "ngsi9/UpdateContextAvailabilitySubscriptionRequest.h"
 #include "ngsi9/UpdateContextAvailabilitySubscriptionResponse.h"

--- a/test/unittests/mongoBackend/mongoUpdateContextCompoundValues_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextCompoundValues_test.cpp
@@ -34,6 +34,7 @@
 #include "common/globals.h"
 #include "orionTypes/OrionValueType.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUpdateContext.h"
 #include "ngsi/EntityId.h"
 #include "ngsi/ContextElementResponse.h"

--- a/test/unittests/mongoBackend/mongoUpdateContextGeo_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextGeo_test.cpp
@@ -32,6 +32,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUpdateContext.h"
 #include "ngsi/EntityId.h"
 #include "ngsi10/UpdateContextRequest.h"

--- a/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContextSubscription_test.cpp
@@ -32,6 +32,7 @@
 #include "logMsg/traceLevels.h"
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUpdateContextSubscription.h"
 #include "ngsi10/UpdateContextSubscriptionRequest.h"
 #include "ngsi10/UpdateContextSubscriptionResponse.h"

--- a/test/unittests/mongoBackend/mongoUpdateContext_2_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_2_test.cpp
@@ -34,6 +34,7 @@
 #include "common/errorMessages.h"
 #include "orionTypes/OrionValueType.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUpdateContext.h"
 #include "mongoBackend/mongoQueryContext.h"
 #include "ngsi/EntityId.h"

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -34,6 +34,7 @@
 #include "common/errorMessages.h"
 #include "orionTypes/OrionValueType.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUpdateContext.h"
 #include "mongoBackend/mongoQueryContext.h"
 #include "ngsi/EntityId.h"

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptionsNoCache_test.cpp
@@ -32,6 +32,7 @@
 #include "common/globals.h"
 #include "cache/subCache.h"
 #include "mongoBackend/MongoGlobal.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "mongoBackend/mongoUpdateContext.h"
 #include "ngsi/EntityId.h"
 #include "ngsi/ContextElementResponse.h"

--- a/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_withOnchangeSubscriptions_test.cpp
@@ -32,6 +32,7 @@
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
 #include "mongoBackend/mongoUpdateContext.h"
+#include "mongoBackend/mongoConnectionPool.h"
 #include "cache/subCache.h"
 #include "ngsi/EntityId.h"
 #include "ngsi/ContextElementResponse.h"


### PR DESCRIPTION
This PR includes two things:

* Move low-level connection-related method from MongoGlobal to mongoConnectionPool
* Avoid the usage of mongo::Query in high-level code. The usage of mongo::Query now takes place only inside collectionRangedQuery()