### PR TITLE
Hardening/mark potentially obsolete rpm related stuff

### DIFF
--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -7,5 +7,5 @@ docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion f
 for file in "$(pwd)/rpm/RPMS/x86_64/*"
 do
   echo "Processing $file file..."
-  curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/$file https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/$file
+  curl -v -f -u telefonica-github:$1 --upload-file $(pwd)/rpm/RPMS/x86_64/$file https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/$file
 done

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -2,11 +2,14 @@
 
 set -e
 
-docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
+secret=$1
+type=$2
+
+docker run -e BROKER_RELEASE=$type -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
 
 for file in "$(pwd)/rpm/RPMS/x86_64"/*
 do
   filename=$(basename $file)
-  echo "Processing $filename file..."
-  curl -v -f -u telefonica-github:$1 --upload-file $file https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/$filename
+  echo "Uploading $filename"
+  curl -v -f -u telefonica-github:$secret --upload-file $file https://nexus.lab.fiware.org/repository/el/8/x86_64/$type/$filename
 done

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -6,7 +6,7 @@ docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion f
 
 for file in "$(pwd)/rpm/RPMS/x86_64"/*
 do
-  filename=$(basename file)
+  filename=$(basename $file)
   echo "Processing $filename file..."
   curl -v -f -u telefonica-github:$1 --upload-file $file https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/$filename
 done

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
+
+file_list=$(ls $(pwd)/rpm/RPMS/x86_64/)
+
+for(String file : FILES_LIST.split("\\r?\\n")){
+  curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/${file} https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/${file}
+}

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -4,8 +4,8 @@ set -e
 
 docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
 
-file_list=$(ls $(pwd)/rpm/RPMS/x86_64/)
-
-for(String file : file_list.split("\\r?\\n")){
-  curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/${file} https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/${file}
-}
+for file in "$(pwd)/rpm/RPMS/x86_64/*"
+do
+  echo "Processing $file file..."
+  curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/$file https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/$file
+done

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -6,6 +6,6 @@ docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion f
 
 file_list=$(ls $(pwd)/rpm/RPMS/x86_64/)
 
-for(String file : FILES_LIST.split("\\r?\\n")){
+for(String file : file_list.split("\\r?\\n")){
   curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/${file} https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/${file}
 }

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -6,6 +6,7 @@ docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion f
 
 for file in "$(pwd)/rpm/RPMS/x86_64"/*
 do
-  echo "Processing $file file..."
-  curl -v -f -u telefonica-github:$1 --upload-file $(pwd)/rpm/RPMS/x86_64/$file https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/$file
+  filename=$(basename file)
+  echo "Processing $filename file..."
+  curl -v -f -u telefonica-github:$1 --upload-file $file https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/$filename
 done

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -4,7 +4,7 @@ set -e
 
 docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
 
-for file in "$(pwd)/rpm/RPMS/x86_64/*"
+for file in "$(pwd)/rpm/RPMS/x86_64"/*
 do
   echo "Processing $file file..."
   curl -v -f -u telefonica-github:$1 --upload-file $(pwd)/rpm/RPMS/x86_64/$file https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/$file

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -23,8 +23,5 @@ jobs:
       - name: Build & Push
         id: rpm_build
         run: |
-          docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
-          file_list=$(ls $(pwd)/rpm/RPMS/x86_64/)
-          for(String file : FILES_LIST.split("\\r?\\n")){ 
-            curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/${file} https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/${file}
-          }
+          ./.github/build-and-push-rpm.sh
+          

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -25,5 +25,6 @@ jobs:
         run: |
           docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
           version=$(cat /src/app/contextBroker/version.h | grep ORION_VERSION | awk '{ print $3}' | sed 's/"//g')
+          echo ${version}
           curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/contextBroker-${version}-nightly.x86_64.rpm https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/contextBroker-${version}-nightly.x86_64.rpm
 

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -1,14 +1,18 @@
 name: Publish rpm from master
 
 on:
+  schedule:
+    # every night at one
+    - cron: '0 1 * * *'
   push:
+    branches:
+      - master
 
-# will produce tags in format fiware/orion:<SEMVER>-PRE-<INCREASING-NUMBER>, f.e. fiware/orion:2.6.0-PRE-12
 env:
   CI_IMAGE: fiware/orion-ci:rpm8
 
 jobs:
-  build-rpm:
+  build-rpm-release:
 
     runs-on: ubuntu-18.04
     if: github.event_name == 'push'
@@ -23,5 +27,21 @@ jobs:
       - name: Build & Push
         id: rpm_build
         run: |
-          ./.github/build-and-push-rpm.sh ${{ secrets.NEXUS_PASSWORD }} 
-          
+          ./.github/build-and-push-rpm.sh ${{ secrets.NEXUS_PASSWORD }} release
+
+  build-rpm-nightly:
+
+    runs-on: ubuntu-18.04
+    if: github.event_name == 'schedule'
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build & Push
+        id: rpm_build
+        run: |
+          ./.github/build-and-push-rpm.sh ${{ secrets.NEXUS_PASSWORD }} nightly

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -2,8 +2,6 @@ name: Publish rpm from master
 
 on:
   push:
-    branches:
-      - master
 
 # will produce tags in format fiware/orion:<SEMVER>-PRE-<INCREASING-NUMBER>, f.e. fiware/orion:2.6.0-PRE-12
 env:

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Build & Push
         id: rpm_build
         run: |
-          ./.github/build-and-push-rpm.sh
+          ./.github/build-and-push-rpm.sh ${{ secrets.NEXUS_PASSWORD }} 
           

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -1,0 +1,46 @@
+name: Publish pre Image from master
+
+on:
+  push:
+    branches:
+      - master
+
+# will produce tags in format fiware/orion:<SEMVER>-PRE-<INCREASING-NUMBER>, f.e. fiware/orion:2.6.0-PRE-12
+env:
+  CI_IMAGE: fiware/orion-ci:rpm8
+
+jobs:
+  build-rpm:
+
+    runs-on: ubuntu-18.04
+    if: github.event_name == 'push'
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build
+        id: rpm_build
+        run: |
+          docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
+
+      - name: Get version
+        id: get_version
+        run: |
+          version=$(cat /src/app/contextBroker/version.h | grep ORION_VERSION | awk '{ print $3}' | sed 's/"//g')
+          echo "::set-output name=version::${version}"
+
+      - name: Push
+        id: push
+        uses: sonatype-nexus-community/nexus-repo-github-action@master
+          with:
+            serverUrl: https://nexus.lab.fiware.org
+            username: admin
+            password: ${{ secrets.password }}
+            format: rpm
+            repository: repository/el/8/x86_64/nightly
+            filename: ./rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm
+

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -5,8 +5,8 @@ on:
     # every night at one
     - cron: '0 1 * * *'
   push:
-    branches:
-      - master
+    tags:
+      - '*.*.*'
 
 env:
   CI_IMAGE: fiware/orion-ci:rpm8

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -39,6 +39,7 @@ jobs:
           username: telefonica-github
           password: ${{ secrets.NEXUS_PASSWORD }}
           format: rpm
+          assets: extension=rpm
           coordinates: directory=8/x86_64/nightly
           repository: el
           filename: ./rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -38,8 +38,8 @@ jobs:
         uses: sonatype-nexus-community/nexus-repo-github-action@master
           with:
             serverUrl: https://nexus.lab.fiware.org
-            username: admin
-            password: ${{ secrets.password }}
+            username: telefonica-github
+            password: ${{ secret.NEXUS_PASSWORD }}
             format: rpm
             repository: repository/el/8/x86_64/nightly
             filename: ./rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -24,7 +24,7 @@ jobs:
         id: rpm_build
         run: |
           docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
-          version=$(cat /src/app/contextBroker/version.h | grep ORION_VERSION | awk '{ print $3}' | sed 's/"//g')
+          version=$(cat $(pwd)/src/app/contextBroker/version.h | grep ORION_VERSION | awk '{ print $3}' | sed 's/"//g')
           echo ${version}
           curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/contextBroker-${version}-nightly.x86_64.rpm https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/contextBroker-${version}-nightly.x86_64.rpm
 

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -24,23 +24,6 @@ jobs:
         id: rpm_build
         run: |
           docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
-
-      - name: Get version
-        id: get_version
-        run: |
           version=$(cat /src/app/contextBroker/version.h | grep ORION_VERSION | awk '{ print $3}' | sed 's/"//g')
-          echo "::set-output name=version::${version}"
-
-      - name: Push
-        id: push
-        uses: sonatype-nexus-community/nexus-repo-github-action@master
-        with:
-          serverUrl: https://nexus.lab.fiware.org
-          username: telefonica-github
-          password: ${{ secrets.NEXUS_PASSWORD }}
-          format: rpm
-          assets: extension=rpm
-          coordinates: directory=8/x86_64/nightly
-          repository: el
-          filename: ./rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm
+          curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm
 

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -25,5 +25,5 @@ jobs:
         run: |
           docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
           version=$(cat /src/app/contextBroker/version.h | grep ORION_VERSION | awk '{ print $3}' | sed 's/"//g')
-          curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm
+          curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/contextBroker-${version}-nightly.x86_64.rpm https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/contextBroker-${version}-nightly.x86_64.rpm
 

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -1,4 +1,4 @@
-name: Publish pre Image from master
+name: Publish rpm from master
 
 on:
   push:

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           serverUrl: https://nexus.lab.fiware.org
           username: telefonica-github
-          password: ${{ secret.NEXUS_PASSWORD }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
           format: rpm
           repository: repository/el/8/x86_64/nightly
           filename: ./rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -24,7 +24,7 @@ jobs:
         id: rpm_build
         run: |
           docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
-          version=$(cat $(pwd)/src/app/contextBroker/version.h | grep ORION_VERSION | awk '{ print $3}' | sed 's/"//g')
-          echo ${version}
-          curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/contextBroker-${version}-nightly.x86_64.rpm https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/contextBroker-${version}-nightly.x86_64.rpm
-
+          file_list=$(ls $(pwd)/rpm/RPMS/x86_64/)
+          for(String file : FILES_LIST.split("\\r?\\n")){ 
+            curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/${file} https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/${file}
+          }

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Push
         id: push
         uses: sonatype-nexus-community/nexus-repo-github-action@master
-          with:
-            serverUrl: https://nexus.lab.fiware.org
-            username: telefonica-github
-            password: ${{ secret.NEXUS_PASSWORD }}
-            format: rpm
-            repository: repository/el/8/x86_64/nightly
-            filename: ./rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm
+        with:
+          serverUrl: https://nexus.lab.fiware.org
+          username: telefonica-github
+          password: ${{ secret.NEXUS_PASSWORD }}
+          format: rpm
+          repository: repository/el/8/x86_64/nightly
+          filename: ./rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm
 

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -39,6 +39,7 @@ jobs:
           username: telefonica-github
           password: ${{ secrets.NEXUS_PASSWORD }}
           format: rpm
-          repository: repository/el/8/x86_64/nightly
+          coordinates: directory=8/x86_64/nightly
+          repository: el
           filename: ./rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm
 

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 1 * * *'
   push:
     tags:
-      - '*.*.*'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
   CI_IMAGE: fiware/orion-ci:rpm8

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
-      - name: Build
+      - name: Build & Push
         id: rpm_build
         run: |
           docker run -e BROKER_RELEASE=nightly -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
           version=$(cat /src/app/contextBroker/version.h | grep ORION_VERSION | awk '{ print $3}' | sed 's/"//g')
-          curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm
+          curl -v -f -u telefonica-github:${{ secrets.NEXUS_PASSWORD }} --upload-file $(pwd)/rpm/RPMS/x86_64/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm https://nexus.lab.fiware.org/repository/el/8/x86_64/nightly/contextBroker-${{ steps.get_version.outputs.version }}-nightly.x86_64.rpm
 


### PR DESCRIPTION
Adds a ci-step to produce the rpm's and push them. 

I would like to add this step into the ci-pipeline, so that we can remove it from our jenkins(where we have a lot of issues with it, due to the jenkins itself). 
 @fgalan Can I send you the secret used in this pipeline per mail? 
