### PR TITLE
Amend text related to StackOverflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,12 @@ contact_links:
     about: check the documentation before asking help or reporting a bug.
   - name: Community Support
     url: https://stackoverflow.com/questions/ask?tags=fiware-orion+fiware
-    about: If you have actually a question about functionality rather than a bug report or feature request, please consider to ask using StackOverflow using the tag fiware-orion instead of opening an issue in the Orion repository.
+    about: |
+      Volunteers from the Open Source FIWARE community monitor the 𝚏𝚒𝚠𝚊𝚛𝚎 tag
+      and related tags over on Stack Overflow. For 𝗱𝗲𝘃𝗲𝗹𝗼𝗽𝗺𝗲𝗻𝘁 𝗾𝘂𝗲𝘀𝘁𝗶𝗼𝗻𝘀 𝗼𝗻𝗹𝘆 you can ask questions
+      over on Stack Overflow provided you follow their rules and guidance on posting and respond to any feedback given.
+      
+      Stack Overflow is a crowd-sourced question and answer website for professional and enthusiast programmers. It is not affliated with this
+      software and 𝗱𝗼𝗲𝘀 𝗻𝗼𝘁 𝗮𝗻𝘀𝘄𝗲𝗿 𝗰𝘂𝘀𝘁𝗼𝗺𝗲𝗿 𝘀𝗲𝗿𝘃𝗶𝗰𝗲 𝗿𝗲𝗹𝗮𝘁𝗲𝗱 𝗾𝘂𝗲𝘀𝘁𝗶𝗼𝗻𝘀.
+      
+      Do not raise a Stack Overflow question for a bug reports or feature requests, stick with opening an issue directly within this repository.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,4 +13,4 @@ contact_links:
       Stack Overflow is a crowd-sourced question and answer website for professional and enthusiast programmers. It is not affliated with this
       software and 𝗱𝗼𝗲𝘀 𝗻𝗼𝘁 𝗮𝗻𝘀𝘄𝗲𝗿 𝗰𝘂𝘀𝘁𝗼𝗺𝗲𝗿 𝘀𝗲𝗿𝘃𝗶𝗰𝗲 𝗿𝗲𝗹𝗮𝘁𝗲𝗱 𝗾𝘂𝗲𝘀𝘁𝗶𝗼𝗻𝘀.
       
-      Do not raise a Stack Overflow question for a bug reports or feature requests, stick with opening an issue directly within this repository.
+      Do not raise a Stack Overflow question for bug reports or feature requests, stick with opening an issue directly within this repository.


### PR DESCRIPTION
Clarify the relationship between Stack Overflow and the GitHub Issues repo with some formatted boilerplate text.

-  It is only volunteers who monitor the [![Support badge](https://img.shields.io/badge/tag-fiware-orange.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/fiware)
-  It is  for **development questions only** <br>see `https://stackoverflow.com/help/how-to-ask`
- Stack Overflow is a (third-party) crowd-sourced question and answer website for professional and enthusiast programmers.
-  It is not affliated with this  software directly
- It does not answer **customer service related questions** <br>see `https://meta.stackoverflow.com/questions/255745/why-cant-i-ask-customer-service-related-questions`