### PR TITLE
FIX simplify mongobackend logic

### DIFF
--- a/src/lib/mongoBackend/mongoConnectionPool.cpp
+++ b/src/lib/mongoBackend/mongoConnectionPool.cpp
@@ -414,7 +414,7 @@ int mongoConnectionPoolInit
 * Very important to call the function 'mongoPoolConnectionRelease' after finishing using the connection !
 *
 */
-DBClientBase* mongoPoolConnectionGet(void)
+static DBClientBase* mongoPoolConnectionGet(void)
 {
   DBClientBase*    connection = NULL;
   struct timespec  startTime;
@@ -453,12 +453,12 @@ DBClientBase* mongoPoolConnectionGet(void)
 }
 
 
-
+#ifndef UNIT_TEST
 /* ****************************************************************************
 *
 * mongoPoolConnectionRelease -
 */
-void mongoPoolConnectionRelease(DBClientBase* connection)
+static void mongoPoolConnectionRelease(DBClientBase* connection)
 {
   sem_wait(&connectionPoolSem);
 
@@ -474,7 +474,7 @@ void mongoPoolConnectionRelease(DBClientBase* connection)
 
   sem_post(&connectionPoolSem);
 }
-
+#endif
 
 
 /* ****************************************************************************

--- a/src/lib/mongoBackend/mongoConnectionPool.h
+++ b/src/lib/mongoBackend/mongoConnectionPool.h
@@ -64,22 +64,6 @@ extern int mongoConnectionPoolInit
 
 /* ****************************************************************************
 *
-* mongoPoolConnectionGet - 
-*/
-extern mongo::DBClientBase* mongoPoolConnectionGet(void);
-
-
-
-/* ****************************************************************************
-*
-* mongoPoolConnectionRelease - 
-*/
-extern void mongoPoolConnectionRelease(mongo::DBClientBase* connection);
-
-
-
-/* ****************************************************************************
-*
 * mongoPoolConnectionSemWaitingTimeGet - 
 */
 extern float mongoPoolConnectionSemWaitingTimeGet(void);


### PR DESCRIPTION
After the simplification donde in PR https://github.com/telefonicaid/fiware-orion/pull/3619 a couple of functions are now internal to mongoConnectionPool.cpp, so they can be removed from the interface provided by mongoConnnectionPool.h. This PR does so.