### PR TITLE
Fix for PATCH update operation when 'multiple SP' or 'SP with wildcard #' is used.

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: response rightly 500 Internal Error when DB query fails (previously 200 OK with empty entities array was returned)
+- Fix: PATCH update operation return right error code, when multiple service paths or service path /# is used (#3812)

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -718,6 +718,13 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
     return 1;
   }
 
+  if (ciP->verb == PATCH && ciP->servicePathV.size() > 1)
+  {
+    OrionError oe(SccBadRequest, "more than one servicepath in patch update request is not allowed");
+    ciP->answer = oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
+    return 1;
+  }
+
   components = stringSplit(servicePath, '/', compV);
 
   if (components > SERVICE_PATH_MAX_LEVELS)
@@ -748,7 +755,16 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
     // /Madrid/Gardens/North# is not allowed
     if ((ix == components - 1) && (compV[ix] == "#"))
     {
-      continue;
+      if (ciP->verb == PATCH)
+      {
+        OrionError oe(SccBadRequest, "servicepath with wildcard # is not allowed in patch update request");
+        ciP->answer = oe.setStatusCodeAndSmartRender(ciP->apiVersion, &(ciP->httpStatusCode));
+        return 3;
+      }
+      else
+      {
+        continue;
+      }
     }
 
     const char* comp = compV[ix].c_str();

--- a/test/functionalTest/cases/3640_PATCH_update_with_wrong_servicepath/3640_PATCH_update_with_wrong_servicepath.test
+++ b/test/functionalTest/cases/3640_PATCH_update_with_wrong_servicepath/3640_PATCH_update_with_wrong_servicepath.test
@@ -38,6 +38,8 @@ brokerStart CB
 # 06. GET v2/entities with servicepath '/Level_1/, /Level_2/' to see all entities present at given SP
 # 07. Attempt to UPDATE entity E1 with A1=11, using PATCH v2/update operation, with servicepath '/#', see 400 error
 # 08. Attempt to UPDATE entity E2 with A2=22, using PATCH v2/update operation, with servicepath '/Level_1/, /Level_2/' see 400 error
+# 09. Attempt to UPDATE entity E1 with A1=12, using PATCH v2/update operation, without specifying servicepath, see 404 error
+# 10. Attempt to UPDATE entity E2 with A2=21, using PATCH v2/update operation, with servicepath '/Level_1/', see 404 error
 #
 
 
@@ -123,6 +125,30 @@ payload='{
     }
 }'
 orionCurl --url '/v2/entities/E2/attrs?type=T2' -X PATCH --payload "$payload" --header "Fiware-ServicePath:/Level_1/, /Level_2/"
+echo
+echo
+
+
+echo "09. Attempt to UPDATE entity E1 with A1=12, using PATCH v2/update operation, without specifying servicepath, see 404 error"
+echo "=========================================================================================================================="
+payload='{
+    "A1": {
+      "value": 12
+    }
+}'
+orionCurl --url '/v2/entities/E1/attrs?type=T1' -X PATCH --payload "$payload"
+echo
+echo
+
+
+echo "10. Attempt to UPDATE entity E2 with A2=21, using PATCH v2/update operation, with servicepath '/Level_1/', see 404 error"
+echo "========================================================================================================================"
+payload='{
+    "A2": {
+      "value": 21
+    }
+}'
+orionCurl --url '/v2/entities/E2/attrs?type=T2' -X PATCH --payload "$payload" --header "Fiware-ServicePath:/Level_1/"
 echo
 echo
 
@@ -271,6 +297,34 @@ Date: REGEX(.*)
 {
     "description": "more than one servicepath in patch update request is not allowed", 
     "error": "BadRequest"
+}
+
+
+09. Attempt to UPDATE entity E1 with A1=12, using PATCH v2/update operation, without specifying servicepath, see 404 error
+==========================================================================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 95
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "The requested entity has not been found. Check type and id", 
+    "error": "NotFound"
+}
+
+
+10. Attempt to UPDATE entity E2 with A2=21, using PATCH v2/update operation, with servicepath '/Level_1/', see 404 error
+========================================================================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 95
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "The requested entity has not been found. Check type and id", 
+    "error": "NotFound"
 }
 
 

--- a/test/functionalTest/cases/3640_PATCH_update_with_wrong_servicepath/3640_PATCH_update_with_wrong_servicepath.test
+++ b/test/functionalTest/cases/3640_PATCH_update_with_wrong_servicepath/3640_PATCH_update_with_wrong_servicepath.test
@@ -1,0 +1,279 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Wildcard (#) and multiple service-path are not allowed in PATCH v2/update operation
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+# 
+# 01. Create entity E1/T1/A1=1, with servicepath '/Level_1/'
+# 02. GET /v2/entities/E1, with servicepath '/Level_1/' to see E1/T1/A1=1
+# 03. Create entity E2/T2/A2=2, with servicepath '/Level_2/'
+# 04. Get /v2/entities/E2, with servicepath '/Level_2/' to see E2/T2/A2=2
+# 05. GET v2/entities with servicepath '/#' to see all entities present at '/#' SP
+# 06. GET v2/entities with servicepath '/Level_1/, /Level_2/' to see all entities present at given SP
+# 07. Attempt to UPDATE entity E1 with A1=11, using PATCH v2/update operation, with servicepath '/#', see 400 error
+# 08. Attempt to UPDATE entity E2 with A2=22, using PATCH v2/update operation, with servicepath '/Level_1/, /Level_2/' see 400 error
+#
+
+
+echo "01. Create entity E1/T1/A1=1, with servicepath '/Level_1/'"
+echo "=========================================================="
+payload='{
+    "id": "E1",
+    "type": "T1",
+    "A1": {
+      "value": 1,
+      "type": "Integer"
+    }
+}'
+orionCurl --url /v2/entities --payload "$payload" --header "Fiware-ServicePath:/Level_1/"
+echo
+echo
+
+
+echo "02. GET /v2/entities/E1 with servicepath '/Level_1/' to see E1/T1/A1=1"
+echo "======================================================================"
+orionCurl --url /v2/entities/E1 --header "Fiware-ServicePath:/Level_1/"
+echo
+echo
+
+
+echo "03. Create entity E2/T2/A2=2, with servicepath '/Level_2/'"
+echo "=========================================================="
+payload='{
+    "id": "E2",
+    "type": "T2",
+    "A2": {
+      "value": 2,
+      "type": "Integer"
+    }
+}'
+orionCurl --url /v2/entities --payload "$payload" --header "Fiware-ServicePath:/Level_2/"
+echo
+echo
+
+
+echo "04. GET /v2/entities/E2 with servicepath '/Level_2/' to see E2/T2/A2=2"
+echo "======================================================================"
+orionCurl --url /v2/entities/E2 --header "Fiware-ServicePath:/Level_2/"
+echo
+echo
+
+
+echo "05. GET v2/entities with servicepath '/#' to see all entities present at '/#' SP"
+echo "================================================================================"
+orionCurl --url /v2/entities --header "Fiware-ServicePath:/#"
+echo
+echo
+
+
+echo "06. GET v2/entities with servicepath '/Level_1/, /Level_2/' to see all entities present at given SP"
+echo "==================================================================================================="
+orionCurl --url /v2/entities --header "Fiware-ServicePath:/Level_1/, /Level_2/"
+echo
+echo
+
+
+echo "07. Attempt to UPDATE entity E1 with A1=11, using PATCH v2/update operation, with servicepath '/#', see 400 error"
+echo "================================================================================================================="
+payload='{
+    {
+      "A1": {
+        "value": 11
+      }
+    }
+}'
+orionCurl --url '/v2/entities/E1/attrs?type=T1' -X PATCH --payload "$payload" --header "Fiware-ServicePath:/#"
+echo
+echo
+
+
+echo "08. Attempt to UPDATE entity E2 with A2=22, using PATCH v2/update operation, with servicepath '/Level_1/, /Level_2/' see 400 error"
+echo "=================================================================================================================================="
+payload='{
+    {
+      "A2": {
+        "value": 22
+      }
+    }
+}'
+orionCurl --url '/v2/entities/E2/attrs?type=T2' -X PATCH --payload "$payload" --header "Fiware-ServicePath:/Level_1/, /Level_2/"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E1/T1/A1=1, with servicepath '/Level_1/'
+==========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=T1
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. GET /v2/entities/E1 with servicepath '/Level_1/' to see E1/T1/A1=1
+======================================================================
+HTTP/1.1 200 OK
+Content-Length: 71
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A1": {
+        "metadata": {},
+        "type": "Integer",
+        "value": 1
+    }, 
+    "id": "E1", 
+    "type": "T1"
+}
+
+
+03. Create entity E2/T2/A2=2, with servicepath '/Level_2/'
+==========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E2?type=T2
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. GET /v2/entities/E2 with servicepath '/Level_2/' to see E2/T2/A2=2
+======================================================================
+HTTP/1.1 200 OK
+Content-Length: 71
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A2": {
+        "metadata": {},
+        "type": "Integer",
+        "value": 2
+    }, 
+    "id": "E2", 
+    "type": "T2"
+}
+
+
+05. GET v2/entities with servicepath '/#' to see all entities present at '/#' SP
+================================================================================
+HTTP/1.1 200 OK
+Content-Length: 145
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A1": {
+            "metadata": {},
+            "type": "Integer",
+            "value": 1
+        }, 
+        "id": "E1", 
+        "type": "T1"
+    }, 
+    {
+        "A2": {
+            "metadata": {},
+            "type": "Integer",
+            "value": 2
+        }, 
+        "id": "E2", 
+        "type": "T2"
+    }
+]
+
+
+06. GET v2/entities with servicepath '/Level_1/, /Level_2/' to see all entities present at given SP
+===================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 145
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "A1": {
+            "metadata": {},
+            "type": "Integer",
+            "value": 1
+        }, 
+        "id": "E1", 
+        "type": "T1"
+    }, 
+    {
+        "A2": {
+            "metadata": {},
+            "type": "Integer",
+            "value": 2
+        }, 
+        "id": "E2", 
+        "type": "T2"
+    }
+]
+
+
+07. Attempt to UPDATE entity E1 with A1=11, using PATCH v2/update operation, with servicepath '/#', see 400 error
+=================================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 105
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "servicepath with wildcard # is not allowed in patch update request", 
+    "error": "BadRequest"
+}
+
+
+08. Attempt to UPDATE entity E2 with A2=22, using PATCH v2/update operation, with servicepath '/Level_1/, /Level_2/' see 400 error
+==================================================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 103
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "more than one servicepath in patch update request is not allowed", 
+    "error": "BadRequest"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fix Issue #3640 for PATCH update operation when 'multiple ServicePath' or 'ServicePath with wildcard #' is used.