### PR TITLE
Update procedure for Ubuntu 20.04 LTS (amd64 and aarch64)

### DIFF
--- a/doc/manuals.jp/admin/build_source.md
+++ b/doc/manuals.jp/admin/build_source.md
@@ -148,50 +148,45 @@ aarch64 アーキテクチャの場合、さらに yum で、python-devel と li
 
 * 生成された RPM は `~/rpmbuild/RPMS/x86_64` ディレクトリに置かれます
 
-<a name="ubuntu-1804-lts"></a>
-## Ubuntu 18.04 LTS
+## Ubuntu 20.04 LTS
 
-**FIXME:** このセクションは、mongoC ドライバーをインストールするための新しい手順を考慮して確認する必要があります。
-
-この手順は、Ubuntu 18.04 LTS 上で x86_64 および aarch64 アーキテクチャ用の Orion Context Broker をすることです。
+この手順は、Ubuntu 20.04 LTS 上で x86_64 および aarch64 アーキテクチャ用の Orion Context Broker をすることです。
 また、Orion が依存する MongoDB 4.4 をビルドするための手順が含まれています。Orion Context Brokerは、ビルドの依存関係と
 して次のライブラリを使用します :
 
-* boost: 1.65.1
+* boost: 1.71.0
 * libmicrohttpd: 0.9.70 (from source)
-* libcurl: 7.58.0
-* openssl: 1.0.2n
-* libuuid: 2.31.1
-* Mongo Driver: legacy-1.1.2 (from source)
+* libcurl: 7.68.0
+* openssl: 1.1.1f
+* libuuid: 2.34-0.1
+* Mongo C driver: 1.17.4 (from source)
 * rapidjson: 1.1.0 (from source)
 * gtest (only for `make unit_test` building target): 1.5 (from sources)
 * gmock (only for `make unit_test` building target): 1.5 (from sources)
-* MongoDB: 4.4.4 (from source)
 
 基本的な手順は次のとおりです (root 権限でコマンドを実行しないと仮定し、root 権限が必要なコマンドに sudo を使用します) :
 
 * 必要なビルドツール (コンパイラなど) をインストールします
 
-        sudo apt install build-essential cmake scons
+        sudo apt install build-essential cmake
 
 * 必要なライブラリをインストールします (次の手順で説明する、ソースから取得する必要があるものを除きます)
 
         sudo apt install libboost-dev libboost-regex-dev libboost-thread-dev libboost-filesystem-dev \
-                         libcurl4-gnutls-dev gnutls-dev libgcrypt-dev libssl1.0-dev uuid-dev libsasl2-dev
+                         libcurl4-gnutls-dev gnutls-dev libgcrypt-dev libssl-dev uuid-dev libsasl2-dev
 
-* ソースから Mongo Driver をインストールします。Mongo Driver 1.1.2 は gcc 4.x でコンパイルすることを想定した、レガシーな
-コードです。そのため、新しい gcc でビルドする場合、一部のウォーニングはエラーとして扱われます。このエラーを避けるために、
-`-Wno-{option name}` オプションを CCFLAGS に追加する必要があります。
+* ソースから Mongo Driver をインストールします
 
-        wget https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.1.2.tar.gz
-        tar xfvz legacy-1.1.2.tar.gz
-        cd mongo-cxx-driver-legacy-1.1.2
-        # The build/linux2/normal/libmongoclient.a library is generated as outcome
-        scons  --use-sasl-client --ssl "CCFLAGS=-Wno-nonnull-compare -Wno-noexcept-type -Wno-format-truncation"
-        # This puts .h files in /usr/local/include/mongo and libmongoclient.a in /usr/local/lib
-        sudo scons install --prefix=/usr/local --use-sasl-client --ssl "CCFLAGS=-Wno-nonnull-compare -Wno-noexcept-type -Wno-format-truncation"
+        wget https://github.com/mongodb/mongo-c-driver/releases/download/1.17.4/mongo-c-driver-1.17.4.tar.gz
+        tar xfvz mongo-c-driver-1.17.4.tar.gz
+        cd mongo-c-driver-1.17.4
+        mkdir cmake-build
+        cd cmake-build
+        cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF ..
+        make
+        sudo make install
 
-* ソースから rapidjson をインストールする :
+* ソースから rapidjson をインストールします :
 
         wget https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz
         tar xfvz v1.1.0.tar.gz
@@ -208,22 +203,6 @@ aarch64 アーキテクチャの場合、さらに yum で、python-devel と li
         sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
         sudo ldconfig      # just in case... it doesn't hurt :)
 
-* ソースから Google Test/Mock をインストールします (このための RPM パッケージがありますが、現在の CMakeLists.txt
-の設定では動作しません)。以前は URL は http://googlemock.googlecode.com/files/gmock-1.5.0.tar.bz2 でしたが、
-Google では2016年8月下旬にそのパッケージを削除したため、動作しなくなりました
-
-        apt install xsltproc
-        wget https://nexus.lab.fiware.org/repository/raw/public/storage/gmock-1.5.0.tar.bz2
-        tar xfvj gmock-1.5.0.tar.bz2
-        cd gmock-1.5.0
-        ./configure
-        make
-        sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
-        sudo ldconfig      # just in case... it doesn't hurt :)
-
-aarch64 アーキテクチャの場合、apt を使用して xsltproc をインストールし、`.-configure` を `--build=arm-linux`
-オプションとともに実行します。
-
 * コードを取得します (または、圧縮されたバージョンや別の URL パターンを使用してダウンロードできます。例えば、
 `git clone git@github.com:telefonicaid/fiware-orion.git`) :
 
@@ -235,33 +214,8 @@ aarch64 アーキテクチャの場合、apt を使用して xsltproc をイン�
         cd fiware-orion
         make
 
-* ソースコードから MongoDB 4.4.4 をビルドしてインストールします。ユニット・テストを実行するには、ユニットとして MongoDB を
-ビルドする必要があり、機能テストは localhost で実行されている mongod に依存します (Ubuntu 18.04 用の MongoDB 4.4 バイナリは
-提供されていません)。ソースコードから MongoDB をビルドする手順は次のとおりです。aarch64 アーキテクチャの場合、追加で
-`-march=armv8-a+crc` オプションを CCFLAGS に追加します。`mongo` コマンドを実行して、MongoDB が正常にインストールされたことを
-確認します。
-
-        # Build MongoDB
-        sudo apt install build-essential cmake scons  # Not required if you installed in previous step
-        sudo apt install python python-pip            # Not required if you installed in previous step
-        pip install --upgrade pip                     # Not required if you installed in previous step
-        cd /opt
-        git clone -b r4.4.4 --depth=1 https://github.com/mongodb/mongo.git
-        cd mongo
-        pip install --user -r buildscripts/requirements.txt
-        python buildscripts/scons.py mongo mongod mongos \
-          "CCFLAGS=-Wno-nonnull-compare -Wno-format-truncation -Wno-noexcept-type" \
-          --wiredtiger=on \
-          --mmapv1=on
-        # Install MongoDB
-        strip -s mongo*
-        sudo cp -a mongo mongod mongos /usr/bin/ 
-        sudo useradd -M -s /bin/false mongodb
-        sudo mkdir /var/lib/mongodb /var/log/mongodb /var/run/mongodb
-        sudo chown mongodb:mongodb /var/lib/mongodb /var/log/mongodb /var/run/mongodb
-        sudo cp -a ./debian/mongod.conf /etc/
-        sudo cp -a ./debian/mongod.service /etc/systemd/system/
-        sudo systemctl start mongod
+* (オプションですが、強くお勧めします) 単体テスト (unit test) と機能テスト (functional tests) を実行します。
+詳細については、[以下のセクション](#testing-and-coverage)をご覧ください。
 
 * バイナリをインストールします。INSTALL_DIR を使用して、インストール・プレフィックス・パス (デフォルトは /usr) を設定する
 ことができます。したがって、broker は `$INSTALL_DIR/bin` ディレクトリにインストールされます
@@ -272,15 +226,44 @@ aarch64 アーキテクチャの場合、apt を使用して xsltproc をイン�
 
         contextBroker --version
 
+<a name="testing-and-coverage"></a>
+### テストとカバレッジ
+
 Orion Context Broker には、次の手順 (オプション) に従って実行することができる、valgrind およびエンド・ツー・エンドのテストの
 機能的なスイートが付属しています :
 
-* 必要なツールをインストールします :
+* ソースから Google Test/Mock をインストールします (このための RPM パッケージがありますが、現在の CMakeLists.txt
+の設定では動作しません)。以前は URL は http://googlemock.googlecode.com/files/gmock-1.5.0.tar.bz2 でしたが、
+Google では2016年8月下旬にそのパッケージを削除したため、動作しなくなりました
 
-        sudo apt install python python-pip curl netcat valgrind bc
-        sudo pip install --upgrade pip
+        sudo apt install python-is-python2 xsltproc
+        wget https://nexus.lab.fiware.org/repository/raw/public/storage/gmock-1.5.0.tar.bz2
+        tar xfvj gmock-1.5.0.tar.bz2
+        cd gmock-1.5.0
+        ./configure
+        make
+        sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
+        sudo ldconfig      # just in case... it doesn't hurt :)
 
-aarch64 アーキテクチャの場合、さらに apt で、python-devel と libffi-devel をインストールします。これは、pyOpenSSL をビルドするときに必要です。
+aarch64 アーキテクチャの場合、`.-configure` を `--build=arm-linux` オプションとともに実行します。
+
+* MongoDB をインストールします (テストはローカルホストで実行されている mongod に依存します)。詳細については、
+  [MongoDB の公式ドキュメント](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/)を確認してください。
+  推奨バージョンは 4.4 です (以前のバージョンで動作する可能性がありますが、お勧めしません)。
+
+* 単体テストを実行します :
+
+        make unit_test
+
+* 機能テストと valgrind テストに必要な追加のツールをインストールします :
+
+        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py 
+        sudo python get-pip.py 
+        sudo apt install netcat valgrind bc 
+        sudo pip install --upgrade pip 
+        pip install virtualenv
+
+aarch64 アーキテクチャの場合、さらに apt で、`python2-dev` と `libffi-dev` をインストールします。これは、pyOpenSSL をビルドするときに必要です。
 
 * テスト・ハーネスのための環境を準備します。基本的には、`accumulator-server.py` スクリプトをコントロールの下にあるパスに
 インストールしなければならず、`~/bin` が推奨です。また、`/usr/bin` のようなシステム・ディレクトリにインストールすることも
@@ -292,7 +275,6 @@ aarch64 アーキテクチャの場合、さらに apt で、python-devel と li
         export PATH=~/bin:$PATH
         make install_scripts INSTALL_DIR=~
         . scripts/testEnv.sh
-        pip install virtualenv
         virtualenv /opt/ft_env
         . /opt/ft_env/bin/activate
         pip install Flask==1.0.2 pyOpenSSL==19.0.0

--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -148,49 +148,44 @@ You can generate the RPM for the source code (optional):
 
 * The generated RPMs are placed in directory `~/rpmbuild/RPMS/x86_64`.
 
-## Ubuntu 18.04 LTS
+## Ubuntu 20.04 LTS
 
-**FIXME:** this section needs to be reviewed taking into account
-the new procedure to install the mongo C driver.
-
-This instruction is how to build the Orion Context Broker for the x86_64 or the aarch64 architecture on Ubuntu 18.04 LTS.
+This instruction is how to build the Orion Context Broker for the x86_64 or the aarch64 architecture on Ubuntu 20.04 LTS.
 And it includes the instruction to build MongoDB 4.4 that the Orion depends on.
 The Orion Context Broker uses the following libraries as build dependencies:
 
-* boost: 1.65.1
+* boost: 1.71.0
 * libmicrohttpd: 0.9.70 (from source)
-* libcurl: 7.58.0
-* openssl: 1.0.2n
-* libuuid: 2.31.1
-* Mongo Driver: legacy-1.1.2 (from source)
+* libcurl: 7.68.0
+* openssl: 1.1.1f
+* libuuid: 2.34-0.1
+* Mongo C driver: 1.17.4 (from source)
 * rapidjson: 1.1.0 (from source)
 * gtest (only for `make unit_test` building target): 1.5 (from sources)
 * gmock (only for `make unit_test` building target): 1.5 (from sources)
-* MongoDB: 4.4.4 (from source)
 
 The basic procedure is as follows (assuming you don't run commands as root, we use sudo for those
 commands that require root privilege):
 
 * Install the needed building tools (compiler, etc.).
 
-        sudo apt install build-essential cmake scons
+        sudo apt install build-essential cmake
 
 * Install the required libraries (except what needs to be taken from source, described in following steps).
 
         sudo apt install libboost-dev libboost-regex-dev libboost-thread-dev libboost-filesystem-dev \
-                         libcurl4-gnutls-dev gnutls-dev libgcrypt-dev libssl1.0-dev uuid-dev libsasl2-dev
+                         libcurl4-gnutls-dev gnutls-dev libgcrypt-dev libssl-dev uuid-dev libsasl2-dev
 
-* Install the Mongo Driver from source. The Mongo Driver 1.1.2 is written in legacy code intended to compile with gcc 4.x.
-So some kind of warnings are treated as errors when building with newer gcc. To avoid such errors, it is necessary to
-add a `-Wno-{option name}` option to CCFLAGS.
+* Install the Mongo Driver from source.
 
-        wget https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.1.2.tar.gz
-        tar xfvz legacy-1.1.2.tar.gz
-        cd mongo-cxx-driver-legacy-1.1.2
-        # The build/linux2/normal/libmongoclient.a library is generated as outcome
-        scons  --use-sasl-client --ssl "CCFLAGS=-Wno-nonnull-compare -Wno-noexcept-type -Wno-format-truncation"
-        # This puts .h files in /usr/local/include/mongo and libmongoclient.a in /usr/local/lib
-        sudo scons install --prefix=/usr/local --use-sasl-client --ssl "CCFLAGS=-Wno-nonnull-compare -Wno-noexcept-type -Wno-format-truncation"
+        wget https://github.com/mongodb/mongo-c-driver/releases/download/1.17.4/mongo-c-driver-1.17.4.tar.gz 
+        tar xfvz mongo-c-driver-1.17.4.tar.gz 
+        cd mongo-c-driver-1.17.4 
+        mkdir cmake-build 
+        cd cmake-build 
+        cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF .. 
+        make 
+        make install
 
 * Install rapidjson from sources:
 
@@ -208,19 +203,6 @@ add a `-Wno-{option name}` option to CCFLAGS.
         sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
         sudo ldconfig      # just in case... it doesn't hurt :)
 
-* Install Google Test/Mock from sources (there are RPM packages for this, but they do not work with the current CMakeLists.txt configuration). Previously the URL was http://googlemock.googlecode.com/files/gmock-1.5.0.tar.bz2 but Google removed that package in late August 2016 and it is no longer working.
-
-        apt install xsltproc
-        wget https://nexus.lab.fiware.org/repository/raw/public/storage/gmock-1.5.0.tar.bz2
-        tar xfvj gmock-1.5.0.tar.bz2
-        cd gmock-1.5.0
-        ./configure
-        make
-        sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
-        sudo ldconfig      # just in case... it doesn't hurt :)
-
-In the case of the aarch64 architecture, run `./configure` with `--build=arm-linux` option.
-
 * Get the code (alternatively you can download it using a zipped version or a different URL pattern, e.g `git clone git@github.com:telefonicaid/fiware-orion.git`):
 
         sudo apt install git
@@ -231,32 +213,7 @@ In the case of the aarch64 architecture, run `./configure` with `--build=arm-lin
         cd fiware-orion
         make
 
-* Build MongoDB 4.4.4 from source code and install it. To run unit test, you have to build MongoDB as the unit and functional
-tests rely on mongod running in localhost (The MongoDB 4.4 binary for Ubuntu 18.04 is not provided.). The instruction to build
-MongoDB from source code is as the following. In the case of the aarch64 architecture, additionally add the `-march=armv8-a+crc`
-option to CCFLAGS. Run the `mongo` command to check that MongoDB has been successfully installed:
-
-        # Build MongoDB
-        sudo apt install build-essential cmake scons  # Not required if you installed in previous step
-        sudo apt install python python-pip            # Not required if you installed in previous step
-        pip install --upgrade pip                     # Not required if you installed in previous step
-        cd /opt
-        git clone -b r4.4.4 --depth=1 https://github.com/mongodb/mongo.git
-        cd mongo
-        pip install --user -r buildscripts/requirements.txt
-        python buildscripts/scons.py mongo mongod mongos \
-          "CCFLAGS=-Wno-nonnull-compare -Wno-format-truncation -Wno-noexcept-type" \
-          --wiredtiger=on \
-          --mmapv1=on
-        # Install MongoDB
-        strip -s mongo*
-        sudo cp -a mongo mongod mongos /usr/bin/ 
-        sudo useradd -M -s /bin/false mongodb
-        sudo mkdir /var/lib/mongodb /var/log/mongodb /var/run/mongodb
-        sudo chown mongodb:mongodb /var/lib/mongodb /var/log/mongodb /var/run/mongodb
-        sudo cp -a ./debian/mongod.conf /etc/
-        sudo cp -a ./debian/mongod.service /etc/systemd/system/
-        sudo systemctl start mongod
+* (Optional but highly recommended) run unit test and functional tests. More on this on [its specific section below](#testing-and-coverage).
 
 * Install the binary. You can use INSTALL_DIR to set the installation prefix path (default is /usr), thus the broker is installed in `$INSTALL_DIR/bin` directory.
 
@@ -266,14 +223,38 @@ option to CCFLAGS. Run the `mongo` command to check that MongoDB has been succes
 
         contextBroker --version
 
+### Testing and coverage
+
 The Orion Context Broker comes with a suite of functional, valgrind and end-to-end tests that you can also run, following the following procedure (optional):
 
-* Install the required tools:
+* Install Google Test/Mock from sources (there are RPM packages for this, but they do not work with the current CMakeLists.txt configuration). Previously the URL was http://googlemock.googlecode.com/files/gmock-1.5.0.tar.bz2 but Google removed that package in late August 2016 and it is no longer working.
 
-        sudo apt install python python-pip curl netcat valgrind bc
-        sudo pip install --upgrade pip
+        apt install python-is-python2 xsltproc
+        wget https://nexus.lab.fiware.org/repository/raw/public/storage/gmock-1.5.0.tar.bz2
+        tar xfvj gmock-1.5.0.tar.bz2
+        cd gmock-1.5.0
+        ./configure
+        make
+        sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
+        sudo ldconfig      # just in case... it doesn't hurt :)
 
-In the case of the aarch64 architecture, additionally install python-devel and libffi-devel using apt. It is needed when building pyOpenSSL.
+In the case of the aarch64 architecture, run `./configure` with `--build=arm-linux` option.
+
+* Install MongoDB (tests rely on mongod running in localhost). Check [the official MongoDB documentation](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/) for details. Recommended version is 4.4 (it may work with previous versions, but we don't recommend it).
+
+* Run unit test:
+
+        make unit_test
+
+* Install additional required tools for functional and valgrind tests:
+
+        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py 
+        sudo python get-pip.py 
+        sudo apt install netcat valgrind bc 
+        sudo pip install --upgrade pip 
+        pip install virtualenv
+
+In the case of the aarch64 architecture, additionally install `python2-dev` and `libffi-dev` using apt. It is needed when building pyOpenSSL.
 
 * Prepare the environment for test harness. Basically, you have to install the `accumulator-server.py` script and in a path under your control, `~/bin` is the recommended one. Alternatively, you can install them in a system directory such as `/usr/bin` but it could collide with an RPM installation, thus it is not recommended. In addition, you have to set several environment variables used by the harness script (see `scripts/testEnv.sh` file) and create a virtualenv environment to use Flask version 1.0.2 instead of default Flask in Ubuntu. Run test harness in this environment.
 
@@ -281,7 +262,6 @@ In the case of the aarch64 architecture, additionally install python-devel and l
         export PATH=~/bin:$PATH
         make install_scripts INSTALL_DIR=~
         . scripts/testEnv.sh
-        pip install virtualenv
         virtualenv /opt/ft_env
         . /opt/ft_env/bin/activate
         pip install Flask==1.0.2 pyOpenSSL==19.0.0


### PR DESCRIPTION
This PR updates the procedure to directly run Orion on Ubuntu (amd64 and aarch64). It would be great if you could review this PR.

Currently, the latest LTS (long term support) version of Ubuntu is 20.04. Therefore, I updated the build and test procedures with new mongo driver on Ubuntu 20.04 insted of 18.04. 

The build logs and test logs are the followings:
- https://github.com/fisuda/report/tree/master/orion/20210321_ubuntu20.04_amd64
- https://github.com/fisuda/report/tree/master/orion/20210321_ubuntu20.04_aarch64

One function test has failed as shown:
- 0706_direct_https_notifications

Related PR: https://github.com/telefonicaid/fiware-orion/pull/3622, https://github.com/telefonicaid/fiware-orion/pull/3632