### PR TITLE
Support CentOS 8 aarch64 for Raspberry Pi

### DIFF
--- a/doc/manuals.jp/admin/build_source.md
+++ b/doc/manuals.jp/admin/build_source.md
@@ -84,12 +84,12 @@ Orion Context Broker には、次の手順に従って実行できる一連の�
         tar xfvj gmock-1.5.0.tar.bz2
         cd gmock-1.5.0
         ./configure
-        make
         sed -i 's/env python/env python2/' gtest/scripts/fuse_gtest_files.py  # little hack to make installation to work on CentOS 8
+        make
         sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
         sudo ldconfig      # just in case... it doesn't hurt :)
 
-aarch64 アーキテクチャの場合、yum を使用して perl-Digest-MD5 と libxslt をインストールし、`--build=arm-linux` オプションを指定して `/configure` を実行します。
+aarch64 アーキテクチャの場合、yum を使用して libxslt をインストールし、`--build=arm-linux` オプションを指定して `/configure` を実行します。
 
 * MongoDB をインストールします (テストはローカルホストで実行されている mongod に依存します)。詳細については、[MongoDB の公式ドキュメント](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-red-hat/)を確認してください。推奨バージョンは 4.4 です (以前のバージョンで動作する可能性がありますが、お勧めしません)。
 
@@ -102,7 +102,7 @@ aarch64 アーキテクチャの場合、yum を使用して perl-Digest-MD5 と
         sudo yum install curl nc valgrind bc
         sudo pip2 install virtualenv
 
-aarch64 アーキテクチャの場合、さらに yum で、python-devel と libffi-devel をインストールします。これは、pyOpenSSL をビルドするときに必要です。
+aarch64 アーキテクチャの場合、さらに yum で、python2-devel, rpm-build と libffi-devel をインストールします。これは、pyOpenSSL をビルドするときに必要です。
 
 
 * テスト・ハーネスのための環境を準備します。基本的には、`accumulator-server.py` スクリプトをコントロールの下にあるパスにインストールしなければならず、`~/bin` が推奨です。また、`/usr/bin` のようなシステム・ディレクトリにインストールすることもできますが、RPM インストールと衝突する可能性がありますので、お勧めしません。さらに、ハーネス・スクリプト (`scripts/testEnv.sh` ファイル参照) で使用されるいくつかの環境変数を設定し、必要な Python パッケージを使用して virtualenv 環境を作成します。

--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -85,12 +85,12 @@ The Orion Context Broker comes with a suite of unit, valgrind and end-to-end tes
         tar xfvj gmock-1.5.0.tar.bz2
         cd gmock-1.5.0
         ./configure
-        make
         sed -i 's/env python/env python2/' gtest/scripts/fuse_gtest_files.py  # little hack to make installation to work on CentOS 8
+        make
         sudo make install  # installation puts .h files in /usr/local/include and library in /usr/local/lib
         sudo ldconfig      # just in case... it doesn't hurt :)
 
-In the case of the aarch64 architecture, install perl-Digest-MD5 and libxslt using yum, and run `./configure` with `--build=arm-linux` option.
+In the case of the aarch64 architecture, install libxslt using yum, and run `./configure` with `--build=arm-linux` option.
 
 * Install MongoDB (tests rely on mongod running in localhost). Check [the official MongoDB documentation](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-red-hat/) for details. Recommended version is 4.4 (it may work with previous versions, but we don't recommend it).
 
@@ -103,7 +103,7 @@ In the case of the aarch64 architecture, install perl-Digest-MD5 and libxslt usi
         sudo yum install curl nc valgrind bc
         sudo pip2 install virtualenv
 
-In the case of the aarch64 architecture, additionally install python-devel and libffi-devel using yum. It is needed when building pyOpenSSL.
+In the case of the aarch64 architecture, additionally install python2-devel, rpm-build and libffi-devel using yum. It is needed when building pyOpenSSL.
 
 * Prepare the environment for test harness. Basically, you have to install the `accumulator-server.py` script and in a path under your control, `~/bin` is the recommended one. Alternatively, you can install them in a system directory such as `/usr/bin` but it could collide with an RPM installation, thus it is not recommended. In addition, you have to set several environment variables used by the harness script (see `scripts/testEnv.sh` file) and create a virtualenv environment with the required Python packages.
 

--- a/docker/raspberry_pi.jp.md
+++ b/docker/raspberry_pi.jp.md
@@ -17,7 +17,7 @@ ARM ベースのデバイスであり、ARM アーキテクチャ用にコンパ
 
 ### Linux OS
 
-現在のところ、Raspberry Pi で64 ビット Linux を使用するオプションは多くありません。Ubuntu 18.04 LTS または 19.10
+現在のところ、Raspberry Pi で64 ビット Linux を使用するオプションは多くありません。Ubuntu 20.04 LTS
 を使用することをお勧めします。[こちら](https://ubuntu.com/download/raspberry-pi)から OS イメージを取得し、
 インストール手順を見つけることができます。
 
@@ -42,25 +42,19 @@ sudo add-apt-repository \
 sudo apt-get install -y docker-ce
 ```
 
-Ubuntu 19.10 (Eoan) 用の Docker バイナリは提供されていないため、Ubuntu 18.04 LTS (Bionic) 用の Docker バイナリを
-インストールする必要があります。`add-apt-repository` コマンドで、`$(lsb_release -cs)` を `bionic` に置き換えてください。
-
 Docker のインストールの詳細は[こちら](https://docs.docker.com/install/linux/docker-ce/ubuntu/)です。
 
 ### Dokcer compose
 
 aarch64 の Docker Compose のバイナリは提供されていません。ソースコードからビルドする必要があります。
-次のようにコマンドを実行して、Docker Compose のバージョン 1.25.1 をインストールできます :
+次のようにコマンドを実行して、Docker Compose のバージョン 1.27.4 をインストールできます :
 
 ```
-git clone -b 1.25.1 https://github.com/docker/compose.git
+git clone -b 1.27.4 https://github.com/docker/compose.git
 cd compose/
-sed -i -e "43i'setuptools<45.0.0'," setup.py
 sudo ./script/build/linux
 sudo cp dist/docker-compose-Linux-aarch64 /usr/local/bin/docker-compose
 ```
-
-注 : sed コマンドを使用して、ビルドエラーを回避するためのパッチが追加されます。
 
 ## Orion のビルド方法
 
@@ -69,7 +63,7 @@ Orion の Docker イメージをビルドするには、Orion リポジトリを
 ```
 git clone https://github.com/telefonicaid/fiware-orion.git
 cd fiware-orion/docker
-docker build --build-arg=centos7 -t orion .
+docker build -t orion .
 ```
 
 ## Orion の実行方法

--- a/docker/raspberry_pi.md
+++ b/docker/raspberry_pi.md
@@ -17,7 +17,7 @@ The target devices are Raspberry Pi 3 and 4 which support the 64 bit ARM archite
 ### Linux OS
 
 As of now, there are not many options to use the 64 bit Linux on Raspberry Pi. 
-To use Ubuntu 18.04 LTS or 19.10 is better. You can get the OS image and find the install instruction 
+To use Ubuntu 20.04 LTS is better. You can get the OS image and find the install instruction
 [here](https://ubuntu.com/download/raspberry-pi).
 
 ### Docker
@@ -41,25 +41,19 @@ sudo add-apt-repository \
 sudo apt-get install -y docker-ce
 ```
 
-As the docker binary for Ubuntu 19.10 (Eoan) is not provided, it is necessary to install the docker binary
-for Ubuntu 18.04 LTS (Bionic). You should replace `$(lsb_release -cs)` with `bionic` in `add-apt-repository` command.
-
 The details to install Docker are [here](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
 
 ### Docker compose
 
 The Docker Compose binary for aarch64 is not provided. It is necessary to build it from its source code.
-You can install the docker compose version 1.25.1 by running the commands as shown:
+You can install the docker compose version 1.27.4 by running the commands as shown:
 
 ```
-git clone -b 1.25.1 https://github.com/docker/compose.git
+git clone -b 1.27.4 https://github.com/docker/compose.git
 cd compose/
-sed -i -e "43i'setuptools<45.0.0'," setup.py
 sudo ./script/build/linux
 sudo cp dist/docker-compose-Linux-aarch64 /usr/local/bin/docker-compose
 ```
-
-Note: A patch to avoid a build error is added by using the sed command.
 
 ## How to build Orion
 
@@ -68,7 +62,7 @@ To build the docker images of Orion, Clone the Orion repository and run the `doc
 ```
 git clone https://github.com/telefonicaid/fiware-orion.git
 cd fiware-orion/docker
-docker build --build-arg=centos7 -t orion .
+docker build -t orion .
 ```
 
 ## How to run Orion


### PR DESCRIPTION
This PR updates documentation to support CentOS 8 aarch64 for Raspberry Pi. This is a way that Orion is run in a docker container on Raspberry Pi. It would be great if you could review this PR.

The test logs are the followings:
https://github.com/fisuda/report/tree/master/orion/20210325_centos8_aarch64

In the function test, one test has failed as shown:

- 1697_more_than_one_bad_input


This test may pass or fail. It seems that the issue is dependent on the timing.  This behavior is the same as before (https://github.com/telefonicaid/fiware-orion/pull/3630).

- more_than_one_bad_input.diff

```
VALIDATION ERROR: input file and reference file have different line count
```

- Expected (more_than_one_bad_input.regexpect)

```
3. grep SUMMARY in log-file (4 transactions, 1 bad input)
==========================================================
Transactions: REGEX((4 _new: 4_|5 _new: 5_))
DB status: ok, raised: _total: 0, new: 0_, released: _total: 0, new: 0_
Notification failure active alarms: 0, raised: _total: 0, new: 0_, released: _total: 0, new: 0_
Bad input active alarms: 1, raised: _total: 1, new: 1_, released: _total: 0, new: 0_

```

- Actual (more_than_one_bad_input.out)

```
03. grep SUMMARY in log-file (4 transactions, 1 bad input)
==========================================================
Transactions: 0 _new: 0_
DB status: ok, raised: _total: 0, new: 0_, released: _total: 0, new: 0_
Notification failure active alarms: 0, raised: _total: 0, new: 0_, released: _total: 0, new: 0_
Bad input active alarms: 0, raised: _total: 0, new: 0_, released: _total: 0, new: 0_
Transactions: 4 _new: 4_
DB status: ok, raised: _total: 0, new: 0_, released: _total: 0, new: 0_
Notification failure active alarms: 0, raised: _total: 0, new: 0_, released: _total: 0, new: 0_
Bad input active alarms: 1, raised: _total: 1, new: 1_, released: _total: 0, new: 0_
```

Related PR: https://github.com/telefonicaid/fiware-orion/pull/3622, https://github.com/telefonicaid/fiware-orion/pull/3630