### PR TITLE
FIX $each usage with $push operator to add several items to array

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Fix: $each usage with $push operator to add several items to array (#744)
 - Fix: allow HTTPS certificates larger than 2048 bytes (#4012)

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -3071,13 +3071,13 @@ static bool calculateOperator(ContextElementResponse* cerP, const std::string& o
         else if (child0->valueType == orion::ValueTypeVector)
         {
           orion::BSONArrayBuilder ba;
-          compoundValueBson(child0->childV, ba);
+          compoundValueBson(child0->childV, ba, false, false);
           b->append(valueKey, ba.arr());
         }
         else if (child0->valueType == orion::ValueTypeObject)
         {
           orion::BSONObjBuilder bo;
-          compoundValueBson(child0->childV, bo);
+          compoundValueBson(child0->childV, bo, false, false);
           b->append(valueKey, bo.obj());
         }
         else if (child0->valueType == orion::ValueTypeNotGiven)
@@ -3179,13 +3179,13 @@ static bool calculateSetOperator(ContextElementResponse* cerP, orion::BSONObjBui
         else if (child->valueType == orion::ValueTypeVector)
         {
           orion::BSONArrayBuilder ba;
-          compoundValueBson(child->childV, ba);
+          compoundValueBson(child->childV, ba, false, false);
           b->append(valueKey, ba.arr());
         }
         else if (child->valueType == orion::ValueTypeObject)
         {
           orion::BSONObjBuilder bo;
-          compoundValueBson(child->childV, bo);
+          compoundValueBson(child->childV, bo, false, false);
           b->append(valueKey, bo.obj());
         }
         else if (child->valueType == orion::ValueTypeNotGiven)

--- a/src/lib/mongoBackend/compoundValueBson.cpp
+++ b/src/lib/mongoBackend/compoundValueBson.cpp
@@ -42,8 +42,10 @@
 * strings2numbers is used only for the GEO_JSON generation logic to ensure NGSIv1
 * strings are converted to numbers (strings are not allowed in GeoJSON)
 *
+* encode set to true only in the calculateOperator functions, eg. to avoid that
+* "$each" get replaced by ">each" (see https://github.com/telefonicaid/fiware-orion/issues/744#issuecomment-996752938)
 */
-void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, orion::BSONArrayBuilder& b, bool strings2numbers)
+void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, orion::BSONArrayBuilder& b, bool strings2numbers, bool encode)
 {
   for (unsigned int ix = 0; ix < children.size(); ++ix)
   {
@@ -77,14 +79,14 @@ void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, o
     {
       orion::BSONArrayBuilder ba;
 
-      compoundValueBson(child->childV, ba, strings2numbers);
+      compoundValueBson(child->childV, ba, strings2numbers, encode);
       b.append(ba.arr());
     }
     else if (child->valueType == orion::ValueTypeObject)
     {
       orion::BSONObjBuilder bo;
 
-      compoundValueBson(child->childV, bo, strings2numbers);
+      compoundValueBson(child->childV, bo, strings2numbers, encode);
       b.append(bo.obj());
     }
     else if (child->valueType == orion::ValueTypeNotGiven)
@@ -106,13 +108,16 @@ void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, o
 *
 * strings2numbers is used only for the GEO_JSON generation logic to ensure NGSIv1
 * strings are converted to numbers (strings are not allowed in GeoJSON)
+*
+* encode set to true only in the calculateOperator functions, eg. to avoid that
+* "$each" get replaced by ">each" (see https://github.com/telefonicaid/fiware-orion/issues/744#issuecomment-996752938)
 */
-void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, orion::BSONObjBuilder& b, bool strings2numbers)
+void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, orion::BSONObjBuilder& b, bool strings2numbers, bool encode)
 {
   for (unsigned int ix = 0; ix < children.size(); ++ix)
   {
     orion::CompoundValueNode*  child         = children[ix];
-    std::string                effectiveName = dbEncode(child->name);
+    std::string                effectiveName = encode? dbEncode(child->name) : child->name;
 
     if (child->valueType == orion::ValueTypeString)
     {
@@ -142,14 +147,14 @@ void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, o
     {
       orion::BSONArrayBuilder ba;
 
-      compoundValueBson(child->childV, ba, strings2numbers);
+      compoundValueBson(child->childV, ba, strings2numbers, encode);
       b.append(effectiveName, ba.arr());
     }
     else if (child->valueType == orion::ValueTypeObject)
     {
       orion::BSONObjBuilder bo;
 
-      compoundValueBson(child->childV, bo, strings2numbers);
+      compoundValueBson(child->childV, bo, strings2numbers, encode);
       b.append(effectiveName, bo.obj());
     }
     else if (child->valueType == orion::ValueTypeNotGiven)

--- a/src/lib/mongoBackend/compoundValueBson.h
+++ b/src/lib/mongoBackend/compoundValueBson.h
@@ -37,7 +37,7 @@
 *
 * compoundValueBson (for objects) -
 */
-extern void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, orion::BSONObjBuilder& b, bool strings2numbers = false);
+extern void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, orion::BSONObjBuilder& b, bool strings2numbers = false, bool encode = true);
 
 
 
@@ -45,6 +45,6 @@ extern void compoundValueBson(const std::vector<orion::CompoundValueNode*>& chil
 *
 * compoundValueBson (for arrays) -
 */
-extern void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, orion::BSONArrayBuilder& b, bool strings2numbers = false);
+extern void compoundValueBson(const std::vector<orion::CompoundValueNode*>& children, orion::BSONArrayBuilder& b, bool strings2numbers = false, bool encode = true);
 
 #endif  // SRC_LIB_MONGOBACKEND_COMPOUNDVALUEBSON_H_

--- a/test/functionalTest/cases/0744_push_several_items_to_array/push_several_items_to_array.test
+++ b/test/functionalTest/cases/0744_push_several_items_to_array/push_several_items_to_array.test
@@ -1,0 +1,196 @@
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute update operator: push with each
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity E with A=[1]
+# 02. Create sub for entity E
+# 03. Update A with $push: $each: [2, 3, 4]
+# 04. Get entity, see E-A=[1,2,3,4]
+# 05. Dump accumulator, see E-A=[1,2,3,4]
+#
+
+
+echo '01. Create entity E with A=[1]'
+echo '=============================='
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": [ 1 ],
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo '02. Create sub for entity E'
+echo '==========================='
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id": "E",
+        "type": "T"
+      }
+    ]
+   },
+  "notification": {
+    "http": {
+      "url": "http://localhost:'$LISTENER_PORT'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo '03. Update A with $push: $each: [2, 3, 4]'
+echo '========================================='
+payload='{
+  "A": {
+    "value": { "$push": { "$each": [2, 3, 4]} },
+    "type": "StructuredValue"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo '04. Get entity, see E-A=[1,2,3,4]'
+echo '================================='
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo '05. Dump accumulator, see E-A=[1,2,3,4]'
+echo '======================================='
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E with A=[1]
+==============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create sub for entity E
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update A with $push: $each: [2, 3, 4]
+=========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Get entity, see E-A=[1,2,3,4]
+=================================
+HTTP/1.1 200 OK
+Content-Length: 84
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A": {
+        "metadata": {},
+        "type": "StructuredValue",
+        "value": [
+            1,
+            2,
+            3,
+            4
+        ]
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+05. Dump accumulator, see E-A=[1,2,3,4]
+=======================================
+POST http://localhost:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 139
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: localhost:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "StructuredValue",
+                "value": [
+                    1,
+                    2,
+                    3,
+                    4
+                ]
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f\-]{24})"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop $LISTENER_PORT
+dbDrop CB


### PR DESCRIPTION
A fix for https://github.com/telefonicaid/fiware-orion/issues/744#issuecomment-996752938

Note this PR doesn't include documentation changes. Under my understanding the usage of `$each` (or any other modifier) is already covered by this statement in documentation (https://fiware-orion.readthedocs.io/en/master/user/update_operators/index.html#how-orion-deals-with-operators):

>  Thus, the execution semantics are the ones described in [MongoDB documentation](https://docs.mongodb.com/manual/reference/operator/update/) for the equivalent operands.