### PR TITLE
ADD  $set update operator

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 - Hardening: noCache flag should be check before removing csub from cache in mongoUnsubscribeContext() (#2879)
+- Add: $set and $unset attribute update operators (#3814, continuation)
 - Add: maxFailsLimit subscription field, so subscription is automatically passed to inactive after that number of failed notification attemps (#3541)
 - Add: failsCounter subscription field, to count the number of consecutive notificaitons fails (#3541)
 - Add: statusLastChange field in csbus collection (as now status is in the csubs cache and we need this field to know if status in the cache or DB is fresher)

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -284,6 +284,14 @@ POST /v2/entities/E/attrs/A
 
 We don't recommend this usage, as the regular update is simpler.
 
+Some additiona notes:
+
+* `$set` will work if the previous attribute value is an empty object (i.e. `{}`)
+* `$set+ will work if the attribute doesn't previously exist in the entity (although the entity
+  itself has to exist, as explained [here](#create-or-replace-entities))
+* `$set` will not work if the previous value of the attribute is not an object (i.e. a context
+  string like `"foo"`). An `InternalServerError` will be raised in this case.
+
 ### `$unset`
 
 To be used with attributes which value is an object to remove a sub-key from the

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -287,7 +287,7 @@ We don't recommend this usage, as the regular update is simpler.
 Some additiona notes:
 
 * `$set` will work if the previous attribute value is an empty object (i.e. `{}`)
-* `$set+ will work if the attribute doesn't previously exist in the entity (although the entity
+* `$set` will work if the attribute doesn't previously exist in the entity (although the entity
   itself has to exist, as explained [here](#create-or-replace-entities))
 * `$set` will not work if the previous value of the attribute is not an object (i.e. a context
   string like `"foo"`). An `InternalServerError` will be raised in this case.

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -178,7 +178,7 @@ For instance, if the preexisting value of attribute A in entity E is `[1, 2, 3]`
 POST /v2/entities/E/attrs/A
 {
   "value": { "$push": 3 },
-  "type": "Number"
+  "type": "Array"
 }
 ```
 
@@ -194,7 +194,7 @@ For instance, if the preexisting value of attribute A in entity E is `[1, 2, 3]`
 POST /v2/entities/E/attrs/A
 {
   "value": { "$addToSet": 4 },
-  "type": "Number"
+  "type": "Array"
 }
 ```
 
@@ -204,7 +204,7 @@ would change the value of attribute A to `[1, 2, 3, 4]`. However, the following 
 POST /v2/entities/E/attrs/A
 {
   "value": { "$addToSet": 3 },
-  "type": "Number"
+  "type": "Array"
 }
 ```
 
@@ -221,7 +221,7 @@ For instance, if the preexisting value of attribute A in entity E is `[1, 2, 3]`
 POST /v2/entities/E/attrs/A
 {
   "value": { "$pull": 2 },
-  "type": "Number"
+  "type": "Array"
 }
 ```
 
@@ -238,7 +238,7 @@ For instance, if the preexisting value of attribute A in entity E is `[1, 2, 3]`
 POST /v2/entities/E/attrs/A
 {
   "value": { "$pullAll": [2, 3] },
-  "type": "Number"
+  "type": "Array"
 }
 ```
 
@@ -256,7 +256,7 @@ following request:
 POST /v2/entities/E/attrs/A
 {
   "value": { "$set": {"Y": 20, "Z": 30} },
-  "type": "Number"
+  "type": "Object"
 }
 ```
 
@@ -268,7 +268,7 @@ For consistence, `$set` can be used with values that are not an object, such as:
 POST /v2/entities/E/attrs/A
 {
   "value": { "$set": "foo" },
-  "type": "Number"
+  "type": "Object"
 }
 ```
 
@@ -278,7 +278,7 @@ which has the same effect than a regular update, i.e.:
 POST /v2/entities/E/attrs/A
 {
   "value": "foo",
-  "type": "Number"
+  "type": "Object"
 }
 ```
 
@@ -294,7 +294,7 @@ following request:
 POST /v2/entities/E/attrs/A
 {
   "value": { "$unset": {"X": 1} },
-  "type": "Number"
+  "type": "Object"
 }
 ```
 
@@ -307,7 +307,7 @@ for simplity but the following request would also work and would be equivalent t
 POST /v2/entities/E/attrs/A
 {
   "value": { "$unset": {"X": null} },
-  "type": "Number"
+  "type": "Object"
 }
 ```
 
@@ -325,7 +325,7 @@ following request:
 POST /v2/entities/E/attrs/A
 {
   "value": { "$set": {"Y": 20, "Z": 30}, "$unset": {"X": 1} },
-  "type": "Number"
+  "type": "Object"
 }
 ```
 
@@ -338,7 +338,7 @@ the other way around. For instance the following request:
 POST /v2/entities/E/attrs/A
 {
   "value": { "$set": {"X": 20, "Z": 30}, "$unset": {"X": 1} },
-  "type": "Number"
+  "type": "Object"
 }
 ```
 

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -282,6 +282,8 @@ POST /v2/entities/E/attrs/A
 }
 ```
 
+We don't recommend this usage, as the regular update is simpler.
+
 ### `$unset`
 
 To be used with attributes which value is an object to remove a sub-key from the

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -300,7 +300,7 @@ POST /v2/entities/E/attrs/A
 }
 ```
 
-would change the value of attribute A to `{"Y": 20}`.
+would change the value of attribute A to `{"Y": 2}`.
 
 The actual value of the sub-key used with `$unset` is not relevant. A value of 1 is recommented
 for simplicity but the following request would also work and would be equivalent to the one above:

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -303,7 +303,7 @@ POST /v2/entities/E/attrs/A
 would change the value of attribute A to `{"Y": 20}`.
 
 The actual value of the sub-key used with `$unset` is not relevant. A value of 1 is recommented
-for simplity but the following request would also work and would be equivalent to the one above:
+for simplicity but the following request would also work and would be equivalent to the one above:
 
 ```
 POST /v2/entities/E/attrs/A

--- a/doc/manuals/user/update_operators.md
+++ b/doc/manuals/user/update_operators.md
@@ -314,6 +314,36 @@ POST /v2/entities/E/attrs/A
 Note that if the value of `$unset` is not an object, it will be ignored. Not existing sub-keys
 are also ignored.
 
+### Combining `$set` and `$unset`
+
+You can combine the usage of `$set` and `$unset` in the same attribute update.
+
+For instance, if the preexisting value of attribute A in entity E is `{"X": 1, "Y": 2}` the
+following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$set": {"Y": 20, "Z": 30}, "$unset": {"X": 1} },
+  "type": "Number"
+}
+```
+
+would change the value of attribute A to `{"Y": 20}`.
+
+The sub-keys in the `$set` value cannot be at the same time in the `$unset` value or
+the other way around. For instance the following request:
+
+```
+POST /v2/entities/E/attrs/A
+{
+  "value": { "$set": {"X": 20, "Z": 30}, "$unset": {"X": 1} },
+  "type": "Number"
+}
+```
+
+would result in error.
+
 ## How Orion deals with operators
 
 Orion doesn't execute the operation itself, but pass it to MongoDB, which is the one actually
@@ -374,24 +404,10 @@ you will get (randomly, in principle) one among this ones:
 * A gets multiply its value by 10
 * A gets is value updated to (literally) this JSON object: `{ "x": 1, "$inc": 1, "$mul": 10 }`
 
-Or even not so weird things... the following request could make sense, to add/update a
-sub-key `X` to attribute `A` and remove a sub-key `Y` in the same operation:
-
-```
-POST /v2/entities/E/attrs/A
-{
-  "value": {
-    "$set": {"X": 10},
-    "$unset": {"Y": 1}
-  },
-  "type": "Number"
-}
-```
-
-but the result would be that only one of them (i.e. either `X` is added/updated or `Y` is removed
-but not both at the same time).
-
 So be careful of avoiding these situations.
+
+The only exception to "use only one operator" rule is the case of `$set` and
+`$unset`, that can be used together [as described above](#combining-set-and-unset).
 
 ## Current limitations
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -3287,7 +3287,7 @@ static bool calculateUnsetOperator(ContextElementResponse* cerP, orion::BSONObjB
       continue;
     }
 
-    // Process the childs of child0
+    // Process the childs of theChild
     for (unsigned int jx = 0; jx < theChild->childV.size(); ++jx)
     {
       CompoundValueNode* child = theChild->childV[jx];

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -3103,7 +3103,7 @@ static bool calculateOperator(ContextElementResponse* cerP, const std::string& o
 *
 * calculateSetOperator -
 *
-* {A: {value: {$set: {X: <V1>, Y: <V2>, ...}} -> {attrs.A.value.X: <V1>, attrs.A.value.Y: <V2> ... }
+* {A: {value: {$set: {X: <V1>, Y: <V2>, ...}}} -> {attrs.A.value.X: <V1>, attrs.A.value.Y: <V2>, ... }
 *
 * Return bool if some content has been added to the BSONObjBuilders passed as parameter
 */
@@ -3502,7 +3502,7 @@ static unsigned int updateEntity
 
     // $set is special, as it is shared with regular (without update operator) attribute modification
     bool calculatedSet = calculateSetOperator(notifyCerP, &toSet);
-    if (calculatedSet || (toSet.nFields() > 0))
+    if (toSet.nFields() > 0)
     {
       updatedEntity.append("$set", toSet.obj());
     }
@@ -3523,7 +3523,7 @@ static unsigned int updateEntity
       bobEach.append("$each", attrNamesAdd.arr());
       toAddToSet.append(ENT_ATTRNAMES, bobEach.obj());
     }
-    if (calculatedAddToSet || (attrNamesAdd.arrSize() > 0))
+    if (toAddToSet.nFields() > 0)
     {
       updatedEntity.append("$addToSet", toAddToSet.obj());
     }
@@ -3538,7 +3538,7 @@ static unsigned int updateEntity
     {
       toPullAll.append(ENT_ATTRNAMES, attrNamesRemove.arr());
     }
-    if (calculatedPullAll || (attrNamesRemove.arrSize() > 0))
+    if (toPullAll.nFields() > 0)
     {
       updatedEntity.append("$pullAll", toPullAll.obj());
     }

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_and_unset_same_time.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_and_unset_same_time.test
@@ -1,0 +1,220 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Operators set and unset used at the same time in the same attribute
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity E with A={X:1, Y:2}
+# 02. Create sub for entity E
+# 03. Update A with $set: {Y:20, Z:30} and $unset {X: 1}
+# 04. Get entity, see E-A={Y: 20, Z:30}
+# 05. Dump accumulator, see E-A={Y: 20, Z:30}
+# 06. Update A with $set: {W:40} and $unset {W: 1}, see error
+#
+
+
+echo '01. Create entity E with A={X:1, Y:2}'
+echo '====================================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": {"X": 1, "Y": 2},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Create sub for entity E'
+echo '==========================='
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+   },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $set: {Y:20, Z:30} and $unset {X: 1}'
+echo '======================================================'
+payload='{
+  "A": {
+    "value": { "$set": {"Y": 20, "Z": 30 }, "$unset": {"X": 1}},
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity, see E-A={Y: 20, Z:30}'
+echo '====================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '05. Dump accumulator, see E-A={Y: 20, Z:30}'
+echo '==========================================='
+accumulatorDump
+echo
+echo
+
+
+echo '06. Update A with $set: {W:40} and $unset {W: 1}, see error'
+echo '==========================================================='
+payload='{
+  "A": {
+    "value": { "$set": {"W": 40}, "$unset": {"W": 1}},
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A={X:1, Y:2}
+=====================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub for entity E
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update A with $set: {Y:20, Z:30} and $unset {X: 1}
+======================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Get entity, see E-A={Y: 20, Z:30}
+=====================================
+HTTP/1.1 200 OK
+Content-Length: 81
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "Y": 20,
+            "Z": 30
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+05. Dump accumulator, see E-A={Y: 20, Z:30}
+===========================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 136
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Number",
+                "value": {
+                    "Y": 20,
+                    "Z": 30
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+
+
+06. Update A with $set: {W:40} and $unset {W: 1}, see error
+===========================================================
+HTTP/1.1 500 Internal Server Error
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Database Error &#40;collection: ftest.entities - REGEX(.*) - exception: Updating the path &#39;attrs.A.value.W&#39; would create a conflict at &#39;attrs.A.value.W&#39;&#41;",
+    "error": "InternalServerError"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop $LISTENER_PORT
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator.test
@@ -1,0 +1,194 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: max
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity E with A={X:1, Y:2}
+# 02. Create sub for entity E
+# 03. Update A with $set: {Y:20, Z:30}
+# 04. Get entity, see E-A={X:1, Y: 20, Z:30}
+# 05. Dump accumulator, see E-A={X:1, Y: 20, Z:30}
+#
+
+
+echo '01. Create entity E with A={X:1, Y:2}'
+echo '====================================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": {"X": 1, "Y": 2},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Create sub for entity E'
+echo '==========================='
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+   },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $set: {Y:20, Z:30}'
+echo '===================================='
+payload='{
+  "A": {
+    "value": { "$set": {"Y": 20, "Z": 30 }},
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity, see E-A={X:1, Y: 20, Z:30}'
+echo '=========================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '05. Dump accumulator, see E-A={X:1, Y: 20, Z:30}'
+echo '================================================'
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A={X:1, Y:2}
+=====================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub for entity E
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update A with $set: {Y:20, Z:30}
+====================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Get entity, see E-A={X:1, Y: 20, Z:30}
+==========================================
+HTTP/1.1 200 OK
+Content-Length: 87
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "X": 1,
+            "Y": 20,
+            "Z": 30
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+05. Dump accumulator, see E-A={X:1, Y: 20, Z:30}
+================================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 142
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Number",
+                "value": {
+                    "X": 1,
+                    "Y": 20,
+                    "Z": 30
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop $LISTENER_PORT
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Attribute update operator: set (with all possible types)
+Attribute update operator: set
 
 --SHELL-INIT--
 dbInit CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Attribute update operator: max
+Attribute update operator: set (with all possible types)
 
 --SHELL-INIT--
 dbInit CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator_all_types.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator_all_types.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Attribute update operator: set
+Attribute update operator: set (with all possible types)
 
 --SHELL-INIT--
 dbInit CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator_all_types.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator_all_types.test
@@ -1,0 +1,657 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: set
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity E with A={X:1, Y:2}
+# 02. Create sub for entity E
+# 03. Update A with $set: {X:"foo"}
+# 04. Get entity, see E-A={X:"foo", Y: 2}
+# 05. Update A with $set: {X:10}
+# 06. Get entity, see E-A={X:10, Y: 2}
+# 07. Update A with $set: {X:true}
+# 08. Get entity, see E-A={X:true, Y: 2}
+# 09. Update A with $set: {X:null}
+# 10. Get entity, see E-A={X:null, Y: 2}
+# 11. Update A with $set: {X:<array>}
+# 12. Get entity, see E-A={X:<array>, Y: 2}
+# 13. Update A with $set: {X:<object>}
+# 14. Get entity, see E-A={X:<object>, Y: 2}
+# 15. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object
+#
+
+
+echo '01. Create entity E with A={X:1, Y:2}'
+echo '====================================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": {"X": 1, "Y": 2},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Create sub for entity E'
+echo '==========================='
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+   },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $set: {X:"foo"}'
+echo '================================='
+payload='{
+  "A": {
+    "value": { "$set": {"X": "foo" }},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity, see E-A={X:"foo", Y: 2}'
+echo '======================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '05. Update A with $set: {X:10}'
+echo '=============================='
+payload='{
+  "A": {
+    "value": { "$set": {"X": 10 }},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '06. Get entity, see E-A={X:10, Y: 2}'
+echo '===================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '07. Update A with $set: {X:true}'
+echo '================================'
+payload='{
+  "A": {
+    "value": { "$set": {"X": true }},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '08. Get entity, see E-A={X:true, Y: 2}'
+echo '======================================'
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '09. Update A with $set: {X:null}'
+echo '================================'
+payload='{
+  "A": {
+    "value": { "$set": {"X": null }},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '10. Get entity, see E-A={X:null, Y: 2}'
+echo '======================================'
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '11. Update A with $set: {X:<array>}'
+echo '==================================='
+payload='{
+  "A": {
+    "value": {
+      "$set": {
+        "X": [
+          "22",
+          {
+            "x" : [ "x1", "x2" ],
+            "y" : 3
+          },
+          [ "z1", "z2" ]
+        ]
+      }
+    },
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '12. Get entity, see E-A={X:<array>, Y: 2}'
+echo '========================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '13. Update A with $set: {X:<object>}'
+echo '===================================='
+payload='{
+  "A": {
+    "value": {
+      "$set": {
+        "X": {
+          "x": {
+            "x1": "a",
+            "x2": "b"
+          },
+          "y": [ "y1", "y2" ]
+        }
+      }
+    },
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '14. Get entity, see E-A={X:<object>, Y: 2}'
+echo '=========================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '15. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object'
+echo '======================================================================================================='
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A={X:1, Y:2}
+=====================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub for entity E
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update A with $set: {X:"foo"}
+=================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Get entity, see E-A={X:"foo", Y: 2}
+=======================================
+HTTP/1.1 200 OK
+Content-Length: 83
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": {
+            "X": "foo",
+            "Y": 2
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+05. Update A with $set: {X:10}
+==============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. Get entity, see E-A={X:10, Y: 2}
+====================================
+HTTP/1.1 200 OK
+Content-Length: 80
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": {
+            "X": 10,
+            "Y": 2
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+07. Update A with $set: {X:true}
+================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+08. Get entity, see E-A={X:true, Y: 2}
+======================================
+HTTP/1.1 200 OK
+Content-Length: 82
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": {
+            "X": true,
+            "Y": 2
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+09. Update A with $set: {X:null}
+================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+10. Get entity, see E-A={X:null, Y: 2}
+======================================
+HTTP/1.1 200 OK
+Content-Length: 82
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": {
+            "X": null,
+            "Y": 2
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+11. Update A with $set: {X:<array>}
+===================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+12. Get entity, see E-A={X:<array>, Y: 2}
+=========================================
+HTTP/1.1 200 OK
+Content-Length: 120
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": {
+            "X": [
+                "22",
+                {
+                    "x": [
+                        "x1",
+                        "x2"
+                    ],
+                    "y": 3
+                },
+                [
+                    "z1",
+                    "z2"
+                ]
+            ],
+            "Y": 2
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+13. Update A with $set: {X:<object>}
+====================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+14. Get entity, see E-A={X:<object>, Y: 2}
+==========================================
+HTTP/1.1 200 OK
+Content-Length: 119
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": {
+            "X": {
+                "x": {
+                    "x1": "a",
+                    "x2": "b"
+                },
+                "y": [
+                    "y1",
+                    "y2"
+                ]
+            },
+            "Y": 2
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+15. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object
+=======================================================================================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 138
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": {
+                    "X": "foo",
+                    "Y": 2
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 135
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": {
+                    "X": 10,
+                    "Y": 2
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 137
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": {
+                    "X": true,
+                    "Y": 2
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 137
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": {
+                    "X": null,
+                    "Y": 2
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 175
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": {
+                    "X": [
+                        "22",
+                        {
+                            "x": [
+                                "x1",
+                                "x2"
+                            ],
+                            "y": 3
+                        },
+                        [
+                            "z1",
+                            "z2"
+                        ]
+                    ],
+                    "Y": 2
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 174
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": {
+                    "X": {
+                        "x": {
+                            "x1": "a",
+                            "x2": "b"
+                        },
+                        "y": [
+                            "y1",
+                            "y2"
+                        ]
+                    },
+                    "Y": 2
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop $LISTENER_PORT
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator_as_regular_update.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator_as_regular_update.test
@@ -31,6 +31,9 @@ accumulatorStart --pretty-print
 --SHELL--
 
 #
+# Note there is no case for object type. Object type has the special
+# behaviour shown in set_operator.test and set_operator_all_types.test
+#
 # 01. Create entity E with A={X:1, Y:2}
 # 02. Create sub for entity E
 # 03. Update A with $set: "foo"
@@ -43,9 +46,7 @@ accumulatorStart --pretty-print
 # 10. Get entity, see E-A=null
 # 11. Update A with $set: <array>
 # 12. Get entity, see E-A=<array>
-# 13. Update A with $set: <object>
-# 14. Get entity, see E-A=<object>
-# 15. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object
+# 13. Dump accumulator, see 5 notifications E-A-X being a string, number, boolean, null and array
 #
 
 
@@ -166,8 +167,8 @@ echo
 echo
 
 
-echo '11. Update A with $set: <array>}'
-echo '================================'
+echo '11. Update A with $set: <array>'
+echo '==============================='
 payload='{
   "A": {
     "value": {
@@ -195,35 +196,7 @@ echo
 echo
 
 
-echo '13. Update A with $set: <object>'
-echo '================================'
-payload='{
-  "A": {
-    "value": {
-      "$set": {
-        "x": {
-          "x1": "a",
-          "x2": "b"
-        },
-        "y": [ "y1", "y2" ]
-      }
-    },
-    "type": "Object"
-  }
-}'
-orionCurl --url /v2/entities/E/attrs --payload "$payload"
-echo
-echo
-
-
-echo '14. Get entity, see E-A=<object>'
-echo '================================'
-orionCurl --url /v2/entities/E
-echo
-echo
-
-
-echo '15. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object'
+echo '13. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object'
 echo '======================================================================================================='
 accumulatorDump
 echo
@@ -231,15 +204,179 @@ echo
 
 
 --REGEXPECT--
+01. Create entity E with A={X:1, Y:2}
+=====================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
 
+
+
+02. Create sub for entity E
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
 Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
-=======================================
+
+
+03. Update A with $set:"foo"
+=================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Get entity, see E-A="foo"
+=============================
+HTTP/1.1 200 OK
+Content-Length: 71
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": "foo"
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+05. Update A with $set: 10
+==========================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. Get entity, see E-A=10
+==========================
+HTTP/1.1 200 OK
+Content-Length: 68
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": 10
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+07. Update A with $set: true
+============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+08. Get entity, see E-A=true
+============================
+HTTP/1.1 200 OK
+Content-Length: 70
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": true
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+09. Update A with $set: null
+============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+10. Get entity, see E-A=null
+============================
+HTTP/1.1 200 OK
+Content-Length: 70
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": null
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+11. Update A with $set: <array>
+===============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+12. Get entity, see E-A=<array>
+===============================
+HTTP/1.1 200 OK
+Content-Length: 108
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Object",
+        "value": [
+            "22",
+            {
+                "x": [
+                    "x1",
+                    "x2"
+                ],
+                "y": 3
+            },
+            [
+                "z1",
+                "z2"
+            ]
+        ]
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+13. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object
+=======================================================================================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 174
+Content-Length: 126
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -253,19 +390,120 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
             "A": {
                 "metadata": {},
                 "type": "Object",
-                "value": {
-                    "X": {
-                        "x": {
-                            "x1": "a",
-                            "x2": "b"
-                        },
-                        "y": [
-                            "y1",
-                            "y2"
-                        ]
+                "value": "foo"
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 123
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": 10
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 125
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": true
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 125
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": null
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 163
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": [
+                    "22",
+                    {
+                        "x": [
+                            "x1",
+                            "x2"
+                        ],
+                        "y": 3
                     },
-                    "Y": 2
-                }
+                    [
+                        "z1",
+                        "z2"
+                    ]
+                ]
             },
             "id": "E",
             "type": "T"

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator_as_regular_update.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator_as_regular_update.test
@@ -1,0 +1,282 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: set (as regular update)
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity E with A={X:1, Y:2}
+# 02. Create sub for entity E
+# 03. Update A with $set: "foo"
+# 04. Get entity, see E-A="foo"
+# 05. Update A with $set: 10
+# 06. Get entity, see E-A=10
+# 07. Update A with $set: true
+# 08. Get entity, see E-A=true
+# 09. Update A with $set: null
+# 10. Get entity, see E-A=null
+# 11. Update A with $set: <array>
+# 12. Get entity, see E-A=<array>
+# 13. Update A with $set: <object>
+# 14. Get entity, see E-A=<object>
+# 15. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object
+#
+
+
+echo '01. Create entity E with A={X:1, Y:2}'
+echo '====================================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": {"X": 1, "Y": 2},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Create sub for entity E'
+echo '==========================='
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+   },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $set:"foo"'
+echo '================================='
+payload='{
+  "A": {
+    "value": { "$set": "foo" },
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity, see E-A="foo"'
+echo '============================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '05. Update A with $set: 10'
+echo '=========================='
+payload='{
+  "A": {
+    "value": { "$set": 10 },
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '06. Get entity, see E-A=10'
+echo '=========================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '07. Update A with $set: true'
+echo '============================'
+payload='{
+  "A": {
+    "value": { "$set": true },
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '08. Get entity, see E-A=true'
+echo '============================'
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '09. Update A with $set: null'
+echo '============================'
+payload='{
+  "A": {
+    "value": { "$set": null },
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '10. Get entity, see E-A=null'
+echo '============================'
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '11. Update A with $set: <array>}'
+echo '================================'
+payload='{
+  "A": {
+    "value": {
+      "$set": [
+        "22",
+        {
+          "x" : [ "x1", "x2" ],
+          "y" : 3
+        },
+        [ "z1", "z2" ]
+      ]
+    },
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '12. Get entity, see E-A=<array>'
+echo '==============================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '13. Update A with $set: <object>'
+echo '================================'
+payload='{
+  "A": {
+    "value": {
+      "$set": {
+        "x": {
+          "x1": "a",
+          "x2": "b"
+        },
+        "y": [ "y1", "y2" ]
+      }
+    },
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '14. Get entity, see E-A=<object>'
+echo '================================'
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '15. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object'
+echo '======================================================================================================='
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 174
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Object",
+                "value": {
+                    "X": {
+                        "x": {
+                            "x1": "a",
+                            "x2": "b"
+                        },
+                        "y": [
+                            "y1",
+                            "y2"
+                        ]
+                    },
+                    "Y": 2
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop $LISTENER_PORT
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator_empty.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator_empty.test
@@ -1,0 +1,192 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: set (with empty object)
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity E with A={}
+# 02. Create sub for entity E
+# 03. Update A with $set: {Y:20, Z:30}
+# 04. Get entity, see E-A={Y: 20, Z:30}
+# 05. Dump accumulator, see E-A={Y: 20, Z:30}
+#
+
+
+echo '01. Create entity E with A={}'
+echo '============================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": {},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Create sub for entity E'
+echo '==========================='
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+   },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $set: {Y:20, Z:30}'
+echo '===================================='
+payload='{
+  "A": {
+    "value": { "$set": {"Y": 20, "Z": 30 }},
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity, see E-A={Y: 20, Z:30}'
+echo '====================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '05. Dump accumulator, see E-A={Y: 20, Z:30}'
+echo '==========================================='
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A={}
+=============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub for entity E
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update A with $set: {Y:20, Z:30}
+====================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Get entity, see E-A={Y: 20, Z:30}
+=====================================
+HTTP/1.1 200 OK
+Content-Length: 81
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "Y": 20,
+            "Z": 30
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+05. Dump accumulator, see E-A={Y: 20, Z:30}
+===========================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 136
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Number",
+                "value": {
+                    "Y": 20,
+                    "Z": 30
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop $LISTENER_PORT
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator_non_existing_attr.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator_non_existing_attr.test
@@ -1,0 +1,188 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: set (with non existing attribute)
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity E without attributes
+# 02. Create sub for entity E
+# 03. Update A with $set: {Y:20, Z:30}
+# 04. Get entity, see E-A={Y: 20, Z:30}
+# 05. Dump accumulator, see E-A={Y: 20, Z:30}
+#
+
+
+echo '01. Create entity E without attributes'
+echo '======================================'
+payload='{
+  "id": "E",
+  "type": "T"
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Create sub for entity E'
+echo '==========================='
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+   },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $set: {Y:20, Z:30}'
+echo '===================================='
+payload='{
+  "A": {
+    "value": { "$set": {"Y": 20, "Z": 30 }},
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity, see E-A={Y: 20, Z:30}'
+echo '====================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '05. Dump accumulator, see E-A={Y: 20, Z:30}'
+echo '==========================================='
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E without attributes
+======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub for entity E
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update A with $set: {Y:20, Z:30}
+====================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Get entity, see E-A={Y: 20, Z:30}
+=====================================
+HTTP/1.1 200 OK
+Content-Length: 81
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "Y": 20,
+            "Z": 30
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+05. Dump accumulator, see E-A={Y: 20, Z:30}
+===========================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 136
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Number",
+                "value": {
+                    "Y": 20,
+                    "Z": 30
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop $LISTENER_PORT
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator_non_object.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator_non_object.test
@@ -124,7 +124,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "Database Error &#40;collection: ftest.entities - REGEX(.*) - exception: Plan executor error during findAndModify :: caused by :: Cannot create field &#39;Y&#39; in element {value: &quot;foo&quot;}&#41;",
+    "description": "Database Error &#40;collection: ftest.entities - REGEX(.*) Cannot create field &#39;Y&#39; in element {value: &quot;foo&quot;}&#41;",
     "error": "InternalServerError"
 }
 

--- a/test/functionalTest/cases/3814_attribute_update_operators/set_operator_non_object.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/set_operator_non_object.test
@@ -1,0 +1,153 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: set (attribute with non object value)
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E with A="foo"
+# 02. Create sub for entity E
+# 03. Update A with $set: {Y:20, Z:30}, see error
+# 04. Get entity, see E-A="foo"
+#
+
+
+echo '01. Create entity E with A="foo"'
+echo '================================'
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": "foo",
+    "type": "Text"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Create sub for entity E'
+echo '==========================='
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+   },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $set: {Y:20, Z:30}, see error'
+echo '==============================================='
+payload='{
+  "A": {
+    "value": { "$set": {"Y": 20, "Z": 30 }},
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity, see E-A="foo"'
+echo '============================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A="foo"
+================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub for entity E
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update A with $set: {Y:20, Z:30}, see error
+===============================================
+HTTP/1.1 500 Internal Server Error
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Database Error &#40;collection: ftest.entities - REGEX(.*) - exception: Plan executor error during findAndModify :: caused by :: Cannot create field &#39;Y&#39; in element {value: &quot;foo&quot;}&#41;",
+    "error": "InternalServerError"
+}
+
+
+04. Get entity, see E-A="foo"
+=============================
+HTTP/1.1 200 OK
+Content-Length: 69
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Text",
+        "value": "foo"
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/several_operators_same_update.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/several_operators_same_update.test
@@ -44,39 +44,43 @@ echo '================='
 payload='{
   "id": "E",
   "type": "T",
-  "A1": {
+  "A01": {
     "value": 1,
     "type": "Number"
   },
-  "A2": {
+  "A02": {
     "value": 5,
     "type": "Number"
   },
-  "A3": {
+  "A03": {
     "value": 5,
     "type": "Number"
   },
-  "A4": {
+  "A04": {
     "value": 3,
     "type": "Number"
   },
-  "A5": {
+  "A05": {
     "value": [ "foo" ],
     "type": "StructuredValue"
   },
-  "A6": {
+  "A06": {
     "value": [ "foo" ],
     "type": "StructuredValue"
   },
-  "A7": {
+  "A07": {
     "value": [ 1, 2, 3, 4],
     "type": "StructuredValue"
   },
-  "A8": {
+  "A08": {
     "value": [ 1, 2, 3, 4],
     "type": "StructuredValue"
   },
-  "A9": {
+  "A09": {
+    "value": {"X": 1, "Y": 2},
+    "type": "StructuredValue"
+  },
+  "A10": {
     "value": {"X": 1, "Y": 2},
     "type": "StructuredValue"
   }
@@ -111,40 +115,44 @@ echo
 echo '03. Update entity using all the operators'
 echo '========================================='
 payload='{
-  "A1": {
+  "A01": {
     "value": { "$inc": 2 },
     "type": "Number"
   },
-  "A2": {
+  "A02": {
     "value": { "$min": 0 },
     "type": "Number"
   },
-  "A3": {
+  "A03": {
     "value": { "$max": 8 },
     "type": "Number"
   },
-  "A4": {
+  "A04": {
     "value": { "$mul": 5 },
     "type": "Number"
   },
-  "A5": {
+  "A05": {
     "value": { "$push": "bar" },
     "type": "StructuredValue"
   },
-  "A6": {
+  "A06": {
     "value": { "$addToSet": "foo" },
     "type": "StructuredValue"
   },
-  "A7": {
+  "A07": {
     "value": { "$pull": 2 },
     "type": "StructuredValue"
   },
-  "A8": {
+  "A08": {
     "value": { "$pullAll": [2, 4] },
     "type": "StructuredValue"
   },
-  "A9": {
+  "A09": {
     "value": { "$set": {"Y": 20, "Z": 30} },
+    "type": "StructuredValue"
+  },
+  "A10": {
+    "value": { "$unset": {"Y": 1} },
     "type": "StructuredValue"
   }
 }'
@@ -199,33 +207,33 @@ Date: REGEX(.*)
 04. Get entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 538
+Content-Length: 610
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "A1": {
+    "A01": {
         "metadata": {},
         "type": "Number",
         "value": 3
     },
-    "A2": {
+    "A02": {
         "metadata": {},
         "type": "Number",
         "value": 0
     },
-    "A3": {
+    "A03": {
         "metadata": {},
         "type": "Number",
         "value": 8
     },
-    "A4": {
+    "A04": {
         "metadata": {},
         "type": "Number",
         "value": 15
     },
-    "A5": {
+    "A05": {
         "metadata": {},
         "type": "StructuredValue",
         "value": [
@@ -233,14 +241,14 @@ Date: REGEX(.*)
             "bar"
         ]
     },
-    "A6": {
+    "A06": {
         "metadata": {},
         "type": "StructuredValue",
         "value": [
             "foo"
         ]
     },
-    "A7": {
+    "A07": {
         "metadata": {},
         "type": "StructuredValue",
         "value": [
@@ -249,7 +257,7 @@ Date: REGEX(.*)
             4
         ]
     },
-    "A8": {
+    "A08": {
         "metadata": {},
         "type": "StructuredValue",
         "value": [
@@ -257,13 +265,20 @@ Date: REGEX(.*)
             3
         ]
     },
-    "A9": {
+    "A09": {
         "metadata": {},
         "type": "StructuredValue",
         "value": {
             "X": 1,
             "Y": 20,
             "Z": 30
+        }
+    },
+    "A10": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": {
+            "X": 1
         }
     },
     "id": "E",
@@ -275,7 +290,7 @@ Date: REGEX(.*)
 ====================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 593
+Content-Length: 665
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -286,27 +301,27 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
 {
     "data": [
         {
-            "A1": {
+            "A01": {
                 "metadata": {},
                 "type": "Number",
                 "value": 3
             },
-            "A2": {
+            "A02": {
                 "metadata": {},
                 "type": "Number",
                 "value": 0
             },
-            "A3": {
+            "A03": {
                 "metadata": {},
                 "type": "Number",
                 "value": 8
             },
-            "A4": {
+            "A04": {
                 "metadata": {},
                 "type": "Number",
                 "value": 15
             },
-            "A5": {
+            "A05": {
                 "metadata": {},
                 "type": "StructuredValue",
                 "value": [
@@ -314,14 +329,14 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
                     "bar"
                 ]
             },
-            "A6": {
+            "A06": {
                 "metadata": {},
                 "type": "StructuredValue",
                 "value": [
                     "foo"
                 ]
             },
-            "A7": {
+            "A07": {
                 "metadata": {},
                 "type": "StructuredValue",
                 "value": [
@@ -330,7 +345,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
                     4
                 ]
             },
-            "A8": {
+            "A08": {
                 "metadata": {},
                 "type": "StructuredValue",
                 "value": [
@@ -338,13 +353,20 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
                     3
                 ]
             },
-            "A9": {
+            "A09": {
                 "metadata": {},
                 "type": "StructuredValue",
                 "value": {
                     "X": 1,
                     "Y": 20,
                     "Z": 30
+                }
+            },
+            "A10": {
+                "metadata": {},
+                "type": "StructuredValue",
+                "value": {
+                    "X": 1
                 }
             },
             "id": "E",

--- a/test/functionalTest/cases/3814_attribute_update_operators/several_operators_same_update.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/several_operators_same_update.test
@@ -75,6 +75,10 @@ payload='{
   "A8": {
     "value": [ 1, 2, 3, 4],
     "type": "StructuredValue"
+  },
+  "A9": {
+    "value": {"X": 1, "Y": 2},
+    "type": "StructuredValue"
   }
 }'
 orionCurl --url /v2/entities --payload "$payload"
@@ -138,6 +142,10 @@ payload='{
   "A8": {
     "value": { "$pullAll": [2, 4] },
     "type": "StructuredValue"
+  },
+  "A9": {
+    "value": { "$set": {"Y": 20, "Z": 30} },
+    "type": "StructuredValue"
   }
 }'
 orionCurl --url /v2/entities/E/attrs --payload "$payload"
@@ -191,7 +199,7 @@ Date: REGEX(.*)
 04. Get entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 462
+Content-Length: 538
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -249,6 +257,15 @@ Date: REGEX(.*)
             3
         ]
     },
+    "A9": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": {
+            "X": 1,
+            "Y": 20,
+            "Z": 30
+        }
+    },
     "id": "E",
     "type": "T"
 }
@@ -258,7 +275,7 @@ Date: REGEX(.*)
 ====================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 517
+Content-Length: 593
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -320,6 +337,15 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
                     1,
                     3
                 ]
+            },
+            "A9": {
+                "metadata": {},
+                "type": "StructuredValue",
+                "value": {
+                    "X": 1,
+                    "Y": 20,
+                    "Z": 30
+                }
             },
             "id": "E",
             "type": "T"

--- a/test/functionalTest/cases/3814_attribute_update_operators/unset_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/unset_operator.test
@@ -1,0 +1,270 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: unset
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity E with A={X:1, Y:2, Z:3}
+# 02. Create sub for entity E
+# 03. Update A with $unset: {Y:1}
+# 04. Get entity, see E-A={X:1, Z:3}
+# 05. Update A with $unset: {X:"foo"}
+# 06. Get entity, see E-A={Z:3}
+# 07. Dump accumulator, see E-A={X:1, Z:3} and E-A={Z:3}
+#
+
+
+echo '01. Create entity E with A={X:1, Y:2, Z:3}'
+echo '=========================================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": {"X": 1, "Y": 2, "Z": 3},
+    "type": "Object"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Create sub for entity E'
+echo '==========================='
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+   },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $unset: {Y:1}'
+echo '==============================='
+payload='{
+  "A": {
+    "value": { "$unset": {"Y": 1}},
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity, see E-A={X:1, Z:3}'
+echo '=================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '05. Update A with $unset: {X:"foo"}'
+echo '==================================='
+payload='{
+  "A": {
+    "value": { "$unset": {"X": "foo" }},
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '05. Get entity, see E-A={Z:3}'
+echo '============================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '07. Dump accumulator, see E-A={X:1, Z:3} and E-A={Z:3}'
+echo '======================================================'
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A={X:1, Y:2, Z:3}
+==========================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub for entity E
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update A with $unset: {Y:1}
+===============================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Get entity, see E-A={X:1, Z:3}
+==================================
+HTTP/1.1 200 OK
+Content-Length: 79
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "X": 1,
+            "Z": 3
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+05. Update A with $unset: {X:"foo"}
+===================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Get entity, see E-A={Z:3}
+=============================
+HTTP/1.1 200 OK
+Content-Length: 73
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "Z": 3
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+07. Dump accumulator, see E-A={X:1, Z:3} and E-A={Z:3}
+======================================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 134
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Number",
+                "value": {
+                    "X": 1,
+                    "Z": 3
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 128
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Number",
+                "value": {
+                    "Z": 3
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop $LISTENER_PORT
+dbDrop CB

--- a/test/functionalTest/cases/3814_attribute_update_operators/unset_operator.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/unset_operator.test
@@ -37,7 +37,9 @@ accumulatorStart --pretty-print
 # 04. Get entity, see E-A={X:1, Z:3}
 # 05. Update A with $unset: {X:"foo"}
 # 06. Get entity, see E-A={Z:3}
-# 07. Dump accumulator, see E-A={X:1, Z:3} and E-A={Z:3}
+# 07. Update A with $unset: {W: 1}
+# 08. Get entity, see E-A={Z:3}
+# 09. Dump accumulator, see E-A={X:1, Z:3}, E-A={Z:3} and E-A={Z:3}
 #
 
 
@@ -82,7 +84,7 @@ echo '03. Update A with $unset: {Y:1}'
 echo '==============================='
 payload='{
   "A": {
-    "value": { "$unset": {"Y": 1}},
+    "value": { "$unset": {"Y": 1} },
     "type": "Number"
   }
 }'
@@ -111,15 +113,35 @@ echo
 echo
 
 
-echo '05. Get entity, see E-A={Z:3}'
+echo '06. Get entity, see E-A={Z:3}'
 echo '============================='
 orionCurl --url /v2/entities/E
 echo
 echo
 
 
-echo '07. Dump accumulator, see E-A={X:1, Z:3} and E-A={Z:3}'
-echo '======================================================'
+echo '07. Update A with $unset: {W: 1}'
+echo '================================'
+payload='{
+  "A": {
+    "value": { "$unset": {"W": 1 }},
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '08. Get entity, see E-A={Z:3}'
+echo '============================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '09. Dump accumulator, see E-A={X:1, Z:3}, E-A={Z:3} and E-A={Z:3}'
+echo '================================================================='
 accumulatorDump
 echo
 echo
@@ -184,7 +206,7 @@ Date: REGEX(.*)
 
 
 
-05. Get entity, see E-A={Z:3}
+06. Get entity, see E-A={Z:3}
 =============================
 HTTP/1.1 200 OK
 Content-Length: 73
@@ -205,8 +227,37 @@ Date: REGEX(.*)
 }
 
 
-07. Dump accumulator, see E-A={X:1, Z:3} and E-A={Z:3}
-======================================================
+07. Update A with $unset: {W: 1}
+================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+08. Get entity, see E-A={Z:3}
+=============================
+HTTP/1.1 200 OK
+Content-Length: 73
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "Number",
+        "value": {
+            "Z": 3
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+09. Dump accumulator, see E-A={X:1, Z:3}, E-A={Z:3} and E-A={Z:3}
+=================================================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
 Content-Length: 134
@@ -225,6 +276,33 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
                 "type": "Number",
                 "value": {
                     "X": 1,
+                    "Z": 3
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 128
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Number",
+                "value": {
                     "Z": 3
                 }
             },

--- a/test/functionalTest/cases/3814_attribute_update_operators/unset_operator_ignored_cases.test
+++ b/test/functionalTest/cases/3814_attribute_update_operators/unset_operator_ignored_cases.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Attribute update operator: set (as regular update)
+Attribute update operator: unset (ignored cases)
 
 --SHELL-INIT--
 dbInit CB
@@ -32,21 +32,21 @@ accumulatorStart --pretty-print
 
 #
 # Note there is no case for object type. Object type has the special
-# behaviour shown in set_operator.test and set_operator_all_types.test
+# behaviour shown in unset_operator.test
 #
 # 01. Create entity E with A={X:1, Y:2}
 # 02. Create sub for entity E
-# 03. Update A with $set: "foo"
-# 04. Get entity, see E-A="foo"
-# 05. Update A with $set: 10
-# 06. Get entity, see E-A=10
-# 07. Update A with $set: true
-# 08. Get entity, see E-A=true
-# 09. Update A with $set: null
-# 10. Get entity, see E-A=null
-# 11. Update A with $set: <array>
-# 12. Get entity, see E-A=<array>
-# 13. Dump accumulator, see 5 notifications E-A-X being a string, number, boolean, null and array
+# 03. Update A with $unset: "foo"
+# 04. Get entity, see E-A={X:1, Y:2}
+# 05. Update A with $unset: 10
+# 06. Get entity, see E-A={X:1, Y:2}
+# 07. Update A with $unset: true
+# 08. Get entity, see E-A={X:1, Y:2}
+# 09. Update A with $unset: null
+# 10. Get entity, see E-A={X:1, Y:2}
+# 11. Update A with $unset: <array>
+# 12. Get entity, see E-A={X:1, Y:2}
+# 13. Dump accumulator, see 5 notifications all them with original entity
 #
 
 
@@ -87,11 +87,11 @@ echo
 echo
 
 
-echo '03. Update A with $set:"foo"'
-echo '============================'
+echo '03. Update A with $unset:"foo"'
+echo '=============================='
 payload='{
   "A": {
-    "value": { "$set": "foo" },
+    "value": { "$unset": "foo" },
     "type": "Object"
   }
 }'
@@ -100,18 +100,18 @@ echo
 echo
 
 
-echo '04. Get entity, see E-A="foo"'
-echo '============================='
+echo '04. Get entity, see E-A={X:1, Y:2}'
+echo '=================================='
 orionCurl --url /v2/entities/E
 echo
 echo
 
 
-echo '05. Update A with $set: 10'
-echo '=========================='
+echo '05. Update A with $unset: 10'
+echo '============================'
 payload='{
   "A": {
-    "value": { "$set": 10 },
+    "value": { "$unset": 10 },
     "type": "Object"
   }
 }'
@@ -120,18 +120,18 @@ echo
 echo
 
 
-echo '06. Get entity, see E-A=10'
-echo '=========================='
+echo '06. Get entity, see E-A={X:1, Y:2}'
+echo '=================================='
 orionCurl --url /v2/entities/E
 echo
 echo
 
 
-echo '07. Update A with $set: true'
-echo '============================'
+echo '07. Update A with $unset: true'
+echo '=============================='
 payload='{
   "A": {
-    "value": { "$set": true },
+    "value": { "$unset": true },
     "type": "Object"
   }
 }'
@@ -140,18 +140,18 @@ echo
 echo
 
 
-echo '08. Get entity, see E-A=true'
-echo '============================'
+echo '08. Get entity, see E-A={X:1, Y:2}'
+echo '=================================='
 orionCurl --url /v2/entities/E
 echo
 echo
 
 
-echo '09. Update A with $set: null'
-echo '============================'
+echo '09. Update A with $unset: null'
+echo '=============================='
 payload='{
   "A": {
-    "value": { "$set": null },
+    "value": { "$unset": null },
     "type": "Object"
   }
 }'
@@ -160,19 +160,19 @@ echo
 echo
 
 
-echo '10. Get entity, see E-A=null'
-echo '============================'
+echo '10. Get entity, see E-A={X:1, Y:2}'
+echo '=================================='
 orionCurl --url /v2/entities/E
 echo
 echo
 
 
-echo '11. Update A with $set: <array>'
-echo '==============================='
+echo '11. Update A with $unset: <array>'
+echo '================================='
 payload='{
   "A": {
     "value": {
-      "$set": [
+      "$unset": [
         "22",
         {
           "x" : [ "x1", "x2" ],
@@ -189,15 +189,15 @@ echo
 echo
 
 
-echo '12. Get entity, see E-A=<array>'
-echo '==============================='
+echo '12. Get entity, see E-A={X:1, Y:2}'
+echo '=================================='
 orionCurl --url /v2/entities/E
 echo
 echo
 
 
-echo '13. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object'
-echo '======================================================================================================='
+echo '13. Dump accumulator, see 5 notifications all them with original entity'
+echo '======================================================================='
 accumulatorDump
 echo
 echo
@@ -224,18 +224,18 @@ Date: REGEX(.*)
 
 
 
-03. Update A with $set:"foo"
-============================
+03. Update A with $unset:"foo"
+==============================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-04. Get entity, see E-A="foo"
-=============================
+04. Get entity, see E-A={X:1, Y:2}
+==================================
 HTTP/1.1 200 OK
-Content-Length: 71
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -244,25 +244,28 @@ Date: REGEX(.*)
     "A": {
         "metadata": {},
         "type": "Object",
-        "value": "foo"
+        "value": {
+            "X": 1,
+            "Y": 2
+        }
     },
     "id": "E",
     "type": "T"
 }
 
 
-05. Update A with $set: 10
-==========================
+05. Update A with $unset: 10
+============================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-06. Get entity, see E-A=10
-==========================
+06. Get entity, see E-A={X:1, Y:2}
+==================================
 HTTP/1.1 200 OK
-Content-Length: 68
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -271,25 +274,28 @@ Date: REGEX(.*)
     "A": {
         "metadata": {},
         "type": "Object",
-        "value": 10
+        "value": {
+            "X": 1,
+            "Y": 2
+        }
     },
     "id": "E",
     "type": "T"
 }
 
 
-07. Update A with $set: true
-============================
+07. Update A with $unset: true
+==============================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-08. Get entity, see E-A=true
-============================
+08. Get entity, see E-A={X:1, Y:2}
+==================================
 HTTP/1.1 200 OK
-Content-Length: 70
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -298,25 +304,28 @@ Date: REGEX(.*)
     "A": {
         "metadata": {},
         "type": "Object",
-        "value": true
+        "value": {
+            "X": 1,
+            "Y": 2
+        }
     },
     "id": "E",
     "type": "T"
 }
 
 
-09. Update A with $set: null
-============================
+09. Update A with $unset: null
+==============================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-10. Get entity, see E-A=null
-============================
+10. Get entity, see E-A={X:1, Y:2}
+==================================
 HTTP/1.1 200 OK
-Content-Length: 70
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -325,25 +334,28 @@ Date: REGEX(.*)
     "A": {
         "metadata": {},
         "type": "Object",
-        "value": null
+        "value": {
+            "X": 1,
+            "Y": 2
+        }
     },
     "id": "E",
     "type": "T"
 }
 
 
-11. Update A with $set: <array>
-===============================
+11. Update A with $unset: <array>
+=================================
 HTTP/1.1 204 No Content
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 
 
-12. Get entity, see E-A=<array>
-===============================
+12. Get entity, see E-A={X:1, Y:2}
+==================================
 HTTP/1.1 200 OK
-Content-Length: 108
+Content-Length: 79
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -352,31 +364,21 @@ Date: REGEX(.*)
     "A": {
         "metadata": {},
         "type": "Object",
-        "value": [
-            "22",
-            {
-                "x": [
-                    "x1",
-                    "x2"
-                ],
-                "y": 3
-            },
-            [
-                "z1",
-                "z2"
-            ]
-        ]
+        "value": {
+            "X": 1,
+            "Y": 2
+        }
     },
     "id": "E",
     "type": "T"
 }
 
 
-13. Dump accumulator, see 6 notifications E-A-X being a string, number, boolean, null, array and object
-=======================================================================================================
+13. Dump accumulator, see 5 notifications all them with original entity
+=======================================================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 126
+Content-Length: 134
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -390,7 +392,10 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
             "A": {
                 "metadata": {},
                 "type": "Object",
-                "value": "foo"
+                "value": {
+                    "X": 1,
+                    "Y": 2
+                }
             },
             "id": "E",
             "type": "T"
@@ -401,7 +406,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
 =======================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 123
+Content-Length: 134
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -415,7 +420,10 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
             "A": {
                 "metadata": {},
                 "type": "Object",
-                "value": 10
+                "value": {
+                    "X": 1,
+                    "Y": 2
+                }
             },
             "id": "E",
             "type": "T"
@@ -426,7 +434,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
 =======================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 125
+Content-Length: 134
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -440,7 +448,10 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
             "A": {
                 "metadata": {},
                 "type": "Object",
-                "value": true
+                "value": {
+                    "X": 1,
+                    "Y": 2
+                }
             },
             "id": "E",
             "type": "T"
@@ -451,7 +462,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
 =======================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 125
+Content-Length: 134
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -465,7 +476,10 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
             "A": {
                 "metadata": {},
                 "type": "Object",
-                "value": null
+                "value": {
+                    "X": 1,
+                    "Y": 2
+                }
             },
             "id": "E",
             "type": "T"
@@ -476,7 +490,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
 =======================================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 163
+Content-Length: 134
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -490,20 +504,10 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
             "A": {
                 "metadata": {},
                 "type": "Object",
-                "value": [
-                    "22",
-                    {
-                        "x": [
-                            "x1",
-                            "x2"
-                        ],
-                        "y": 3
-                    },
-                    [
-                        "z1",
-                        "z2"
-                    ]
-                ]
+                "value": {
+                    "X": 1,
+                    "Y": 2
+                }
             },
             "id": "E",
             "type": "T"


### PR DESCRIPTION
somehow continues #3814 with new operator `$set`

- [x] $unset
- [x] testing with arrays (what we want to do here?) -> _as regular update_
- [x] test all possible types
    * `{A: {value: {$set: {X: "foo"}}}}`
    * `{A: {value: {$set: {X: 1}}}}`
    * `{A: {value: {$set: {X: true}}}}`
    * `{A: {value: {$set: {X: null}}}}`
    * `{A: {value: {$set: {X: {object}}}}}`
    * `{A: {value: {$set: {X: [array]}}}}`
- [x] more testing situations. They should be equivalent to regular update
    * `{A: {value: {$set: "foo"}}}`
    * `{A: {value: {$set: 1}}}`
    * `{A: {value: {$set: true}}}`
    * `{A: {value: {$set: null}}}`
    * ~`{A: {value: {$set: <object>}}}`~ not really, this is not a regular update
    * `{A: {value: {$set: <array>}}}`
- [x] documentation
- [x] CNR
- [x] .test to cover $set and $unset at the same time + related documentation fixes
- [x] `$set: {X: 1}` usage on non existing attribute should create attribute with object value `{X: 1}` (test+ doc)
- [x] `$set: {X: 1}` usage on existing attribute but not an object (eg. string)... what would happen? (test + doc)