### PR TITLE
Concretize MongoDB-backup documentation

### DIFF
--- a/doc/manuals/admin/database_admin.md
+++ b/doc/manuals/admin/database_admin.md
@@ -23,8 +23,7 @@ site](https://education.mongodb.com/)). Otherwise, we recommend to be very caref
 The usual procedure for MongoDB databases is used.
 
 Use mongobackup command to get a backup of the Orion Context Broker
-database. It is strongly recommended that you stop the broker before
-doing a backup.
+database. In case a sharded MongoDB is used, the broker needs to be stopped before the backup or one of the tools mentioned in the [MongoDB-Documentation](https://docs.mongodb.com/manual/administration/backup-sharded-clusters/) has to be used.
 
 ```
 mongodump --host <dbhost> --db <db>

--- a/doc/manuals/admin/database_admin.md
+++ b/doc/manuals/admin/database_admin.md
@@ -23,7 +23,11 @@ site](https://education.mongodb.com/)). Otherwise, we recommend to be very caref
 The usual procedure for MongoDB databases is used.
 
 Use mongobackup command to get a backup of the Orion Context Broker
-database. In case a sharded MongoDB is used, the broker needs to be stopped before the backup or one of the tools mentioned in the [MongoDB-Documentation](https://docs.mongodb.com/manual/administration/backup-sharded-clusters/) has to be used.
+database, due to several operational reasons:
+
+* From a point of view of MongoDB, if you are using a sharded cluster, you could backup inconsistent data, depending of your backup strategy/tool. MongoDB administration is out of the scope of this documentation, but you can have a look to [official MongoDB documentation](https://docs.mongodb.com/manual/administration/backup-sharded-clusters/) about this topic.
+
+* From a point of view of Context Broker, your backup could end in a intermediate state. For instance, if CB is processing a `POST /v2/op/update` operation with an array of three entities [E1, E2, E3] and you don't stop the CB and take the backup in the middle, maybe the backup includes E1 changes, but not changes for E2 and E3. The backup doesn't ensure "transactional consistency" during `POST /v2/op/update` (i.e. all the three entities or none of them updated).
 
 ```
 mongodump --host <dbhost> --db <db>


### PR DESCRIPTION
We got requests from users about the backup of MongoDB, since stopping the broker for backup interferes with the availability requirements. While stopping the broker for is required for sharded MongoDB installations, its not a necessity for replica-sets.