### PR TITLE
Update function test procedure for Ubuntu

### DIFF
--- a/doc/manuals.jp/admin/build_source.md
+++ b/doc/manuals.jp/admin/build_source.md
@@ -279,8 +279,9 @@ aarch64 アーキテクチャの場合、さらに apt で、`python2-dev` と `
         . /opt/ft_env/bin/activate
         pip install Flask==1.0.2 pyOpenSSL==19.0.0
 
-* テスト・ハーネスを実行してください (時間がかかりますので、気をつけてください)
+* テスト・ハーネスを実行してください (時間がかかりますので、気をつけてください) make コマンドでテストを開始する前に、テストが失敗しないように次のパッチを適用してください。
 
+        sed -i -e "s/Peer certificate cannot be authenticated[^\"]*/SSL peer certificate or SSH remote key was not OK/" /opt/fiware-orion/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
         make functional_test INSTALL_DIR=~
 
 * すべての機能テストに合格したら、valgrind テストを実行できます (これは機能テストよりも時間がかかります) :

--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -266,8 +266,9 @@ In the case of the aarch64 architecture, additionally install `python2-dev` and 
         . /opt/ft_env/bin/activate
         pip install Flask==1.0.2 pyOpenSSL==19.0.0
 
-* Run test harness (it takes some time, please be patient).
+* Run test harness (it takes some time, please be patient). Before starting test by make command, apply the following patch to avoid test failing.
 
+        sed -i -e "s/Peer certificate cannot be authenticated[^\"]*/SSL peer certificate or SSH remote key was not OK/" /opt/fiware-orion/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
         make functional_test INSTALL_DIR=~
 
 * Once passed all the functional tests, you can run the valgrind tests (this will take longer than the functional tests, arm yourself with a lot of patience):


### PR DESCRIPTION
The `0706_direct_https_notifications` test for CentOS 8 fails on Ubuntu 20.04 because Orion built on Centos 8 and Orion built on Ubuntu 20.04 have different dependent libraries.  This PR updates function test procedure for Ubuntu 20.04 to avoid test failing.

The result of test is following:
https://github.com/fisuda/report/tree/master/orion/20210325_ubuntu20.04_0706_direct_https_notifications

It is needed to change three lines as shown:

```
$ git diff direct_https_notifications_no_accept_selfsigned.test
diff --git a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
index 812d8f36f..c6e1008d1 100644
--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
@@ -90,8 +90,8 @@ echo
 echo "04. Look in the CB log for the warning about cert not accepted"
 echo "=============================================================="
 
-LINE1=$(grep "Peer certificate cannot be authenticated" /tmp/contextBroker.log | grep "notification failure" | awk -F 'notification failure for queue worker: ' '{print $2}')
-LINE2=$(grep "Peer certificate cannot be authenticated" /tmp/contextBroker.log | grep "notification failure" | awk -F 'notification failure for sender-thread: ' '{print $2}')
+LINE1=$(grep "SSL peer certificate or SSH remote key was not OK" /tmp/contextBroker.log | grep "notification failure" | awk -F 'notification failure for queue worker: ' '{print $2}')
+LINE2=$(grep "SSL peer certificate or SSH remote key was not OK" /tmp/contextBroker.log | grep "notification failure" | awk -F 'notification failure for sender-thread: ' '{print $2}')
 
 # Depending CB_THREADPOOL=ON|OFF, either LINE1 or LINE2 has the text we are looking for but not both at the same time
 echo $LINE1$LINE2
@@ -127,7 +127,7 @@ Date: REGEX(.*)
 
 04. Look in the CB log for the warning about cert not accepted
 ==============================================================
-Peer certificate cannot be authenticated with given CA certificates
+SSL peer certificate or SSH remote key was not OK
 
 
 --TEARDOWN--
```

Related issue: #3820