### PR TITLE
FIX logForHumans including full time information

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: response rightly 500 Internal Error when DB query fails (previously 200 OK with empty entities array was returned)
+- Fix: -logForHumans traces including full timestamp information

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -960,7 +960,7 @@ int main(int argC, char* argV[])
     paConfig("log to screen",                 (void*) true);  
     if (paIsSet(argC, argV, (PaArgument*) paArgs, "-logForHumans"))
     {
-      paConfig("screen line format", (void*) "TYPE@TIME  FILE[LINE]: TEXT");
+      paConfig("screen line format", (void*) "TYPE@DATE  FILE[LINE]: TEXT");
     }
     else
     {


### PR DESCRIPTION
Before the PR:

```
INFO@12:49:49  contextBroker.cpp[1012]: start command line <contextBroker -fg -logForHumans -logLevel INFO>
INFO@12:49:49  contextBroker.cpp[1080]: Orion Context Broker is running
INFO@12:49:49  mongoConnectionPool.cpp[506]: Connected to mongodb://localhost/?connectTimeoutMS=10000 (dbName: orion, poolsize: 10)
INFO@12:49:49  contextBroker.cpp[1206]: Startup completed
```

After the PR:

```
INFO@2021-03-25T13:03:31.496Z  contextBroker.cpp[1012]: start command line <contextBroker -fg -logForHumans -logLevel INFO>
INFO@2021-03-25T13:03:31.496Z  contextBroker.cpp[1080]: Orion Context Broker is running
INFO@2021-03-25T13:03:31.518Z  mongoConnectionPool.cpp[506]: Connected to mongodb://localhost/?connectTimeoutMS=10000 (dbName: orion, poolsize: 10)
INFO@2021-03-25T13:03:31.523Z  contextBroker.cpp[1206]: Startup completed
```

It's better to include ms information.