### PR TITLE
Attribute operators (first part: without notifications)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Add: attribute update computed values based in operators: $inc, $min, $max, $mul, $push, $addToSet, $pull, $pullAll (without notifications) (#3814)

--- a/doc/manuals/user/README.md
+++ b/doc/manuals/user/README.md
@@ -12,6 +12,7 @@
   * [MQTT notifications](mqtt_notifications.md)
   * [Transient Entities](transient_entities.md)
   * [Structured values for attributes](structured_attribute_valued.md)
+  * [Update operators for attribute values](update_operators.md)
   * [Context Providers registration and request forwarding](context_providers.md)
   * [Attribute metadata](metadata.md)
   * [Filtering results](filtering.md)

--- a/doc/manuals/user/ngsiv2_implementation_notes.md
+++ b/doc/manuals/user/ngsiv2_implementation_notes.md
@@ -1,6 +1,7 @@
 # <a name="top"></a>NGSIv2 Implementation Notes
 
 * [Forbidden characters](#forbidden-characters)
+* [Update operators for attribute values](#update-operators-for-attribute-values)
 * [Custom payload decoding on notifications](#custom-payload-decoding-on-notifications)
 * [Option to disable custom notifications](#option-to-disable-custom-notifications)
 * [Non-modifiable headers in custom notifications](#non-modifiable-headers-in-custom-notifications)
@@ -45,6 +46,27 @@ Note that you can use "TextUnrestricted" attribut type (and special attribute ty
 the ones defined in the NGSIv2 Specification) in order to skip forbidden characters checkings
 in the attribute value. However, it could have security implications (possible script
 injections attacks) so use it at your own risk!
+
+[Top](#top)
+
+## Update operators for attribute values
+
+Some attribute value updates has special semantics, beyond the ones described in the
+NGSIv2 specification. In particular we can do requests like this one:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$inc": 3 },
+  "type": "Number"
+}
+```
+
+which means *"increase the value of attribute A by 3".
+
+This functionality is usefeul to reduce the complexity of applications and avoid
+race conditions in applications that access simultaneously to the same piece of
+context. More detail in [specific documentation](update_operators.md).
 
 [Top](#top)
 

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -323,7 +323,7 @@ POST /v2/entities/E/attrs/A
 ```
 
 The attribute A in entity E will be increased by 2 (so if you do after that for instance
-`GET /v2/entities/E/attrs/A you will get the increased value). But in notifications triggered
+`GET /v2/entities/E/attrs/A` you will get the increased value). But in notifications triggered
 by this update you will see (literally) this JSON object: `{ "$inc": 2 }`.
 
 ### Create or replace entities

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -269,7 +269,7 @@ The result would be this error:
 500 Internal Server Error
 
 {"error":"InternalServerError","description":"Database Error &#40;collection: orion.entities - update&#40;&#41;: &lt;{ &quot;_id.id&quot; : &quot;E&quot;, &quot;_id.type&quot; : &quot;T&quot;, &quot;_id.servicePath&quot; : &quot;/&quot; },{ &quot;$set&quot; : { &quot;attrs.A.type&quot; : &quot;Number&quot;, &quot;attrs.A.mdNames&quot; : [  ], &quot;attrs.A.creDate&quot; : 1631801113.0986146927, &quot;attrs.A.modDate&quot; : 1631801407.5359125137, &quot;modDate&quot; : 1631801407.5359227657, &quot;lastCorrelator&quot; : &quot;cbe6923c-16f7-11ec-977e-000c29583ca5&quot; }, &quot;$unset&quot; : { &quot;attrs.A.md&quot; : 1, &quot;location&quot; : 1, &quot;expDate&quot; : 1 }, &quot;$inc&quot; : { &quot;attrs.A.value&quot; : &quot;foo&quot; } }&gt; - exception: Cannot increment with non-numeric argument: {attrs.A.value: &quot;foo&quot;}&#41;"}
-``
+```
 
 which decoded is:
 

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -1,0 +1,361 @@
+# Update operators for attribute values
+
+## Introduction
+
+The usual way of modifying context with Orion is through attribute updates with particular values.
+However, in some cases, it is better to provide an operation to be evaluated on the existing attribute
+value. Let's see it with an example.
+
+Let's consider an entity `AccessControl1` with an attribute `count` that measures the number of people
+that crosses the access control. A context-aware application is in charge of updating context
+(eg. based in a sensor measures). Whenever somebody crosses the access, the application has to:
+
+* Read the value of the attribute, e.g. `GET /v2/entities/attrs/count`. Let's consider the value is 43
+* Calculate the  new value (43 plus 1 is 44)
+* Update the attribute with the new value, e.g. `PUT /v2/entities/attrs/count { "value": 44, "type": "Number" }`
+
+In sum, the application has to read, calculate and update which increases its complexity.
+
+The problem gets worse if several context-aware applications are accessing simultaneously to the same
+piece of context. For instance, instead of a single access count, we have a `Zone1` which has an
+attribute `count` with an aggregate of all the people that enters into the zone no matter which
+access (assuming that the zone has many accesses).
+
+We have application A managing one of the accesses and application B managing other of the accesses.
+Both applications update `count` attribute in `Zone1` when somebody crosses the respective accesses.
+Most of the time there is no problem:
+
+* Somebody crosses access managed by A
+* Application A does the read-calculate-cycle and update `count` in `Zone1`. Let's consider the values
+  was 43 before updating, now `count` value is 44
+* After some time, somebody crosses access managed by B
+* Application B does the read-calculate-cycle and update `count` in `Zone1`. So now `count` value is 45
+
+However, if both access-crossing events occurs very close in time problems may occur:
+
+* Somebody crosses access A at the same time somebody crosses access B
+* Application A reads count 43
+* Application B reads count before A can calculate and update, so getting same value 43
+* Application A sum 1 to 43 and update 44
+* Application B does the same, and update 44
+* Thus, the count is wrong: it should be 45 but it's 44!
+
+We call this kind of problem *race condition* (due to the different speed in which events take place in
+application A and B). It can be solved with the Orion update operators functionality, in particular
+with the increment operator.
+
+So, both applications instead of updating directly a particular value (such as 44 or 45) send a
+*"increment by 1"* update, this way:
+
+```
+POST /v2/entities/Zone1/attrs/count
+{
+  "value": { "$inc": 1 },
+  "type": "Number"
+}
+```
+
+The same case would be as follows now:
+
+* At a given moment count in Zone1 is 43 and somebody crosses access A at the same time somebody
+  crosses access B
+* Application A updates `count` with `{"$inc": 1}`
+* Application B updates `count` with `{"$inc": 1}`
+* Orion ensures that operations are executed atomically. It does not matter if the increment done
+by application A comes before increment done by application B or viceversa. The result is the same: 45
+
+Thus, update operators solve both problems:
+
+* Complexity. Now applications do not need to do a read-calculate-update cycle. Just updating
+  (with the operator) is enough.
+* Race conditions. This is solved due to Orion ensures that these operations are executed atomically
+  on the context attributes. Many applications can update the same piece of context without problems.
+
+## Supported operators
+
+Orion update operators are based on a subset of the ones implemented by MongoDB
+(described [here](https://docs.mongodb.com/manual/reference/operator/update/)). A description follows.
+
+### `$inc`
+
+Increase by a given value.
+
+For instance, if the preexisting value of attribute A in entity E is 10 the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$inc": 2 },
+  "type": "Number"
+}
+```
+
+would change the value of attribute A to 12.
+
+This operator only accept numeric values (either positive or negative, interger or decimal).
+
+### `$mul`
+
+Multiply by a given value
+
+For instance, if the preexisting value of attribute A in entity E is 10 the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$mul": 2 },
+  "type": "Number"
+}
+```
+
+would change the value of attribute A to 20.
+
+This operator only accept numeric values (either positive or negative, interger or decimal).
+
+### `$min`
+
+Updates value if current value is greater than the one provides.
+
+For instance, if the preexisting value of attribute A in entity E is 10 the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$min": 2 },
+  "type": "Number"
+}
+```
+
+would change the value of attribute A to 2. However, the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$min": 20 },
+  "type": "Number"
+}
+```
+
+would not change attribute value.
+
+Appart from numbers, other value types are supported (eg, strings).
+
+### `$max`
+
+Updates value if current value is lesser than the one provides.
+
+For instance, if the preexisting value of attribute A in entity E is 10 the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$max": 12 },
+  "type": "Number"
+}
+```
+
+would change the value of attribute A to 12. However, the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$max": 4 },
+  "type": "Number"
+}
+```
+
+would not change attribute value.
+
+Appart from numbers, other value types are supported (eg, strings).
+
+### `$push`
+
+To be used with attributes which value is an array, add an item to the array.
+
+For instance, if the preexisting value of attribute A in entity E is `[1, 2, 3]` the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$push": 3 },
+  "type": "Number"
+}
+```
+
+would change the value of attribute A to `[1, 2, 3, 3]`
+
+### `$addToSet`
+
+Similar to push but avoids duplications.
+
+For instance, if the preexisting value of attribute A in entity E is `[1, 2, 3]` the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$addToSet": 4 },
+  "type": "Number"
+}
+```
+
+would change the value of attribute A to `[1, 2, 3, 4]`. However, the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$addToSet": 3 },
+  "type": "Number"
+}
+```
+
+would not change attribute value.
+
+### `$pull`
+
+To be used with attributes which value is an array, removes all ocurrences of the item
+passes as parameter.
+
+For instance, if the preexisting value of attribute A in entity E is `[1, 2, 3]` the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$pull": 2 },
+  "type": "Number"
+}
+```
+
+would change the value of attribute A to `[1, 3]`.
+
+### `$pullAll`
+
+To be used with attributes which value is an array. The parameter is also an array. All
+the ocurrences of any of the members of the array used as parameter are removed.
+
+For instance, if the preexisting value of attribute A in entity E is `[1, 2, 3]` the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$pullAll": [2, 3] },
+  "type": "Number"
+}
+```
+
+would change the value of attribute A to `[1]`.
+
+## How Orion deals with operators
+
+Orion doesn't execute the operation itself, but pass it to MongoDB, which is the one actually
+executing in the attribute value stored in the database. Thus, the execution semantics are the
+ones described in [MongoDB documentation](https://docs.mongodb.com/manual/reference/operator/update/)
+for the equivalent operands.
+
+If the operation results in error at MongoDB level, the error is progressed as is as a
+500 Internal Error in the client response. For instance, `$inc` operator only support numerical values in
+MongoDB. So if we send this request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$inc": "foo" },
+  "type": "Number"
+}
+```
+
+The result would be this error:
+
+```
+500 Internal Server Error
+
+{"error":"InternalServerError","description":"Database Error &#40;collection: orion.entities - update&#40;&#41;: &lt;{ &quot;_id.id&quot; : &quot;E&quot;, &quot;_id.type&quot; : &quot;T&quot;, &quot;_id.servicePath&quot; : &quot;/&quot; },{ &quot;$set&quot; : { &quot;attrs.A.type&quot; : &quot;Number&quot;, &quot;attrs.A.mdNames&quot; : [  ], &quot;attrs.A.creDate&quot; : 1631801113.0986146927, &quot;attrs.A.modDate&quot; : 1631801407.5359125137, &quot;modDate&quot; : 1631801407.5359227657, &quot;lastCorrelator&quot; : &quot;cbe6923c-16f7-11ec-977e-000c29583ca5&quot; }, &quot;$unset&quot; : { &quot;attrs.A.md&quot; : 1, &quot;location&quot; : 1, &quot;expDate&quot; : 1 }, &quot;$inc&quot; : { &quot;attrs.A.value&quot; : &quot;foo&quot; } }&gt; - exception: Cannot increment with non-numeric argument: {attrs.A.value: &quot;foo&quot;}&#41;"}
+``
+
+which decoded is:
+
+```
+"error":"InternalServerError","description":"Database Error (collection: orion.entities - update(): <{ "_id.id" : "E", "_id.type" : "T", "_id.servicePath" : "/" },{ "$set" : { "attrs.A.type" : "Number", "attrs.A.mdNames" : [  ], "attrs.A.creDate" : 1631801113.0986146927, "attrs.A.modDate" : 1631801407.5359125137, "modDate" : 1631801407.5359227657, "lastCorrelator" : "cbe6923c-16f7-11ec-977e-000c29583ca5" }, "$unset" : { "attrs.A.md" : 1, "location" : 1, "expDate" : 1 }, "$inc" : { "attrs.A.value" : "foo" } }> - exception: Cannot increment with non-numeric argument: {attrs.A.value: "foo"})"}
+```
+
+and if we look at the end, we can see the error reported by MongoDB:
+
+```
+Cannot increment with non-numeric argument: {attrs.A.value: "foo"})"}
+```
+
+In addition, note that Orion assumes that the value for the attribute in the request
+is a JSON object which just one key (the operator). If you do a weird thing something like this:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": {
+    "x": 1
+    "$inc": 1,
+    "$mul": 10
+  },
+  "type": "Number"
+}
+```
+
+
+you will get (randomly, in princple) one among this ones:
+
+* A gets increased its value by 1
+* A gets multiply its value by 10
+* A gets is value updated to (literally) this JSON object: `{ "x": 1, "$inc": 1, "$mul": 10 }`
+
+So be careful of avoiding this situations.
+
+## Current limitations
+
+### Notifications
+
+By the moment, this functionality does not work with notifications. The notified value is literally
+the operator. For instance if you update using this:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$inc": 2 },
+  "type": "Number"
+}
+```
+
+The attribute A in entity E will be increased by 2 (so if you do after that for instance
+`GET /v2/entities/E/attrs/A you will get the increased value). But in notifications triggered
+by this update you will see (literally) this JSON object: `{ "$inc": 2 }`.
+
+### Create or replace entities
+
+Update operators cannot be used in entity creation or replace operations. For instance if
+you create an entity this way:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": { "$inc": 2 },
+    "type": "Number"
+  }
+}
+```
+
+the attribute A in the just created entity will have as value (literally) this JSON object: `{ "$inc": 2 }`.
+
+However, note that the case of adding new attributes to existing entities will work. For instance if
+we already have an entity E with attributes A and B and we append C this way:
+
+```
+POST /v2/entities/E
+{
+  "C": {
+    "value": { "$inc": 2 },
+    "type": "Number"
+  }
+}
+```
+
+then C will be created with value `2`.

--- a/doc/manuals/user/walkthrough_apiv2.md
+++ b/doc/manuals/user/walkthrough_apiv2.md
@@ -607,6 +607,10 @@ use complex structures or custom metadata. These are advanced topics, described 
 More details on adding/removing attributes can be found in [this section](update_action_types.md)
 of the manual.
 
+In the examples of this walkthrough we update attributes with particular values,
+such as `26.5`. However, you can also do updates like *"increase tempeture by 2.5 degrees"*.
+This kind of updates are an advanced topic, described in [this document](update_operators.md).
+
 [Top](#top)
 
 ### Subscriptions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ pages:
       - 'MQTT notifications': 'user/mqtt_notifications.md'
       - 'Transient Entities': 'user/transient_entities.md'
       - 'Structured values for attributes': 'user/structured_attribute_valued.md'
+      - 'Update operators for attribute values: 'user/update_operators.md'
       - 'Context Providers and request forwarding': 'user/context_providers.md'
       - 'Attribute Metadata': 'user/metadata.md'
       - 'Filtering': 'user/filtering.md'

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -3052,6 +3052,15 @@ static bool calculateOperator(ContextElementResponse* cerP, const std::string& o
   for (unsigned int ix = 0; ix < cerP->entity.attributeVector.size(); ++ix)
   {
     ContextAttribute* attr = cerP->entity.attributeVector[ix];
+
+    // previousValue equal to NULL is a way of detecting attributes that has been created
+    // due to append. These ones are not included in calculated operator BSONObjBuilder, as they
+    // has been already included in $set
+    if (attr->previousValue == NULL)
+    {
+      continue;
+    }
+
     if (attr->compoundValueP != NULL)
     {
       CompoundValueNode* child0 = attr->compoundValueP->childV[0];

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -485,13 +485,17 @@ static bool isSomeCalculatedOperatorUsed(ContextAttribute* caP)
     return false;
   }
 
-  if ((caP->compoundValueP->childV[0]->name == "$inc") ||
-      (caP->compoundValueP->childV[0]->name == "$min") ||
-      (caP->compoundValueP->childV[0]->name == "$max") ||
-      (caP->compoundValueP->childV[0]->name == "$mul") ||
-      (caP->compoundValueP->childV[0]->name == "$push") ||
-      (caP->compoundValueP->childV[0]->name == "$addToSet") ||
-      (caP->compoundValueP->childV[0]->name == "$pull") ||
+  for (unsigned ix = 0; ix < UPDATE_OPERATORS_NUMBER; ix++)
+  {
+    if (caP->compoundValueP->childV[0]->name == UPDATE_OPERATORS[ix])
+    {
+      return true;
+    }
+  }
+
+  // $addToSet and $pullAll are not included in UPDATE_OPERATORS, so they
+  // are checked separartelly
+  if ((caP->compoundValueP->childV[0]->name == "$addToSet") ||
       (caP->compoundValueP->childV[0]->name == "$pullAll"))
   {
     return true;
@@ -3437,38 +3441,16 @@ static unsigned int updateEntity
       updatedEntity.append("$pullAll", toPullAll.obj());
     }
 
-    orion::BSONObjBuilder toInc;
-    orion::BSONObjBuilder toMin;
-    orion::BSONObjBuilder toMax;
-    orion::BSONObjBuilder toMul;
-    orion::BSONObjBuilder toPush;
-    orion::BSONObjBuilder toPull;
     // Note we call calculateOperator* function using notifyCerP instead than eP, given that
     // eP doesn't contain any compound (as they are "stolen" by notifyCerP during the update
     // processing process)
-    if (calculateOperator(notifyCerP, "$inc", &toInc))
+    for (unsigned ix = 0; ix < UPDATE_OPERATORS_NUMBER; ix++)
     {
-      updatedEntity.append("$inc", toInc.obj());
-    }
-    if (calculateOperator(notifyCerP, "$min", &toMin))
-    {
-      updatedEntity.append("$min", toMin.obj());
-    }
-    if (calculateOperator(notifyCerP, "$max", &toMax))
-    {
-      updatedEntity.append("$max", toMax.obj());
-    }
-    if (calculateOperator(notifyCerP, "$mul", &toMul))
-    {
-      updatedEntity.append("$mul", toMul.obj());
-    }
-    if (calculateOperator(notifyCerP, "$push", &toPush))
-    {
-      updatedEntity.append("$push", toPush.obj());
-    }
-    if (calculateOperator(notifyCerP, "$pull", &toPull))
-    {
-      updatedEntity.append("$pull", toPull.obj());
+      orion::BSONObjBuilder b;
+      if (calculateOperator(notifyCerP, UPDATE_OPERATORS[ix], &b))
+      {
+        updatedEntity.append(UPDATE_OPERATORS[ix], b.obj());
+      }
     }
   }
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -807,7 +807,7 @@ static bool updateAttribute
     newAttr.append(ENT_ATTRS_CREATION_DATE, now);
     newAttr.append(ENT_ATTRS_MODIFICATION_DATE, now);
 
-    caP->valueBson(newAttr, attrType, ngsiv1Autocast && (apiVersion == V1));
+    caP->valueBson(std::string(ENT_ATTRS_VALUE), &newAttr, attrType, ngsiv1Autocast && (apiVersion == V1));
 
     /* Custom metadata */
     orion::BSONObj    md;
@@ -877,7 +877,7 @@ static bool appendAttribute
   orion::BSONObjBuilder ab;
 
   /* 1. Value */
-  caP->valueBson(ab, caP->type, ngsiv1Autocast && (apiVersion == V1));
+  caP->valueBson(std::string(ENT_ATTRS_VALUE), &ab, caP->type, ngsiv1Autocast && (apiVersion == V1));
 
   /* 2. Type */
   if ((apiVersion == V2) && !caP->typeGiven)
@@ -2748,7 +2748,7 @@ static bool createEntity
     bsonAttr.append(ENT_ATTRS_CREATION_DATE, now);
     bsonAttr.append(ENT_ATTRS_MODIFICATION_DATE, now);
 
-    attrsV[ix]->valueBson(bsonAttr, attrType, ngsiv1Autocast && (apiVersion == V1));
+    attrsV[ix]->valueBson(std::string(ENT_ATTRS_VALUE), &bsonAttr, attrType, ngsiv1Autocast && (apiVersion == V1));
 
     std::string effectiveName = dbEncode(attrsV[ix]->name);
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -531,7 +531,7 @@ static bool mergeAttrInfo
   {
     if (!isSomeCalculatedOperatorUsed(caP))
     {
-      caP->valueBson(composedName, toSet, getStringFieldF(attr, ENT_ATTRS_TYPE), ngsiv1Autocast && (apiVersion == V1));
+      caP->valueBson(composedName + "." + ENT_ATTRS_VALUE, toSet, getStringFieldF(attr, ENT_ATTRS_TYPE), ngsiv1Autocast && (apiVersion == V1));
     }
   }
   else
@@ -3426,7 +3426,7 @@ static unsigned int updateEntity
       updatedEntity.append("$addToSet", toAddToSet.obj());
     }
 
-    // $addToSet is special, as it is shared between attrsName removals and
+    // $pullAll is special, as it is shared between attrsName removals and
     // attribute operator. Probably both cases cannot happen at the same
     // time (as attrsName removal can only happen in DELETE updates), but
     // the logic supports the simultenous case
@@ -3441,7 +3441,7 @@ static unsigned int updateEntity
       updatedEntity.append("$pullAll", toPullAll.obj());
     }
 
-    // Note we call calculateOperator* function using notifyCerP instead than eP, given that
+    // Note we call calculateOperator() function using notifyCerP instead than eP, given that
     // eP doesn't contain any compound (as they are "stolen" by notifyCerP during the update
     // processing process)
     for (unsigned ix = 0; ix < UPDATE_OPERATORS_NUMBER; ix++)

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -490,7 +490,8 @@ static bool isSomeCalculatedOperatorUsed(ContextAttribute* caP)
       (caP->compoundValueP->childV[0]->name == "$max") ||
       (caP->compoundValueP->childV[0]->name == "$mul") ||
       (caP->compoundValueP->childV[0]->name == "$push") ||
-      (caP->compoundValueP->childV[0]->name == "$addToSet"))
+      (caP->compoundValueP->childV[0]->name == "$addToSet") ||
+      (caP->compoundValueP->childV[0]->name == "$pull"))
   {
     return true;
   }
@@ -3432,6 +3433,7 @@ static unsigned int updateEntity
     orion::BSONObjBuilder toMax;
     orion::BSONObjBuilder toMul;
     orion::BSONObjBuilder toPush;
+    orion::BSONObjBuilder toPull;
     // Note we call calculateOperator* function using notifyCerP instead than eP, given that
     // eP doesn't contain any compound (as they are "stolen" by notifyCerP during the update
     // processing process)
@@ -3454,6 +3456,10 @@ static unsigned int updateEntity
     if (calculateOperator(notifyCerP, "$push", &toPush))
     {
       updatedEntity.append("$push", toPush.obj());
+    }
+    if (calculateOperator(notifyCerP, "$pull", &toPull))
+    {
+      updatedEntity.append("$pull", toPull.obj());
     }
   }
 

--- a/src/lib/mongoBackend/compoundValueBson.h
+++ b/src/lib/mongoBackend/compoundValueBson.h
@@ -32,6 +32,12 @@
 #include "mongoDriver/BSONArrayBuilder.h"
 
 
+/* ****************************************************************************
+*
+* compoundValueBson (for a single child) -
+*/
+extern void compoundValueBson(orion::CompoundValueNode* children, orion::BSONObjBuilder& b, bool strings2numbers = false);
+
 
 /* ****************************************************************************
 *

--- a/src/lib/mongoBackend/compoundValueBson.h
+++ b/src/lib/mongoBackend/compoundValueBson.h
@@ -32,12 +32,6 @@
 #include "mongoDriver/BSONArrayBuilder.h"
 
 
-/* ****************************************************************************
-*
-* compoundValueBson (for a single child) -
-*/
-extern void compoundValueBson(orion::CompoundValueNode* children, orion::BSONObjBuilder& b, bool strings2numbers = false);
-
 
 /* ****************************************************************************
 *

--- a/src/lib/mongoBackend/dbConstants.h
+++ b/src/lib/mongoBackend/dbConstants.h
@@ -26,7 +26,7 @@
 * Author: Fermín Galán
 */
 
-
+#include <string>
 
 /* ***************************************************************************
 *
@@ -129,5 +129,14 @@
 #define STATUS_ACTIVE        "active"
 #define STATUS_INACTIVE      "inactive"
 #define STATUS_ONESHOT       "oneshot"
+
+
+
+/* ****************************************************************************
+*
+* Attribute update operators (except $addToSet and $pullAll, which are special ones)
+*/
+#define UPDATE_OPERATORS_NUMBER 6
+const std::string UPDATE_OPERATORS[UPDATE_OPERATORS_NUMBER] = { "$inc", "$min", "$max", "$mul", "$push", "$pull" };
 
 #endif  // SRC_LIB_MONGOBACKEND_DBCONSTANTS_H_

--- a/src/lib/mongoBackend/location.cpp
+++ b/src/lib/mongoBackend/location.cpp
@@ -185,7 +185,7 @@ static bool getGeoJson
     orion::BSONObjBuilder bo;
 
     // Autocast doesn't make sense in this context, strings2numbers enabled in the case of NGSIv1
-    caP->valueBson(bo, "", true, apiVersion == V1);
+    caP->valueBson(std::string(ENT_ATTRS_VALUE), &bo, "", true, apiVersion == V1);
     geoJson->appendElements(getObjectFieldF(bo.obj(), ENT_ATTRS_VALUE));
 
     return true;

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -53,27 +53,6 @@
 *
 * ContextAttribute::bsonAppendAttrValue -
 *
-* Used to render attribute value to BSON, using a intermediate BSONObjBuilder. To
-* be used by the APPEND and REPLACE logic
-*
-* FIXME PR: try to unify both functions
-*/
-void ContextAttribute::bsonAppendAttrValue(orion::BSONObjBuilder& bsonAttr, const std::string& attrType, bool autocast) const
-{
-  bsonAppendAttrValue(std::string(ENT_ATTRS_VALUE), &bsonAttr, attrType, autocast);
-}
-
-
-
-/* ****************************************************************************
-*
-* ContextAttribute::bsonAppendAttrValue -
-*
-* Used to render attribute value to BSON, directly in the toSet builder. To
-* be used by the UPDATE logic
-*
-* FIXME PR: try to unify both functions
-*
 */
 void ContextAttribute::bsonAppendAttrValue
 (
@@ -160,26 +139,6 @@ void ContextAttribute::bsonAppendAttrValue
 *
 * ContextAttribute::valueBson -
 *
-* Used to render attribute value to BSON, using a intermediate BSONObjBuilder. To
-* be used by the APPEND and REPLACE logic
-*
-* FIXME PR: try to unify both functions
-*/
-void ContextAttribute::valueBson(orion::BSONObjBuilder& bsonAttr, const std::string& attrType, bool autocast, bool strings2numbers) const
-{
-  valueBson(std::string(ENT_ATTRS_VALUE), &bsonAttr, attrType, autocast, strings2numbers);
-}
-
-
-
-/* ****************************************************************************
-*
-* ContextAttribute::valueBson -
-*
-* Used to render attribute value to BSON, directly in the toSet builder. To
-* be used by the UPDATE logic
-*
-* FIXME PR: try to unify both functions
 */
 void ContextAttribute::valueBson
 (

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -53,6 +53,10 @@
 *
 * ContextAttribute::bsonAppendAttrValue -
 *
+* Used to render attribute value to BSON, using a intermediate BSONObjBuilder. To
+* be used by the APPEND and REPLACE logic
+*
+* FIXME PR: try to unify both functions
 */
 void ContextAttribute::bsonAppendAttrValue(orion::BSONObjBuilder& bsonAttr, const std::string& attrType, bool autocast) const
 {
@@ -131,9 +135,103 @@ void ContextAttribute::bsonAppendAttrValue(orion::BSONObjBuilder& bsonAttr, cons
 
 /* ****************************************************************************
 *
+* ContextAttribute::bsonAppendAttrValue -
+*
+* Used to render attribute value to BSON, directly in the toSet builder. To
+* be used by the UPDATE logic
+*
+* FIXME PR: try to unify both functions
+*
+*/
+void ContextAttribute::bsonAppendAttrValue
+(
+  const std::string&      composedName,
+  orion::BSONObjBuilder*  toSet,
+  const std::string&      attrType,
+  bool                    autocast
+) const
+{
+  std::string effectiveStringValue = stringValue;
+  bool        effectiveBoolValue   = boolValue;
+  double      effectiveNumberValue = numberValue;
+  orion::ValueType   effectiveValueType   = valueType;
+
+  // Checking for ValueTypeString is an additional safety measure (ensuring that the attribute came from NGSIv1 in plain text)
+  if ((autocast) && (effectiveValueType == orion::ValueTypeString))
+  {
+    // Autocast only for selected attribute types
+    if ((attrType == DEFAULT_ATTR_NUMBER_TYPE) || (attrType == NUMBER_TYPE_ALT))
+    {
+      if (str2double(effectiveStringValue.c_str(), &effectiveNumberValue))
+      {
+        effectiveValueType = orion::ValueTypeNumber;
+      }
+      // Note that if str2double() fails, we keep ValueTypeString and everything works like without autocast
+    }
+    if (attrType == DEFAULT_ATTR_BOOL_TYPE)
+    {
+      // Note that we cannot use isTrue() or isFalse() functions, as they consider also 0 and 1 as
+      // valid true/false values and JSON spec mandates exactly true or false
+      if (effectiveStringValue == "true")
+      {
+        effectiveBoolValue = true;
+        effectiveValueType = orion::ValueTypeBoolean;
+      }
+      else if (effectiveStringValue == "false")
+      {
+        effectiveBoolValue = false;
+        effectiveValueType = orion::ValueTypeBoolean;
+      }
+      // Note that if above checks fail, we keep ValueTypeString and everything works like without autocast
+    }
+    if ((attrType == DATE_TYPE) || (attrType == DATE_TYPE_ALT))
+    {
+      effectiveNumberValue = parse8601Time(effectiveStringValue);
+      if (effectiveNumberValue != -1)
+      {
+        effectiveValueType = orion::ValueTypeNumber;
+      }
+      // Note that if parse8601Time() fails, we keep ValueTypeString and everything works like without autocast
+    }
+  }
+
+  switch (effectiveValueType)
+  {
+    case orion::ValueTypeString:
+      toSet->append(composedName + "." + ENT_ATTRS_VALUE, effectiveStringValue);
+      break;
+
+    case orion::ValueTypeNumber:
+      toSet->append(composedName + "." + ENT_ATTRS_VALUE, effectiveNumberValue);
+      break;
+
+    case orion::ValueTypeBoolean:
+      toSet->append(composedName + "." + ENT_ATTRS_VALUE, effectiveBoolValue);
+      break;
+
+    case orion::ValueTypeNull:
+      toSet->appendNull(composedName + "." + ENT_ATTRS_VALUE);
+      break;
+
+    case orion::ValueTypeNotGiven:
+      LM_E(("Runtime Error (value not given in compound value)"));
+      break;
+
+    default:
+      LM_E(("Runtime Error (unknown attribute type: %d)", valueType));
+  }
+}
+
+
+
+/* ****************************************************************************
+*
 * ContextAttribute::valueBson -
 *
-* Used to render attribute value to BSON, appended into the bsonAttr builder
+* Used to render attribute value to BSON, using a intermediate BSONObjBuilder. To
+* be used by the APPEND and REPLACE logic
+*
+* FIXME PR: try to unify both functions
 */
 void ContextAttribute::valueBson(orion::BSONObjBuilder& bsonAttr, const std::string& attrType, bool autocast, bool strings2numbers) const
 {
@@ -175,6 +273,80 @@ void ContextAttribute::valueBson(orion::BSONObjBuilder& bsonAttr, const std::str
     {
       // FIXME P4: this is somehow redundant. See https://github.com/telefonicaid/fiware-orion/issues/271
       bsonAttr.appendNull(ENT_ATTRS_VALUE);
+    }
+    else if (compoundValueP->valueType == orion::ValueTypeNotGiven)
+    {
+      LM_E(("Runtime Error (value not given in compound value)"));
+    }
+    else
+    {
+      LM_E(("Runtime Error (Unknown type in compound value)"));
+    }
+  }
+}
+
+
+
+
+
+
+
+/* ****************************************************************************
+*
+* ContextAttribute::valueBson -
+*
+* Used to render attribute value to BSON, directly in the toSet builder. To
+* be used by the UPDATE logic
+*
+* FIXME PR: try to unify both functions
+*/
+void ContextAttribute::valueBson
+(
+  const std::string&      composedName,
+  orion::BSONObjBuilder*  toSet,
+  const std::string&      attrType,
+  bool                    autocast,
+  bool                    strings2numbers
+) const
+{
+  if (compoundValueP == NULL)
+  {
+    bsonAppendAttrValue(composedName, toSet, attrType, autocast);
+  }
+  else
+  {
+    if (compoundValueP->valueType == orion::ValueTypeVector)
+    {
+      orion::BSONArrayBuilder b;
+      compoundValueBson(compoundValueP->childV, b, strings2numbers);
+      toSet->append(composedName + "." + ENT_ATTRS_VALUE, b.arr());
+    }
+    else if (compoundValueP->valueType == orion::ValueTypeObject)
+    {
+      orion::BSONObjBuilder b;
+
+      compoundValueBson(compoundValueP->childV, b, strings2numbers);
+      toSet->append(composedName + "." + ENT_ATTRS_VALUE, b.obj());
+    }
+    else if (compoundValueP->valueType == orion::ValueTypeString)
+    {
+      // FIXME P4: this is somehow redundant. See https://github.com/telefonicaid/fiware-orion/issues/271
+      toSet->append(composedName + "." + ENT_ATTRS_VALUE, compoundValueP->stringValue);
+    }
+    else if (compoundValueP->valueType == orion::ValueTypeNumber)
+    {
+      // FIXME P4: this is somehow redundant. See https://github.com/telefonicaid/fiware-orion/issues/271
+      toSet->append(composedName + "." + ENT_ATTRS_VALUE, compoundValueP->numberValue);
+    }
+    else if (compoundValueP->valueType == orion::ValueTypeBoolean)
+    {
+      // FIXME P4: this is somehow redundant. See https://github.com/telefonicaid/fiware-orion/issues/271
+      toSet->append(composedName + "." + ENT_ATTRS_VALUE, compoundValueP->boolValue);
+    }
+    else if (compoundValueP->valueType == orion::ValueTypeNull)
+    {
+      // FIXME P4: this is somehow redundant. See https://github.com/telefonicaid/fiware-orion/issues/271
+      toSet->appendNull(composedName + "." + ENT_ATTRS_VALUE);
     }
     else if (compoundValueP->valueType == orion::ValueTypeNotGiven)
     {

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -121,8 +121,14 @@ public:
   void         release(void);
   std::string  getName(void);
 
-  /* Used to render attribute value to BSON */
+  /* Used to render attribute value to BSON. There are two variants,
+   * one for APPEND/REPLACE and other for UPDATE */
   void valueBson(orion::BSONObjBuilder& bsonAttr, const std::string& attrType, bool autocast, bool strings2numbers = false) const;
+  void valueBson(const std::string&      composedName,
+                 orion::BSONObjBuilder*  toSet,
+                 const std::string&      attrType,
+                 bool autocast,
+                 bool strings2numbers = false) const;
 
   /* Helper method to be use in some places wher '%s' is needed */
   std::string  getValue(void) const;
@@ -135,7 +141,12 @@ private:
   void filterAndOrderMetadata(const std::vector<std::string>&  metadataFilter,
                               std::vector<Metadata*>*          orderedMetadata);
 
+  /* As with valueBson(), there are two variants of this method: one for APPEND/REPLACE and other for UPDATE */
   void bsonAppendAttrValue(orion::BSONObjBuilder& bsonAttr, const std::string& attrType, bool autocast) const;
+  void bsonAppendAttrValue(const std::string&      composedName,
+                           orion::BSONObjBuilder*  toSet,
+                           const std::string&      attrType,
+                           bool autocast) const;
 
 } ContextAttribute;
 

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -121,14 +121,12 @@ public:
   void         release(void);
   std::string  getName(void);
 
-  /* Used to render attribute value to BSON. There are two variants,
-   * one for APPEND/REPLACE and other for UPDATE */
-  void valueBson(orion::BSONObjBuilder& bsonAttr, const std::string& attrType, bool autocast, bool strings2numbers = false) const;
-  void valueBson(const std::string&      composedName,
-                 orion::BSONObjBuilder*  toSet,
+  /* Used to render attribute value to BSON */
+  void valueBson(const std::string&      valueKey,
+                 orion::BSONObjBuilder*  bsonAttr,
                  const std::string&      attrType,
-                 bool autocast,
-                 bool strings2numbers = false) const;
+                 bool                    autocast,
+                 bool                    strings2numbers = false) const;
 
   /* Helper method to be use in some places wher '%s' is needed */
   std::string  getValue(void) const;
@@ -141,12 +139,10 @@ private:
   void filterAndOrderMetadata(const std::vector<std::string>&  metadataFilter,
                               std::vector<Metadata*>*          orderedMetadata);
 
-  /* As with valueBson(), there are two variants of this method: one for APPEND/REPLACE and other for UPDATE */
-  void bsonAppendAttrValue(orion::BSONObjBuilder& bsonAttr, const std::string& attrType, bool autocast) const;
-  void bsonAppendAttrValue(const std::string&      composedName,
-                           orion::BSONObjBuilder*  toSet,
+  void bsonAppendAttrValue(const std::string&      valueKey,
+                           orion::BSONObjBuilder*  bsonAttr,
                            const std::string&      attrType,
-                           bool autocast) const;
+                           bool                    autocast) const;
 
 } ContextAttribute;
 

--- a/test/functionalTest/cases/0876_attribute_dates/attrs_dates_overridden_by_user.test
+++ b/test/functionalTest/cases/0876_attribute_dates/attrs_dates_overridden_by_user.test
@@ -150,21 +150,21 @@ echo
 echo
 
 
-echo "13. GET /v2/entities?mq=A.dateModified>2049-01-01 and get nothing"
+echo "12. GET /v2/entities?mq=A.dateModified>2049-01-01 and get nothing"
 echo "================================================================="
 orionCurl --url '/v2/entities?mq=A.dateModified>2049-01-01'
 echo
 echo
 
 
-echo "14. GET /v2/entities?mq=A.dateCreated<2049-01-01 and get E1"
+echo "13. GET /v2/entities?mq=A.dateCreated<2049-01-01 and get E1"
 echo "==========================================================="
 orionCurl --url '/v2/entities?mq=A.dateCreated<2049-01-01'
 echo
 echo
 
 
-echo "15. GET /v2/entities?mq=A.dateModified<2049-01-01 and get E1"
+echo "14. GET /v2/entities?mq=A.dateModified<2049-01-01 and get E1"
 echo "============================================================"
 orionCurl --url '/v2/entities?mq=A.dateModified<2049-01-01'
 echo
@@ -386,7 +386,7 @@ Date: REGEX(.*)
 []
 
 
-13. GET /v2/entities?mq=A.dateModified>2049-01-01 and get nothing
+12. GET /v2/entities?mq=A.dateModified>2049-01-01 and get nothing
 =================================================================
 HTTP/1.1 200 OK
 Content-Length: 2
@@ -397,7 +397,7 @@ Date: REGEX(.*)
 []
 
 
-14. GET /v2/entities?mq=A.dateCreated<2049-01-01 and get E1
+13. GET /v2/entities?mq=A.dateCreated<2049-01-01 and get E1
 ===========================================================
 HTTP/1.1 200 OK
 Content-Length: 71
@@ -418,7 +418,7 @@ Date: REGEX(.*)
 ]
 
 
-15. GET /v2/entities?mq=A.dateModified<2049-01-01 and get E1
+14. GET /v2/entities?mq=A.dateModified<2049-01-01 and get E1
 ============================================================
 HTTP/1.1 200 OK
 Content-Length: 71

--- a/test/functionalTest/cases/3814_attribute_update_operators/addtoset_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/addtoset_operator.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Attribute update operator: push
+Attribute update operator: addToSet
 
 --SHELL-INIT--
 dbInit CB
@@ -31,12 +31,12 @@ brokerStart CB
 
 #
 # 01. Create entity E with A=[1] and B=[{x:1}]
-# 02. Update A with $push: 2
-# 03. Update A with $push: foo
-# 04. Update B with $push: {y:2}
-# 05. Update B with $push: [z]
-# 06. Update A with $push: foo (duplicated)
-# 07. Get entity, see E-A=[1,2,foo,foo] and E-B=[{x:1},{y:2},[z]]
+# 02. Update A with $addToSet: 1 (already in the array)
+# 03. Update A with $addToSet: foo
+# 04. Update B with $addToSet: {x:1} (already in the array)
+# 05. Update B with $addToSet: [z]
+# 06. Update A with $addToSet: bar and new attribute C at the same time
+# 07. Get entity, see E-A=[1,foo,bar], E-B=[{x:1},[z]], E-C=3
 #
 
 
@@ -59,11 +59,11 @@ echo
 echo
 
 
-echo '02. Update A with $push: 2'
-echo '=========================='
+echo '02. Update A with $addToSet: 1 (already in the array)'
+echo '====================================================='
 payload='{
   "A": {
-    "value": { "$push": 2 },
+    "value": { "$addToSet": 1 },
     "type": "StructuredValue"
   }
 }'
@@ -72,11 +72,11 @@ echo
 echo
 
 
-echo '03. Update A with $push: foo'
-echo '============================'
+echo '03. Update A with $addToSet: foo'
+echo '================================'
 payload='{
   "A": {
-    "value": { "$push": "foo" },
+    "value": { "$addToSet": "foo" },
     "type": "StructuredValue"
   }
 }'
@@ -85,11 +85,11 @@ echo
 echo
 
 
-echo '04. Update B with $push: {y:2}'
-echo '=============================='
+echo '04. Update B with $addToSet: {x:1} (already in the array)'
+echo '========================================================='
 payload='{
   "B": {
-    "value": { "$push": {"y": 2} },
+    "value": { "$addToSet": {"x": 1} },
     "type": "StructuredValue"
   }
 }'
@@ -98,11 +98,11 @@ echo
 echo
 
 
-echo '05. Update B with $push: [z]'
-echo '============================'
+echo '05. Update B with $addToSet: [z]'
+echo '================================'
 payload='{
   "B": {
-    "value": { "$push": [ "z" ] },
+    "value": { "$addToSet": [ "z" ] },
     "type": "StructuredValue"
   }
 }'
@@ -111,12 +111,16 @@ echo
 echo
 
 
-echo '06. Update A with $push: foo (duplicated)'
-echo '========================================='
+echo '06. Update A with $addToSet: bar and new attribute C at the same time'
+echo '====================================================================='
 payload='{
   "A": {
-    "value": { "$push": "foo" },
+    "value": { "$addToSet": "bar" },
     "type": "StructuredValue"
+  },
+  "C": {
+    "value": 3,
+    "type": "Number"
   }
 }'
 orionCurl --url /v2/entities/E/attrs --payload "$payload"
@@ -124,8 +128,8 @@ echo
 echo
 
 
-echo '07. Get entity, see E-A=[1,2,foo,foo] and E-B=[{x:1},{y:2},[z]]'
-echo '==============================================================='
+echo '07. Get entity, see E-A=[1,foo,bar], E-B=[{x:1},[z]], E-C=3'
+echo '==========================================================='
 orionCurl --url /v2/entities/E
 echo
 echo
@@ -142,50 +146,50 @@ Date: REGEX(.*)
 
 
 
-02. Update A with $push: 2
-==========================
+02. Update A with $addToSet: 1 (already in the array)
+=====================================================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-03. Update A with $push: foo
-============================
+03. Update A with $addToSet: foo
+================================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-04. Update B with $push: {y:2}
-==============================
+04. Update B with $addToSet: {x:1} (already in the array)
+=========================================================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-05. Update B with $push: [z]
-============================
+05. Update B with $addToSet: [z]
+================================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-06. Update A with $push: foo (duplicated)
-=========================================
+06. Update A with $addToSet: bar and new attribute C at the same time
+=====================================================================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-07. Get entity, see E-A=[1,2,foo,foo] and E-B=[{x:1},{y:2},[z]]
-===============================================================
+07. Get entity, see E-A=[1,foo,bar], E-B=[{x:1},[z]], E-C=3
+===========================================================
 HTTP/1.1 200 OK
-Content-Length: 169
+Content-Length: 205
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -196,9 +200,8 @@ Date: REGEX(.*)
         "type": "StructuredValue",
         "value": [
             1,
-            2,
             "foo",
-            "foo"
+            "bar"
         ]
     },
     "B": {
@@ -208,13 +211,15 @@ Date: REGEX(.*)
             {
                 "x": 1
             },
-            {
-                "y": 2
-            },
             [
                 "z"
             ]
         ]
+    },
+    "C": {
+        "metadata": {},
+        "type": "Number",
+        "value": 3
     },
     "id": "E",
     "type": "T"

--- a/test/functionalTest/cases/3814_attribute_update_operators/append_attribute_with_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/append_attribute_with_operator.test
@@ -39,6 +39,8 @@ brokerStart CB
 # 07. Get entity, see A=6, B=9, C=2
 # 08. Update/append E with A=0, C={$inc:2}, D={$inc:5}, E=10 with batch operation
 # 09. Get entity, see A=0, B=9, C=4, D=5, E=10
+# 10. Update/append E with B=0, D={$inc:5}, F={$inc:-1}, G=8 with upsert operation
+# 11. Get entity, see A=0, B=0, C=4, D=10, E=10, F=-1, G=8
 #
 
 
@@ -163,6 +165,41 @@ echo
 
 echo '09. Get entity, see A=0, B=9, C=4, D=5, E=10'
 echo '============================================'
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '10. Update/append E with B=0, D={$inc:5}, F={$inc:-1}, G=8 with upsert operation'
+echo '================================================================================'
+payload='{
+  "id": "E",
+  "type": "T",
+  "B": {
+    "value": 0,
+    "type": "Number"
+  },
+  "D": {
+    "value": { "$inc": 5 },
+    "type": "Number"
+  },
+  "F": {
+    "value": { "$inc": -1 },
+    "type": "Number"
+  },
+  "G": {
+    "value": 8,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities?options=upsert --payload "$payload"
+echo
+echo
+echo
+
+
+echo '11. Get entity, see A=0, B=0, C=4, D=10, E=10, F=-1, G=8'
+echo '========================================================'
 orionCurl --url /v2/entities/E
 echo
 echo
@@ -321,6 +358,65 @@ Date: REGEX(.*)
         "metadata": {},
         "type": "Number",
         "value": 10
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+10. Update/append E with B=0, D={$inc:5}, F={$inc:-1}, G=8 with upsert operation
+================================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+
+11. Get entity, see A=0, B=0, C=4, D=10, E=10, F=-1, G=8
+========================================================
+HTTP/1.1 200 OK
+Content-Length: 346
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": 0
+    },
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": 0
+    },
+    "C": {
+        "metadata": {},
+        "type": "Number",
+        "value": 4
+    },
+    "D": {
+        "metadata": {},
+        "type": "Number",
+        "value": 10
+    },
+    "E": {
+        "metadata": {},
+        "type": "Number",
+        "value": 10
+    },
+    "F": {
+        "metadata": {},
+        "type": "Number",
+        "value": -1
+    },
+    "G": {
+        "metadata": {},
+        "type": "Number",
+        "value": 8
     },
     "id": "E",
     "type": "T"

--- a/test/functionalTest/cases/3814_attribute_update_operators/append_attribute_with_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/append_attribute_with_operator.test
@@ -1,0 +1,332 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Append attributes with operators to existing entity
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with A=1
+# 02. Update/append E with B={$inc:3}
+# 03. Get entity, see A=1, B=3
+# 04. Update/append E with A=4, B={$inc:3}
+# 05. Get entity, see A=4, B=6
+# 06. Update/append E with A={$inc:2}, B={$inc:3}, C={$inc:2}
+# 07. Get entity, see A=6, B=9, C=2
+# 08. Update/append E with A=0, C={$inc:2}, D={$inc:5}, E=10 with batch operation
+# 09. Get entity, see A=0, B=9, C=4, D=5, E=10
+#
+
+
+echo '01. Create entity E with A=1'
+echo '============================'
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Update/append E with B={$inc:3}'
+echo '==================================='
+payload='{
+  "B": {
+    "value": { "$inc": 3 },
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '03. Get entity, see A=1, B=3'
+echo '============================'
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '04. Update/append E with A=4, B={$inc:3}'
+echo '========================================'
+payload='{
+  "A": {
+    "value": 4,
+    "type": "Number"
+  },
+  "B": {
+    "value": { "$inc": 3 },
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '05. Get entity, see A=4, B=6'
+echo '============================'
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '06. Update/append E with A={$inc:2}, B={$inc:3}, C={$inc:2}'
+echo '==========================================================='
+payload='{
+  "A": {
+    "value": { "$inc": 2 },
+    "type": "Number"
+  },
+  "B": {
+    "value": { "$inc": 3 },
+    "type": "Number"
+  },
+  "C": {
+    "value": { "$inc": 2 },
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '07. Get entity, see A=6, B=9, C=2'
+echo '================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '08. Update/append E with A=0, C={$inc:2}, D={$inc:5}, E=10 with batch operation'
+echo '==============================================================================='
+payload='{
+  "actionType": "append",
+  "entities": [
+    {
+      "id": "E",
+      "type": "T",
+      "A": {
+        "value": 0,
+        "type": "Number"
+      },
+      "C": {
+        "value": { "$inc": 2 },
+        "type": "Number"
+      },
+      "D": {
+        "value": { "$inc": 5 },
+        "type": "Number"
+      },
+      "E": {
+        "value": 10,
+        "type": "Number"
+      }
+    }
+  ]
+}'
+orionCurl --url /v2/op/update --payload "$payload"
+echo
+echo
+
+
+echo '09. Get entity, see A=0, B=9, C=4, D=5, E=10'
+echo '============================================'
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A=1
+============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Update/append E with B={$inc:3}
+===================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Get entity, see A=1, B=3
+============================
+HTTP/1.1 200 OK
+Content-Length: 113
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": 1
+    },
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": 3
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+04. Update/append E with A=4, B={$inc:3}
+========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Get entity, see A=4, B=6
+============================
+HTTP/1.1 200 OK
+Content-Length: 113
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": 4
+    },
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": 6
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+06. Update/append E with A={$inc:2}, B={$inc:3}, C={$inc:2}
+===========================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+07. Get entity, see A=6, B=9, C=2
+=================================
+HTTP/1.1 200 OK
+Content-Length: 159
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": 6
+    },
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": 9
+    },
+    "C": {
+        "metadata": {},
+        "type": "Number",
+        "value": 2
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+08. Update/append E with A=0, C={$inc:2}, D={$inc:5}, E=10 with batch operation
+===============================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+09. Get entity, see A=0, B=9, C=4, D=5, E=10
+============================================
+HTTP/1.1 200 OK
+Content-Length: 252
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": 0
+    },
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": 9
+    },
+    "C": {
+        "metadata": {},
+        "type": "Number",
+        "value": 4
+    },
+    "D": {
+        "metadata": {},
+        "type": "Number",
+        "value": 5
+    },
+    "E": {
+        "metadata": {},
+        "type": "Number",
+        "value": 10
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/cover_all_update_flavours_with_operators.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/cover_all_update_flavours_with_operators.test
@@ -1,0 +1,276 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Cover all update cases using operators
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with A1-6 set to 0
+# 02. POST /v2/op/update UPDATE - A1={$inc:1}
+# 03. POST /v2/op/update APPEND - A2={$inc:2}
+# 04. POST /v2/entity/E/attrs - A3={$inc:3}
+# 05. PATCH /v2/entity/E/attrs - A4={$inc:4}
+# 06. PUT /v2/entity/E/attrs/A5 {$inc:5}
+# 07. PUT /v2/entity/E/attrs/A6/value {$inc:6}
+# 08. Get entity, see A1=1...A6=6
+#
+
+
+echo '01. Create entity E with A1-6 set to 0'
+echo '======================================'
+payload='{
+  "id": "E",
+  "type": "T",
+  "A1": {
+    "value": 0,
+    "type": "Number"
+  },
+  "A2": {
+    "value": 0,
+    "type": "Number"
+  },
+  "A3": {
+    "value": 0,
+    "type": "Number"
+  },
+  "A4": {
+    "value": 0,
+    "type": "Number"
+  },
+  "A5": {
+    "value": 0,
+    "type": "Number"
+  },
+  "A6": {
+    "value": 0,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. POST /v2/op/update UPDATE - A1={$inc:1}'
+echo '==========================================='
+payload='{
+  "actionType": "update",
+  "entities": [
+    {
+      "id": "E",
+      "type": "T",
+      "A1": {
+        "value": { "$inc": 1 },
+        "type": "Number"
+      }
+    }
+  ]
+}'
+orionCurl --url /v2/op/update --payload "$payload"
+echo
+echo
+
+
+echo '03. POST /v2/op/update APPEND - A2={$inc:2}'
+echo '==========================================='
+payload='{
+  "actionType": "append",
+  "entities": [
+    {
+      "id": "E",
+      "type": "T",
+      "A2": {
+        "value": { "$inc": 2 },
+        "type": "Number"
+      }
+    }
+  ]
+}'
+orionCurl --url /v2/op/update --payload "$payload"
+echo
+echo
+
+
+echo '04. POST /v2/entity/E/attrs - A3={$inc:3}'
+echo '========================================='
+payload='{
+  "A3": {
+    "value": { "$inc": 3 },
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '05. PATCH /v2/entity/E/attrs - A4={$inc:4}'
+echo '=========================================='
+payload='{
+  "A4": {
+    "value": { "$inc": 4 },
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo '06. PUT /v2/entity/E/attrs/A5 {$inc:5}'
+echo '======================================'
+payload='{
+  "value": { "$inc": 5 },
+  "type": "Number"
+}'
+orionCurl --url /v2/entities/E/attrs/A5 --payload "$payload" -X PUT
+echo
+echo
+
+
+echo '07. PUT /v2/entity/E/attrs/A6/value {$inc:6}'
+echo '============================================'
+payload='{ "$inc": 6 }'
+orionCurl --url /v2/entities/E/attrs/A6/value --payload "$payload" -X PUT
+echo
+echo
+
+
+echo '08. Get entity, see A1=1...A6=6'
+echo '==============================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A1-6 set to 0
+======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. POST /v2/op/update UPDATE - A1={$inc:1}
+===========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. POST /v2/op/update APPEND - A2={$inc:2}
+===========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. POST /v2/entity/E/attrs - A3={$inc:3}
+=========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. PATCH /v2/entity/E/attrs - A4={$inc:4}
+==========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. PUT /v2/entity/E/attrs/A5 {$inc:5}
+======================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+07. PUT /v2/entity/E/attrs/A6/value {$inc:6}
+============================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+08. Get entity, see A1=1...A6=6
+===============================
+HTTP/1.1 200 OK
+Content-Length: 303
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A1": {
+        "metadata": {},
+        "type": "Number",
+        "value": 1
+    },
+    "A2": {
+        "metadata": {},
+        "type": "Number",
+        "value": 2
+    },
+    "A3": {
+        "metadata": {},
+        "type": "Number",
+        "value": 3
+    },
+    "A4": {
+        "metadata": {},
+        "type": "Number",
+        "value": 4
+    },
+    "A5": {
+        "metadata": {},
+        "type": "Number",
+        "value": 5
+    },
+    "A6": {
+        "metadata": {},
+        "type": "Number",
+        "value": 6
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/creating_entity_with_operators.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/creating_entity_with_operators.test
@@ -34,6 +34,8 @@ brokerStart CB
 # 02. Get entity E1, see A={$inc:1}, B=2
 # 03. Create entity E2 with A={$max:10}, B=4 using batch operation
 # 04. Get entity E2, see A={$max:10}, B=4
+# 05. Create entity E3 with A={$min:2}, B=3 using upsert operation
+# 06. Get entity E3, see A={$min:2}, B=3
 #
 
 
@@ -90,6 +92,32 @@ echo
 echo '04. Get entity E2, see A={$max:10}, B=4'
 echo '======================================='
 orionCurl --url /v2/entities/E2
+echo
+echo
+
+
+echo '05. Create entity E3 with A={$min:2}, B=3 using upsert operation'
+echo '================================================================'
+payload='{
+  "id": "E3",
+  "type": "T",
+  "A": {
+    "value": { "$min": 2},
+    "type": "Number"
+  },
+  "B": {
+    "value": 3,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities?options=upsert --payload "$payload"
+echo
+echo
+
+
+echo '06. Get entity E3, see A={$min:2}, B=3'
+echo '======================================='
+orionCurl --url /v2/entities/E3
 echo
 echo
 
@@ -161,6 +189,41 @@ Date: REGEX(.*)
         "value": 4
     },
     "id": "E2",
+    "type": "T"
+}
+
+
+05. Create entity E3 with A={$min:2}, B=3 using upsert operation
+================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E3?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. Get entity E3, see A={$min:2}, B=3
+=======================================
+HTTP/1.1 200 OK
+Content-Length: 123
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "$min": 2
+        }
+    },
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": 3
+    },
+    "id": "E3",
     "type": "T"
 }
 

--- a/test/functionalTest/cases/3814_attribute_update_operators/creating_entity_with_operators.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/creating_entity_with_operators.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Create/append/replace operations using operators
+Create entity with operators
 
 --SHELL-INIT--
 dbInit CB
@@ -30,18 +30,17 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. Create entity E with A={$inc:1}, B=2
-# 02. Update/append E with B={$inc:3}, C={$inc:4}
-# 03. Get entity, see A={$inc:1}, B=5, C={$inc:4}
-# 04. Replace entity with D={$inc:5}
-# 05. Get entity, see D={$inc:5}
+# 01. Create entity E1 with A={$inc:1}, B=2
+# 02. Get entity E1, see A={$inc:1}, B=2
+# 03. Create entity E2 with A={$max:10}, B=4 using batch operation
+# 04. Get entity E2, see A={$max:10}, B=4
 #
 
 
-echo '01. Create entity E with A={$inc:1}, B=2'
-echo '========================================'
+echo '01. Create entity E1 with A={$inc:1}, B=2'
+echo '========================================='
 payload='{
-  "id": "E",
+  "id": "E1",
   "type": "T",
   "A": {
     "value": { "$inc": 1},
@@ -57,73 +56,59 @@ echo
 echo
 
 
-echo '02. Update/append E with B={$inc:3}, C={$inc:4}'
-echo '==============================================='
+echo '02. Get entity E1, see A={$inc:1}, B=2'
+echo '======================================'
+orionCurl --url /v2/entities/E1
+echo
+echo
+
+
+echo '03. Create entity E2 with A={$max:10}, B=4 using batch operation'
+echo '================================================================'
 payload='{
-  "B": {
-    "value": { "$inc": 3 },
-    "type": "Number"
-  },
-  "C": {
-    "value": { "$inc": 4 },
-    "type": "Number"
-  }
+  "actionType": "append",
+  "entities": [
+    {
+      "id": "E2",
+      "type": "T",
+      "A": {
+        "value": { "$max": 10 },
+        "type": "Number"
+      },
+      "B": {
+        "value": 4,
+        "type": "Number"
+      }
+    }
+  ]
 }'
-orionCurl --url /v2/entities/E/attrs --payload "$payload"
+orionCurl --url /v2/op/update --payload "$payload"
 echo
 echo
 
 
-echo '03. Get entity, see A={$inc:1}, B=5, C={$inc:4}'
-echo '==============================================='
-orionCurl --url /v2/entities/E
-echo
-echo
-
-
-echo '04. Replace entity with D={$inc:5}'
-echo '=================================='
-payload='{
-  "D": {
-    "value": { "$inc": 5 },
-    "type": "Number"
-  }
-}'
-orionCurl --url /v2/entities/E/attrs --payload "$payload" -X PUT
-echo
-echo
-
-
-echo '05. Get entity, see D={$inc:5}'
-echo '=============================='
-orionCurl --url /v2/entities/E
+echo '04. Get entity E2, see A={$max:10}, B=4'
+echo '======================================='
+orionCurl --url /v2/entities/E2
 echo
 echo
 
 
 --REGEXPECT--
-01. Create entity E with A={$inc:1}, B=2
-========================================
+01. Create entity E1 with A={$inc:1}, B=2
+=========================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Location: /v2/entities/E?type=T
+Location: /v2/entities/E1?type=T
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-02. Update/append E with B={$inc:3}, C={$inc:4}
-===============================================
-HTTP/1.1 204 No Content
-Fiware-Correlator: REGEX([0-9a-f\-]{36})
-Date: REGEX(.*)
-
-
-
-03. Get entity, see A={$inc:1}, B=5, C={$inc:4}
-===============================================
+02. Get entity E1, see A={$inc:1}, B=2
+======================================
 HTTP/1.1 200 OK
-Content-Length: 177
+Content-Length: 123
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -139,45 +124,43 @@ Date: REGEX(.*)
     "B": {
         "metadata": {},
         "type": "Number",
-        "value": 5
+        "value": 2
     },
-    "C": {
-        "metadata": {},
-        "type": "Number",
-        "value": {
-            "$inc": 4
-        }
-    },
-    "id": "E",
+    "id": "E1",
     "type": "T"
 }
 
 
-04. Replace entity with D={$inc:5}
-==================================
+03. Create entity E2 with A={$max:10}, B=4 using batch operation
+================================================================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-05. Get entity, see D={$inc:5}
-==============================
+04. Get entity E2, see A={$max:10}, B=4
+=======================================
 HTTP/1.1 200 OK
-Content-Length: 76
+Content-Length: 124
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "D": {
+    "A": {
         "metadata": {},
         "type": "Number",
         "value": {
-            "$inc": 5
+            "$max": 10
         }
     },
-    "id": "E",
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": 4
+    },
+    "id": "E2",
     "type": "T"
 }
 

--- a/test/functionalTest/cases/3814_attribute_update_operators/creating_or_appending_operators.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/creating_or_appending_operators.test
@@ -1,0 +1,187 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Create/append/replace operations using operators
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with A={$inc:1}, B=2
+# 02. Update/append E with B={$inc:3}, C={$inc:4}
+# 03. Get entity, see A={$inc:1}, B=5, C={$inc:4}
+# 04. Replace entity with D={$inc:5}
+# 05. Get entity, see D={$inc:5}
+#
+
+
+echo '01. Create entity E with A={$inc:1}, B=2'
+echo '========================================'
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": { "$inc": 1},
+    "type": "Number"
+  },
+  "B": {
+    "value": 2,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Update/append E with B={$inc:3}, C={$inc:4}'
+echo '==============================================='
+payload='{
+  "B": {
+    "value": { "$inc": 3 },
+    "type": "Number"
+  },
+  "C": {
+    "value": { "$inc": 4 },
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '03. Get entity, see A={$inc:1}, B=5, C={$inc:4}'
+echo '==============================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '04. Replace entity with D={$inc:5}'
+echo '=================================='
+payload='{
+  "D": {
+    "value": { "$inc": 5 },
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload" -X PUT
+echo
+echo
+
+
+echo '05. Get entity, see D={$inc:5}'
+echo '=============================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A={$inc:1}, B=2
+========================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Update/append E with B={$inc:3}, C={$inc:4}
+===============================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Get entity, see A={$inc:1}, B=5, C={$inc:4}
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 177
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "$inc": 1
+        }
+    },
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": 5
+    },
+    "C": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "$inc": 4
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+04. Replace entity with D={$inc:5}
+==================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Get entity, see D={$inc:5}
+==============================
+HTTP/1.1 200 OK
+Content-Length: 76
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "D": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "$inc": 5
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/inc_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/inc_operator.test
@@ -1,0 +1,116 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attributes and metadata starting with dollar sign in the name
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with A=1
+# 02. Update A with $inc: 2
+# 03. Get entity, see E-A=3
+#
+
+
+echo '01. Create entity E with A=1'
+echo '============================'
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Update A with $inc: 2'
+echo '========================='
+payload='{
+  "A": {
+    "value": { "$inc": 2 },
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '03. Get entity, see E-A=3'
+echo '========================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+
+
+--REGEXPECT--
+01. Create entity E with A=1
+============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Update A with $inc: 2
+=========================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Get entity, see E-A=3
+=========================
+HTTP/1.1 200 OK
+Content-Length: 67
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": 3
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/max_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/max_operator.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Attribute update operator: inc
+Attribute update operator: max
 
 --SHELL-INIT--
 dbInit CB
@@ -30,19 +30,19 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. Create entity E with A=1
-# 02. Update A with $inc: 2
-# 03. Get entity, see E-A=3
+# 01. Create entity E with A=5
+# 02. Update A with $max: 10
+# 03. Get entity, see E-A=10
 #
 
 
-echo '01. Create entity E with A=1'
+echo '01. Create entity E with A=5'
 echo '============================'
 payload='{
   "id": "E",
   "type": "T",
   "A": {
-    "value": 1,
+    "value": 5,
     "type": "Number"
   }
 }'
@@ -51,11 +51,11 @@ echo
 echo
 
 
-echo '02. Update A with $inc: 2'
-echo '========================='
+echo '02. Update A with $max: 10'
+echo '=========================='
 payload='{
   "A": {
-    "value": { "$inc": 2 },
+    "value": { "$max": 10 },
     "type": "Number"
   }
 }'
@@ -64,15 +64,15 @@ echo
 echo
 
 
-echo '03. Get entity, see E-A=3'
-echo '========================='
+echo '03. Get entity, see E-A=10'
+echo '=========================='
 orionCurl --url /v2/entities/E
 echo
 echo
 
 
 --REGEXPECT--
-01. Create entity E with A=1
+01. Create entity E with A=5
 ============================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -82,18 +82,18 @@ Date: REGEX(.*)
 
 
 
-02. Update A with $inc: 2
-=========================
+02. Update A with $max: 10
+==========================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-03. Get entity, see E-A=3
-=========================
+03. Get entity, see E-A=10
+==========================
 HTTP/1.1 200 OK
-Content-Length: 67
+Content-Length: 68
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -102,7 +102,7 @@ Date: REGEX(.*)
     "A": {
         "metadata": {},
         "type": "Number",
-        "value": 3
+        "value": 10
     },
     "id": "E",
     "type": "T"

--- a/test/functionalTest/cases/3814_attribute_update_operators/min_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/min_operator.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Attribute update operator: inc
+Attribute update operator: min
 
 --SHELL-INIT--
 dbInit CB
@@ -30,19 +30,19 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. Create entity E with A=1
-# 02. Update A with $inc: 2
-# 03. Get entity, see E-A=3
+# 01. Create entity E with A=5
+# 02. Update A with $min: 2
+# 03. Get entity, see E-A=2
 #
 
 
-echo '01. Create entity E with A=1'
+echo '01. Create entity E with A=5'
 echo '============================'
 payload='{
   "id": "E",
   "type": "T",
   "A": {
-    "value": 1,
+    "value": 5,
     "type": "Number"
   }
 }'
@@ -51,11 +51,11 @@ echo
 echo
 
 
-echo '02. Update A with $inc: 2'
+echo '02. Update A with $min: 2'
 echo '========================='
 payload='{
   "A": {
-    "value": { "$inc": 2 },
+    "value": { "$min": 2 },
     "type": "Number"
   }
 }'
@@ -64,7 +64,7 @@ echo
 echo
 
 
-echo '03. Get entity, see E-A=3'
+echo '03. Get entity, see E-A=2'
 echo '========================='
 orionCurl --url /v2/entities/E
 echo
@@ -72,7 +72,7 @@ echo
 
 
 --REGEXPECT--
-01. Create entity E with A=1
+01. Create entity E with A=5
 ============================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -82,7 +82,7 @@ Date: REGEX(.*)
 
 
 
-02. Update A with $inc: 2
+02. Update A with $min: 2
 =========================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -90,7 +90,7 @@ Date: REGEX(.*)
 
 
 
-03. Get entity, see E-A=3
+03. Get entity, see E-A=2
 =========================
 HTTP/1.1 200 OK
 Content-Length: 67
@@ -102,7 +102,7 @@ Date: REGEX(.*)
     "A": {
         "metadata": {},
         "type": "Number",
-        "value": 3
+        "value": 2
     },
     "id": "E",
     "type": "T"

--- a/test/functionalTest/cases/3814_attribute_update_operators/mul_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/mul_operator.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Attribute update operator: inc
+Attribute update operator: mul
 
 --SHELL-INIT--
 dbInit CB
@@ -30,19 +30,19 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. Create entity E with A=1
-# 02. Update A with $inc: 2
-# 03. Get entity, see E-A=3
+# 01. Create entity E with A=5
+# 02. Update A with $mul: 3
+# 03. Get entity, see E-A=15
 #
 
 
-echo '01. Create entity E with A=1'
+echo '01. Create entity E with A=5'
 echo '============================'
 payload='{
   "id": "E",
   "type": "T",
   "A": {
-    "value": 1,
+    "value": 5,
     "type": "Number"
   }
 }'
@@ -51,11 +51,11 @@ echo
 echo
 
 
-echo '02. Update A with $inc: 2'
+echo '02. Update A with $mul: 3'
 echo '========================='
 payload='{
   "A": {
-    "value": { "$inc": 2 },
+    "value": { "$mul": 3 },
     "type": "Number"
   }
 }'
@@ -64,15 +64,15 @@ echo
 echo
 
 
-echo '03. Get entity, see E-A=3'
-echo '========================='
+echo '03. Get entity, see E-A=15'
+echo '=========================='
 orionCurl --url /v2/entities/E
 echo
 echo
 
 
 --REGEXPECT--
-01. Create entity E with A=1
+01. Create entity E with A=5
 ============================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -82,7 +82,7 @@ Date: REGEX(.*)
 
 
 
-02. Update A with $inc: 2
+02. Update A with $mul: 3
 =========================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
@@ -90,10 +90,10 @@ Date: REGEX(.*)
 
 
 
-03. Get entity, see E-A=3
-=========================
+03. Get entity, see E-A=15
+==========================
 HTTP/1.1 200 OK
-Content-Length: 67
+Content-Length: 68
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -102,7 +102,7 @@ Date: REGEX(.*)
     "A": {
         "metadata": {},
         "type": "Number",
-        "value": 3
+        "value": 15
     },
     "id": "E",
     "type": "T"

--- a/test/functionalTest/cases/3814_attribute_update_operators/pull_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/pull_operator.test
@@ -1,0 +1,175 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: pull
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with A=[1,2,foo], B=[{x:1},{y:2},[z]], C=3
+# 02. Update A with $pull: foo
+# 03. Update B with $pull: {y:2}
+# 04. Delete attribute C
+# 05. Get entity, see E-A=[1,foo] and E-B=[{x:1},[z]]
+#
+
+
+echo '01. Create entity E with A=[1,2,foo], B=[{x:1},{y:2},[z]], C=3'
+echo '=============================================================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": [ 1, 2, "foo" ],
+    "type": "StructuredValue"
+  },
+  "B": {
+    "value": [ {"x": 1}, {"y": 2}, ["z"] ],
+    "type": "StructuredValue"
+  },
+  "C": {
+    "value": 3,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Update A with $pull: foo'
+echo '============================'
+payload='{
+  "A": {
+    "value": { "$pull": "foo" },
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '03. Update B with $pull: {y:2}'
+echo '=============================='
+payload='{
+  "B": {
+    "value": { "$pull": {"y": 2} },
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Delete attribute C'
+echo '======================'
+orionCurl --url /v2/entities/E/attrs/C -X DELETE
+echo
+echo
+
+
+echo '05. Get entity, see E-A=[1,2] and E-B=[{x:1},[z]]'
+echo '================================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A=[1,2,foo], B=[{x:1},{y:2},[z]], C=3
+==============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Update A with $pull: foo
+============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update B with $pull: {y:2}
+==============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Delete attribute C
+======================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Get entity, see E-A=[1,2] and E-B=[{x:1},[z]]
+=================================================
+HTTP/1.1 200 OK
+Content-Length: 149
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            1,
+            2
+        ]
+    },
+    "B": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            {
+                "x": 1
+            },
+            [
+                "z"
+            ]
+        ]
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/pullall_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/pullall_operator.test
@@ -1,0 +1,171 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: pullAll
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with A=[1,2,foo], B=[{x:1},{y:2},[z]], C=3
+# 02. Update A with $pullAll: [1,foo]
+# 03. Update B with $pullAll: [{y:2},{x:1}}
+# 04. Delete attribute C
+# 05. Get entity, see E-A=[2] and E-B=[[z]]
+#
+
+
+echo '01. Create entity E with A=[1,2,foo], B=[{x:1},{y:2},[z]], C=3'
+echo '=============================================================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": [ 1, 2, "foo" ],
+    "type": "StructuredValue"
+  },
+  "B": {
+    "value": [ {"x": 1}, {"y": 2}, ["z"] ],
+    "type": "StructuredValue"
+  },
+  "C": {
+    "value": 3,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Update A with $pull: [1,foo]'
+echo '================================'
+payload='{
+  "A": {
+    "value": { "$pullAll": [1, "foo"] },
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '03. Update B with $pullAll: [{y:2},{x:1}]'
+echo '========================================='
+payload='{
+  "B": {
+    "value": { "$pullAll": [{"y": 2}, {"x": 1} ]},
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Delete attribute C'
+echo '======================'
+orionCurl --url /v2/entities/E/attrs/C -X DELETE
+echo
+echo
+
+
+echo '05. Get entity, see E-A=[2] and E-B=[[z]]'
+echo '========================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A=[1,2,foo], B=[{x:1},{y:2},[z]], C=3
+==============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Update A with $pull: [1,foo]
+================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update B with $pullAll: [{y:2},{x:1}]
+=========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Delete attribute C
+======================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Get entity, see E-A=[2] and E-B=[[z]]
+=========================================
+HTTP/1.1 200 OK
+Content-Length: 139
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            2
+        ]
+    },
+    "B": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            [
+                "z"
+            ]
+        ]
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/push_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/push_operator.test
@@ -1,0 +1,203 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: inc
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with A=[1] and B=[{x:1}]
+# 02. Update A with $push: 2
+# 03. Update A with $push: foo
+# 04. Update B with $push: {y:2}
+# 05. Update B with $push: [z]
+# 06. Get entity, see E-A=[1,2,foo] and E-B=[{x:1},{y:2},[z]]
+#
+
+
+echo '01. Create entity E with A=[1] and B=[{x:1}]'
+echo '============================================'
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": [ 1 ],
+    "type": "StructuredValue"
+  },
+  "B": {
+    "value": [ {"x": 1} ],
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Update A with $push: 2'
+echo '=========================='
+payload='{
+  "A": {
+    "value": { "$push": 2 },
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $push: foo'
+echo '============================'
+payload='{
+  "A": {
+    "value": { "$push": "foo" },
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Update B with $push: {y:2}'
+echo '=============================='
+payload='{
+  "B": {
+    "value": { "$push": {"y": 2} },
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '05. Update B with $push: [z]'
+echo '============================'
+payload='{
+  "B": {
+    "value": { "$push": [ "z" ] },
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '06. Get entity, see E-A=[1,2,foo] and E-B=[{x:1},{y:2},[z]]'
+echo '==========================================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A=[1] and B=[{x:1}]
+============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Update A with $push: 2
+==========================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update A with $push: foo
+============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Update B with $push: {y:2}
+==============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Update B with $push: [z]
+============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. Get entity, see E-A=[1,2,foo] and E-B=[{x:1},{y:2},[z]]
+===========================================================
+HTTP/1.1 200 OK
+Content-Length: 163
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            1,
+            2,
+            "foo"
+        ]
+    },
+    "B": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            {
+                "x": 1
+            },
+            {
+                "y": 2
+            },
+            [
+                "z"
+            ]
+        ]
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/replace_entity_with_operators.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/replace_entity_with_operators.test
@@ -1,0 +1,168 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Replace entity with operators
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with A=1, B=2
+# 02. Get entity E, see A=1, B=2
+# 03. Replace entity E with B={$inc:3}, C=3
+# 04. Get entity E, see B={$inc:3}, C=3
+#
+
+
+echo '01. Create entity E with A=1, B=2'
+echo '================================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Number"
+  },
+  "B": {
+    "value": 2,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Get entity E, see A=1, B=2'
+echo '=============================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '03. Replace entity E with B={$inc:3}, C=3'
+echo '========================================='
+payload='{
+  "actionType": "replace",
+  "entities": [
+    {
+      "id": "E",
+      "type": "T",
+      "B": {
+        "value": { "$inc": 3},
+        "type": "Number"
+      },
+      "C": {
+        "value": 3,
+        "type": "Number"
+      }
+    }
+  ]
+}'
+orionCurl --url /v2/op/update --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity E, see B={$inc:3}, C=3'
+echo '====================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A=1, B=2
+=================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Get entity E, see A=1, B=2
+==============================
+HTTP/1.1 200 OK
+Content-Length: 113
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": 1
+    },
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": 2
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+03. Replace entity E with B={$inc:3}, C=3
+=========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Get entity E, see B={$inc:3}, C=3
+=====================================
+HTTP/1.1 200 OK
+Content-Length: 122
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "B": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "$inc": 3
+        }
+    },
+    "C": {
+        "metadata": {},
+        "type": "Number",
+        "value": 3
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/several_operators_same_update.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/several_operators_same_update.test
@@ -1,0 +1,217 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Several operators in the same update operation
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity
+# 02. Update entity using all the operators
+# 03. Get entity
+#
+
+
+echo '01. Create entity'
+echo '================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A1": {
+    "value": 1,
+    "type": "Number"
+  },
+  "A2": {
+    "value": 5,
+    "type": "Number"
+  },
+  "A3": {
+    "value": 5,
+    "type": "Number"
+  },
+  "A4": {
+    "value": 3,
+    "type": "Number"
+  },
+  "A5": {
+    "value": [ "foo" ],
+    "type": "StructuredValue"
+  },
+  "A6": {
+    "value": [ "foo" ],
+    "type": "StructuredValue"
+  },
+  "A7": {
+    "value": [ 1, 2, 3, 4],
+    "type": "StructuredValue"
+  },
+  "A8": {
+    "value": [ 1, 2, 3, 4],
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Update entity using all the operators'
+echo '========================================='
+payload='{
+  "A1": {
+    "value": { "$inc": 2 },
+    "type": "Number"
+  },
+  "A2": {
+    "value": { "$min": 0 },
+    "type": "Number"
+  },
+  "A3": {
+    "value": { "$max": 8 },
+    "type": "Number"
+  },
+  "A4": {
+    "value": { "$mul": 5 },
+    "type": "Number"
+  },
+  "A5": {
+    "value": { "$push": "bar" },
+    "type": "StructuredValue"
+  },
+  "A6": {
+    "value": { "$addToSet": "foo" },
+    "type": "StructuredValue"
+  },
+  "A7": {
+    "value": { "$pull": 2 },
+    "type": "StructuredValue"
+  },
+  "A8": {
+    "value": { "$pullAll": [2, 4] },
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '03. Get entity'
+echo '=============='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity
+=================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Update entity using all the operators
+=========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Get entity
+==============
+HTTP/1.1 200 OK
+Content-Length: 462
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A1": {
+        "metadata": {},
+        "type": "Number",
+        "value": 3
+    },
+    "A2": {
+        "metadata": {},
+        "type": "Number",
+        "value": 0
+    },
+    "A3": {
+        "metadata": {},
+        "type": "Number",
+        "value": 8
+    },
+    "A4": {
+        "metadata": {},
+        "type": "Number",
+        "value": 15
+    },
+    "A5": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            "foo",
+            "bar"
+        ]
+    },
+    "A6": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            "foo"
+        ]
+    },
+    "A7": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            1,
+            3,
+            4
+        ]
+    },
+    "A8": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            1,
+            3
+        ]
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Issue #3814

- [x] $inc, $max, $min, $mul
- [x] $push, $addToSet, $pull, $pullAll
- [ ] ~$bit~
- [x] Documentation, including
    - MongoDB errors pass-through explanation
    - Only works if operator is the first key, others keys (children > 0) are ignored. Random child if more than one.
    - What happen in create or replace operations?
    - Notification limitation (by the moment...)
- [x] CNR