### PR TITLE
FIX make some changes to be more compatible with CentOS 8 RPM build procedure

### DIFF
--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -21,6 +21,14 @@
 %define name contextBroker
 %define owner orion 
 
+# To avoid problems in CentOS 8
+%define debug_package %{nil}
+
+# To avoid /usr/lib/.build-id files in the package. This seems to be a
+# new feature of CentOS 8 (see https://fedoraproject.org/wiki/Changes/ParallelInstallableDebuginfo)
+# but by the moment we are going to disable it to build as in CentOS 7
+%define _build_id_links none
+
 # Don't byte compile python code
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
@@ -134,6 +142,8 @@ cp etc/init.d/contextBroker.centos $RPM_BUILD_ROOT/etc/init.d/%{name}
 chmod 755 $RPM_BUILD_ROOT/etc/init.d/%{name}
 mkdir -p $RPM_BUILD_ROOT/etc/sysconfig
 cp etc/config/contextBroker $RPM_BUILD_ROOT/etc/sysconfig/%{name}
+# remove spureous files we have detected are generated in CentOS 8 build
+rm -rf $RPM_BUILD_ROOT/usr/lib/.build-id
 
 echo "%%defattr(-, root, root, - )" > MANIFEST
 (cd %{buildroot}; find . -type f -or -type l | sed -e s/^.// -e /^$/d) >>MANIFEST
@@ -155,7 +165,8 @@ grep "tests" MANIFEST > MANIFEST.broker-tests
 #    to configure MongoDB repository, check [this piece of documentation about that](http://docs.mongodb.org/manual/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux/).
 #
 %package tests
-Requires: %{name}, python, python-flask, python-jinja2, nc, curl, libxml2, mongo-10gen 
+#FIXME: obsolete packcages names. Probably it's better to remove the contextBroker-test packages at all that solve this...
+#Requires: %{name}, python, python-flask, python-jinja2, nc, curl, libxml2, mongo-10gen 
 Summary: Test suite for %{name}
 %description tests
 Test suite for %{name}

--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -21,13 +21,15 @@
 %define name contextBroker
 %define owner orion 
 
-# To avoid problems in CentOS 8
+%if 0%{?rhel} > 7
+# To avoid problems in CentOS 8 with empty files in debug package
+# see https://www.programmersought.com/article/24984333483/
 %define debug_package %{nil}
-
 # To avoid /usr/lib/.build-id files in the package. This seems to be a
 # new feature of CentOS 8 (see https://fedoraproject.org/wiki/Changes/ParallelInstallableDebuginfo)
 # but by the moment we are going to disable it to build as in CentOS 7
 %define _build_id_links none
+%endif
 
 # Don't byte compile python code
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')

--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -142,8 +142,6 @@ cp etc/init.d/contextBroker.centos $RPM_BUILD_ROOT/etc/init.d/%{name}
 chmod 755 $RPM_BUILD_ROOT/etc/init.d/%{name}
 mkdir -p $RPM_BUILD_ROOT/etc/sysconfig
 cp etc/config/contextBroker $RPM_BUILD_ROOT/etc/sysconfig/%{name}
-# remove spureous files we have detected are generated in CentOS 8 build
-rm -rf $RPM_BUILD_ROOT/usr/lib/.build-id
 
 echo "%%defattr(-, root, root, - )" > MANIFEST
 (cd %{buildroot}; find . -type f -or -type l | sed -e s/^.// -e /^$/d) >>MANIFEST
@@ -165,7 +163,7 @@ grep "tests" MANIFEST > MANIFEST.broker-tests
 #    to configure MongoDB repository, check [this piece of documentation about that](http://docs.mongodb.org/manual/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux/).
 #
 %package tests
-#FIXME: obsolete packcages names. Probably it's better to remove the contextBroker-test packages at all that solve this...
+#FIXME: obsolete packages names. Probably it's better to remove the contextBroker-test packages at all that solve this...
 #Requires: %{name}, python, python-flask, python-jinja2, nc, curl, libxml2, mongo-10gen 
 Summary: Test suite for %{name}
 %description tests

--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: latin-1 -*-
 # Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
 #

--- a/scripts/managedb/garbage-collector.py
+++ b/scripts/managedb/garbage-collector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: latin-1 -*-
 # Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
 #

--- a/scripts/managedb/latest-updates.py
+++ b/scripts/managedb/latest-updates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: latin-1 -*-
 # Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
 #

--- a/scripts/monit_log_processing.py
+++ b/scripts/monit_log_processing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: latin-1 -*-
 # Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
 #

--- a/test/check_rpm/check_rpm.sh
+++ b/test/check_rpm/check_rpm.sh
@@ -38,7 +38,7 @@ _logStage "######## Checking MongoDB... ########"
 _log "#### Check the MongoDB process... ####"
 # Check the if the mongod is installed/running
 _log "#### Checking the mongodb status... #####"
-if [ "`sudo /etc/init.d/mongod status | grep pid`" == "" ]; then
+if [ "`sudo service mongod status | grep 'forked process' | awk -F 'forked process: ' '{print $2}'`" == "" ]; then
 	_logError ".............. Mongo is NOT running .............."
 	exit 1
 else
@@ -102,8 +102,9 @@ fi
 echo ""
 
 ## Check if the contextBroker is listen the specific ports
+## (We use contextBroke as we have discovered that in CentOS 8 netstat may cut the name in the display)
 _logStage "######## Checking the contextBroker service ########"
-if [ "`sudo netstat -putan | grep contextBroker`" == "" ]; then
+if [ "`sudo netstat -putan | grep contextBroke`" == "" ]; then
 	_logError ".............. contextBroker is not LISTEN .............."
 	exit 1
 else
@@ -137,7 +138,7 @@ echo ""
 
 ## Uninstall the contextBroker RPM
 _logStage "######## Uninstall the contextBroker RPM ########"
-sudo rpm -e contextBroker &> /dev/null
+sudo rpm -e contextBroker contextBroker-tests &> /dev/null
 result=$?
 if [[ $result -ne 0 ]]; then 
 	_logError ".............. Uninstall failed .............."

--- a/test/functionalTest/fixContentLengths.py
+++ b/test/functionalTest/fixContentLengths.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: latin-1 -*-
 # Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
 #

--- a/test/functionalTest/testDiff.py
+++ b/test/functionalTest/testDiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: latin-1 -*-
 # Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
 #

--- a/test/functionalTest/testJson.py
+++ b/test/functionalTest/testJson.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: latin-1 -*-
 # Copyright 2018 Telefonica Investigacion y Desarrollo, S.A.U
 #


### PR DESCRIPTION
This has arisen in the context of PR https://github.com/telefonicaid/fiware-orion/pull/3622. These are changes needed for rpm build in CentOS 8, which at the same time are compatible with CentOS 7 (as far as we have checked).