### PR TITLE
Fix statusCode for createEntity (Post v2/entities op) with wrong GeoJSON

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Hardening: Improve notification pool worker thread termination logic (#3877)
 - Remove: deprecated feature initial notification upon subscription creation or update
+- Fix: return 400 instead of 500 when GeoJSON syntax error occur (#3347)

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -2796,6 +2796,10 @@ static bool createEntity
       {
         oeP->fill(SccInvalidModification, "Already Exists", "Unprocessable");
       }
+      else if (errDetail->find("Can't extract geo keys") != std::string::npos)
+      {
+        oeP->fill(SccBadRequest, "Bad Request", "BadRequest");
+      }
       else
       {
         oeP->fill(SccReceiverInternalError, *errDetail, "InternalError");

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -2798,7 +2798,7 @@ static bool createEntity
       }
       else if (errDetail->find("Can't extract geo keys") != std::string::npos)
       {
-        oeP->fill(SccBadRequest, "Bad Request", "BadRequest");
+        oeP->fill(SccBadRequest, "Wrong GeoJson", "BadRequest");
       }
       else
       {

--- a/test/functionalTest/cases/3347_createEntity_with_wrong_GeoJSON/createEntity_with_wrong_GeoJSON.test
+++ b/test/functionalTest/cases/3347_createEntity_with_wrong_GeoJSON/createEntity_with_wrong_GeoJSON.test
@@ -1,0 +1,172 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Create entity with WRONG GeoJSON
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0
+
+--SHELL--
+
+#
+# 01. Create entity with correct GeoJSON
+# 02. GET /v2/entities/K
+# 03. Create entity with WRONG GeoJSON1
+# 04. Create entity with WRONG GeoJSON2
+#
+
+echo "01. Create entity with correct GeoJSON"
+echo "======================================"
+payload='{
+   "id": "K",
+   "type":"T",
+   "location":
+   {
+      "type":"geo:json",
+      "value":
+      {
+        "type":"Point",
+        "coordinates":[2,1]
+      }
+   }
+}'
+orionCurl --url '/v2/entities' --payload "${payload}"
+echo
+echo
+
+
+echo "02. GET /v2/entities/K"
+echo "======================"
+orionCurl --url /v2/entities/K
+echo
+echo
+
+
+echo "03. Create entity with WRONG GeoJSON1"
+echo "====================================="
+payload='{
+   "id": "M",
+   "type":"N",
+   "location":
+   {
+      "type":"geo:json",
+      "value":
+      {
+        "type":"PointKK3",
+        "coordinates":[2,1]
+      }
+   }
+}'
+orionCurl --url '/v2/entities' --payload "${payload}"
+echo
+echo
+
+
+echo "04. Create entity with WRONG GeoJSON2"
+echo "====================================="
+payload='{
+   "id": "M",
+   "type":"N",
+   "location":
+   {
+      "type":"geo:json",
+      "value":
+      {
+        "type":"Point",
+        "coordinates":[[2,1]]
+      }
+   }
+}'
+orionCurl --url '/v2/entities' --payload "${payload}"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity with correct GeoJSON
+======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/K?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. GET /v2/entities/K 
+======================
+HTTP/1.1 200 OK
+Content-Length: 111
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "id": "K",
+    "location": {
+        "metadata": {},
+        "type": "geo:json",
+        "value": {
+            "coordinates": [
+                2,
+                1
+            ],
+            "type": "Point"
+        }
+    },
+    "type": "T"
+}
+
+
+03. Create entity with WRONG GeoJSON1
+=====================================
+HTTP/1.1 400 Bad Request
+Content-Length: 50
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Bad Request",
+    "error": "BadRequest"
+}
+
+
+04. Create entity with WRONG GeoJSON2
+=====================================
+HTTP/1.1 400 Bad Request
+Content-Length: 50
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Bad Request",
+    "error": "BadRequest"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3347_createEntity_with_wrong_GeoJSON/createEntity_with_wrong_GeoJSON.test
+++ b/test/functionalTest/cases/3347_createEntity_with_wrong_GeoJSON/createEntity_with_wrong_GeoJSON.test
@@ -142,13 +142,13 @@ Date: REGEX(.*)
 03. Create entity with WRONG GeoJSON1
 =====================================
 HTTP/1.1 400 Bad Request
-Content-Length: 50
+Content-Length: 52
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "Bad Request",
+    "description": "Wrong GeoJson",
     "error": "BadRequest"
 }
 
@@ -156,13 +156,13 @@ Date: REGEX(.*)
 04. Create entity with WRONG GeoJSON2
 =====================================
 HTTP/1.1 400 Bad Request
-Content-Length: 50
+Content-Length: 52
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "Bad Request",
+    "description": "Wrong GeoJson",
     "error": "BadRequest"
 }
 


### PR DESCRIPTION
New PR issue #3347 to fix the statusCode of createEntity (Post v2/entities) operation when wrongly formed GeoJSON sent.
(old PR #3733 )