### PR TITLE
ADD ftest for MQTT connection alarm

### DIFF
--- a/src/lib/mqtt/MqttConnectionManager.cpp
+++ b/src/lib/mqtt/MqttConnectionManager.cpp
@@ -256,7 +256,8 @@ MqttConnection* MqttConnectionManager::getConnection(const std::string& host, in
      int resultCode = mosquitto_connect(cP->mosq, host.c_str(), port, MQTT_DEFAULT_KEEPALIVE);
      if (resultCode != MOSQ_ERR_SUCCESS)
      {
-       LM_E(("Runtime Error (error calling mosquitto_connect: %s (%d): %s)", endpoint.c_str(), resultCode, mosquitto_strerror(resultCode)));
+       // Alarm is raised in this case
+       alarmMgr.mqttConnectionError(endpoint, mosquitto_strerror(resultCode));
        mosquitto_destroy(cP->mosq);
        cP->mosq = NULL;
        return cP;
@@ -270,7 +271,7 @@ MqttConnection* MqttConnectionManager::getConnection(const std::string& host, in
      // We block until the connect callback release the connection semaphore
      sem_wait(&cP->connectionSem);
 
-     // Check if the connection went ok (if not, alarm is raised)
+     // Check if the connection went ok (if not, e.g wrong user/pass, alarm is raised)
      if (cP->conectionResult)
      {
        alarmMgr.mqttConnectionError(endpoint, mosquitto_connack_string(cP->conectionResult));

--- a/test/functionalTest/cases/3001_mqtt_alarms/mqtt_alarms_log_summary.test
+++ b/test/functionalTest/cases/3001_mqtt_alarms/mqtt_alarms_log_summary.test
@@ -1,0 +1,228 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# NOT VALGRIND READY ...
+# The log summary is heavily dependent on the timing, which is totally off under valgrind ...
+
+
+--NAME--
+MQTT alarms summary
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0 IPv4 -logSummary 5
+
+--SHELL--
+
+#
+# FIXME: this test relies on an external service (mqtt.flespi.io) which we don't control
+# It would be better to use a MQTT broker running by us (docker?)
+#
+# 01. Sleep 6 and see 0-0 raised and 0-0 released
+# 02. Create MQTT sub with wrong user/pass
+# 03. Upsert to trigger first MQTT notification, which fails and raises alarm
+# 04. Sleep 5 and see 1-1 raised and 0-0 released
+# 05. Sleep 5 and see 1-0 raised and 0-0 released
+# 06. Update subscription to fix user/pass
+# 07. Upsert to trigger MQTT notification, which successes and release alarm
+# 08. Sleep 5 and see 1-0 raised and 1-1 released
+# 09. Sleep 5 and see 1-0 raised and 1-0 released
+#
+
+echo "01. Sleep 6 and see 0-0 raised and 0-0 released"
+echo "==============================================="
+sleep 6
+cat /tmp/contextBroker.log | grep SUMMARY | grep MQTT | tail -n 1 | awk -F 'msg=' '{print $2}'
+echo
+echo
+
+
+echo "02. Create MQTT sub with wrong user/pass"
+echo "========================================"
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+  },
+  "notification": {
+    "mqtt": {
+      "url": "mqtt://mqtt.flespi.io:1883",
+      "user": "user",
+      "passwd": "xxxx",
+      "topic": "sub1"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+SUB_ID=$(echo "$_responseHeaders" | grep Location | awk -F/ '{ print $4 }' | tr -d "\r\n")
+
+
+echo "03. Upsert to trigger MQTT notification, which fails but not re-raises alarm"
+echo "============================================================================"
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Float"
+  }
+}'
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+
+
+echo "04. Sleep 5 and see 1-1 raised and 0-0 released"
+echo "==============================================="
+sleep 5
+cat /tmp/contextBroker.log | grep SUMMARY | grep MQTT | tail -n 1 | awk -F 'msg=' '{print $2}'
+echo
+echo
+
+
+echo "05. Sleep 5 and see 1-0 raised and 0-0 released"
+echo "==============================================="
+sleep 5
+cat /tmp/contextBroker.log | grep SUMMARY | grep MQTT | tail -n 1 | awk -F 'msg=' '{print $2}'
+echo
+echo
+
+
+echo "06. Update subscription to fix user/pass"
+echo "========================================"
+payload='{
+  "notification": {
+    "mqtt": {
+      "url": "mqtt://mqtt.flespi.io:1883",
+      "user": "SeY7oD5XPa1UENBiOLPHqWXmj4r4OZHu4tsgWn1AmTkQuMW6lCDCmqMvi1oURVfJ",
+      "passwd": "xxxx",
+      "topic": "sub1"
+    }
+  }
+}'
+orionCurl -X PATCH --url "/v2/subscriptions/$SUB_ID" --payload "$payload"
+echo
+echo
+
+
+echo "07. Upsert to trigger third MQTT notification, which is ok and releases alarm"
+echo "============================================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Float"
+  }
+}'
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+
+
+echo "08. Sleep 5 and see 1-0 raised and 1-1 released"
+echo "==============================================="
+sleep 5
+cat /tmp/contextBroker.log | grep SUMMARY | grep MQTT | tail -n 1 | awk -F 'msg=' '{print $2}'
+echo
+echo
+
+
+echo "09. Sleep 5 and see 1-0 raised and 1-0 released"
+echo "==============================================="
+sleep 5
+cat /tmp/contextBroker.log | grep SUMMARY | grep MQTT | tail -n 1 | awk -F 'msg=' '{print $2}'
+echo
+echo
+
+
+--REGEXPECT--
+01. Sleep 6 and see 0-0 raised and 0-0 released
+===============================================
+MQTT connection failure active alarms: 0, raised: (total: 0, new: 0), released: (total: 0, new: 0)
+
+
+02. Create MQTT sub with wrong user/pass
+========================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Upsert to trigger MQTT notification, which fails but not re-raises alarm
+============================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Sleep 5 and see 1-1 raised and 0-0 released
+===============================================
+MQTT connection failure active alarms: 1, raised: (total: 1, new: 1), released: (total: 0, new: 0)
+
+
+05. Sleep 5 and see 1-0 raised and 0-0 released
+===============================================
+MQTT connection failure active alarms: 1, raised: (total: 1, new: 0), released: (total: 0, new: 0)
+
+
+06. Update subscription to fix user/pass
+========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+07. Upsert to trigger third MQTT notification, which is ok and releases alarm
+=============================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+08. Sleep 5 and see 1-0 raised and 1-1 released
+===============================================
+MQTT connection failure active alarms: 0, raised: (total: 1, new: 0), released: (total: 1, new: 1)
+
+
+09. Sleep 5 and see 1-0 raised and 1-0 released
+===============================================
+MQTT connection failure active alarms: 0, raised: (total: 1, new: 0), released: (total: 1, new: 0)
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3001_mqtt_alarms/mqtt_alarms_none.test
+++ b/test/functionalTest/cases/3001_mqtt_alarms/mqtt_alarms_none.test
@@ -1,0 +1,142 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+MQTT alarm: no alarms case
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0 IPV4
+
+--SHELL--
+
+#
+# Hint: use this to run the MQTT broker needed for this .test:
+#
+#   docker run -d -p 1883:1883 eclipse-mosquitto:1.6.7
+#
+# 01. Create MQTT sub with right enpdoint (localhost:1883)
+# 02. Upsert three times to trigger three MQTT notifications
+# 03. Check logs and see three MQTT notifications and no alarms
+#
+
+echo "01. Create MQTT sub with right enpdoint (localhost:1883)"
+echo "========================================================"
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+  },
+  "notification": {
+    "mqtt": {
+      "url": "mqtt://localhost:1883",
+      "topic": "sub1"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Upsert three times to trigger three MQTT notifications"
+echo "=========================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Float"
+  }
+}'
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+
+
+echo "03. Check logs and see three MQTT notifications and no alarms"
+echo "============================================================="
+cat /tmp/contextBroker.log | grep -v 'corr=N/A' | awk -F 'msg=' '{print $2}'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create MQTT sub with right enpdoint (localhost:1883)
+========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Upsert three times to trigger three MQTT notifications
+==========================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Check logs and see three MQTT notifications and no alarms
+=============================================================
+#SORT_START
+Request received: POST /v2/subscriptions, request payload (142 bytes): { "subject": { "entities": [ { "id": "E", "type": "T" } ] }, "notification": { "mqtt": { "url": "mqtt://localhost:1883", "topic": "sub1" } } }, response code: 201
+Request received: POST /v2/entities?options=forcedUpdate,upsert, request payload (64 bytes): { "id": "E", "type": "T", "A": { "value": 1, "type": "Float" } }, response code: 204
+MQTT Notif delivered REGEX(.*): broker: localhost:1883, topic: sub1
+Request received: POST /v2/entities?options=forcedUpdate,upsert, request payload (64 bytes): { "id": "E", "type": "T", "A": { "value": 1, "type": "Float" } }, response code: 204
+MQTT Notif delivered REGEX(.*): broker: localhost:1883, topic: sub1
+Request received: POST /v2/entities?options=forcedUpdate,upsert, request payload (64 bytes): { "id": "E", "type": "T", "A": { "value": 1, "type": "Float" } }, response code: 204
+MQTT Notif delivered REGEX(.*): broker: localhost:1883, topic: sub1
+#SORT_END
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3001_mqtt_alarms/mqtt_alarms_raise_and_release.test
+++ b/test/functionalTest/cases/3001_mqtt_alarms/mqtt_alarms_raise_and_release.test
@@ -1,0 +1,206 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+MQTT alarm: alarms raise/release case
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0 IPV4
+
+--SHELL--
+
+#
+# FIXME: this test relies on an external service (mqtt.flespi.io) which we don't control
+# It would be better to use a MQTT broker running by us (docker?)
+#
+# 01. Create MQTT sub with wrong user/pass
+# 02. Upsert to trigger first MQTT notification, which fails and raises alarm
+# 03. Upsert to trigger second MQTT notification, which fails but not re-raises alarm
+# 04. Update subscription to fix user/pass
+# 05. Upsert to trigger third MQTT notification, which is ok and releases alarm
+# 06. Check logs and see 1 raised alarm and 1 released alarm
+#
+
+echo "01. Create MQTT sub with wrong user/pass"
+echo "========================================"
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+  },
+  "notification": {
+    "mqtt": {
+      "url": "mqtt://mqtt.flespi.io:1883",
+      "user": "user",
+      "passwd": "xxxx",
+      "topic": "sub1"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+SUB_ID=$(echo "$_responseHeaders" | grep Location | awk -F/ '{ print $4 }' | tr -d "\r\n")
+
+
+echo "02. Upsert to trigger first MQTT notification, which fails and raises alarm"
+echo "==========================================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Float"
+  }
+}'
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+
+
+echo "03. Upsert to trigger second MQTT notification, which fails but not re-raises alarm"
+echo "==================================================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Float"
+  }
+}'
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+
+
+echo "04. Update subscription to fix user/pass"
+echo "========================================"
+payload='{
+  "notification": {
+    "mqtt": {
+      "url": "mqtt://mqtt.flespi.io:1883",
+      "user": "SeY7oD5XPa1UENBiOLPHqWXmj4r4OZHu4tsgWn1AmTkQuMW6lCDCmqMvi1oURVfJ",
+      "passwd": "xxxx",
+      "topic": "sub1"
+    }
+  }
+}'
+orionCurl -X PATCH --url "/v2/subscriptions/$SUB_ID" --payload "$payload"
+echo
+echo
+
+
+echo "05. Upsert to trigger third MQTT notification, which is ok and releases alarm"
+echo "============================================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Float"
+  }
+}'
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+
+# Given the MQTT broker is a remote system in the Internet, we have to wait some
+# times so full logs get generated
+sleep 1s
+
+echo "06. Check logs and see 1 raised alarm and 1 released alarm"
+echo "=========================================================="
+cat /tmp/contextBroker.log | grep -v 'corr=N/A' | awk -F 'msg=' '{print $2}'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create MQTT sub with wrong user/pass
+========================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Upsert to trigger first MQTT notification, which fails and raises alarm
+===========================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Upsert to trigger second MQTT notification, which fails but not re-raises alarm
+===================================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Update subscription to fix user/pass
+========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Upsert to trigger third MQTT notification, which is ok and releases alarm
+=============================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. Check logs and see 1 raised alarm and 1 released alarm
+==========================================================
+#SORT_START
+Request received: POST /v2/subscriptions, request payload (181 bytes): { "subject": { "entities": [ { "id": "E", "type": "T" } ] }, "notification": { "mqtt": { "url": "mqtt://mqtt.flespi.io:1883", "user": "user", "passwd": "xxxx", "topic": "sub1" } } }, response code: 201
+Request received: POST /v2/entities?options=forcedUpdate,upsert, request payload (64 bytes): { "id": "E", "type": "T", "A": { "value": 1, "type": "Float" } }, response code: 204
+Raising alarm MqttConnectionError mqtt.flespi.io:1883: Connection Refused: bad user name or password.
+Request received: POST /v2/entities?options=forcedUpdate,upsert, request payload (64 bytes): { "id": "E", "type": "T", "A": { "value": 1, "type": "Float" } }, response code: 204
+Request received: PATCH /v2/subscriptions/REGEX(.*): { "notification": { "mqtt": { "url": "mqtt://mqtt.flespi.io:1883", "user": "SeY7oD5XPa1UENBiOLPHqWXmj4r4OZHu4tsgWn1AmTkQuMW6lCDCmqMvi1oURVfJ", "passwd": "xxxx", "topic": "sub1" } } }, response code: 204
+Request received: POST /v2/entities?options=forcedUpdate,upsert, request payload (64 bytes): { "id": "E", "type": "T", "A": { "value": 1, "type": "Float" } }, response code: 204
+Releasing alarm MqttConnectionError mqtt.flespi.io:1883
+MQTT Notif delivered REGEX(.*): broker: mqtt.flespi.io:1883, topic: sub1
+#SORT_END
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3001_mqtt_alarms/mqtt_alarms_raise_repeate_and_release.test
+++ b/test/functionalTest/cases/3001_mqtt_alarms/mqtt_alarms_raise_repeate_and_release.test
@@ -1,0 +1,207 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+MQTT alarm: alarms raise/repeat/release case
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0 IPV4 -relogAlarms
+
+--SHELL--
+
+#
+# FIXME: this test relies on an external service (mqtt.flespi.io) which we don't control
+# It would be better to use a MQTT broker running by us (docker?)
+#
+# 01. Create MQTT sub with wrong user/pass
+# 02. Upsert to trigger first MQTT notification, which fails and raises alarm
+# 03. Upsert to trigger second MQTT notification, which fails and re-logs alarm
+# 04. Update subscription to fix user/pass
+# 05. Upsert to trigger third MQTT notification, which is ok and releases alarm
+# 06. Check logs and see 1 raised alarm, 1 repeat alarm and 1 released alarm
+#
+
+echo "01. Create MQTT sub with wrong user/pass"
+echo "========================================"
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+  },
+  "notification": {
+    "mqtt": {
+      "url": "mqtt://mqtt.flespi.io:1883",
+      "user": "user",
+      "passwd": "xxxx",
+      "topic": "sub1"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+SUB_ID=$(echo "$_responseHeaders" | grep Location | awk -F/ '{ print $4 }' | tr -d "\r\n")
+
+
+echo "02. Upsert to trigger first MQTT notification, which fails and raises alarm"
+echo "==========================================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Float"
+  }
+}'
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+
+
+echo "03. Upsert to trigger second MQTT notification, which fails and re-logs alarm"
+echo "============================================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Float"
+  }
+}'
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+
+
+echo "04. Update subscription to fix user/pass"
+echo "========================================"
+payload='{
+  "notification": {
+    "mqtt": {
+      "url": "mqtt://mqtt.flespi.io:1883",
+      "user": "SeY7oD5XPa1UENBiOLPHqWXmj4r4OZHu4tsgWn1AmTkQuMW6lCDCmqMvi1oURVfJ",
+      "passwd": "xxxx",
+      "topic": "sub1"
+    }
+  }
+}'
+orionCurl -X PATCH --url "/v2/subscriptions/$SUB_ID" --payload "$payload"
+echo
+echo
+
+
+echo "05. Upsert to trigger third MQTT notification, which is ok and releases alarm"
+echo "============================================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Float"
+  }
+}'
+orionCurl --url '/v2/entities?options=forcedUpdate,upsert' --payload "$payload"
+echo
+echo
+
+# Given the MQTT broker is a remote system in the Internet, we have to wait some
+# times so full logs get generated
+sleep 1s
+
+echo "06. Check logs and see 1 raised alarm, 1 repeat alarm and 1 released alarm"
+echo "=========================================================================="
+cat /tmp/contextBroker.log | grep -v 'corr=N/A' | awk -F 'msg=' '{print $2}'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create MQTT sub with wrong user/pass
+========================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Upsert to trigger first MQTT notification, which fails and raises alarm
+===========================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Upsert to trigger second MQTT notification, which fails and re-logs alarm
+=============================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Update subscription to fix user/pass
+========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Upsert to trigger third MQTT notification, which is ok and releases alarm
+=============================================================================
+HTTP/1.1 204 No Content
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. Check logs and see 1 raised alarm, 1 repeat alarm and 1 released alarm
+==========================================================================
+#SORT_START
+Request received: POST /v2/subscriptions, request payload (181 bytes): { "subject": { "entities": [ { "id": "E", "type": "T" } ] }, "notification": { "mqtt": { "url": "mqtt://mqtt.flespi.io:1883", "user": "user", "passwd": "xxxx", "topic": "sub1" } } }, response code: 201
+Request received: POST /v2/entities?options=forcedUpdate,upsert, request payload (64 bytes): { "id": "E", "type": "T", "A": { "value": 1, "type": "Float" } }, response code: 204
+Raising alarm MqttConnectionError mqtt.flespi.io:1883: Connection Refused: bad user name or password.
+Request received: POST /v2/entities?options=forcedUpdate,upsert, request payload (64 bytes): { "id": "E", "type": "T", "A": { "value": 1, "type": "Float" } }, response code: 204
+Repeated MqttConnectionError mqtt.flespi.io:1883: Connection Refused: bad user name or password.
+Request received: PATCH /v2/subscriptions/REGEX(.*): { "notification": { "mqtt": { "url": "mqtt://mqtt.flespi.io:1883", "user": "SeY7oD5XPa1UENBiOLPHqWXmj4r4OZHu4tsgWn1AmTkQuMW6lCDCmqMvi1oURVfJ", "passwd": "xxxx", "topic": "sub1" } } }, response code: 204
+Request received: POST /v2/entities?options=forcedUpdate,upsert, request payload (64 bytes): { "id": "E", "type": "T", "A": { "value": 1, "type": "Float" } }, response code: 204
+Releasing alarm MqttConnectionError mqtt.flespi.io:1883
+MQTT Notif delivered REGEX(.*): broker: mqtt.flespi.io:1883, topic: sub1
+#SORT_END
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
.test coverage of the manual test cases described in https://github.com/telefonicaid/fiware-orion/pull/3964#issuecomment-947467919

Correspondence:

- Case A: mqtt_alarms_none.test
- Case B: mqtt_alarms_raise_and_release.test
- Case C: mqtt_alarms_raise_repeate_and_release.test
- Case D: mqtt_alarms_log_summary.test

along with a small fix in the connection greation logic.