### PR TITLE
FIX semTake and semGive move to private in AlarmManager class

### DIFF
--- a/src/lib/alarmMgr/AlarmManager.h
+++ b/src/lib/alarmMgr/AlarmManager.h
@@ -63,8 +63,6 @@ class AlarmManager
 
   int  init(bool logAlreadyRaisedAlarms);
 
-  void         semTake(void);
-  void         semGive(void);
   const char*  semGet(void);
 
   void notificationErrorLogAlwaysSet(bool _notificationErrorLogAlways);
@@ -92,6 +90,8 @@ class AlarmManager
 
  private:
   int  semInit(void);
+  void semTake(void);
+  void semGive(void);
 };
 
 #endif  // SRC_LIB_ALARMMGR_ALARMMANAGER_H_


### PR DESCRIPTION
Only internal members can take/release the sem.