### PR TITLE
Update ftest readme python dependencies

### DIFF
--- a/test/functionalTest/README.md
+++ b/test/functionalTest/README.md
@@ -26,7 +26,6 @@ Next install accumulator-server.py depencencies:
 ```
 pip install Flask==1.0.2
 pip install pyOpenSSL==19.0.0
-pip install python-etcd==0.4.5
 pip install paho-mqtt==1.5.1
 ```
 

--- a/test/functionalTest/README.md
+++ b/test/functionalTest/README.md
@@ -26,6 +26,8 @@ Next install accumulator-server.py depencencies:
 ```
 pip install Flask==1.0.2
 pip install pyOpenSSL==19.0.0
+pip install python-etcd==0.4.5
+pip install paho-mqtt==1.5.1
 ```
 
 Next, install the accumulator-server.py script itself:


### PR DESCRIPTION
Added MQTT dependencies install step to functional tests readme 

Before installing the dependencies, trying to run the accumulator gives an output error:

```
Traceback (most recent call last):
  File "/usr/bin/accumulator-server.py", line 61, in <module>
    import paho.mqtt.client as mqtt
ImportError: No module named paho.mqtt.client
```