### PR TITLE
[WIP] FIX increase IP_LENGTH_MAX

### DIFF
--- a/src/lib/common/limits.h
+++ b/src/lib/common/limits.h
@@ -63,7 +63,7 @@
 *
 * Others -
 */
-#define IP_LENGTH_MAX           15     // Based on xxx.xxx.xxx.xxx
+#define IP_LENGTH_MAX           45     // Based on IPv6 max length, see https://stackoverflow.com/questions/166132/maximum-length-of-the-textual-representation-of-an-ipv6-address
 #define STRING_SIZE_FOR_INT     16     // Room enough for a 32 bit integer
 #define STRING_SIZE_FOR_LONG    20     // Room enough for a 64 bit integer
 #define STRING_SIZE_FOR_DOUBLE  64     // Room enough for a double


### PR DESCRIPTION
Issue #3884

Not sure if this size will suffice. Moreover, no matter how longer the size is, a malicious user could always use even a larger payload. Maybe an additional fix to truncate should be needed, but not sure in which place (log library internals...).

Feedback pending, see https://github.com/telefonicaid/fiware-orion/issues/3884#issuecomment-906395500

CC: @jason-fox @kzangeli 

- [ ] CNR