### PR TITLE
 FIX gmtime() -> gmtime_r() (master)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,6 +3,7 @@
 - Fix: avoid creating orion database in -multiservice mode (#3179)
 - Fix: upgrade rapidjson dependecy from 1.0.2 to 1.1.0
 - Fix: upgrade microhttpd dependency from 0.9.48 to 0.9.70
+- Fix: potencial race condition related with DateTime attributes due to the usage of thread unsafe functions
 - Fix: wrong 204 code was responded (instead of 501) when using idPattern in POST /v2/op/update operation (#3427)
 - Fix: changed the name of pretty much all the environment variables for Orion. E.g. adding prefix 'ORION_'
 - Add: milliseconds support in DateTime attributes and metadata, included dateCreated and dateModified built-ins (#432, #2670, #3412, #3666)

--- a/src/lib/common/string.cpp
+++ b/src/lib/common/string.cpp
@@ -1004,8 +1004,6 @@ std::string double2string(double f)
 *
 * isodate2str -
 *
-* FIXME P6: change implementation to use gmtime_r
-*
 */
 std::string isodate2str(double timestamp)
 {
@@ -1052,7 +1050,10 @@ std::string isodate2str(double timestamp)
   int     micros    = ms * 1000000;
   int     millis    = (micros + 1) / 1000;   // (timestamp - seconds) * 1000 gives rounding errors ...
 
-  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%S", gmtime(&seconds));
+  // Unused, but needed to fullfill gmtime_r() signature
+  struct tm  tmP;
+
+  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%S", gmtime_r(&seconds, &tmP));
 
   char* eob = &buffer[strlen(buffer)];
   sprintf(eob, ".%03dZ", millis);


### PR DESCRIPTION
A backport of 6e4299ba2fd1458b1e3cd8f0d7b0374fb544af03 in PR https://github.com/telefonicaid/fiware-orion/pull/3698 (for branch release/2.4.0) into master.

Note this time we cannot use a cherry-pick, as the base of code to apply the change has changed from release/2.4.0 to current master.