### PR TITLE
FIX loop protectiong

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+- Fix: extend loop protection to any request (not only custom notifications) to cover potential update loops due to CEP integration
 - Hardening: Improve notification pool worker thread termination logic (#3877)
 - Remove: deprecated feature initial notification upon subscription creation or update

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -3101,10 +3101,10 @@ static unsigned int updateEntity
   notifyCerP->entity.creDate = r.hasField(ENT_CREATION_DATE)     ? getNumberFieldF(r, ENT_CREATION_DATE)     : -1;
   notifyCerP->entity.modDate = r.hasField(ENT_MODIFICATION_DATE) ? getNumberFieldF(r, ENT_MODIFICATION_DATE) : -1;
 
-  // The logic to detect notification loops is to check that the correlator in the request differs from the last one seen for the entity and,
-  // in addition, the request was sent due to a custom notification
+  // The logic to detect notification loops is to check that the correlator in the request differs from the last one seen for the entity
+  // (for any kind of request, not only forged by custom notification, e.g. CEP rule)
   bool loopDetected = false;
-  if ((ngsiV2AttrsFormat == "custom") && (r.hasField(ENT_LAST_CORRELATOR)))
+  if (r.hasField(ENT_LAST_CORRELATOR))
   {
     loopDetected = (getStringFieldF(r, ENT_LAST_CORRELATOR) == correlatorRoot(fiwareCorrelator));
   }


### PR DESCRIPTION
This PR improves loop protection. Until this PR, this protection only works for self-custom notifications but now it works in any case (e.g. CEP loops).

It is not easy to test this PR without adding an extra tool (i.e. accumulator-py like) to redirect a notification back to the CB with a modification in the attribute name (pure self-notification doesn't work, as the attribute value doesn't change so a new notification is not triggered). Thus in this case no ftest can be added and we have tested manually the following way:

1. Hack the CB code so attributes with same value also trigger notifications:

```diff
diff --git a/src/lib/mongoBackend/MongoCommonUpdate.cpp b/src/lib/mongoBackend/MongoCommonUpdate.cpp
index a3fd978f0..47bb19e3a 100644
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -306,6 +306,8 @@ static bool equalMetadata(const orion::BSONObj& md1, const orion::BSONObj& md2)
 */
 static bool attrValueChanges(const orion::BSONObj& attr, ContextAttribute* caP, const bool& forcedUpdate, ApiVersion apiVersion)
 {
+  return true;
+
   /* Not finding the attribute field at MongoDB is considered as an implicit "" */
   if (!attr.hasField(ENT_ATTRS_VALUE))
   {
```

2. Check that the following tets works (based in exiting cases/2937_self_notification_protection/self_notification_one_hop.test)

```
--NAME--
Self notification protection one-hop case with regular (non custom) subscription

--SHELL-INIT--
dbInit CB
brokerStart CB

--SHELL--

#
# 01. Create self-subscription for entity E attribute A
# 02. Create entity with A = boom
# 03. Wait for a while and check that only one notification was sent
# 04. Get entity with value boomx
# 05. Check the warning about loop detection in the log

echo "01. Create self-subscription for entity E attribute A"
echo "====================================================="
payload='{
  "subject": {
    "entities": [
      {
        "id" : "E"
      }
    ],
    "condition": {
      "attrs": [ "A" ]
    }
  },
  "notification": {
    "http": {
      "url": "http://localhost:'${CB_PORT}'/v2/op/notify"
    }
  }
}'
orionCurl --url /v2/subscriptions --payload "$payload"
echo
echo


echo "02. Create entity with A = boom"
echo "==============================="
payload='{
  "id": "E",
  "type": "Thing",
  "A": {
    "value": "boom",
    "type": "Text"
  }
}'
orionCurl --url /v2/entities --payload "$payload"
echo
echo


echo "03. Wait for a while and check that only one notification was sent"
echo "=================================================================="
sleep 5s
orionCurl --url /v2/subscriptions
echo
echo


echo "04. Get entity with value boom"
echo "=============================="
orionCurl --url /v2/entities/E
echo
echo


echo "05. Check the warning about loop detection in the log"
echo "====================================================="
egrep 'WARN' /tmp/contextBroker.log
echo
echo


--REGEXPECT--
01. Create self-subscription for entity E attribute A
=====================================================
HTTP/1.1 201 Created
Content-Length: 0
Location: /v2/subscriptions/REGEX([0-9a-f]{24})
Fiware-Correlator: REGEX([0-9a-f\-]{36})
Date: REGEX(.*)



02. Create entity with A = boom
===============================
HTTP/1.1 201 Created
Content-Length: 0
Location: /v2/entities/E?type=Thing
Fiware-Correlator: REGEX([0-9a-f\-]{36})
Date: REGEX(.*)



03. Wait for a while and check that only one notification was sent
==================================================================
HTTP/1.1 200 OK
Content-Length: 372
Content-Type: application/json
Fiware-Correlator: REGEX([0-9a-f\-]{36})
Date: REGEX(.*)

[
    {
        "id": "REGEX([0-9a-f]{24})",
        "notification": {
            "attrs": [],
            "attrsFormat": "normalized",
            "http": {
                "url": "http://localhost:REGEX(\d+)/v2/op/notify"
            },
            "lastNotification": "REGEX(.*)",
            "lastSuccess": "REGEX(.*)",
            "lastSuccessCode": 200,
            "onlyChangedAttrs": false,
            "timesSent": 1
        },
        "status": "active",
        "subject": {
            "condition": {
                "attrs": [
                    "A"
                ]
            },
            "entities": [
                {
                    "id": "E"
                }
            ]
        }
    }
]


04. Get entity with value boom
==============================
HTTP/1.1 200 OK
Content-Length: 74
Content-Type: application/json
Fiware-Correlator: REGEX([0-9a-f\-]{36})
Date: REGEX(.*)

{
    "A": {
        "metadata": {},
        "type": "Text",
        "value": "boom"
    },
    "id": "E",
    "type": "Thing"
}


05. Check the warning about loop detection in the log
=====================================================
REGEX(.*) msg=Notification loop detected for entity id <E> type <Thing>, skipping subscription triggering


--TEARDOWN--
brokerStop CB
dbDrop CB
```

3. If we revert the change done in this PR and run the tests again, we can check it fails (`"timesSent": 961` instead of `"timesSent": 1` and step 05 doesn't show the expected line in the logs). This validates the fix done.