### PR TITLE
ADD CB_NO_CACHE=ON variant to functional tests for GitActions (second try)

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -40,6 +40,11 @@ jobs:
           - -e FT_FROM_IX=601 -e FT_TO_IX=900
           - -e FT_FROM_IX=901 -e FT_TO_IX=1200
           - -e FT_FROM_IX=1201
+          - -e CB_NO_CACHE=ON -e FT_FROM_IX=0 -e FT_TO_IX=300
+          - -e CB_NO_CACHE=ON -e FT_FROM_IX=301 -e FT_TO_IX=600
+          - -e CB_NO_CACHE=ON -e FT_FROM_IX=601 -e FT_TO_IX=900
+          - -e CB_NO_CACHE=ON -e FT_FROM_IX=901 -e FT_TO_IX=1200
+          - -e CB_NO_CACHE=ON -e FT_FROM_IX=1201
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Re-do of PR https://github.com/telefonicaid/fiware-orion/pull/3978 in the right place. From old PR:
> 
> A couple of issues has been detected with this PR:
> 
>    * Thottring problems - [Throttling is not working properly upon subscription updates when cache is used #3981](https://github.com/telefonicaid/fiware-orion/issues/3981) (indirectly detected in 0673_xauth_token/auth_token_three_steps.test)
>    * timesSent counter shouldn't be reset upon subscription update, detected with 3001_mqtt_alarms/mqtt_alarms_raise_and_release.test and 3001_mqtt_alarms/mqtt_alarms_raise_repeat_and_release.test)
> 
> The will be fixed in master branch, then this PR will be upgrade to check now all tests are ok.

Fixes has been applied to master, so now tests should pass in this PR.
