### PR TITLE
FIX upgrade mongo legacy driver to a new one written in C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,9 @@ SET (BOOST_MT
 # Static libs common to contextBroker and unitTest binaries
 SET (COMMON_STATIC_LIBS
     microhttpd.a
-    mongoclient.a
+    # FIXME OLD-DR: not working... using dynamic
+    #libmongoc-static-1.0.a
+    #libbson-static-1.0.a
 )
 
 SET (DYNAMIC_LIBS
@@ -225,6 +227,10 @@ SET (DYNAMIC_LIBS
     uuid
     crypto
     sasl2
+    # FIXME OLD-DR: I prefer static...
+    # (https://stackoverflow.com/questions/65937063/undefined-reference-to-symbol-error-when-linking-mongo-c-driver-static-library)
+    mongoc-1.0
+    bson-1.0
 )
 
 #
@@ -243,6 +249,12 @@ endif (UNIT_TEST)
 # Common include
 #
 include_directories("/usr/include")
+
+
+# Needed for the new C driver
+include_directories("/usr/local/include/libmongoc-1.0")
+include_directories("/usr/local/include/libbson-1.0")
+
 
 #
 # Library directories

--- a/src/app/contextBroker/CMakeLists.txt
+++ b/src/app/contextBroker/CMakeLists.txt
@@ -82,7 +82,7 @@ ELSEIF(${DISTRO} STREQUAL "Fedora_20")
 # specify switch
 
 ELSE()  
-  TARGET_LINK_LIBRARIES(contextBroker ${STATIC_LIBS} -lmongoclient ${BOOST} ${DYNAMIC_LIBS})
+  TARGET_LINK_LIBRARIES(contextBroker ${STATIC_LIBS} ${BOOST} ${DYNAMIC_LIBS})
 ENDIF()
 
 IF (${DISTRO} MATCHES "Ubuntu.*")

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -494,7 +494,8 @@ void daemonize(void)
   }
 
   // We have to call this after a fork, see: http://api.mongodb.org/cplusplus/2.2.2/classmongo_1_1_o_i_d.html
-  mongo::OID::justForked();
+  // FIXME OLD-DR: this is probably not needed with C driver
+  //mongo::OID::justForked();
 }
 
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1469,16 +1469,18 @@ static bool addTriggeredSubscriptions_noCache
 
   /* For each one of the subscriptions found, add it to the map (if not already there),
    * after checking triggering attributes */
-  while (orion::moreSafe(&cursor))
+  orion::BSONObj sub;
+  while (cursor.next(&sub))
   {
-    orion::BSONObj sub;
+
+    /* FIXME OLD-DR: remove?
     std::string    err;
 
     if (!nextSafeOrErrorFF(cursor, &sub, &err))
     {
       LM_E(("Runtime Error (exception in nextSafe(): %s - query: %s)", err.c_str(), bgP->query.toString().c_str()));
       continue;
-    }
+    }*/
     orion::BSONElement  idField  = getFieldFF(sub, "_id");
 
     //
@@ -1850,8 +1852,8 @@ static unsigned int processSubscriptions
         continue;
       }
 
-      orion::BSONObj areaFilter;
-      if (!processAreaScopeV2(&geoScope, &areaFilter))
+      orion::BSONObjBuilder bobQuery;
+      if (!processAreaScopeV2(&geoScope, &bobQuery, true))
       {
         // Error in processAreaScopeV2 is interpreted as no-match (conservative approach)
         continue;
@@ -1862,16 +1864,14 @@ static unsigned int processSubscriptions
       std::string  keyId   = "_id." ENT_ENTITY_ID;
       std::string  keyType = "_id." ENT_ENTITY_TYPE;
       std::string  keySp   = "_id." ENT_SERVICE_PATH;
-      std::string  keyLoc  = ENT_LOCATION "." ENT_LOCATION_COORDS;
+
       std::string  id      = notifyCerP->entity.id;
       std::string  type    = notifyCerP->entity.type;
       std::string  sp      = notifyCerP->entity.servicePath;
 
-      orion::BSONObjBuilder bobQuery;
       bobQuery.append(keyId, id);
       bobQuery.append(keyType, type);
       bobQuery.append(keySp, sp);
-      bobQuery.append(keyLoc, areaFilter);
 
       unsigned long long n;
       if (!collectionCount(getEntitiesCollectionName(tenant), bobQuery.obj(), &n, &filterErr))
@@ -3598,15 +3598,15 @@ unsigned int processContextElement
   std::vector<orion::BSONObj>  results;
   unsigned int                 docs = 0;
 
-  while (orion::moreSafe(&cursor))
+  orion::BSONObj r;
+  while (cursor.next(&r))
   {
-    orion::BSONObj r;
-
+    /* FIXME OLD-DR: remove?
     if (!nextSafeOrErrorFF(cursor, &r, &err))
     {
       LM_E(("Runtime Error (exception in nextSafe(): %s - query: %s)", err.c_str(), query.toString().c_str()));
       continue;
-    }
+    }*/
 
     docs++;
     LM_T(LmtMongo, ("retrieved document [%d]: '%s'", docs, r.toString().c_str()));
@@ -3633,7 +3633,8 @@ unsigned int processContextElement
     // FIXME OLD-DR: this is a kind of black magic... would we need this owned thing with the new driver? let's see...
     // by the moment we are using the "low level" forbidden methods to solve the issue
     //
-    results.push_back(orion::BSONObj(r.get().getOwned()));
+    //results.push_back(orion::BSONObj(r.get().getOwned()));
+    results.push_back(r);
   }
 
   orion::releaseMongoConnection(connection);

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -261,7 +261,7 @@ extern bool includedAttribute(const std::string& attrName, const StringList& att
 * processAreaScopeV2 -
 *
 */
-extern bool processAreaScopeV2(const Scope* scoP, orion::BSONObj* areaQueryP);
+extern bool processAreaScopeV2(const Scope* scoP, orion::BSONObjBuilder* queryP, bool avoidNearUsasge = false);
 
 
 

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -307,15 +307,16 @@ void mongoListSubscriptions
   /* Process query result */
   unsigned int docs = 0;
 
-  while (orion::moreSafe(&cursor))
+  orion::BSONObj  r;
+  while (cursor.next(&r))
   {
-    orion::BSONObj  r;
-
+    /* FIXME OLD-DR: remove?
     if (!nextSafeOrErrorFF(cursor, &r, &err))
     {
       LM_E(("Runtime Error (exception in nextSafe(): %s - query: %s)", err.c_str(), q.toString().c_str()));
       continue;
     }
+    */
 
     docs++;
     LM_T(LmtMongo, ("retrieved document [%d]: '%s'", docs, r.toString().c_str()));
@@ -386,10 +387,10 @@ void mongoGetSubscription
   TIME_STAT_MONGO_READ_WAIT_STOP();
 
   /* Process query result */
-  if (orion::moreSafe(&cursor))
+  orion::BSONObj r;
+  if (cursor.next(&r))
   {
-    orion::BSONObj r;
-
+    /* FIXME OLD-DR: remove?
     if (!nextSafeOrErrorFF(cursor, &r, &err))
     {
       orion::releaseMongoConnection(connection);
@@ -397,7 +398,7 @@ void mongoGetSubscription
       reqSemGive(__FUNCTION__, "Mongo Get Subscription", reqSemTaken);
       *oe = OrionError(SccReceiverInternalError, std::string("exception in nextSafe(): ") + err.c_str());
       return;
-    }
+    }*/
     LM_T(LmtMongo, ("retrieved document: '%s'", r.toString().c_str()));
 
     setNewSubscriptionId(sub, r);
@@ -406,6 +407,7 @@ void mongoGetSubscription
     setNotification(sub, r, tenant);
     setStatus(sub, r);
 
+    /* FIXME OLD-DR: excesive checing. By defition _id is unique, you will not get more than one
     if (orion::moreSafe(&cursor))
     {
       orion::releaseMongoConnection(connection);
@@ -415,7 +417,7 @@ void mongoGetSubscription
       *oe = OrionError(SccConflict);
 
       return;
-    }
+    }*/
   }
   else
   {

--- a/src/lib/mongoBackend/mongoRegisterContext.cpp
+++ b/src/lib/mongoBackend/mongoRegisterContext.cpp
@@ -110,11 +110,14 @@ HttpStatusCode mongoRegisterContext
 
   if (!orion::collectionFindOne(colName, bob.obj(), &reg, &err))
   {
-    reqSemGive(__FUNCTION__, "ngsi9 register request", reqSemTaken);
+    // FIXME OLD-DR: at the present moment we are unable to know if false means: "no result" or
+    // "fail in cursor". Asked: https://stackoverflow.com/questions/66027858/how-to-get-errors-when-calling-mongoc-collection-find-function
+    // We assume "no result" by the moment, so disabling this code.
+    /*reqSemGive(__FUNCTION__, "ngsi9 register request", reqSemTaken);
     responseP->errorCode.fill(SccReceiverInternalError, err);
     ++noOfRegistrationUpdateErrors;
 
-    return SccOk;
+    return SccOk;*/
   }
 
   if (reg.isEmpty())

--- a/src/lib/mongoBackend/mongoRegistrationDelete.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationDelete.cpp
@@ -99,10 +99,10 @@ void mongoRegistrationDelete
   TIME_STAT_MONGO_READ_WAIT_STOP();
 
   /* Process query result */
-  if (orion::moreSafe(&cursor))
+  orion::BSONObj r;
+  if (cursor.next(&r))
   {
-    orion::BSONObj r;
-
+    /* FIXME OLD-DR: remove?
     if (!nextSafeOrErrorFF(cursor, &r, &err))
     {
       orion::releaseMongoConnection(connection);
@@ -110,10 +110,11 @@ void mongoRegistrationDelete
       reqSemGive(__FUNCTION__, "Mongo Delete Registration", reqSemTaken);
       oeP->fill(SccReceiverInternalError, std::string("exception in nextSafe(): ") + err.c_str());
       return;
-    }
+    }*/
 
     LM_T(LmtMongo, ("retrieved document: '%s'", r.toString().c_str()));
 
+    /* Useless checking: by definition _id is unique
     if (orion::moreSafe(&cursor))  // There can only be one registration for a given ID
     {
       orion::releaseMongoConnection(connection);
@@ -121,7 +122,7 @@ void mongoRegistrationDelete
       reqSemGive(__FUNCTION__, "Mongo Delete Registration", reqSemTaken);
       oeP->fill(SccConflict, "");
       return;
-    }
+    }*/
 
     if (!orion::collectionRemove(getRegistrationsCollectionName(tenant), q, &err))
     {

--- a/src/lib/mongoBackend/mongoRegistrationGet.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationGet.cpp
@@ -282,9 +282,10 @@ void mongoRegistrationGet
   TIME_STAT_MONGO_READ_WAIT_STOP();
 
   /* Process query result */
-  if (orion::moreSafe(&cursor))
+  orion::BSONObj r;
+  if (cursor.next(&r))
   {
-    orion::BSONObj r;
+    /* FIXME OLD-DR: remove?
     if (!nextSafeOrErrorFF(cursor, &r, &err))
     {
       orion::releaseMongoConnection(connection);
@@ -292,7 +293,7 @@ void mongoRegistrationGet
       reqSemGive(__FUNCTION__, "Mongo Get Registration", reqSemTaken);
       oeP->fill(SccReceiverInternalError, std::string("exception in nextSafe(): ") + err.c_str());
       return;
-    }
+    }*/
     LM_T(LmtMongo, ("retrieved document: '%s'", r.toString().c_str()));
 
     //
@@ -313,6 +314,7 @@ void mongoRegistrationGet
     setExpires(regP, r);
     setStatus(regP, r);
 
+    /* FIXME OLD-DR: excesive checking. Looking by _id you cannot get more than one result!
     if (orion::moreSafe(&cursor))  // Can only be one ...
     {
       orion::releaseMongoConnection(connection);
@@ -320,7 +322,7 @@ void mongoRegistrationGet
       reqSemGive(__FUNCTION__, "Mongo Get Registration", reqSemTaken);
       oeP->fill(SccConflict, "");
       return;
-    }
+    }*/
   }
   else
   {
@@ -393,16 +395,17 @@ void mongoRegistrationsGet
 
   /* Process query result */
   int docs = 0;
-  while (orion::moreSafe(&cursor))
+  orion::BSONObj        r;
+  while (cursor.next(&r))
   {
-    orion::BSONObj        r;
     ngsiv2::Registration  reg;
 
+    /* FIXME OLD-DR: remove?
     if (!nextSafeOrErrorFF(cursor, &r, &err))
     {
       LM_E(("Runtime Error (exception in nextSafe(): %s - query: %s)", err.c_str(), q.toString().c_str()));
       continue;
-    }
+    }*/
 
     LM_T(LmtMongo, ("retrieved document [%d]: '%s'", docs, r.toString().c_str()));
     ++docs;

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -467,16 +467,17 @@ void mongoSubCacheRefresh(const std::string& database)
   TIME_STAT_MONGO_READ_WAIT_STOP();
 
   int subNo = 0;
-  while (orion::moreSafe(&cursor))
+  orion::BSONObj  sub;
+  while (cursor.next(&sub))
   {
-    orion::BSONObj  sub;
+    /* FIXME OLD-DR: remove?
     std::string     err;
 
     if (!nextSafeOrErrorFF(cursor, &sub, &err))
     {
       LM_E(("Runtime Error (exception in nextSafe(): %s - query: %s)", err.c_str(), query.toString().c_str()));
       continue;
-    }
+    }*/
 
     int r = mongoSubCacheItemInsert(tenant.c_str(), sub);
     if (r == 0)

--- a/src/lib/mongoBackend/mongoUnsubscribeContext.cpp
+++ b/src/lib/mongoBackend/mongoUnsubscribeContext.cpp
@@ -106,20 +106,22 @@ HttpStatusCode mongoUnsubscribeContext
 
   if (!orion::collectionFindOne(getSubscribeContextCollectionName(tenant), bobId.obj(), &sub, &err))
   {
-    reqSemGive(__FUNCTION__, "ngsi10 unsubscribe request (mongo db exception)", reqSemTaken);
+    // FIXME OLD-DR: at the present moment we are unable to know if false means: "no result" or
+    // "fail in cursor". Asked: https://stackoverflow.com/questions/66027858/how-to-get-errors-when-calling-mongoc-collection-find-function
+    // We assume "no result" by the moment, so disabling this code.
+    /*reqSemGive(__FUNCTION__, "ngsi10 unsubscribe request (mongo db exception)", reqSemTaken);
 
     responseP->statusCode.fill(SccReceiverInternalError, err);
     responseP->oe.fill(SccReceiverInternalError, err, "InternalError");
 
-    return SccOk;
+    return SccOk;*/
   }
 
   if (sub.isEmpty())
   {
     reqSemGive(__FUNCTION__, "ngsi10 unsubscribe request (no subscriptions found)", reqSemTaken);
 
-    responseP->statusCode.fill(SccContextElementNotFound,
-                               std::string("subscriptionId: /") + requestP->subscriptionId.get() + "/");
+    responseP->statusCode.fill(SccContextElementNotFound);
     responseP->oe.fill(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_SUBSCRIPTION, ERROR_NOT_FOUND);
 
     return SccOk;

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -900,10 +900,13 @@ std::string mongoUpdateSubscription
   bob.append("_id", id);
   if (!orion::collectionFindOne(getSubscribeContextCollectionName(tenant), bob.obj(), &subOrig, &err))
   {
-    reqSemGive(__FUNCTION__, "ngsiv2 update subscription request (mongo db exception)", reqSemTaken);
+    // FIXME OLD-DR: at the present moment we are unable to know if false means: "no result" or
+    // "fail in cursor". Asked: https://stackoverflow.com/questions/66027858/how-to-get-errors-when-calling-mongoc-collection-find-function
+    // We assume "no result" by the moment, so disabling this code.
+    /*reqSemGive(__FUNCTION__, "ngsiv2 update subscription request (mongo db exception)", reqSemTaken);
     oe->fill(SccReceiverInternalError, err);
 
-    return "";
+    return "";*/
   }
 
   if (subOrig.isEmpty())

--- a/src/lib/mongoDriver/BSONArray.cpp
+++ b/src/lib/mongoDriver/BSONArray.cpp
@@ -27,6 +27,8 @@
 
 #include "mongoDriver/BSONArray.h"
 
+#include "logMsg/logMsg.h"  // FIXME OLD-DR: remove after use
+
 namespace orion
 {
 /* ****************************************************************************
@@ -35,6 +37,30 @@ namespace orion
 */
 BSONArray::BSONArray()
 {
+  // FIXME OLD-DR: is this constructor really needed?
+  b = bson_new();
+}
+
+
+
+/* ****************************************************************************
+*
+* BSONArray::BSONArray -
+*/
+BSONArray::BSONArray(const BSONArray& _ba)
+{
+  b = bson_copy(_ba.get());
+}
+
+
+
+/* ****************************************************************************
+*
+* BSONArray::~BSONArray -
+*/
+BSONArray::~BSONArray(void)
+{
+  bson_destroy(b);
 }
 
 
@@ -45,7 +71,7 @@ BSONArray::BSONArray()
 */
 int BSONArray::nFields(void) const
 {
-  return ba.nFields();
+  return bson_count_keys(b);
 }
 
 
@@ -54,9 +80,32 @@ int BSONArray::nFields(void) const
 *
 * BSONArray::toString -
 */
-std::string BSONArray::toString(void)
+std::string BSONArray::toString(void) const
 {
-  return ba.toString();
+  char* str = bson_array_as_json(b, NULL);
+  std::string s(str);
+  bson_free(str);
+  return s;
+}
+
+
+
+/* ****************************************************************************
+*
+* BSONArray::operator= -
+*
+* FIXME OLD-DR: we should try to use const BSONArray& as argument
+*/
+BSONArray& BSONArray::operator= (BSONArray rhs)
+{
+  // check not self-assignment
+  if (this != &rhs)
+  {
+    // destroy existing b object, then copy rhs.b object
+    bson_destroy(b);
+    b = bson_copy(rhs.b);
+  }
+  return *this;
 }
 
 
@@ -68,10 +117,11 @@ std::string BSONArray::toString(void)
 /* ****************************************************************************
 *
 * BSONArray::BSONArray -
+*
 */
-BSONArray::BSONArray(const mongo::BSONArray& _ba)
+BSONArray::BSONArray(const bson_t* _b)
 {
-  ba = _ba;
+  b = bson_copy(_b);
 }
 
 
@@ -80,9 +130,9 @@ BSONArray::BSONArray(const mongo::BSONArray& _ba)
 *
 * BSONObj::get -
 */
-mongo::BSONArray BSONArray::get(void) const
+bson_t* BSONArray::get(void) const
 {
-  return ba;
+  return b;
 }
 }
 

--- a/src/lib/mongoDriver/BSONArray.h
+++ b/src/lib/mongoDriver/BSONArray.h
@@ -27,8 +27,7 @@
 */
 
 #include <string>
-
-#include "mongo/bson/bson.h"  // FIXME OLD-DR: change in next PoC stage
+#include <bson/bson.h>
 
 namespace orion
 {
@@ -39,17 +38,21 @@ namespace orion
 class BSONArray
 {
  private:
-  mongo::BSONArray  ba;
+  bson_t*  b;
 
  public:
   // methods to be used by client code (without references to low-level driver code)
   BSONArray();
+  BSONArray(const BSONArray& _ba);
   int nFields(void) const;
-  std::string toString(void);
+  std::string toString(void) const;
+  BSONArray& operator= (BSONArray rhs);
 
   // methods to be used only by mongoDriver/ code (with references to low-level driver code)
-  explicit BSONArray(const mongo::BSONArray& _ba);
-  mongo::BSONArray get(void) const;
+  BSONArray(const bson_t* _b);
+  ~BSONArray(void);
+  bson_t* get(void) const;
+
 };
 }
 

--- a/src/lib/mongoDriver/BSONArrayBuilder.h
+++ b/src/lib/mongoDriver/BSONArrayBuilder.h
@@ -31,8 +31,6 @@
 #include "mongoDriver/BSONArray.h"
 #include "mongoDriver/BSONObj.h"
 
-#include "mongo/bson/bsonobjbuilder.h"  // FIXME OLD-DR: change in next PoC stage
-
 namespace orion
 {
 /* ****************************************************************************
@@ -42,7 +40,10 @@ namespace orion
 class BSONArrayBuilder
 {
  private:
-  mongo::BSONArrayBuilder  bab;
+  bson_t*     b;
+  uint32_t    size;     // current number of elements in array builder (starts at 0)
+  char        buf[16];  // for internal use in append methods. FIXME OLD-DR: unhardwire 16
+  const char* key;      // for internal use in append methods
 
  public:
   // methods to be used by client code (without references to low-level driver code)
@@ -57,9 +58,10 @@ class BSONArrayBuilder
   void append(bool value);
   void appendNull(void);
   void appendRegex(const std::string& value);
+  BSONArrayBuilder& operator= (BSONArrayBuilder rhs);
 
   // methods to be used only by mongoDriver/ code (with references to low-level driver code)
-  // (none so far)
+  ~BSONArrayBuilder(void);
 };
 }
 

--- a/src/lib/mongoDriver/BSONDate.cpp
+++ b/src/lib/mongoDriver/BSONDate.cpp
@@ -57,7 +57,7 @@ bool BSONDate::equal(unsigned long long m)
 *
 * BSONDate::get -
 */
-mongo::Date_t BSONDate::get(void) const
+int64_t BSONDate::get(void) const
 {
   return date;
 }

--- a/src/lib/mongoDriver/BSONDate.h
+++ b/src/lib/mongoDriver/BSONDate.h
@@ -28,8 +28,7 @@
 
 #include <string>
 #include <vector>
-
-#include "mongo/util/time_support.h"  // FIXME OLD-DR: change in next PoC stage
+#include <stdint.h>  // CentOS 7 needs this explicit declaration (and doesn't hurts in other OS)
 
 namespace orion
 {
@@ -41,7 +40,7 @@ namespace orion
 class BSONDate
 {
  private:
-  mongo::Date_t date;
+  unsigned long long date;
 
  public:
   // methods to be used by client code (without references to low-level driver code)
@@ -49,7 +48,7 @@ class BSONDate
   bool equal(unsigned long long m);
 
   // methods to be used only by mongoDriver/ code (with references to low-level driver code)
-  mongo::Date_t get(void) const;
+  int64_t get(void) const;
 };
 }
 

--- a/src/lib/mongoDriver/BSONElement.h
+++ b/src/lib/mongoDriver/BSONElement.h
@@ -28,8 +28,7 @@
 
 #include <string>
 #include <vector>
-
-#include "mongo/bson/bson.h"  // FIXME OLD-DR: change in next PoC stage
+#include <bson/bson.h>
 
 #include "mongoDriver/BSONObj.h"
 #include "mongoDriver/BSONDate.h"
@@ -47,7 +46,8 @@ class BSONObj;
 class BSONElement
 {
  private:
-  mongo::BSONElement  be;
+  std::string   field;
+  bson_value_t  bv;
 
  public:
   // methods to be used by client code (without references to low-level driver code)
@@ -66,8 +66,7 @@ class BSONElement
   bool eoo(void) const;
 
   // methods to be used only by mongoDriver/ code (with references to low-level driver code)
-  explicit BSONElement(const mongo::BSONElement& _bo);
-  mongo::BSONElement get(void) const;
+  BSONElement(const std::string& _field, const bson_value_t* _bv);
 };
 }
 

--- a/src/lib/mongoDriver/BSONObjBuilder.h
+++ b/src/lib/mongoDriver/BSONObjBuilder.h
@@ -27,13 +27,12 @@
 */
 
 #include <string>
+#include <bson/bson.h>
 
 #include "mongoDriver/BSONObj.h"
 #include "mongoDriver/OID.h"
 #include "mongoDriver/BSONArray.h"
 #include "mongoDriver/BSONDate.h"
-
-#include "mongo/bson/bsonobjbuilder.h"  // FIXME OLD-DR: change in next PoC stage
 
 namespace orion
 {
@@ -44,7 +43,7 @@ namespace orion
 class BSONObjBuilder
 {
  private:
-  mongo::BSONObjBuilder  bob;
+  bson_t*  b;
 
  public:
   // methods to be used by client code (without references to low-level driver code)
@@ -64,9 +63,10 @@ class BSONObjBuilder
   void appendNull(const std::string& key);
   void appendElements(orion::BSONObj b);
   BSONObj obj(void);
+  BSONObjBuilder& operator= (BSONObjBuilder rhs);
 
   // methods to be used only by mongoDriver/ code (with references to low-level driver code)
-  // (none so far)
+  ~BSONObjBuilder(void);
 };
 }
 

--- a/src/lib/mongoDriver/BSONTypes.h
+++ b/src/lib/mongoDriver/BSONTypes.h
@@ -51,7 +51,8 @@ enum BSONType {
     NumberInt = 16,
     Timestamp = 17,
     NumberLong = 18,
-    JSTypeMax = 18,
+    JSTypeMax = 19,
+    BigDecimal = 20,
     MaxKey = 127
 };
 }

--- a/src/lib/mongoDriver/DBConnection.cpp
+++ b/src/lib/mongoDriver/DBConnection.cpp
@@ -44,7 +44,7 @@ DBConnection::DBConnection()
 */
 bool DBConnection::operator== (const DBConnection &rhs)
 {
-  return dbcP == rhs.dbcP;
+  return (dbcP == rhs.dbcP);
 }
 
 
@@ -59,6 +59,7 @@ bool DBConnection::isNull(void)
 }
 
 
+
 ///////// from now on, only methods with low-level driver types in return or parameters /////////
 
 
@@ -67,7 +68,7 @@ bool DBConnection::isNull(void)
 *
 * DBConnection::DBConnection -
 */
-DBConnection::DBConnection(mongo::DBClientBase* _dbcP)
+DBConnection::DBConnection(mongoc_client_t* _dbcP)
 {
   dbcP = _dbcP;
 }
@@ -79,7 +80,7 @@ DBConnection::DBConnection(mongo::DBClientBase* _dbcP)
 * DBConnection::get -
 */
 
-mongo::DBClientBase* DBConnection::get(void)
+mongoc_client_t* DBConnection::get(void)
 {
   return dbcP;
 }

--- a/src/lib/mongoDriver/DBConnection.h
+++ b/src/lib/mongoDriver/DBConnection.h
@@ -26,7 +26,7 @@
 * Author: Fermín Galán
 */
 
-#include "mongo/client/dbclient.h"  // FIXME OLD-DR: change in next PoC stage
+#include <mongoc/mongoc.h>
 
 namespace orion
 {
@@ -37,7 +37,7 @@ namespace orion
 class DBConnection
 {
  private:
-  mongo::DBClientBase* dbcP;
+  mongoc_client_t*  dbcP;
 
  public:
   // methods to be used by client code (without references to low-level driver code)
@@ -46,8 +46,8 @@ class DBConnection
   bool isNull(void);
 
   // methods to be used only by mongoDriver/ code (with references to low-level driver code)
-  explicit DBConnection(mongo::DBClientBase* _dbc);
-  mongo::DBClientBase* get(void);
+  explicit DBConnection(mongoc_client_t* _dbcP);
+  mongoc_client_t* get(void);
 };
 }
 

--- a/src/lib/mongoDriver/DBCursor.h
+++ b/src/lib/mongoDriver/DBCursor.h
@@ -26,13 +26,13 @@
 * Author: Fermín Galán
 */
 
-#include "mongo/client/dbclient.h"  // FIXME OLD-DR: change in next PoC stage
+#include <mongoc/mongoc.h>
 
 #include "mongoDriver/BSONObj.h"
 
-#define NEXTSAFE_CODE_NO_ERROR 0
-#define NEXTSAFE_CODE_MONGO_EXCEPTION 1
-#define NEXTSAFE_CODE_NO_MONGO_EXCEPTION 2
+#define ON_NEXT_NO_ERROR         0
+#define ON_NEXT_MANAGED_ERROR    1
+#define ON_NEXT_UNMANAGED_ERROR  2
 
 namespace orion
 {
@@ -43,17 +43,18 @@ namespace orion
 class DBCursor
 {
  private:
-  std::auto_ptr<mongo::DBClientCursor> dbc;
+  mongoc_cursor_t* c;
 
  public:
   // methods to be used by client code (without references to low-level driver code)
   DBCursor();
   bool more(void);
-  BSONObj nextSafe(int* errCode = NULL, std::string* err = NULL);
+  bool next(BSONObj* nextDoc, int* errTypeP = NULL, std::string* err = NULL);
   bool isNull(void);
 
   // methods to be used only by mongoDriver/ code (with references to low-level driver code)
-  void set(std::auto_ptr<mongo::DBClientCursor> _dbc);
+  void set(mongoc_cursor_t* _c);
+  ~DBCursor();
 };
 }
 

--- a/src/lib/mongoDriver/OID.h
+++ b/src/lib/mongoDriver/OID.h
@@ -27,8 +27,7 @@
 */
 
 #include <string>
-
-#include "mongo/bson/bson.h"  // FIXME OLD-DR: change in next PoC stage
+#include <bson/bson.h>
 
 namespace orion
 {
@@ -39,7 +38,7 @@ namespace orion
 class OID
 {
  private:
-  mongo::OID  oid;
+  bson_oid_t  oid;
 
  public:
   // methods to be used by client code (without references to low-level driver code)
@@ -49,8 +48,7 @@ class OID
   std::string toString(void);
 
   // methods to be used only by mongoDriver/ code (with references to low-level driver code)
-  explicit OID(const mongo::OID& _bo);
-  mongo::OID get(void) const;
+  bson_oid_t get(void) const;
 };
 }
 

--- a/src/lib/mongoDriver/connectionOperations.cpp
+++ b/src/lib/mongoDriver/connectionOperations.cpp
@@ -24,9 +24,6 @@
 */
 #include <string>
 
-#include "mongo/client/dbclient.h"
-// #include "mongo/client/index_spec.h"  // FIXME OLD-DR: to be needed soon
-
 #include "logMsg/traceLevels.h"
 #include "logMsg/logMsg.h"
 #include "common/string.h"
@@ -35,10 +32,13 @@
 #include "alarmMgr/alarmMgr.h"
 
 #include "mongoDriver/connectionOperations.h"
+#include "mongoDriver/BSONObjBuilder.h"
+#include "mongoDriver/BSONArrayBuilder.h"
 #include "mongoDriver/mongoConnectionPool.h"
 
 
 
+#if 0
 /* ****************************************************************************
 *
 * orion::collectionQuery -
@@ -111,9 +111,84 @@ bool orion::collectionQuery
   alarmMgr.dbErrorReset();
   return true;
 }
+#endif
 
 
 
+/* ****************************************************************************
+*
+* orion::collectionQuery -
+*
+* Different from others, this function doesn't use getMongoConnection() and
+* releaseMongoConnection(). It is assumed that the caller will do, as the
+* connection cannot be released before the cursor has been used.
+*/
+bool orion::collectionQuery
+(
+  orion::DBConnection    _connection,
+  const std::string&     col,
+  const orion::BSONObj&  _q,
+  orion::DBCursor*       cursor,
+  std::string*           err
+)
+{
+  // FIXME OLD-DR: change function signature to have db and col separately and remove
+  // this tokenization logic
+  std::stringstream ss(col);
+  std::vector<std::string> tokens;
+  while(ss.good())
+  {
+    std::string substr;
+    getline(ss, substr, '.');
+    tokens.push_back(substr);
+  }
+
+  // Getting & checking connection
+  mongoc_client_t* connection = _connection.get();
+  if (connection == NULL)
+  {
+    LM_E(("Fatal Error (null DB connection)"));
+    *err = "null DB connection";
+
+    return false;
+  }
+
+  // Get low level driver object
+  bson_t* q = _q.get();
+  char* bsonStr = bson_as_relaxed_extended_json(q, NULL);
+
+  LM_T(LmtMongo, ("query() in '%s' collection: '%s'", col.c_str(), bsonStr));
+  mongoc_collection_t *collection = mongoc_client_get_collection(connection, tokens[0].c_str(), tokens[1].c_str());
+  cursor->set(mongoc_collection_find_with_opts(collection, q, NULL, NULL));
+  mongoc_collection_destroy(collection);
+
+  // FIXME OLD-DR: how to manage errors? this function doesn't use bson_error_t...
+  // Is enough just checking for return cursor pointer NULL-ness? Note that
+  // doc http://mongoc.org/libmongoc/1.17.3/mongoc_collection_find_with_opts.html
+  // doesn't describes NULL as a possible return value...
+  // Asked: https://stackoverflow.com/questions/66027858/how-to-get-errors-when-calling-mongoc-collection-update-function
+  if (cursor->isNull())
+  {
+    std::string msg = std::string("collection: ") + col +
+      " - query(): " + bsonStr +
+      " - exception: Null cursor from mongo (details on this is found in the source code";
+
+    *err = "Database Error (" + msg + ")";
+    alarmMgr.dbError(msg);
+
+    return false;
+  }
+
+  alarmMgr.dbErrorReset();
+
+  bson_free(bsonStr);
+
+  return true;
+}
+
+
+
+#if 0
 /* ****************************************************************************
 *
 * orion::collectionRangedQuery -
@@ -203,8 +278,125 @@ bool orion::collectionRangedQuery
   alarmMgr.dbErrorReset();
   return true;
 }
+#endif
 
 
+
+/* ****************************************************************************
+*
+* orion::collectionRangedQuery -
+*
+* Different from others, this function doesn't use getMongoConnection() and
+* releaseMongoConnection(). It is assumed that the caller will do, as the
+* connection cannot be released before the cursor has been used.
+*/
+bool orion::collectionRangedQuery
+(
+  orion::DBConnection    _connection,
+  const std::string&     col,
+  const orion::BSONObj&  _q,
+  const orion::BSONObj&  _sort,  // FIXME: this change can be propagated independtly to master
+  int                    limit,
+  int                    offset,
+  orion::DBCursor*       cursor,
+  long long*             count,
+  std::string*           err
+)
+{
+  // FIXME OLD-DR: change function signature to have db and col separately and remove
+  // this tokenization logic
+  std::stringstream ss(col);
+  std::vector<std::string> tokens;
+  while(ss.good())
+  {
+    std::string substr;
+    getline(ss, substr, '.');
+    tokens.push_back(substr);
+  }
+
+  // Getting & checking connection
+  mongoc_client_t* connection = _connection.get();
+  if (connection == NULL)
+  {
+    LM_E(("Fatal Error (null DB connection)"));
+    *err = "null DB connection";
+
+    return false;
+  }
+
+  // Getting low level driver object
+  bson_t*     q = _q.get();
+  char* bsonStr = bson_as_relaxed_extended_json(q, NULL);
+
+  LM_T(LmtMongo, ("query() in '%s' collection limit=%d, offset=%d: '%s'",
+                  col.c_str(), limit, offset, bsonStr));
+  mongoc_collection_t *collection = mongoc_client_get_collection(connection, tokens[0].c_str(), tokens[1].c_str());
+
+  // First, set countP (if used). In the case of error, we return early and the actual query doesn't take place
+  if (count != NULL)
+  {
+    bson_error_t error;
+    long long n = mongoc_collection_count_documents(collection, q, NULL, NULL, NULL, &error);
+    if (n >= 0)
+    {
+      *count = n;
+    }
+    else
+    {
+      std::string msg = std::string("collection: ") + col.c_str() +
+        " - count_documents(): " + bsonStr +
+        " - exception: " + error.message;
+
+      *err = "Database Error (" + msg + ")";
+      alarmMgr.dbError(msg);
+
+      mongoc_collection_destroy(collection);
+      bson_free(bsonStr);
+
+      return false;
+    }
+  }
+
+  // Build the options document
+  bson_t* opt = bson_new();
+  BSON_APPEND_DOCUMENT(opt, "sort", _sort.get());
+  BSON_APPEND_INT32(opt, "limit", limit);
+  BSON_APPEND_INT32(opt, "skip", offset);
+
+  cursor->set(mongoc_collection_find_with_opts(collection, q, opt, NULL));
+
+  bson_destroy(opt);
+  mongoc_collection_destroy(collection);
+
+  // FIXME OLD-DR: how to manage errors? this function doesn't use bson_error_t...
+  // Is enough just checking for return cursor pointer NULL-ness? Note that
+  // doc http://mongoc.org/libmongoc/1.17.3/mongoc_collection_find_with_opts.html
+  // doesn't describes NULL as a possible return value...
+  // Asked: https://stackoverflow.com/questions/66027858/how-to-get-errors-when-calling-mongoc-collection-update-function
+  if (cursor->isNull())
+  {
+    std::string msg = std::string("collection: ") + col +
+      " - query(): " + bsonStr +
+      " - exception: Null cursor from mongo (details on this is found in the source code";
+
+    *err = "Database Error (" + msg + ")";
+    alarmMgr.dbError(msg);
+
+    return false;
+  }
+
+  LM_T(LmtOldInfo, ("Database Operation Successful (query: %s)", bsonStr));
+
+  alarmMgr.dbErrorReset();
+
+  bson_free(bsonStr);
+
+  return true;
+}
+
+
+
+#if 0
 /* ****************************************************************************
 *
 * orion::collectionCount -
@@ -274,9 +466,86 @@ bool orion::collectionCount
   alarmMgr.dbErrorReset();
   return true;
 }
+#endif
 
 
 
+/* ****************************************************************************
+*
+* orion::collectionCount -
+*/
+bool orion::collectionCount
+(
+  const std::string&     col,
+  const orion::BSONObj&  _q,
+  unsigned long long*    c,
+  std::string*           err
+)
+{
+  TIME_STAT_MONGO_READ_WAIT_START();
+
+  // FIXME OLD-DR: change function signature to have db and col separately and remove
+  // this tokenization logic
+  std::stringstream ss(col);
+  std::vector<std::string> tokens;
+  while(ss.good())
+  {
+    std::string substr;
+    getline(ss, substr, '.');
+    tokens.push_back(substr);
+  }
+
+  // Getting & checking connection
+  orion::DBConnection connection = orion::getMongoConnection();
+  if (connection.isNull())
+  {
+    TIME_STAT_MONGO_READ_WAIT_STOP();
+
+    LM_E(("Fatal Error (null DB connection)"));
+    *err = "null DB connection";
+
+    orion::releaseMongoConnection(connection);
+    return false;
+  }
+
+  // Get low level driver object
+  const bson_t* doc = _q.get();
+  char* bsonStr = bson_as_relaxed_extended_json(doc, NULL);
+
+  LM_T(LmtMongo, ("count_documents() in '%s' collection: '%s'", col.c_str(), bsonStr));
+
+  mongoc_collection_t* collection = mongoc_client_get_collection(connection.get(), tokens[0].c_str(), tokens[1].c_str());
+
+  bson_error_t error;
+  long long n = mongoc_collection_count_documents(collection, doc, NULL, NULL, NULL, &error);
+
+  mongoc_collection_destroy(collection);
+  orion::releaseMongoConnection(connection);
+  TIME_STAT_MONGO_READ_WAIT_STOP();
+
+  if (n >= 0)
+  {
+    LM_T(LmtOldInfo, ("Database Operation Successful (count_documents: %s)", bsonStr));
+    *c = n;
+    alarmMgr.dbErrorReset();
+  }
+  else
+  {
+    std::string msg = std::string("collection: ") + col.c_str() +
+      " - count_documents(): " + bsonStr +
+      " - exception: " + error.message;
+
+    *err = "Database Error (" + msg + ")";
+    alarmMgr.dbError(msg);
+  }
+
+  bson_free(bsonStr);
+
+  return (n >= 0);
+}
+
+
+#if 0
 /* ****************************************************************************
 *
 * orion::collectionFindOne -
@@ -346,9 +615,58 @@ bool orion::collectionFindOne
   alarmMgr.dbErrorReset();
   return true;
 }
+#endif
 
 
 
+/* ****************************************************************************
+*
+* orion::collectionFindOne -
+*
+* FIXME OLD-DR: is seems there is no findOne native operation in the driver
+* (asked at https://stackoverflow.com/questions/66030072/is-there-a-findone-operation-in-the-mongo-c-driver)
+* By the moment this function implements findOne on top of collectionFindRangedQuery
+*/
+bool orion::collectionFindOne
+(
+  const std::string&     col,
+  const orion::BSONObj&  _q,
+  orion::BSONObj*        doc,
+  std::string*           err
+)
+{
+  TIME_STAT_MONGO_READ_WAIT_START();
+
+  orion::DBConnection connection = orion::getMongoConnection();
+
+  orion::DBCursor cursor;
+
+  if (!collectionRangedQuery(connection, col, _q, orion::BSONObj(), 1, 0, &cursor, NULL, err))
+  {
+    orion::releaseMongoConnection(connection);
+    TIME_STAT_MONGO_READ_WAIT_STOP();
+    return false;
+  }
+
+  // Get exactly one item from cursor (checking that at least one result exist)
+  BSONObj b;
+  bool success = cursor.next(&b);
+
+  if (success)
+  {
+    // We only return the BSON in doc argument in success case
+    *doc = b;
+  }
+
+  orion::releaseMongoConnection(connection);
+  TIME_STAT_MONGO_READ_WAIT_STOP();
+
+  return success;
+}
+
+
+
+#if 0
 /* ****************************************************************************
 *
 * orion::collectionInsert -
@@ -418,9 +736,86 @@ bool orion::collectionInsert
   alarmMgr.dbErrorReset();
   return true;
 }
+#endif
 
 
 
+/* ****************************************************************************
+*
+* orion::collectionInsert -
+*/
+bool orion::collectionInsert
+(
+  const std::string&     col,
+  const orion::BSONObj&  _doc,
+  std::string*           err
+)
+{
+  TIME_STAT_MONGO_WRITE_WAIT_START();
+
+  // FIXME OLD-DR: change function signature to have db and col separately and remove
+  // this tokenization logic
+  std::stringstream ss(col);
+  std::vector<std::string> tokens;
+  while(ss.good())
+  {
+    std::string substr;
+    getline(ss, substr, '.');
+    tokens.push_back(substr);
+  }
+
+  // Getting & checking connection
+  orion::DBConnection connection = orion::getMongoConnection();
+  if (connection.isNull())
+  {
+    TIME_STAT_MONGO_WRITE_WAIT_STOP();
+
+    LM_E(("Fatal Error (null DB connection)"));
+    *err = "null DB connection";
+
+    orion::releaseMongoConnection(connection);
+    return false;
+  }
+
+  // Get low level driver object
+  const bson_t* doc = _doc.get();
+  char* bsonStr = bson_as_relaxed_extended_json(doc, NULL);
+
+  LM_T(LmtMongo, ("insert_one() in '%s' collection: '%s'", col.c_str(), bsonStr));
+
+  mongoc_collection_t *collection = mongoc_client_get_collection(connection.get(), tokens[0].c_str(), tokens[1].c_str());
+
+  bson_error_t error;
+  bson_t* opt = BCON_NEW("validate", BCON_BOOL(false));
+  bool success = mongoc_collection_insert_one(collection, doc, opt, NULL, &error);
+
+  bson_destroy(opt);
+  mongoc_collection_destroy(collection);
+  orion::releaseMongoConnection(connection);
+  TIME_STAT_MONGO_WRITE_WAIT_STOP();
+
+  if (success)
+  {
+    LM_T(LmtOldInfo, ("Database Operation Successful (insert: %s)", bsonStr));
+    alarmMgr.dbErrorReset();
+  }
+  else
+  {
+    std::string msg = std::string("collection: ") + col.c_str() +
+      " - insert_one(): " + bsonStr +
+      " - exception: " + error.message;
+
+    *err = "Database Error (" + msg + ")";
+    alarmMgr.dbError(msg);
+  }
+
+  bson_free(bsonStr);
+
+  return success;
+}
+
+
+#if 0
 /* ****************************************************************************
 *
 * orion::collectionUpdate -
@@ -497,9 +892,95 @@ bool orion::collectionUpdate
 
   return true;
 }
+#endif
 
 
 
+/* ****************************************************************************
+*
+* orion::collectionUpdate -
+*/
+bool orion::collectionUpdate
+(
+  const std::string&     col,
+  const orion::BSONObj&  _q,
+  const orion::BSONObj&  _doc,
+  bool                   upsert,
+  std::string*           err
+)
+{
+  TIME_STAT_MONGO_WRITE_WAIT_START();
+
+  // FIXME OLD-DR: change function signature to have db and col separately and remove
+  // this tokenization logic
+  std::stringstream ss(col);
+  std::vector<std::string> tokens;
+  while(ss.good())
+  {
+    std::string substr;
+    getline(ss, substr, '.');
+    tokens.push_back(substr);
+  }
+
+  // Getting & checking connection
+  orion::DBConnection connection = orion::getMongoConnection();
+  if (connection.isNull())
+  {
+    TIME_STAT_MONGO_WRITE_WAIT_STOP();
+
+    LM_E(("Fatal Error (null DB connection)"));
+    *err = "null DB connection";
+
+    orion::releaseMongoConnection(connection);
+    return false;
+  }
+
+  // Get log level driver objects
+  const bson_t* q   = _q.get();
+  const bson_t* doc = _doc.get();
+  char* bsonQStr   = bson_as_relaxed_extended_json(q, NULL);
+  char* bsonDocStr = bson_as_relaxed_extended_json(doc, NULL);
+
+  LM_T(LmtMongo, ("update() in '%s' collection: query='%s' doc='%s', upsert=%s",
+                  col.c_str(),
+                  bsonQStr,
+                  bsonDocStr,
+                  FT(upsert)));
+
+  mongoc_collection_t *collection = mongoc_client_get_collection(connection.get(), tokens[0].c_str(), tokens[1].c_str());
+
+  bson_error_t error;
+  bool success = mongoc_collection_update(collection,
+                                          upsert ? MONGOC_UPDATE_UPSERT : MONGOC_UPDATE_NONE,
+                                          q, doc, NULL, &error);
+
+  mongoc_collection_destroy(collection);
+  orion::releaseMongoConnection(connection);
+  TIME_STAT_MONGO_WRITE_WAIT_STOP();
+
+  if (success)
+  {
+    LM_T(LmtOldInfo, ("Database Operation Successful (update: <%s, %s>)", bsonQStr, bsonDocStr));
+    alarmMgr.dbErrorReset();
+  }
+  else
+  {
+    std::string msg = std::string("collection: ") + col.c_str() +
+      " - update(): <" + bsonQStr + "," + bsonDocStr + ">" +
+      " - exception: " + error.message;
+
+    *err = "Database Error (" + msg + ")";
+    alarmMgr.dbError(msg);
+  }
+
+  bson_free(bsonQStr);
+  bson_free(bsonDocStr);
+
+  return success;
+}
+
+
+#if 0
 /* ****************************************************************************
 *
 * orion::collectionRemove -
@@ -569,9 +1050,85 @@ bool orion::collectionRemove
   alarmMgr.dbErrorReset();
   return true;
 }
+#endif
 
 
 
+/* ****************************************************************************
+*
+* orion::collectionRemove -
+*/
+bool orion::collectionRemove
+(
+  const std::string&     col,
+  const orion::BSONObj&  _q,
+  std::string*           err
+)
+{
+  TIME_STAT_MONGO_WRITE_WAIT_START();
+
+  // FIXME OLD-DR: change function signature to have db and col separately and remove
+  // this tokenization logic
+  std::stringstream ss(col);
+  std::vector<std::string> tokens;
+  while(ss.good())
+  {
+    std::string substr;
+    getline(ss, substr, '.');
+    tokens.push_back(substr);
+  }
+
+  // Getting & checking conection
+  orion::DBConnection connection = orion::getMongoConnection();
+  if (connection.isNull())
+  {
+    TIME_STAT_MONGO_WRITE_WAIT_STOP();
+
+    LM_E(("Fatal Error (null DB connection)"));
+    *err = "null DB connection";
+
+    orion::releaseMongoConnection(connection);
+    return false;
+  }
+
+  // Get low level driver object
+  const bson_t* q = _q.get();
+  char* bsonStr = bson_as_relaxed_extended_json(q, NULL);
+
+  LM_T(LmtMongo, ("remove() in '%s' collection: {%s}", col.c_str(), bsonStr));
+
+  mongoc_collection_t *collection = mongoc_client_get_collection(connection.get(), tokens[0].c_str(), tokens[1].c_str());
+
+  bson_error_t error;
+  bool success = mongoc_collection_remove(collection, MONGOC_REMOVE_NONE, q, NULL, &error);
+
+  mongoc_collection_destroy(collection);
+  orion::releaseMongoConnection(connection);
+  TIME_STAT_MONGO_WRITE_WAIT_STOP();
+
+  if (success)
+  {
+    LM_T(LmtOldInfo, ("Database Operation Successful (remove: %s)", bsonStr));
+    alarmMgr.dbErrorReset();
+  }
+  else
+  {
+    std::string msg = std::string("collection: ") + col.c_str() +
+      " - remove(): " + bsonStr +
+      " - exception: " + error.message;
+
+    *err = "Database Error (" + msg + ")";
+    alarmMgr.dbError(msg);
+  }
+
+  bson_free(bsonStr);
+
+  return success;
+}
+
+
+
+#if 0
 /* ****************************************************************************
 *
 * orion::collectionCreateIndex -
@@ -653,9 +1210,61 @@ bool orion::collectionCreateIndex
 
   return true;
 }
+#endif
 
 
 
+/* ****************************************************************************
+*
+* orion::collectionCreateIndex -
+*/
+bool orion::collectionCreateIndex
+(
+  const std::string&     col,
+  const std::string&     name,
+  const orion::BSONObj&  _index,
+  const bool&            isTTL,
+  std::string*           err
+)
+{
+  // Recomended way: using commands (see http://mongoc.org/libmongoc/current/create-indexes.html)
+
+  // FIXME OLD-DR: change function signature to have db and col separately and remove
+  // this tokenization logic
+  std::stringstream ss(col);
+  std::vector<std::string> tokens;
+  while(ss.good())
+  {
+    std::string substr;
+    getline(ss, substr, '.');
+    tokens.push_back(substr);
+  }
+
+  // Prepare command
+  orion::BSONObjBuilder    cmd;
+  orion::BSONObjBuilder    index;
+  orion::BSONArrayBuilder  indexes;
+
+  index.append("key", _index);
+  index.append("name", name);
+  if (isTTL)
+  {
+    index.append("expireAfterSeconds", 0);
+  }
+
+  indexes.append(index.obj());
+
+  cmd.append("createIndexes", tokens[1]);
+  cmd.append("indexes", indexes.arr());
+
+  // Run index creation (result is irrelevant)
+  orion::BSONObj r;
+  return runCollectionCommand(col, cmd.obj(), &r, err);
+}
+
+
+
+#if 0
 /* ****************************************************************************
 *
 * orion::runCollectionCommand -
@@ -704,7 +1313,7 @@ bool orion::runCollectionCommand
   //
   TIME_STAT_MONGO_COMMAND_WAIT_START();
 
-  // FIXME DR-OLD: re-assign a veriable that comes from the function parameters is weird...
+  // FIXME OLD-DR: re-assign a veriable that comes from the function parameters is weird...
   // probably this should be improved. Maybe a solution is to unify both runCollectionCommand functions
   // into just one (the one that needs connection as parameters, assuming not NULL as other functions
   // in this file)
@@ -774,6 +1383,301 @@ bool orion::runCollectionCommand
   *result = orion::BSONObj(mResult);
   alarmMgr.dbErrorReset();
   return true;
+}
+#endif
+
+
+/* ****************************************************************************
+*
+* orion::collectionAggregate -
+*
+*/
+bool orion::collectionAggregate
+(
+  orion::DBConnection      _connection,
+  const std::string&       col,
+  const orion::BSONArray&  _pipeline,
+  unsigned int             batchSize,
+  DBCursor*                cursor,
+  std::string*             err
+)
+{
+  // FIXME OLD-DR: change function signature to have db and col separately and remove
+  // this tokenization logic
+  std::stringstream ss(col);
+  std::vector<std::string> tokens;
+  while(ss.good())
+  {
+    std::string substr;
+    getline(ss, substr, '.');
+    tokens.push_back(substr);
+  }
+
+  // Getting & checking connection
+  mongoc_client_t* connection = _connection.get();
+  if (connection == NULL)
+  {
+    LM_E(("Fatal Error (null DB connection)"));
+    *err = "null DB connection";
+
+    return false;
+  }
+
+  // Get low level driver object
+  bson_t* pipeline = _pipeline.get();
+  char* bsonStr = bson_array_as_json(pipeline, NULL);
+
+  bson_t* opt = bson_new();
+  BSON_APPEND_INT32(opt, "batchSize", batchSize);
+
+  LM_T(LmtMongo, ("aggregate() in '%s' collection: '%s'", col.c_str(), bsonStr));
+  mongoc_collection_t *collection = mongoc_client_get_collection(connection, tokens[0].c_str(), tokens[1].c_str());
+
+  cursor->set(mongoc_collection_aggregate(collection, MONGOC_QUERY_NONE, pipeline, opt, NULL));
+
+  bson_destroy(opt);
+  mongoc_collection_destroy(collection);
+
+  // FIXME OLD-DR: how to manage errors? this function doesn't use bson_error_t...
+  // Is enough just checking for return cursor pointer NULL-ness? Note that
+  // doc http://mongoc.org/libmongoc/1.17.3/mongoc_collection_find_with_opts.html
+  // doesn't describes NULL as a possible return value...
+  // Asked: https://stackoverflow.com/questions/66027858/how-to-get-errors-when-calling-mongoc-collection-update-function
+  if (cursor->isNull())
+  {
+    std::string msg = std::string("collection: ") + col +
+      " - aggregate(): " + bsonStr +
+      " - exception: Null cursor from mongo (details on this is found in the source code";
+
+    *err = "Database Error (" + msg + ")";
+    alarmMgr.dbError(msg);
+
+    return false;
+  }
+
+  alarmMgr.dbErrorReset();
+
+  bson_free(bsonStr);
+
+  return true;
+}
+
+
+
+/* ****************************************************************************
+*
+* runDatabaseCommand -
+*
+*/
+bool orion::runDatabaseCommand
+(
+  const std::string&     db,
+  const orion::BSONObj&  command,
+  orion::BSONObj*        result,
+  std::string*           err
+)
+{
+  TIME_STAT_MONGO_COMMAND_WAIT_START();
+
+  // Getting & checking connection
+  orion::DBConnection connection = orion::getMongoConnection();
+  if (connection.isNull())
+  {
+    TIME_STAT_MONGO_COMMAND_WAIT_STOP();
+
+    LM_E(("Fatal Error (null DB connection)"));
+    *err = "null DB connection";
+
+    orion::releaseMongoConnection(connection);
+    return false;
+  }
+
+  // Get low level driver object
+  const bson_t* doc = command.get();
+  char* bsonStr = bson_as_relaxed_extended_json(doc, NULL);
+
+  LM_T(LmtMongo, ("runCommand() in '%s' database: '%s'", db.c_str(), bsonStr));
+
+  mongoc_database_t* database = mongoc_client_get_database(connection.get(), db.c_str());
+
+  bson_t reply;
+  bson_error_t error;
+
+  // FIXME OLD-DR: there is also a function mongoc_database_write_command_with_opts, pretty similar
+  // but for write operations  (this is the one we use for createIndex). As far as I checked, all
+  // the usages are for read operations (aggregate, listDatabases and buildInfo), but maybe we should
+  // make the name of the function more explicit, i.e. runCollectionReadCommand
+  // Moreover, there are more functions for command... Unclear. Asked (for collections commands, but
+  // I guess it's pretty much the same) here: https://stackoverflow.com/questions/66031779/several-functions-in-mongo-c-driver-to-run-commands-on-collections-in-which-cas
+  bool success = mongoc_database_command_with_opts(database, doc, NULL, NULL, &reply, &error);
+
+  mongoc_database_destroy(database);
+  orion::releaseMongoConnection(connection);
+  TIME_STAT_MONGO_COMMAND_WAIT_STOP();
+
+  if (success)
+  {
+    LM_T(LmtOldInfo, ("Database Operation Successful (command: %s)", bsonStr));
+    *result = orion::BSONObj(&reply);
+    alarmMgr.dbErrorReset();
+  }
+  else
+  {
+    std::string msg = std::string("database: ") + db.c_str() +
+      " - runCommand(): " + bsonStr +
+      " - exception: " + error.message;
+
+    *err = "Database Error (" + msg + ")";
+    alarmMgr.dbError(msg);
+  }
+
+  bson_destroy(&reply);
+  bson_free(bsonStr);
+
+  return success;
+}
+
+
+
+/* ****************************************************************************
+*
+* orion::runCollectionCommand -
+*
+* FIXME OLD-DR: after the creation of runDatabaseCommand() this function is completely
+* unneded
+*/
+bool orion::runCollectionCommand
+(
+  const std::string&     col,
+  const orion::BSONObj&  command,
+  orion::BSONObj*        result,
+  std::string*           err
+)
+{
+  orion::DBConnection connection;
+
+  // Note that connection has a NULL mongo::DBConnection inside, so having the same
+  // effect that the version of this method for the old driver.
+
+  return orion::runCollectionCommand(connection, col, command, result, err);
+}
+
+
+
+/* ****************************************************************************
+*
+* runCollectionCommand -
+*
+* NOTE
+*   Different from other functions in this module, this function can get the connection
+*   in the params, instead of using getMongoConnection().
+*   This is only done from DB connection bootstrapping code .
+*
+* FIXME OLD-DR: after the creation of runDatabaseCommand() this function is could
+* be modified to ommit 'connection' from parameters and make it similar to other
+* fucntions such as collectionInsert, collectionUpdate, etc. Maybe it is not used a this
+* moment but it's a good function for a module containing collection operations on DB
+*
+* FIXME OLD-DR: check if a the end we have callas to this function in client code
+* (probably we should include it in mongoDriver API but warng about no-usage in
+* a comment in that case)
+*/
+bool orion::runCollectionCommand
+(
+  orion::DBConnection    connection,
+  const std::string&     col,
+  const orion::BSONObj&  command,
+  orion::BSONObj*        result,
+  std::string*           err
+)
+{
+  bool releaseConnection = false;
+
+  //
+  // The call to TIME_STAT_MONGO_COMMAND_WAIT_START must be on toplevel so that local variables
+  // are visible for TIME_STAT_MONGO_COMMAND_WAIT_STOP()
+  //
+  // FIXME OLD-DR: but TIME_STAT_MONGO_COMMAND_WAIT_STOP is not always called... it depends on
+  // releaseConnection value. Check original implementation (it's the same)
+  //
+  TIME_STAT_MONGO_COMMAND_WAIT_START();
+
+  // FIXME OLD-DR: change function signature to have db and col separately and remove
+  // this tokenization logic
+  std::stringstream ss(col);
+  std::vector<std::string> tokens;
+  while(ss.good())
+  {
+    std::string substr;
+    getline(ss, substr, '.');
+    tokens.push_back(substr);
+  }
+
+  // FIXME OLD-DR: re-assign a veriable that comes from the function parameters is weird...
+  // probably this should be improved. Maybe a solution is to unify both runCollectionCommand functions
+  // into just one (the one that needs connection as parameters, assuming not NULL as other functions
+  // in this file)
+
+  if (connection.isNull())
+  {
+    connection        = orion::getMongoConnection();
+    releaseConnection = true;
+
+    if (connection.isNull())
+    {
+      TIME_STAT_MONGO_COMMAND_WAIT_STOP();
+      LM_E(("Fatal Error (null DB connection)"));
+
+      return false;
+    }
+  }
+
+  // Get low level driver object
+  const bson_t* doc = command.get();
+  char* bsonStr = bson_as_relaxed_extended_json(doc, NULL);
+
+  LM_T(LmtMongo, ("runCommand() in '%s' collection: '%s'", col.c_str(), bsonStr));
+
+  mongoc_collection_t* collection = mongoc_client_get_collection(connection.get(), tokens[0].c_str(), tokens[1].c_str());
+
+  bson_t reply;
+  bson_error_t error;
+
+  // FIXME OLD-DR: there is also a function mongoc_collection_write_command_with_opts, pretty similar
+  // but for write operations  (this is the one we use for createIndex). As far as I checked, all
+  // the usages are for read operations (aggregate, listDatabases and buildInfo), but maybe we should
+  // make the name of the function more explicit, i.e. runCollectionReadCommand
+  // Moreover, there are more functions for command... Unclear. Asked here: https://stackoverflow.com/questions/66031779/several-functions-in-mongo-c-driver-to-run-commands-on-collections-in-which-cas
+  bool success = mongoc_collection_command_with_opts(collection, doc, NULL, NULL, &reply, &error);
+
+  mongoc_collection_destroy(collection);
+
+  if (releaseConnection)
+  {
+    orion::releaseMongoConnection(connection);
+    TIME_STAT_MONGO_COMMAND_WAIT_STOP();
+  }
+
+  if (success)
+  {
+    LM_T(LmtOldInfo, ("Database Operation Successful (command: %s)", bsonStr));
+    *result = orion::BSONObj(&reply);
+    alarmMgr.dbErrorReset();
+  }
+  else
+  {
+    std::string msg = std::string("collection: ") + col.c_str() +
+      " - runCommand(): " + bsonStr +
+      " - exception: " + error.message;
+
+    *err = "Database Error (" + msg + ")";
+    alarmMgr.dbError(msg);
+  }
+
+  bson_destroy(&reply);
+  bson_free(bsonStr);
+
+  return success;
 }
 
 

--- a/src/lib/mongoDriver/connectionOperations.h
+++ b/src/lib/mongoDriver/connectionOperations.h
@@ -30,6 +30,7 @@
 #include "mongoDriver/DBConnection.h"
 #include "mongoDriver/DBCursor.h"
 #include "mongoDriver/BSONObj.h"
+#include "mongoDriver/BSONArray.h"
 
 namespace orion
 
@@ -148,8 +149,42 @@ extern bool collectionRemove
 extern bool collectionCreateIndex
 (
   const std::string&  col,
+  const std::string&  name,
   const BSONObj&      indexes,
   const bool&         isTTL,
+  std::string*        err
+);
+
+
+
+/* ****************************************************************************
+*
+* orion::collectionQuery -
+*
+* FIXME OLD-DR: connection should be passed by reference
+*/
+extern bool collectionAggregate
+(
+  DBConnection        connection,
+  const std::string&  col,
+  const BSONArray&      pipeline,
+  unsigned int        batchSize,
+  DBCursor*           cursor,
+  std::string*        err
+);
+
+
+
+/* ****************************************************************************
+*
+* runDatabaseCommand -
+*
+*/
+extern bool runDatabaseCommand
+(
+  const std::string&  db,
+  const BSONObj&      command,
+  BSONObj*            result,
   std::string*        err
 );
 

--- a/src/lib/mongoDriver/safeMongo.h
+++ b/src/lib/mongoDriver/safeMongo.h
@@ -57,7 +57,7 @@
 #define getFieldFF(b, field)                 orion::getField(b, field, __FUNCTION__,  __LINE__)
 #define setStringVectorFF(b, field, v)       orion::setStringVector(b, field, v, __FUNCTION__,  __LINE__)
 
-#define nextSafeOrErrorFF(c, r, err)         orion::nextSafeOrError(c, r, err, __FUNCTION__,  __LINE__)
+//#define nextSafeOrErrorFF(c, r, err)         orion::nextSafeOrError(c, r, err, __FUNCTION__,  __LINE__)
 
 namespace orion
 {
@@ -201,7 +201,7 @@ extern void setStringVector
 );
 
 
-
+#if 0
 /* ****************************************************************************
 *
 * moreSafe -
@@ -222,6 +222,7 @@ extern bool nextSafeOrError
   const std::string&  caller = "<none>",
   int                 line   = 0
 );
+#endif
 
 
 

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -126,14 +126,14 @@ ContextElementResponse::ContextElementResponse
   // Attribute vector
   // FIXME P5: constructor for orion::BSONObj could be added to ContextAttributeVector/ContextAttribute classes, to make building more modular
   //
-  orion::BSONObj                attrs = getObjectFieldFF(entityDoc, ENT_ATTRS);
+  orion::BSONObj         attrs = getObjectFieldFF(entityDoc, ENT_ATTRS);
   std::set<std::string>  attrNames;
 
   attrs.getFieldNames(attrNames);
   for (std::set<std::string>::iterator i = attrNames.begin(); i != attrNames.end(); ++i)
   {
     std::string        attrName                = *i;
-    orion::BSONObj            attr                    = getObjectFieldFF(attrs, attrName);
+    orion::BSONObj     attr                    = getObjectFieldFF(attrs, attrName);
     ContextAttribute*  caP                     = NULL;
     ContextAttribute   ca;
     bool               noLocationMetadata      = true;

--- a/src/lib/serviceRoutines/versionTreat.cpp
+++ b/src/lib/serviceRoutines/versionTreat.cpp
@@ -41,9 +41,8 @@
 #include "rest/ConnectionInfo.h"
 #include "rapidjson/rapidjson.h"
 #include "serviceRoutines/versionTreat.h"
-#include "mongo/version.h"
 
-
+#include <boost/version.hpp>
 
 /* ****************************************************************************
 *
@@ -76,7 +75,10 @@ std::string libVersions(void)
   total += mhd     + "\"" + MHD_get_version()    +   "\"" + ",\n";
   total += ssl     + "\"" + SHLIB_VERSION_NUMBER  "\"" + ",\n";
   total += rjson   + "\"" + RAPIDJSON_VERSION_STRING "\"" + ",\n";
-  total += mongo   + "\"legacy-" + mongo::client::kVersionString + "\"" + "\n";
+  // FIXME OLD-DR: do this the proper way, see:
+  // http://mongoc.org/libmongoc/current/mongoc_version.html
+  // http://mongoc.org/libbson/current/version.html
+  total += mongo   + "\"legacy-1.1.2\"" + "\n";
 
   return total;
 }

--- a/test/functionalTest/cases/0000_json_parse/jsonParsePostUnsubscribeContext.test
+++ b/test/functionalTest/cases/0000_json_parse/jsonParsePostUnsubscribeContext.test
@@ -98,7 +98,7 @@ echo "4: ***********************************"
 --REGEXPECT--
 1: ***********************************
 HTTP/1.1 200 OK
-Content-Length: 170
+Content-Length: 115
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -106,7 +106,6 @@ Date: REGEX(.*)
 {
     "statusCode": {
         "code": "404",
-        "details": "subscriptionId: /012345678901234567890123/",
         "reasonPhrase": "No context element found"
     },
     "subscriptionId": "012345678901234567890123"

--- a/test/functionalTest/cases/0117_convop_using_standard_ops/deleteSubscriptionConvOp.test
+++ b/test/functionalTest/cases/0117_convop_using_standard_ops/deleteSubscriptionConvOp.test
@@ -173,15 +173,14 @@ Date: REGEX(.*)
 02. DELETE /v1/contextSubscriptions/123456789012345678901234 and see it fail
 ============================================================================
 HTTP/1.1 200 OK
-Content-Length: 170
+Content-Length: 115
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
     "statusCode": {
-        "code": "404", 
-        "details": "subscriptionId: /123456789012345678901234/", 
+        "code": "404",
         "reasonPhrase": "No context element found"
     }, 
     "subscriptionId": "123456789012345678901234"

--- a/test/functionalTest/cases/3658_env_vars/env_vars.test
+++ b/test/functionalTest/cases/3658_env_vars/env_vars.test
@@ -46,6 +46,7 @@ echo "02. Set the broker pidfile using env var ORION_PID_PATH=/tmp/cb3658.pid, s
 echo "================================================================================================================================================"
 export ORION_PID_PATH=/tmp/cb3658.pid
 rm -f $ORION_PID_PATH
+export ORION_PORT=$CB_PORT
 contextBroker
 sleep .1
 if [ ! -f $ORION_PID_PATH ]


### PR DESCRIPTION
(This PR is one of the stages of the the bigger PR #3622)

This PR replaces the old legacy C++ driver by the mongo official C driver. Thus, changes are isolated to mongoDriver/,
but some justified exceptions exists, as described following:

Changes in the code *outside* mongoDriver/ (i.e. client code of mongoDriver/)

* The way in which cursor are used has been simplified, now just using `DBcursor::next()`. The usage of
  `nextSafeOrErrorFF()` and `orion::moreSafe()` has been removed. Similar adaptations in the usage of `orion::collectionFindOne()`.
* New method `orion::runDatabaseCoomand()` instead of `orion::runCollectionCommand()` for operations in the `admin` DB in MongoGlobal.cpp
* Index `name` as parameter in `orion::collectionCreateIndex()` (needed by the underlying driver and doesn't hurt anyway)
* `processAreaScope()` and `processAreaScopeV2()` modifications due to coundDocument() needs a special way of geo-queris which use "near" as geo-relation
* `mongoQueryType()` has been reworked to pay an old debt introduced in Orion 2.1.0 due to the limitations of the legacy driver with MongoDB >=3.6. That MongoDB implemented cursors for aggregation operations (vs. result JSON object, in MongoDB <3.6). The old driver doesn't support cursor for aggregations and we need to do a "dirty trick" that time. Now, we are using a cursor-based implementation and a new function has been introduced in the mongoDriver/ API: `orion::collectionAggregate()`.
* Remove some legacy driver black magic in contextBroker.cpp and MongoCommonUpdate.cpp

Changes in functional test:

* In a couple of .test, removed extra field `detail` in 404 responses when subscription is not found in the NGSIv1 API. In ffact, this field was redundant  (`subscriptionId` contains the same information) and, anway, NGSIv1 is deprecated this is very very minor :)
* Small improvement in test/functionalTest/cases/3658_env_vars/env_vars.test to avoid port collision with CB instances running in the standard port (1026) when the tests are passed.
  
Many FIXME OLD-DR comments have been added to this PR. They will be worked and cleaned up in a next stage of the PR #3622.

Note that GitActtion flow for functional test works in this PR for commit 44bb684: https://github.com/telefonicaid/fiware-orion/actions/runs/561260411
