### PR TITLE
FIX remove old stuff

### DIFF
--- a/src/lib/apiTypesV2/HttpInfo.cpp
+++ b/src/lib/apiTypesV2/HttpInfo.cpp
@@ -51,16 +51,6 @@ HttpInfo::HttpInfo() : verb(NOVERB), custom(false), includePayload(true)
 
 /* ****************************************************************************
 *
-* HttpInfo::HttpInfo - 
-*/
-HttpInfo::HttpInfo(const std::string& _url) : url(_url), verb(NOVERB), custom(false), includePayload(true)
-{
-}
-
-
-
-/* ****************************************************************************
-*
 * HttpInfo::toJson -
 */
 std::string HttpInfo::toJson()

--- a/src/lib/apiTypesV2/HttpInfo.h
+++ b/src/lib/apiTypesV2/HttpInfo.h
@@ -51,7 +51,6 @@ struct HttpInfo
   bool                                includePayload;
 
   HttpInfo();
-  explicit HttpInfo(const std::string& _url);
 
   std::string  toJson();
   void         fill(const orion::BSONObj& bo);

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -2185,7 +2185,7 @@ bool condValueAttrMatch(const orion::BSONObj& sub, const std::vector<std::string
 *
 * subToEntityIdVector -
 *
-* Extract the entity ID vector from a BSON document (in the format of the csubs/casub
+* Extract the entity ID vector from a BSON document (in the format of the csubs
 * collection)
 */
 EntityIdVector subToEntityIdVector(const orion::BSONObj& sub)
@@ -2317,7 +2317,7 @@ void subToNotifyList
 *
 * subToAttributeList -
 *
-* Extract the attribute list from a BSON document (in the format of the csubs/casub
+* Extract the attribute list from a BSON document (in the format of the csubs
 * collection)
 */
 StringList subToAttributeList
@@ -2359,7 +2359,7 @@ StringList subToAttributeList
 *
 * subToAttributeList -
 *
-* Extract the attribute list from a BSON document (in the format of the csubs/casub
+* Extract the attribute list from a BSON document (in the format of the csubs
 * collection)
 */
 StringList subToAttributeList(const orion::BSONObj& sub)

--- a/src/lib/mongoBackend/dbConstants.h
+++ b/src/lib/mongoBackend/dbConstants.h
@@ -41,7 +41,7 @@
 /* ***************************************************************************
 *
 * Constant strings for field names in collection (first characters
-* are the code name: REG_, ENT_, CSUB_ and CASUB_)
+* are the code name: REG_, ENT_ and CSUB_)
 */
 #define REG_CONTEXT_REGISTRATION     "contextRegistration"
 #define REG_PROVIDING_APPLICATION    "providingApplication"
@@ -116,17 +116,6 @@
 #define CSUB_LASTFAILUREASON         "lastFailureReason"
 #define CSUB_LASTSUCCESS             "lastSuccess"
 #define CSUB_LASTSUCCESSCODE         "lastSuccessCode"
-
-#define CASUB_EXPIRATION             "expiration"
-#define CASUB_REFERENCE              "reference"
-#define CASUB_ENTITIES               "entities"
-#define CASUB_ATTRS                  "attrs"
-#define CASUB_ENTITY_ID              "id"
-#define CASUB_ENTITY_TYPE            "type"
-#define CASUB_ENTITY_ISPATTERN       "isPattern"
-#define CASUB_LASTNOTIFICATION       "lastNotification"
-#define CASUB_COUNT                  "count"
-#define CASUB_FORMAT                 "format"
 
 
 


### PR DESCRIPTION
This PR removes:

* Unneeded constructor in httpInfo
* Old casub lefovers (functionality removed in CB 2.6.0 time ago but it seems we missed some things ;)