### PR TITLE
FIX testHarness.sh to reduce diff noise due to trailing whitespaces

### DIFF
--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -723,6 +723,7 @@ function partExecute()
   if [ "$what" == "shell" ]
   then
     mv $dirname/$filename.$what.stdout $dirname/$filename.out # We are very much used to this name ...
+    sed -i 's/[[:space:]]*$//' $dirname/$filename.out         # Remove trailing whitespace in .out (reduces diff noise)
 
     #
     # Special sorted diff or normal REGEX diff ?


### PR DESCRIPTION
This would simplify a lot the inspections of ftest differences in case of ail with tools like meld.

Before this PR:

![imagen](https://user-images.githubusercontent.com/1534240/139052137-b179f40e-a2aa-4784-9b07-38e7dad38c10.png)

After this PR:

![imagen](https://user-images.githubusercontent.com/1534240/139052037-1700e604-eacb-4083-8655-72735323866f.png)

Very much noisy in the first case.
