### PR TITLE
FIX some valgrind errors

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1022,32 +1022,6 @@ static bool addTriggeredSubscriptions_withCache
       continue;
     }
 
-
-    //
-    // FIXME P4: See issue #2076.
-    //           aList is just a copy of cSubP->attributes - would be good to avoid
-    //           as a reference to the CachedSubscription is already in TriggeredSubscription
-    //           cSubP->attributes is of type    std::vector<std::string>
-    //           while AttributeList contains a  std::vector<std::string>
-    //           Practically the same, except for the methods that AttributeList offers.
-    //           Perhaps CachedSubscription should include an AttributeList (cSubP->attributes)
-    //           instead of its std::vector<std::string> ... ?
-    //
-    StringList aList;
-    bool op = false;
-    if (cSubP->onlyChanged)
-    {
-      subToNotifyList(modifiedAttrs, cSubP->notifyConditionV, cSubP->attributes, attributes, aList, cSubP->blacklist, op);
-      if (op)
-      {
-        continue;
-      }
-    }
-    else
-    {
-      aList.fill(cSubP->attributes);
-    }
-
     // Throttling
     if ((cSubP->throttling != -1) && (cSubP->lastNotificationTime != 0))
     {
@@ -1082,6 +1056,31 @@ static bool addTriggeredSubscriptions_withCache
                          cSubP->lastNotificationTime,
                          now,
                          now - cSubP->lastNotificationTime));
+    }
+
+    //
+    // FIXME P4: See issue #2076.
+    //           aList is just a copy of cSubP->attributes - would be good to avoid
+    //           as a reference to the CachedSubscription is already in TriggeredSubscription
+    //           cSubP->attributes is of type    std::vector<std::string>
+    //           while AttributeList contains a  std::vector<std::string>
+    //           Practically the same, except for the methods that AttributeList offers.
+    //           Perhaps CachedSubscription should include an AttributeList (cSubP->attributes)
+    //           instead of its std::vector<std::string> ... ?
+    //
+    StringList aList;
+    bool op = false;
+    if (cSubP->onlyChanged)
+    {
+      subToNotifyList(modifiedAttrs, cSubP->notifyConditionV, cSubP->attributes, attributes, aList, cSubP->blacklist, op);
+      if (op)
+      {
+        continue;
+      }
+    }
+    else
+    {
+      aList.fill(cSubP->attributes);
     }
 
     TriggeredSubscription* subP = new TriggeredSubscription((long long) cSubP->throttling,


### PR DESCRIPTION
This PR continues #3680, fixing the pending errors:

```
4 test cases show valgrind errors:
  889: special_metadata_in_notifications_ngsiv1 shows 7 valgrind errors
  890: special_metadata_in_notifications shows 7 valgrind errors
  1102: notify_only_attributes_that_change_empty_cond_empty_notify shows 21 valgrind errors
  1108: notify_only_attributes_that_change_with_cond_empty_notify shows 21 valgrind errors
``` 

Honestly, I'm not sure why this works, but anyway seems to be a improvements: if the notification is blocked due to throttling, there is no need of doing the `aList` preparation.