### PR TITLE
ADD CPr HTTPS test cases

### DIFF
--- a/test/functionalTest/cases/4041_cprs_https/ngsiv2_query_one_forward_query_https.test
+++ b/test/functionalTest/cases/4041_cprs_https/ngsiv2_query_one_forward_query_https.test
@@ -1,0 +1,200 @@
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+One Forward Query To Context Provider (using HTTPS), query made in NGSIv2
+
+--SHELL-INIT--
+dbInit CB
+dbInit CP1
+brokerStart CB 0 IPV4 -insecureNotif
+
+# Run CP1 using HTTPS
+${SCRIPT_HOME}/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
+export BROKER_AWAIT_SLEEP_TIME=6
+brokerStart CP1 0-255 IPV4 -https -key /tmp/harnessTest.key -cert /tmp/harnessTest.pem
+unset BROKER_AWAIT_SLEEP_TIME
+
+--SHELL--
+
+#
+# 01. Update/APPEND E1/T1/A1 in CP1
+# 02. Register E1/T1/A1 in CB, provApp: HTTPS CP1
+# 03. Query E1/T1/A1 in CB
+# 04. Query E1/T1/A1 in CP1
+#
+
+echo "01. Update/APPEND E1/T1/A1 in CP1"
+echo "================================="
+payload='{
+  "contextElements": [
+    {
+      "type": "T1",
+      "id":   "E1",
+      "attributes": [
+        {
+          "name": "A1",
+          "type": "string",
+          "value": "A1 in CP1"
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --host "https://localhost" --url /v1/updateContext --payload "$payload" --port $CP1_PORT --cacert /tmp/harnessTest.pem
+echo
+echo
+
+
+echo "02. Register E1/T1/A1 in CB, provApp: HTTPS CP1"
+echo "==============================================="
+payload='{
+  "contextRegistrations": [
+  {
+    "entities": [
+      {
+         "type": "T1",
+         "isPattern": "false",
+         "id": "E1"
+      }
+    ],
+    "attributes": [
+      {
+        "name": "A1",
+        "type": "string"
+      }
+    ],
+    "providingApplication": "https://localhost:'${CP1_PORT}'/v1"
+    }
+ ],
+ "duration": "P1M"
+}'
+orionCurl --url /v1/registry/registerContext --payload "$payload"
+echo
+echo
+
+
+echo "03. Query E1/T1/A1 in CB"
+echo "========================"
+orionCurl --url /v2/entities/E1
+echo
+echo
+
+
+echo "04. Query E1/T1/A1 in CP1"
+echo "========================="
+orionCurl --host "https://localhost" --url /v2/entities/E1 --port $CP1_PORT --cacert /tmp/harnessTest.pem
+echo
+echo
+
+
+--REGEXPECT--
+01. Update/APPEND E1/T1/A1 in CP1
+=================================
+HTTP/1.1 200 OK
+Content-Length: 189
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": ""
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+02. Register E1/T1/A1 in CB, provApp: HTTPS CP1
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 62
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "duration": "P1M",
+    "registrationId": "REGEX([0-9a-f]{24})"
+}
+
+
+03. Query E1/T1/A1 in CB
+========================
+HTTP/1.1 200 OK
+Content-Length: 80
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A1": {
+        "metadata": {},
+        "type": "string",
+        "value": "A1 in CP1"
+    },
+    "id": "E1",
+    "type": "T1"
+}
+
+
+04. Query E1/T1/A1 in CP1
+=========================
+HTTP/1.1 200 OK
+Content-Length: 80
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "A1": {
+        "metadata": {},
+        "type": "string",
+        "value": "A1 in CP1"
+    },
+    "id": "E1",
+    "type": "T1"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+brokerStop CP1
+dbDrop CB
+dbDrop CP1

--- a/test/functionalTest/cases/4041_cprs_https/ngsiv2_update_one_forward_https.test
+++ b/test/functionalTest/cases/4041_cprs_https/ngsiv2_update_one_forward_https.test
@@ -1,0 +1,270 @@
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+One Forward Update To Context Provider (using HTTPS)
+
+--SHELL-INIT--
+dbInit CB
+dbInit CP1
+brokerStart CB 0 IPV4 -insecureNotif
+
+# Run CP1 using HTTPS
+${SCRIPT_HOME}/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
+export BROKER_AWAIT_SLEEP_TIME=6
+brokerStart CP1 0-255 IPV4 -https -key /tmp/harnessTest.key -cert /tmp/harnessTest.pem
+unset BROKER_AWAIT_SLEEP_TIME
+
+--SHELL--
+
+#
+# 01. Update/APPEND E1/T1/A1 in CP1
+# 02. Register E1/T1/A1 in CB, provApp: HTTPS CP1
+# 03. Update/UPDATE E1/T1/A1
+# 04. Query E1/T1/A1 in CB
+# 05. Query E1/T1/A1 in CP1
+#
+
+echo "01. Update/APPEND E1/T1/A1 in CP1"
+echo "================================="
+payload='{
+  "contextElements": [
+    {
+      "type": "T1",
+      "id":   "E1",
+      "attributes": [
+        {
+          "name": "A1",
+          "type": "string",
+          "value": "A1 in CP1"
+        }
+      ]
+    }
+  ],
+  "updateAction": "APPEND"
+}'
+orionCurl --host "https://localhost" --url /v1/updateContext --payload "$payload" --port $CP1_PORT --cacert /tmp/harnessTest.pem
+echo
+echo
+
+
+echo "02. Register E1/T1/A1 in CB, provApp: HTTPS CP1"
+echo "==============================================="
+payload='{
+  "contextRegistrations": [
+  {
+    "entities": [
+      {
+         "type": "T1",
+         "isPattern": "false",
+         "id": "E1"
+      }
+    ],
+    "attributes": [
+      {
+        "name": "A1",
+        "type": "string"
+      }
+    ],
+    "providingApplication": "https://localhost:'${CP1_PORT}'/v1"
+    }
+ ],
+ "duration": "P1M"
+}'
+orionCurl --url /v1/registry/registerContext --payload "$payload"
+echo
+echo
+
+
+echo "03. Update/UPDATE E1/T1/A1"
+echo "=========================="
+payload='{
+  "A1": {
+      "type": "string",
+      "value": "A1 via CB"
+  }
+}'
+orionCurl --url /v2/entities/E1/attrs?type=T1 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo "04. Query E1/T1/A1 in CB"
+echo "========================"
+payload='{
+  "entities": [
+    {
+      "id":   "E1",
+      "type": "T1"
+    }
+  ],
+  "attributes": [
+    "A1"
+  ]
+}'
+orionCurl --url /v1/queryContext --payload "$payload"
+echo
+echo
+
+
+echo "05. Query E1/T1/A1 in CP1"
+echo "========================="
+payload='{
+  "entities": [
+    {
+      "id":   "E1",
+      "type": "T1"
+    }
+  ],
+  "attributes": [
+    "A1"
+  ]
+}'
+orionCurl --host "https://localhost" --url /v1/queryContext --port $CP1_PORT --payload "$payload" --cacert /tmp/harnessTest.pem
+echo
+echo
+
+
+--REGEXPECT--
+01. Update/APPEND E1/T1/A1 in CP1
+=================================
+HTTP/1.1 200 OK
+Content-Length: 189
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": ""
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+02. Register E1/T1/A1 in CB, provApp: HTTPS CP1
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 62
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "duration": "P1M",
+    "registrationId": "REGEX([0-9a-f]{24})"
+}
+
+
+03. Update/UPDATE E1/T1/A1
+==========================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Query E1/T1/A1 in CB
+========================
+HTTP/1.1 200 OK
+Content-Length: 198
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "A1 via CB"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+05. Query E1/T1/A1 in CP1
+=========================
+HTTP/1.1 200 OK
+Content-Length: 198
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "A1",
+                        "type": "string",
+                        "value": "A1 via CB"
+                    }
+                ],
+                "id": "E1",
+                "isPattern": "false",
+                "type": "T1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
+}
+
+
+--TEARDOWN--
+brokerStop CB
+brokerStop CP1
+dbDrop CB
+dbDrop CP1


### PR DESCRIPTION
New test cases arisen from issue #4041 

Tests are based in existing ones. The following diff shows the differents:

Query test:

```diff
--- cases/0787_cprs_full_functional_v2/ngsiv2_query_one_forward_query.test	2021-12-16 12:39:08.588628212 +0100
+++ cases/4041_cprs_https/ngsiv2_query_one_forward_query_https.test	2022-01-19 12:09:58.330223096 +0100
@@ -1,4 +1,4 @@
-# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
 #
 # This file is part of Orion Context Broker.
 #
@@ -21,19 +21,24 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-One Forward Query To Context Provider, query made in NGSIv2
+One Forward Query To Context Provider (using HTTPS), query made in NGSIv2
 
 --SHELL-INIT--
 dbInit CB
 dbInit CP1
-brokerStart CB
-brokerStart CP1
+brokerStart CB 0 IPV4 -insecureNotif
+
+# Run CP1 using HTTPS
+${SCRIPT_HOME}/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
+export BROKER_AWAIT_SLEEP_TIME=6
+brokerStart CP1 0-255 IPV4 -https -key /tmp/harnessTest.key -cert /tmp/harnessTest.pem
+unset BROKER_AWAIT_SLEEP_TIME
 
 --SHELL--
 
 #
 # 01. Update/APPEND E1/T1/A1 in CP1
-# 02. Register E1/T1/A1 in CB, provApp: CP1
+# 02. Register E1/T1/A1 in CB, provApp: HTTPS CP1
 # 03. Query E1/T1/A1 in CB
 # 04. Query E1/T1/A1 in CP1
 #
@@ -56,13 +61,13 @@
   ],
   "updateAction": "APPEND"
 }'
-orionCurl --url /v1/updateContext --payload "$payload" --port $CP1_PORT
+orionCurl --host "https://localhost" --url /v1/updateContext --payload "$payload" --port $CP1_PORT --cacert /tmp/harnessTest.pem
 echo
 echo
 
 
-echo "02. Register E1/T1/A1 in CB, provApp: CP1"
-echo "========================================="
+echo "02. Register E1/T1/A1 in CB, provApp: HTTPS CP1"
+echo "==============================================="
 payload='{
   "contextRegistrations": [
   {
@@ -79,7 +84,7 @@
         "type": "string"
       }
     ],
-    "providingApplication": "http://localhost:'${CP1_PORT}'/v1"
+    "providingApplication": "https://localhost:'${CP1_PORT}'/v1"
     }
  ],
  "duration": "P1M"
@@ -98,7 +103,7 @@
 
 echo "04. Query E1/T1/A1 in CP1"
 echo "========================="
-orionCurl --url /v2/entities/E1 --port $CP1_PORT
+orionCurl --host "https://localhost" --url /v2/entities/E1 --port $CP1_PORT --cacert /tmp/harnessTest.pem
 echo
 echo
 
@@ -136,8 +141,8 @@
 }
 
 
-02. Register E1/T1/A1 in CB, provApp: CP1
-=========================================
+02. Register E1/T1/A1 in CB, provApp: HTTPS CP1
+===============================================
 HTTP/1.1 200 OK
 Content-Length: 62
 Content-Type: application/json
```

Update test:

```diff
--- cases/0787_cprs_full_functional_v2/ngsiv2_update_one_forward.test	2021-12-16 12:39:08.592628190 +0100
+++ cases/4041_cprs_https/ngsiv2_update_one_forward_https.test	2022-01-19 12:11:25.310131243 +0100
@@ -1,4 +1,4 @@
-# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
 #
 # This file is part of Orion Context Broker.
 #
@@ -21,19 +21,24 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-One Forward Update To Context Provider
+One Forward Update To Context Provider (using HTTPS)
 
 --SHELL-INIT--
 dbInit CB
 dbInit CP1
-brokerStart CB
-brokerStart CP1
+brokerStart CB 0 IPV4 -insecureNotif
+
+# Run CP1 using HTTPS
+${SCRIPT_HOME}/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
+export BROKER_AWAIT_SLEEP_TIME=6
+brokerStart CP1 0-255 IPV4 -https -key /tmp/harnessTest.key -cert /tmp/harnessTest.pem
+unset BROKER_AWAIT_SLEEP_TIME
 
 --SHELL--
 
 #
 # 01. Update/APPEND E1/T1/A1 in CP1
-# 02. Register E1/T1/A1 in CB, provApp: CP1
+# 02. Register E1/T1/A1 in CB, provApp: HTTPS CP1
 # 03. Update/UPDATE E1/T1/A1
 # 04. Query E1/T1/A1 in CB
 # 05. Query E1/T1/A1 in CP1
@@ -57,13 +62,13 @@
   ],
   "updateAction": "APPEND"
 }'
-orionCurl --url /v1/updateContext --payload "$payload" --port $CP1_PORT
+orionCurl --host "https://localhost" --url /v1/updateContext --payload "$payload" --port $CP1_PORT --cacert /tmp/harnessTest.pem
 echo
 echo
 
 
-echo "02. Register E1/T1/A1 in CB, provApp: CP1"
-echo "========================================="
+echo "02. Register E1/T1/A1 in CB, provApp: HTTPS CP1"
+echo "==============================================="
 payload='{
   "contextRegistrations": [
   {
@@ -80,7 +85,7 @@
         "type": "string"
       }
     ],
-    "providingApplication": "http://localhost:'${CP1_PORT}'/v1"
+    "providingApplication": "https://localhost:'${CP1_PORT}'/v1"
     }
  ],
  "duration": "P1M"
@@ -134,7 +139,7 @@
     "A1"
   ]
 }'
-orionCurl --url /v1/queryContext --port $CP1_PORT --payload "$payload"
+orionCurl --host "https://localhost" --url /v1/queryContext --port $CP1_PORT --payload "$payload" --cacert /tmp/harnessTest.pem
 echo
 echo
 
@@ -172,8 +177,8 @@
 }
 
 
-02. Register E1/T1/A1 in CB, provApp: CP1
-=========================================
+02. Register E1/T1/A1 in CB, provApp: HTTPS CP1
+===============================================
 HTTP/1.1 200 OK
 Content-Length: 62
 Content-Type: application/json
```

As you can see, tests is the seem. The only thing that change is usage of HTTPS in the CPr

CC: @Anjali-NEC 