### PR TITLE
Add documentation how to build Orion binary for Ubuntu 18.04 LTS

### DIFF
--- a/doc/manuals.jp/admin/build_source.md
+++ b/doc/manuals.jp/admin/build_source.md
@@ -144,3 +144,183 @@ aarch64 アーキテクチャの場合、さらに yum で、python-devel と li
         make rpm
 
 * 生成された RPM は `~/rpmbuild/RPMS/x86_64` ディレクトリに置かれます
+
+<a name="ubuntu-1804-lts"></a>
+## Ubuntu 18.04 LTS
+
+この手順は、Ubuntu 18.04 LTS 上で x86_64 および aarch64 アーキテクチャ用の Orion Context Broker をすることです。
+また、Orion が依存する MongoDB 3.6 をビルドするための手順が含まれています。Orion Context Brokerは、ビルドの依存関係と
+して次のライブラリを使用します :
+
+* boost: 1.65.1
+* libmicrohttpd: 0.9.48 (from source)
+* libcurl: 7.58.0
+* openssl: 1.0.2n
+* libuuid: 2.31.1
+* Mongo Driver: legacy-1.1.2 (from source)
+* rapidjson: 1.0.2 (from source)
+* gtest (only for `make unit_test` building target): 1.5 (from sources)
+* gmock (only for `make unit_test` building target): 1.5 (from sources)
+* MongoDB: 3.6.17 (from source)
+
+基本的な手順は次のとおりです (root 権限でコマンドを実行しないと仮定し、root 権限が必要なコマンドに sudo を使用します) :
+
+* 必要なビルドツール (コンパイラなど) をインストールします
+
+        sudo apt install build-essential cmake scons
+
+* 必要なライブラリをインストールします (次の手順で説明する、ソースから取得する必要があるものを除きます)
+
+        sudo apt install libboost-dev libboost-regex-dev libboost-thread-dev libboost-filesystem-dev \
+                         libcurl4-gnutls-dev gnutls-dev libgcrypt-dev libssl1.0-dev uuid-dev libsasl2-dev
+
+* ソースから Mongo Driver をインストールします。Mongo Driver 1.1.2 は gcc 4.x でコンパイルすることを想定した、レガシーな
+コードです。そのため、新しい gcc でビルドする場合、一部のウォーニングはエラーとして扱われます。このエラーを避けるために、
+`-Wno-{option name}` オプションを CCFLAGS に追加する必要があります。
+
+        wget https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.1.2.tar.gz
+        tar xfvz legacy-1.1.2.tar.gz
+        cd mongo-cxx-driver-legacy-1.1.2
+        # The build/linux2/normal/libmongoclient.a library is generated as outcome
+        scons  --use-sasl-client --ssl "CCFLAGS=-Wno-nonnull-compare -Wno-noexcept-type -Wno-format-truncation"
+        # This puts .h files in /usr/local/include/mongo and libmongoclient.a in /usr/local/lib
+        sudo scons install --prefix=/usr/local --use-sasl-client --ssl "CCFLAGS=-Wno-nonnull-compare -Wno-noexcept-type -Wno-format-truncation"
+
+* ソースから rapidjson をインストールする :
+
+        wget https://github.com/miloyip/rapidjson/archive/v1.0.2.tar.gz
+        tar xfvz v1.0.2.tar.gz
+        sudo mv rapidjson-1.0.2/include/rapidjson/ /usr/local/include
+
+* ソースから libmicrohttpd をインストールします (`./configure` 下のコマンドはライブラリの最小限のフットプリントを
+得るための推奨ビルド設定を示していますが、上級ユーザの方は好きなように設定できます)
+
+        wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.48.tar.gz
+        tar xvf libmicrohttpd-0.9.48.tar.gz
+        cd libmicrohttpd-0.9.48
+        ./configure --disable-messages --disable-postprocessor --disable-dauth
+        make
+        sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
+        sudo ldconfig      # just in case... it doesn't hurt :)
+
+* ソースから Google Test/Mock をインストールします (このための RPM パッケージがありますが、現在の CMakeLists.txt
+の設定では動作しません)。以前は URL は http://googlemock.googlecode.com/files/gmock-1.5.0.tar.bz2 でしたが、
+Google では2016年8月下旬にそのパッケージを削除したため、動作しなくなりました
+
+        apt install xsltproc
+        wget https://nexus.lab.fiware.org/repository/raw/public/storage/gmock-1.5.0.tar.bz2
+        tar xfvj gmock-1.5.0.tar.bz2
+        cd gmock-1.5.0
+        ./configure
+        make
+        sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
+        sudo ldconfig      # just in case... it doesn't hurt :)
+
+aarch64 アーキテクチャの場合、apt を使用して xsltproc をインストールし、`.-configure` を `--build=arm-linux`
+オプションとともに実行します。
+
+* コードを取得します (または、圧縮されたバージョンや別の URL パターンを使用してダウンロードできます。例えば、
+`git clone git@github.com:telefonicaid/fiware-orion.git`) :
+
+        sudo apt install git
+        git clone https://github.com/telefonicaid/fiware-orion
+
+* ソースをビルドします :
+
+        cd fiware-orion
+        make
+
+* ソースコードから MongoDB 3.6.17 をビルドしてインストールします。ユニット・テストを実行するには、ユニットとして MongoDB を
+ビルドする必要があり、機能テストは localhost で実行されている mongod に依存します (Ubuntu 18.04 用の MongoDB 3.6 バイナリは
+提供されていません)。ソースコードから MongoDB をビルドする手順は次のとおりです。aarch64 アーキテクチャの場合、追加で
+`-march=armv8-a+crc` オプションを CCFLAGS に追加します。`mongo` コマンドを実行して、MongoDB が正常にインストールされたことを
+確認します。
+
+        # Build MongoDB
+        sudo apt install build-essential cmake scons  # Not required if you installed in previous step
+        sudo apt install python python-pip            # Not required if you installed in previous step
+        pip install --upgrade pip                     # Not required if you installed in previous step
+        cd /opt
+        git clone -b r3.6.17 --depth=1 https://github.com/mongodb/mongo.git
+        cd mongo
+        pip install --user -r buildscripts/requirements.txt
+        python buildscripts/scons.py mongo mongod mongos \
+          "CCFLAGS=-Wno-nonnull-compare -Wno-format-truncation -Wno-noexcept-type" \
+          --wiredtiger=on \
+          --mmapv1=on
+        # Install MongoDB
+        strip -s mongo*
+        sudo cp -a mongo mongod mongos /usr/bin/ 
+        sudo useradd -M -s /bin/false mongodb
+        sudo mkdir /var/lib/mongodb /var/log/mongodb /var/run/mongodb
+        sudo chown mongodb:mongodb /var/lib/mongodb /var/log/mongodb /var/run/mongodb
+        sudo cp -a ./debian/mongod.conf /etc/
+        sudo cp -a ./debian/mongod.service /etc/systemd/system/
+        sudo systemctl start mongod
+
+* バイナリをインストールします。INSTALL_DIR を使用して、インストール・プレフィックス・パス (デフォルトは /usr) を設定する
+ことができます。したがって、broker は `$INSTALL_DIR/bin` ディレクトリにインストールされます
+
+        sudo make install INSTALL_DIR=/usr
+
+* broker のバージョン・メッセージを呼び出し、すべてが正常であることを確認してください :
+
+        contextBroker --version
+
+Orion Context Broker には、次の手順 (オプション) に従って実行することができる、valgrind およびエンド・ツー・エンドのテストの
+機能的なスイートが付属しています :
+
+* 必要なツールをインストールします :
+
+        sudo apt install python python-pip curl netcat valgrind bc
+        sudo pip install --upgrade pip
+
+aarch64 アーキテクチャの場合、さらに apt で、python-devel と libffi-devel をインストールします。これは、pyOpenSSL をビルドするときに必要です。
+
+* テスト・ハーネスのための環境を準備します。基本的には、`accumulator-server.py` スクリプトをコントロールの下にあるパスに
+インストールしなければならず、`~/bin` が推奨です。また、`/usr/bin` のようなシステム・ディレクトリにインストールすることも
+できますが、RPM インストールと衝突する可能性がありますので、お勧めしません。さらに、ハーネス・スクリプト (`scripts/testEnv.sh`
+ファイル参照) で使用されるいくつかの環境変数を設定し、Ubuntu のデフォルトの Flask の代わりに Flask version 1.0.2 を使用する
+ために、virtualenv 環境を作成する必要があります。この環境でテスト・ハーネスを実行します。
+
+        mkdir ~/bin
+        export PATH=~/bin:$PATH
+        make install_scripts INSTALL_DIR=~
+        . scripts/testEnv.sh
+        pip install virtualenv
+        virtualenv /opt/ft_env
+        . /opt/ft_env/bin/activate
+        pip install Flask==1.0.2 pyOpenSSL==19.0.0
+
+* テスト・ハーネスを実行してください (時間がかかりますので、気をつけてください)
+
+        make functional_test INSTALL_DIR=~
+
+* すべての機能テストに合格したら、valgrind テストを実行できます (これは機能テストよりも時間がかかります) :
+
+        make valgrind
+
+次の手順を使用して、Orion Context Broker のカバレッジレポートを生成できます (オプション) :
+
+* lcov ツールをインストールします
+
+        sudo apt install lcov
+
+* まず、unit_test と functional_test の成功パスを実行して、すべてが正常であることを確認します (上記参照)
+
+* カバレッジを実行します
+
+        make coverage INSTALL_DIR=~
+
+* テストの実行後にシステムサービスとして Orion を実行するためのセットアップを行います。`curl localhost:1026/version` コマンドを実行して、
+セットアップが成功したことを確認します :
+
+        sudo mkdir /etc/sysconfig
+        sudo cp /opt/fiware-orion/etc/config/contextBroker /etc/sysconfig/
+        sudo touch /var/log/contextBroker/contextBroker.log
+        sudo chown orion /var/log/contextBroker/contextBroker.log
+        sudo cp /opt/fiware-orion/rpm/SOURCES/etc/logrotate.d/logrotate-contextBroker-daily /etc/logrotate.d/
+        sudo cp /opt/fiware-orion/rpm/SOURCES/etc/sysconfig/logrotate-contextBroker-size /etc/sysconfig/
+        sudo cp /opt/fiware-orion/rpm/SOURCES/etc/cron.d/cron-logrotate-contextBroker-size /etc/cron.d/
+        sudo systemctl daemon-reload
+        sudo systemctl start contextBroker.service 

--- a/doc/manuals.jp/admin/build_source.md
+++ b/doc/manuals.jp/admin/build_source.md
@@ -144,27 +144,3 @@ aarch64 アーキテクチャの場合、さらに yum で、python-devel と li
         make rpm
 
 * 生成された RPM は `~/rpmbuild/RPMS/x86_64` ディレクトリに置かれます
-
-### SASL と SSL をサポートする MongoDB ドライバの構築
-
-手順は次のとおりです :
-
-```
-wget https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.1.2.tar.gz
-tar xfvz legacy-1.1.2.tar.gz cd mongo-cxx-driver-legacy-1.1.2
-yum install cyrus-sasl-devel
-scons --use-sasl-client --ssl                                   # The build/linux2/normal/libmongoclient.a library is generated as outcome
-sudo scons install --prefix=/usr/local --use-sasl-client --ssl  # This puts .h files in /usr/local/include/mongo and libmongoclient.a in /usr/local/lib
-```
-
-## その他
-
-CentOS 7.x とは異なるシステムで Orion をビルドしている場合は、お気軽にご連絡いただき、このセクションの拡張にご協力ください。おそらく、新しい情報でこのファイルを変更するためのプル・リクエストを実行することが最良の方法です。ありがとう！
-
-### Debian 7
-
-パッケージは基本的に上記の RedHat/CentOS と同じですが、yum ではなく apt-get を使ってパッケージをインストールする必要があります。
-
-Google Test と Google Mock バージョン 1.5 をソースから直接インストールします。
-
-Debian 7.0 (1.9) に付属している lcov にはバグがあります (https://bugs.launchpad.net/ubuntu/+source/lcov/+bug/1163758 を参照)。ソースから lcov 1.10 をインストールします。

--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -103,7 +103,7 @@ The Orion Context Broker comes with a suite of functional, valgrind and end-to-e
 
 In the case of the aarch64 architecture, additionally install python-devel and libffi-devel using yum. It is needed when building pyOpenSSL.
 
-* Prepare the environment for test harness. Basically, you have to install the `accumulator-server.py` script and in a path under your control, `~/bin` is the recommended one. Alternatively, you can install them in a system directory such as `/usr/bin` but it could collide with an RPM installation, thus it is not recommended. In addition, you have to set several environment variables used by the harness script (see `scripts/testEnv.sh` file) and create a virtualenv envirionment to use Flask version 1.0.2 instead of default Flask in CentOS7. Run test harness in this environment.
+* Prepare the environment for test harness. Basically, you have to install the `accumulator-server.py` script and in a path under your control, `~/bin` is the recommended one. Alternatively, you can install them in a system directory such as `/usr/bin` but it could collide with an RPM installation, thus it is not recommended. In addition, you have to set several environment variables used by the harness script (see `scripts/testEnv.sh` file) and create a virtualenv environment to use Flask version 1.0.2 instead of default Flask in CentOS7. Run test harness in this environment.
 
         mkdir ~/bin
         export PATH=~/bin:$PATH
@@ -145,3 +145,170 @@ You can generate the RPM for the source code (optional):
         make rpm
 
 * The generated RPMs are placed in directory `~/rpmbuild/RPMS/x86_64`.
+
+## Ubuntu 18.04 LTS
+
+This instruction is how to build the Orion Context Broker for the x86_64 or the aarch64 architecture on Ubuntu 18.04 LTS.
+And it includes the instruction to build MongoDB 3.6 that the Orion depends on.
+The Orion Context Broker uses the following libraries as build dependencies:
+
+* boost: 1.65.1
+* libmicrohttpd: 0.9.48 (from source)
+* libcurl: 7.58.0
+* openssl: 1.0.2n
+* libuuid: 2.31.1
+* Mongo Driver: legacy-1.1.2 (from source)
+* rapidjson: 1.0.2 (from source)
+* gtest (only for `make unit_test` building target): 1.5 (from sources)
+* gmock (only for `make unit_test` building target): 1.5 (from sources)
+* MongoDB: 3.6.17 (from source)
+
+The basic procedure is as follows (assuming you don't run commands as root, we use sudo for those
+commands that require root privilege):
+
+* Install the needed building tools (compiler, etc.).
+
+        sudo apt install build-essential cmake scons
+
+* Install the required libraries (except what needs to be taken from source, described in following steps).
+
+        sudo apt install libboost-dev libboost-regex-dev libboost-thread-dev libboost-filesystem-dev \
+                         libcurl4-gnutls-dev gnutls-dev libgcrypt-dev libssl1.0-dev uuid-dev libsasl2-dev
+
+* Install the Mongo Driver from source. The Mongo Driver 1.1.2 is written in legacy code intended to compile with gcc 4.x.
+So some kind of warnings are treated as errors when building with newer gcc. To avoid such errors, it is necessary to
+add a `-Wno-{option name}` option to CCFLAGS.
+
+        wget https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.1.2.tar.gz
+        tar xfvz legacy-1.1.2.tar.gz
+        cd mongo-cxx-driver-legacy-1.1.2
+        # The build/linux2/normal/libmongoclient.a library is generated as outcome
+        scons  --use-sasl-client --ssl "CCFLAGS=-Wno-nonnull-compare -Wno-noexcept-type -Wno-format-truncation"
+        # This puts .h files in /usr/local/include/mongo and libmongoclient.a in /usr/local/lib
+        sudo scons install --prefix=/usr/local --use-sasl-client --ssl "CCFLAGS=-Wno-nonnull-compare -Wno-noexcept-type -Wno-format-truncation"
+
+* Install rapidjson from sources:
+
+        wget https://github.com/miloyip/rapidjson/archive/v1.0.2.tar.gz
+        tar xfvz v1.0.2.tar.gz
+        sudo mv rapidjson-1.0.2/include/rapidjson/ /usr/local/include
+
+* Install libmicrohttpd from sources (the `./configure` command below shows the recommended build configuration to get minimum library footprint, but if you are an advanced user, you can configure as you prefer)
+
+        wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.48.tar.gz
+        tar xvf libmicrohttpd-0.9.48.tar.gz
+        cd libmicrohttpd-0.9.48
+        ./configure --disable-messages --disable-postprocessor --disable-dauth
+        make
+        sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
+        sudo ldconfig      # just in case... it doesn't hurt :)
+
+* Install Google Test/Mock from sources (there are RPM packages for this, but they do not work with the current CMakeLists.txt configuration). Previously the URL was http://googlemock.googlecode.com/files/gmock-1.5.0.tar.bz2 but Google removed that package in late August 2016 and it is no longer working.
+
+        apt install xsltproc
+        wget https://nexus.lab.fiware.org/repository/raw/public/storage/gmock-1.5.0.tar.bz2
+        tar xfvj gmock-1.5.0.tar.bz2
+        cd gmock-1.5.0
+        ./configure
+        make
+        sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
+        sudo ldconfig      # just in case... it doesn't hurt :)
+
+In the case of the aarch64 architecture, run `./configure` with `--build=arm-linux` option.
+
+* Get the code (alternatively you can download it using a zipped version or a different URL pattern, e.g `git clone git@github.com:telefonicaid/fiware-orion.git`):
+
+        sudo apt install git
+        git clone https://github.com/telefonicaid/fiware-orion
+
+* Build the source:
+
+        cd fiware-orion
+        make
+
+* Build MongoDB 3.6.17 from source code and install it. To run unit test, you have to build MongoDB as the unit and functional
+tests rely on mongod running in localhost (The MongoDB 3.6 binary for Ubuntu 18.04 is not provided.). The instruction to build
+MongoDB from source code is as the following. In the case of the aarch64 architecture, additionally add the `-march=armv8-a+crc`
+option to CCFLAGS. Run the `mongo` command to check that MongoDB has been successfully installed:
+
+        # Build MongoDB
+        sudo apt install build-essential cmake scons  # Not required if you installed in previous step
+        sudo apt install python python-pip            # Not required if you installed in previous step
+        pip install --upgrade pip                     # Not required if you installed in previous step
+        cd /opt
+        git clone -b r3.6.17 --depth=1 https://github.com/mongodb/mongo.git
+        cd mongo
+        pip install --user -r buildscripts/requirements.txt
+        python buildscripts/scons.py mongo mongod mongos \
+          "CCFLAGS=-Wno-nonnull-compare -Wno-format-truncation -Wno-noexcept-type" \
+          --wiredtiger=on \
+          --mmapv1=on
+        # Install MongoDB
+        strip -s mongo*
+        sudo cp -a mongo mongod mongos /usr/bin/ 
+        sudo useradd -M -s /bin/false mongodb
+        sudo mkdir /var/lib/mongodb /var/log/mongodb /var/run/mongodb
+        sudo chown mongodb:mongodb /var/lib/mongodb /var/log/mongodb /var/run/mongodb
+        sudo cp -a ./debian/mongod.conf /etc/
+        sudo cp -a ./debian/mongod.service /etc/systemd/system/
+        sudo systemctl start mongod
+
+* Install the binary. You can use INSTALL_DIR to set the installation prefix path (default is /usr), thus the broker is installed in `$INSTALL_DIR/bin` directory.
+
+        sudo make install INSTALL_DIR=/usr
+
+* Check that everything is ok, invoking the broker version message:
+
+        contextBroker --version
+
+The Orion Context Broker comes with a suite of functional, valgrind and end-to-end tests that you can also run, following the following procedure (optional):
+
+* Install the required tools:
+
+        sudo apt install python python-pip curl netcat valgrind bc
+        sudo pip install --upgrade pip
+
+In the case of the aarch64 architecture, additionally install python-devel and libffi-devel using apt. It is needed when building pyOpenSSL.
+
+* Prepare the environment for test harness. Basically, you have to install the `accumulator-server.py` script and in a path under your control, `~/bin` is the recommended one. Alternatively, you can install them in a system directory such as `/usr/bin` but it could collide with an RPM installation, thus it is not recommended. In addition, you have to set several environment variables used by the harness script (see `scripts/testEnv.sh` file) and create a virtualenv environment to use Flask version 1.0.2 instead of default Flask in Ubuntu. Run test harness in this environment.
+
+        mkdir ~/bin
+        export PATH=~/bin:$PATH
+        make install_scripts INSTALL_DIR=~
+        . scripts/testEnv.sh
+        pip install virtualenv
+        virtualenv /opt/ft_env
+        . /opt/ft_env/bin/activate
+        pip install Flask==1.0.2 pyOpenSSL==19.0.0
+
+* Run test harness (it takes some time, please be patient).
+
+        make functional_test INSTALL_DIR=~
+
+* Once passed all the functional tests, you can run the valgrind tests (this will take longer than the functional tests, arm yourself with a lot of patience):
+
+        make valgrind
+
+You can generate coverage reports for the Orion Context Broker using the following procedure (optional):
+
+* Install the lcov tool
+
+        sudo apt install lcov
+
+* Do first a successful pass for unit_test and functional_test, to check that everything is ok (see above)
+
+* Run coverage
+
+        make coverage INSTALL_DIR=~
+
+* Setup for running Orion as system service after running tests. Run the `curl localhost:1026/version` command to check that the setup has been successful:
+
+        sudo mkdir /etc/sysconfig
+        sudo cp /opt/fiware-orion/etc/config/contextBroker /etc/sysconfig/
+        sudo touch /var/log/contextBroker/contextBroker.log
+        sudo chown orion /var/log/contextBroker/contextBroker.log
+        sudo cp /opt/fiware-orion/rpm/SOURCES/etc/logrotate.d/logrotate-contextBroker-daily /etc/logrotate.d/
+        sudo cp /opt/fiware-orion/rpm/SOURCES/etc/sysconfig/logrotate-contextBroker-size /etc/sysconfig/
+        sudo cp /opt/fiware-orion/rpm/SOURCES/etc/cron.d/cron-logrotate-contextBroker-size /etc/cron.d/
+        sudo systemctl daemon-reload
+        sudo systemctl start contextBroker.service 

--- a/docker/raspberry_pi.jp.md
+++ b/docker/raspberry_pi.jp.md
@@ -5,7 +5,9 @@ Raspberry Pi で Docker を使用すると、Orion Context Broker を非常に�
 [Raspberry Pi](https://www.raspberrypi.org/) は、低価格のクレジット・カード・サイズのコンピュータです。
 ARM ベースのデバイスであり、ARM アーキテクチャ用にコンパイルされたバイナリが必要です。 Orion の Docker
 イメージをビルドして実行するには、ARM architecture 用の 64 ビット Linux と Docker を Raspberry Pi に
-インストールします。
+インストールします。Raspberry Pi にインストールされたオペレーティング・システムで Orion を直接ビルド
+して実行する場合は、その方法に関する
+[ドキュメント](../doc/manuals.jp/admin/build_source.md#ubuntu-1804-lts)を参照してください。
 
 ## 前提条件
 

--- a/docker/raspberry_pi.md
+++ b/docker/raspberry_pi.md
@@ -5,12 +5,14 @@ You can run Orion Context Broker very easily using docker on Raspberry Pi.
 The [Raspberry Pi](https://www.raspberrypi.org/) is a low cost, credit-card sized computer.
 It is an ARM based device and requires binaries compiled for the ARM architecture. 
 To build and run the docker image of Orion, the 64 bit Linux and docker for the ARM architecture are installed on Raspberry Pi.
+If you want to build and run Orion directly on an operating system installed on a Raspberry Pi, See the
+[documentation](../doc/manuals/admin/build_source.md#ubuntu-1804-lts) on how to do this.
 
 ## Prerequisites
 
 ### Hardware
 
-The target hardwares are Raspberry Pi 3 and 4 which support the 64bit ARM architecture (aarch64).
+The target devices are Raspberry Pi 3 and 4 which support the 64 bit ARM architecture (aarch64).
 
 ### Linux OS
 
@@ -44,10 +46,10 @@ for Ubuntu 18.04 LTS (Bionic). You should replace `$(lsb_release -cs)` with `bio
 
 The details to install Docker are [here](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
 
-### Dokcer compose
+### Docker compose
 
 The Docker Compose binary for aarch64 is not provided. It is necessary to build it from its source code.
-You can install the docker compose versin 1.25.1 by running the commands as shown:
+You can install the docker compose version 1.25.1 by running the commands as shown:
 
 ```
 git clone -b 1.25.1 https://github.com/docker/compose.git


### PR DESCRIPTION
This PR adds a documentation how to build Orion binary for Ubuntu 18.04 LTS. By this, Orion can be directly run on Ubuntu for the x86_64 or aarch64 architecture. And the PR also includes fixing typos in build_source.md and raspberry_pi.md.

I have built and tested Orion with devices installed Ubuntu 18.04 LTS of each architecture. The build logs and test logs are here (https://github.com/fisuda/report/tree/master/orion/20200303_orion_ubuntu18.04).

In the case of the aarch64, One function test has failed as shown:

- 1697_more_than_one_bad_input

It seems that the issue is dependent on the timing. So, it passed by changing the value of `-logSummary` option.

It would be great if you could review this PR.

Thank you.
