### PR TITLE
Update contextBroker.spec to fix rpm build

### DIFF
--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -46,7 +46,7 @@ URL:        http://catalogue.fiware.org/enablers/publishsubscribe-context-broker
 Source:     %{name}-%{broker_version}.tar.gz
 BuildRoot: /var/tmp/%{name}-buildroot
 Requires:  libstdc++, boost-thread, boost-filesystem, gnutls, libgcrypt, libcurl, openssl, logrotate, libuuid
-Buildrequires: gcc, cmake, gcc-c++, gnutls-devel, libgcrypt-devel, libcurl-devel, openssl-devel, boost-devel, libuuid-devel
+Buildrequires: gcc, gcc-c++, gnutls-devel, libgcrypt-devel, libcurl-devel, openssl-devel, boost-devel, libuuid-devel
 Requires(pre): shadow-utils
 
 %description

--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -46,6 +46,8 @@ URL:        http://catalogue.fiware.org/enablers/publishsubscribe-context-broker
 Source:     %{name}-%{broker_version}.tar.gz
 BuildRoot: /var/tmp/%{name}-buildroot
 Requires:  libstdc++, boost-thread, boost-filesystem, gnutls, libgcrypt, libcurl, openssl, logrotate, libuuid
+# FIXME currently cmake is installed from source, but we hope in the future revert this situation. See more detail at https://github.com/telefonicaid/fiware-orion/blob/master/docker/Dockerfile#L61
+#Buildrequires: gcc, cmake, gcc-c++, gnutls-devel, libgcrypt-devel, libcurl-devel, openssl-devel, boost-devel, libuuid-devel
 Buildrequires: gcc, gcc-c++, gnutls-devel, libgcrypt-devel, libcurl-devel, openssl-devel, boost-devel, libuuid-devel
 Requires(pre): shadow-utils
 


### PR DESCRIPTION
cmake is installed from source and therefore not recognized as an installed package. Needs to be removed for the build to work.