### PR TITLE
FIX gmtime() -> gmtime_r() (release/2.4.0)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,0 @@
-- Fix: potencial race condition related with DateTime attributes due to the usage of thread unsafe functions

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: potencial race condition related with DateTime attributes due to the usage of thread unsafe functions

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![SOF support badge](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/orion.svg)](http://stackoverflow.com/questions/tagged/fiware-orion)
 [![NGSI v2](https://nexus.lab.fiware.org/repository/raw/public/badges/specifications/ngsiv2.svg)](http://fiware-ges.github.io/orion/api/v2/stable/)
 <br>
-[![Documentation badge](https://img.shields.io/readthedocs/fiware-orion/2.4.0.svg)](https://fiware-orion.rtfd.io/en/2.4.0/)
+[![Documentation badge](https://img.shields.io/readthedocs/fiware-orion/2.4.1.svg)](https://fiware-orion.rtfd.io/en/2.4.1/)
 [![Build badge](https://img.shields.io/travis/telefonicaid/fiware-orion.svg)](https://travis-ci.org/telefonicaid/fiware-orion/)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/orion.svg)
 

--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -176,6 +176,9 @@ if [ "$1" == "0" ]; then
 fi
 
 %changelog
+* Wed Sep 23 2020 Fermin Galan <fermin.galanmarquez@telefonica.com> 2.4.1-1
+- Fix: potencial race condition related with DateTime attributes due to the usage of thread unsafe functions
+
 * Tue Mar 31 2020 Fermin Galan <fermin.galanmarquez@telefonica.com> 2.4.0-1
 - Add: TextUnrestricted attribute type to avoid forbidden chars checking (#3550)
 - Add: notification flow control on update (#3568)

--- a/src/app/contextBroker/version.h
+++ b/src/app/contextBroker/version.h
@@ -28,6 +28,6 @@
 
 
 
-#define ORION_VERSION "2.4.0"
+#define ORION_VERSION "2.4.1"
 
 #endif  // SRC_APP_CONTEXTBROKER_VERSION_H_

--- a/src/lib/common/defaultValues.h
+++ b/src/lib/common/defaultValues.h
@@ -41,6 +41,6 @@
 *
 * API Documentation - The link to the the GEri documentation, either in the gh-pages (.github.io/) inside the fiware organization in GitHub or ReadTheDocs manual.
 */
-#define API_DOC                               "https://fiware-orion.rtfd.io/en/2.4.0/"
+#define API_DOC                               "https://fiware-orion.rtfd.io/en/2.4.1/"
 
 #endif  // SRC_LIB_COMMON_DEFAULTVALUES_H_

--- a/src/lib/common/string.cpp
+++ b/src/lib/common/string.cpp
@@ -1003,17 +1003,19 @@ std::string double2string(double f)
 *
 * isodate2str -
 *
-* FIXME P6: change implementation to use gmtime_r
-*
 */
 std::string isodate2str(long long timestamp)
 {
   // 80 bytes is enough to store any ISO8601 string safely
-  // We use gmtime() to get UTC strings, otherwise we would use localtime()
+  // We use gmtime_r() to get UTC strings, otherwise we would use localtime()
   // Date pattern: 1970-04-26T17:46:40.00Z
   char   buffer[80];
+
+  // Unused, but needed to fullfill gmtime_r() signature
+  struct tm  tmP;
+
   time_t rawtime = (time_t) timestamp;
-  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%S.00Z", gmtime(&rawtime));
+  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%S.00Z", gmtime_r(&rawtime, &tmP));
   return std::string(buffer);
 }
 


### PR DESCRIPTION
Hotfix 2.4.1 (in release/2.4.0). The same fix will be ported to master in a separate PR.

Regression unit_test:

```
...
[----------] Global test environment tear-down
[==========] 864 tests from 128 test cases ran. (48004 ms total)
[  PASSED  ] 864 tests.

  YOU HAVE 16 DISABLED TESTS

------------------------------- unit_test ended ---------------------------------

```

Regression functional_test:

```
...
1144/1145: 3608_killer_request_apiv1/killer_request_apiv1_deeply_nested_attr.test .......................................  02 seconds
1145/1145: 3608_killer_request_apiv1/killer_request_apiv1_parsing_cases_bis.test ........................................  03 seconds
Total test time: 4524.06 seconds

1 test cases OK in the second attempt:
  o  3389_forced_update_option/3389_forced_update_option_batch_string.test

WARNING: 5 test cases disabled:
  o  2: 0000_bad_requests/exit.test
  o  30: 0000_ipv6_support/ipv4_only.test
  o  31: 0000_ipv6_support/ipv6_only.test
  o  390: 0917_queryContext_behaves_differently/query_with_and_without_forwarding.test
  o  624: 1310_suspect_200OK/suspect_200OK.test
```