### PR TITLE
FIX add subId/regId in "response NOT OK" WARN log traces

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -8,6 +8,7 @@
 - Fix: crash when updating attribute with empty JSON object or array (#3995)
 - Fix: csubs cache logic has to ignore fiware-sevice information if -multiservice is not used
 - Fix: subscription throttling was not working with value 1 second
+- Fix: add subId/regId in "response NOT OK" WARN log traces (#4013)
 - Remove: status "failed" in subscriptions (use failsCounter greater than 0 instead)
 - Hardening: refactor PATCH /v2/subscriptions/{subId} logic avoiding over-quering MongoDB and possible (although very rare) crash situations during csub cache (#3701)
 - Upgrade Dockerfile base image from centos8.3.2011 to centos8.4.2105

--- a/doc/manuals.jp/admin/logs.md
+++ b/doc/manuals.jp/admin/logs.md
@@ -289,21 +289,21 @@ time=2020-10-26T14:48:37.192Z | lvl=INFO | corr=54393a44-179a-11eb-bb87-000c29df
 400 での通知エンドポイントのレスポンス (WARN トレースがプリントされます) :
 
 ```
-time=2020-10-26T14:49:34.619Z | lvl=WARN | corr=7689f6ba-179a-11eb-ac4c-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000009 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification response NOT OK, http code: 400
+time=2020-10-26T14:49:34.619Z | lvl=WARN | corr=7689f6ba-179a-11eb-ac4c-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000009 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification (subId: 5f96e1fdb14e7532482ac795) response NOT OK, http code: 400
 time=2020-10-26T14:49:34.619Z | lvl=INFO | corr=7689f6ba-179a-11eb-ac4c-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000009 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=logTracing.cpp[63]:logInfoHttpNotification | msg=Notif delivered (subId: 5f96e1fdb14e7532482ac795): POST localhost:1028/giveme400, response code: 400
 ```
 
 404 での通知エンドポイントのレスポンス (WARN トレースがプリントされます) :
 
 ```
-time=2020-10-26T14:51:40.764Z | lvl=WARN | corr=c1b8e9c0-179a-11eb-9edc-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000012 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification response NOT OK, http code: 404
+time=2020-10-26T14:51:40.764Z | lvl=WARN | corr=c1b8e9c0-179a-11eb-9edc-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000012 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification (subId: 5f96e27cb14e7532482ac796) response NOT OK, http code: 404
 time=2020-10-26T14:51:40.764Z | lvl=INFO | corr=c1b8e9c0-179a-11eb-9edc-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000012 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=logTracing.cpp[63]:logInfoHttpNotification | msg=Notif delivered (subId: 5f96e27cb14e7532482ac796): POST localhost:1028/giveme404, response code: 404
 ```
 
 500 での通知エンドポイントのレスポンス (WARN トレースがプリントされます) :
 
 ```
-time=2020-10-26T14:53:04.246Z | lvl=WARN | corr=f37b5024-179a-11eb-9ce6-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000015 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification response NOT OK, http code: 500
+time=2020-10-26T14:53:04.246Z | lvl=WARN | corr=f37b5024-179a-11eb-9ce6-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000015 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification (subId: 5f96e2cfb14e7532482ac797) response NOT OK, http code: 500
 time=2020-10-26T14:53:04.247Z | lvl=INFO | corr=f37b5024-179a-11eb-9ce6-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000015 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=logTracing.cpp[63]:logInfoHttpNotification | msg=Notif delivered (subId: 5f96e2cfb14e7532482ac797): POST localhost:1028/giveme500, response code: 500
 ```
 

--- a/doc/manuals/admin/logs.md
+++ b/doc/manuals/admin/logs.md
@@ -350,21 +350,21 @@ time=2020-10-26T14:48:37.192Z | lvl=INFO | corr=54393a44-179a-11eb-bb87-000c29df
 Notification endpoint response with 400 (a WARN trace is printed):
 
 ```
-time=2020-10-26T14:49:34.619Z | lvl=WARN | corr=7689f6ba-179a-11eb-ac4c-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000009 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification response NOT OK, http code: 400
+time=2020-10-26T14:49:34.619Z | lvl=WARN | corr=7689f6ba-179a-11eb-ac4c-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000009 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification (subId: 5f96e1fdb14e7532482ac795) response NOT OK, http code: 400
 time=2020-10-26T14:49:34.619Z | lvl=INFO | corr=7689f6ba-179a-11eb-ac4c-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000009 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=logTracing.cpp[63]:logInfoHttpNotification | msg=Notif delivered (subId: 5f96e1fdb14e7532482ac795): POST localhost:1028/giveme400, response code: 400
 ```
 
 Notification endpoint response with 404 (a WARN trace is printed):
 
 ```
-time=2020-10-26T14:51:40.764Z | lvl=WARN | corr=c1b8e9c0-179a-11eb-9edc-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000012 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification response NOT OK, http code: 404
+time=2020-10-26T14:51:40.764Z | lvl=WARN | corr=c1b8e9c0-179a-11eb-9edc-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000012 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification (subId: 5f96e27cb14e7532482ac796) response NOT OK, http code: 404
 time=2020-10-26T14:51:40.764Z | lvl=INFO | corr=c1b8e9c0-179a-11eb-9edc-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000012 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=logTracing.cpp[63]:logInfoHttpNotification | msg=Notif delivered (subId: 5f96e27cb14e7532482ac796): POST localhost:1028/giveme404, response code: 404
 ```
 
 Notification endpoint response with 500 (a WARN trace is printed)
 
 ```
-time=2020-10-26T14:53:04.246Z | lvl=WARN | corr=f37b5024-179a-11eb-9ce6-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000015 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification response NOT OK, http code: 500
+time=2020-10-26T14:53:04.246Z | lvl=WARN | corr=f37b5024-179a-11eb-9ce6-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000015 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification (subId: 5f96e2cfb14e7532482ac797) response NOT OK, http code: 500
 time=2020-10-26T14:53:04.247Z | lvl=INFO | corr=f37b5024-179a-11eb-9ce6-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000015 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=logTracing.cpp[63]:logInfoHttpNotification | msg=Notif delivered (subId: 5f96e2cfb14e7532482ac797): POST localhost:1028/giveme500, response code: 500
 ```
 

--- a/src/lib/ngsiNotify/doNotify.cpp
+++ b/src/lib/ngsiNotify/doNotify.cpp
@@ -64,6 +64,7 @@ static void doNotifyHttp(SenderThreadParams* params, CURL* curl, SyncQOverflow<s
   url = endpoint + params->resource;
 
   int r =  httpRequestSend(curl,
+                       "subId: " + params->subscriptionId,
                        params->from,
                        params->ip,
                        params->port,

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -240,6 +240,7 @@ static int contentLenParse(char* s)
 int httpRequestSend
 (
    CURL*                                      _curl,
+   const std::string&                         idStringForLogs,
    const std::string&                         from,
    const std::string&                         _ip,
    unsigned short                             port,
@@ -644,11 +645,11 @@ int httpRequestSend
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, statusCodeP);
     if ((*statusCodeP < 300) && (*statusCodeP > 199))
     {
-      LM_T(LmtOldInfo, ("Notification response OK, http code: %d", *statusCodeP));
+      LM_T(LmtOldInfo, ("Notification (%s) response OK, http code: %d", idStringForLogs.c_str(), *statusCodeP));
     }
     else
     {
-      LM_W(("Notification response NOT OK, http code: %d", *statusCodeP));
+      LM_W(("Notification (%s) response NOT OK, http code: %d", idStringForLogs.c_str(), *statusCodeP));
     }
   }
 

--- a/src/lib/rest/httpRequestSend.h
+++ b/src/lib/rest/httpRequestSend.h
@@ -50,6 +50,7 @@ extern void httpRequestInit(long defaultTimeoutInMilliseconds);
 extern int httpRequestSend
 (
   CURL*                                      curl,
+  const std::string&                         idStringForLogs,
   const std::string&                         from,
   const std::string&                         ip,
   unsigned short                             port,

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -271,6 +271,7 @@ static bool queryForward
   url = ip + ":" + portV + resource;
 
   r = httpRequestSend(NULL,
+                      "regId: " + regId,
                       fromIp,  // thread variable
                       ip,
                       port,

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -209,6 +209,7 @@ static bool updateForward
   url = ip + ":" + portV + resource;
 
   r = httpRequestSend(NULL,
+                      "regId: " + regId,
                       fromIp,   // thread variable
                       ip,
                       port,


### PR DESCRIPTION
Issue https://github.com/telefonicaid/fiware-orion/issues/4013

CC: @Anjali-NEC just in case you'd be interested in how the issue has been solved