### PR TITLE
Add machine information in GET /version

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -7,3 +7,4 @@
 - Hardening: upgrade Mongo driver dependency form C++ legacy-1.1.2 to C 1.17.4 (#3132, #3797 and possibly #3717, #3778, #3326)
 - Remove: MONGODB-CR as -dbAuthMech
 - Fix: response rightly 500 Internal Error when DB query fails (previously 200 OK with empty entities array was returned)
+- Hardening: Add machine information in GET /version

--- a/doc/manuals.jp/admin/sanity_check.md
+++ b/doc/manuals.jp/admin/sanity_check.md
@@ -22,13 +22,14 @@ curl --header 'Accept: application/json' localhost:1026/version
 ```
 {
   "orion" : {
-    "version" : "2.4.0-next",
+    "version" : "2.6.0-next",
     "uptime" : "0 d, 0 h, 2 m, 30 s",
     "git_hash" : "f2a3d436b2b507c5fd1611492ad7fad386901952",
     "compile_time" : "Thu Oct 29 16:56:16 CEST 2020",
     "compiled_by" : "fermin",
     "compiled_in" : "debvm",
     "release_date" : "Thu Oct 29 16:56:16 CEST 2020",
+    "machine" : "x86_64",
     "doc" : "https://fiware-orion.rtfd.io/",
     "libversions": ...
   }

--- a/doc/manuals/admin/sanity_check.md
+++ b/doc/manuals/admin/sanity_check.md
@@ -24,13 +24,14 @@ curl --header 'Accept: application/json' localhost:1026/version
 ```
 {
   "orion" : {
-    "version" : "2.4.0-next",
+    "version" : "2.6.0-next",
     "uptime" : "0 d, 0 h, 2 m, 30 s",
     "git_hash" : "f2a3d436b2b507c5fd1611492ad7fad386901952",
     "compile_time" : "Thu Oct 29 16:56:16 CEST 2020",
     "compiled_by" : "fermin",
     "compiled_in" : "debvm",
     "release_date" : "Thu Oct 29 16:56:16 CEST 2020",
+    "machine" : "x86_64",
     "doc" : "https://fiware-orion.rtfd.io/",
     "libversions": ...
   }

--- a/scripts/build/compileInfo.sh
+++ b/scripts/build/compileInfo.sh
@@ -27,6 +27,7 @@ fi
 git_hash=$(git log | grep commit | head -1 | awk '{ print $2 }')
 user=$(whoami)
 host=$(hostname)
+machine=$(uname -m)
 
 if [ -n "$git_hash" ]; then
     hash=$git_hash
@@ -68,6 +69,7 @@ echo '#define COMPILE_TIME     "'${date}'"'                                     
 echo '#define COMPILED_BY      "'${user}'"'                                         >> $TMP_FILE
 echo '#define COMPILED_IN      "'${host}'"'                                         >> $TMP_FILE
 echo '#define RELEASE_DATE     "'${date}'"'                                         >> $TMP_FILE
+echo '#define MACHINE_ARCH     "'${machine}'"'                                      >> $TMP_FILE
 echo                                                                                >> $TMP_FILE
 echo '#endif  // SRC_LIB_COMMON_COMPILEINFO_H_'                                     >> $TMP_FILE
 

--- a/src/lib/serviceRoutines/versionTreat.cpp
+++ b/src/lib/serviceRoutines/versionTreat.cpp
@@ -150,6 +150,7 @@ std::string versionTreat
   out += "  \"compiled_by\" : \"" + std::string(COMPILED_BY) + "\",\n";
   out += "  \"compiled_in\" : \"" + std::string(COMPILED_IN) + "\",\n";
   out += "  \"release_date\" : \"" + std::string(RELEASE_DATE) + "\",\n";
+  out += "  \"machine\" : \"" + std::string(MACHINE_ARCH) + "\",\n";
   out += "  \"doc\" : \"" + std::string(API_DOC) + "\"," "\n" + "  " + libVersions();
   out += "  }\n";
   out += "}\n";

--- a/test/functionalTest/cases/0000_ipv6_support/ipv4_ipv6_both.test
+++ b/test/functionalTest/cases/0000_ipv6_support/ipv4_ipv6_both.test
@@ -144,6 +144,7 @@ Date: REGEX(.*)
   "compiled_by" : "REGEX(.*)",
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
+  "machine" : "REGEX(.*)",
   "doc" : "REGEX(.*)",
   "libversions": {
      "boost": "REGEX(.*)",
@@ -173,6 +174,7 @@ Date: REGEX(.*)
   "compiled_by" : "REGEX(.*)",
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
+  "machine" : "REGEX(.*)",
   "doc" : "REGEX(.*)",
   "libversions": {
      "boost": "REGEX(.*)",

--- a/test/functionalTest/cases/0000_version_operation/version_via_rest.test
+++ b/test/functionalTest/cases/0000_version_operation/version_via_rest.test
@@ -57,6 +57,7 @@ Date: REGEX(.*)
   "compiled_by" : "REGEX(.*)",
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
+  "machine" : "REGEX(.*)",
   "doc" : "REGEX(.*)",
   "libversions": {
      "boost": "REGEX(.*)",

--- a/test/functionalTest/cases/0501_cors/version_request.test
+++ b/test/functionalTest/cases/0501_cors/version_request.test
@@ -87,6 +87,7 @@ Date: REGEX(.*)
   "compiled_by" : "REGEX(.*)",
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
+  "machine" : "REGEX(.*)",
   "doc" : "REGEX(.*)",
   "libversions": {
      "boost": "REGEX(.*)",
@@ -121,6 +122,7 @@ Date: REGEX(.*)
   "compiled_by" : "REGEX(.*)",
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
+  "machine" : "REGEX(.*)",
   "doc" : "REGEX(.*)",
   "libversions": {
      "boost": "REGEX(.*)",
@@ -153,6 +155,7 @@ Date: REGEX(.*)
   "compiled_by" : "REGEX(.*)",
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
+  "machine" : "REGEX(.*)",
   "doc" : "REGEX(.*)",
   "libversions": {
      "boost": "REGEX(.*)",

--- a/test/functionalTest/cases/1916_fiware_correlator/fiware_correlator.test
+++ b/test/functionalTest/cases/1916_fiware_correlator/fiware_correlator.test
@@ -66,6 +66,7 @@ Date: REGEX(.*)
   "compiled_by" : "REGEX(.*)",
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
+  "machine" : "REGEX(.*)",
   "doc" : "REGEX(.*)",
   "libversions": {
      "boost": "REGEX(.*)",
@@ -98,6 +99,7 @@ Date: REGEX(.*)
   "compiled_by" : "REGEX(.*)",
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
+  "machine" : "REGEX(.*)",
   "doc" : "REGEX(.*)",
   "libversions": {
      "boost": "REGEX(.*)",

--- a/test/unittests/serviceRoutines/versionTreat_test.cpp
+++ b/test/unittests/serviceRoutines/versionTreat_test.cpp
@@ -71,6 +71,7 @@ TEST(versionTreat, ok)
   // "  \"compile_time\" : \".*\",\n"
   // "  \"compiled_by\" : \".*\",\n"
   // "  \"compiled_in\" : \".*\"\n"
+  // "  \"machine\" : \".*\"\n"
   // "  \"doc\" : \".*\"\n"
   // "  \"libversions\" : (drill down) "\n"
   // "}\n"
@@ -86,6 +87,7 @@ TEST(versionTreat, ok)
   EXPECT_TRUE(strstr(out.c_str(), "compiled_in") != NULL);
   EXPECT_TRUE(strstr(out.c_str(), "compiled_by") != NULL);
   EXPECT_TRUE(strstr(out.c_str(), "release_date") != NULL);
+  EXPECT_TRUE(strstr(out.c_str(), "machine") != NULL);
   EXPECT_TRUE(strstr(out.c_str(), "doc") != NULL);
   EXPECT_TRUE(strstr(out.c_str(), "libversions") != NULL);
 


### PR DESCRIPTION
This PR adds  machine information in GET /version. It would be great if you could review this PR.

The examples are following:

- amd64
```
{
"orion" : {
  "version" : "2.6.0-next",
  "uptime" : "0 d, 0 h, 0 m, 4 s",
  "git_hash" : "fffcc0ab1b75e3d067bc66d0f79943fce84a0e00",
  "compile_time" : "Sat Mar 27 11:29:20 JST 2021",
  "compiled_by" : "root",
  "compiled_in" : "n5000",
  "release_date" : "Sat Mar 27 11:29:20 JST 2021",
  "machine" : "x86_64",
  "doc" : "https://fiware-orion.rtfd.io/",
  "libversions": {
     "boost": "1_71",
     "libcurl": "libcurl/7.68.0 GnuTLS/3.6.13 zlib/1.2.11 brotli/1.0.7 libidn2/2.2.0 libpsl/0.21.0 (+libidn2/2.2.0) libssh/0.9.3/openssl/zlib nghttp2/1.40.0 librtmp/2.3",
     "libmicrohttpd": "0.9.70",
     "openssl": "1.1",
     "rapidjson": "1.1.0",
     "mongoc": "1.17.4",
     "bson": "1.17.4"
  }
}
}
```
- aarch64
```
{
"orion" : {
  "version" : "2.6.0-next",
  "uptime" : "0 d, 0 h, 0 m, 3 s",
  "git_hash" : "2378db353c96d4f50e1b670f9504496d022b98b9",
  "compile_time" : "Sat Mar 27 13:23:33 JST 2021",
  "compiled_by" : "root",
  "compiled_in" : "pi4u1",
  "release_date" : "Sat Mar 27 13:23:33 JST 2021",
  "machine" : "aarch64",
  "doc" : "https://fiware-orion.rtfd.io/",
  "libversions": {
     "boost": "1_71",
     "libcurl": "libcurl/7.68.0 GnuTLS/3.6.13 zlib/1.2.11 brotli/1.0.7 libidn2/2.2.0 libpsl/0.21.0 (+libidn2/2.2.0) libssh/0.9.3/openssl/zlib nghttp2/1.40.0 librtmp/2.3",
     "libmicrohttpd": "0.9.70",
     "openssl": "1.1",
     "rapidjson": "1.1.0",
     "mongoc": "1.17.4",
     "bson": "1.17.4"
  }
}
}
```