### PR TITLE
FIX DateTime attribute macro rendering in custom notifications was numeric instead of ISO8601

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 - Fix: avoid duplicated attributes and metadata in arrays in POST /v2/subscriptions and PATCH /v2/subscriptions/{subId} (#2101)
 - Fix: $each usage with $push operator to add several items to array (#744)
 - Fix: allow HTTPS certificates larger than 2048 bytes (#4012)
+- Fix: DateTime attribute macro rendering in custom notifications was numeric instead of ISO8601 (#3894)
 - Fix: buffer overflow problem in logs subsystem for from= field, causing crash in some cases (#3884)

--- a/src/lib/common/macroSubstitute.cpp
+++ b/src/lib/common/macroSubstitute.cpp
@@ -45,13 +45,22 @@ static void attributeValue(std::string* valueP, const std::vector<ContextAttribu
       continue;
     }
 
+    bool isDateType = vec[ix]->type == DATE_TYPE? true : false;
+
     if (vec[ix]->valueType == orion::ValueTypeString)
     {
       *valueP = vec[ix]->stringValue;
     }
     else if (vec[ix]->valueType == orion::ValueTypeNumber)
     {
-      *valueP = double2string(vec[ix]->numberValue);
+      if (isDateType)
+      {
+        *valueP = isodate2str(vec[ix]->numberValue);
+      }
+      else
+      {
+        *valueP = double2string(vec[ix]->numberValue);
+      }
     }
     else if (vec[ix]->valueType == orion::ValueTypeBoolean)
     {

--- a/test/functionalTest/cases/3894_datetime_custom_notif/datetime_custom_notif.test
+++ b/test/functionalTest/cases/3894_datetime_custom_notif/datetime_custom_notif.test
@@ -1,0 +1,169 @@
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Support of DateTime values in custom notifications
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create custom subscription using DateTime attribute DT in every possible place
+# 02. Create entity with DT=2022-01-27T13:16:00Z
+# 03. Update entity with DT=2022-01-28T00:00:00Z
+# 04. Dump accumulator, see 2 notifications with the proper DateTimes
+#
+
+echo "01. Create custom subscription using DateTime attribute DT in every possible place"
+echo "=================================================================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id" : "E",
+        "type": "T"
+      }
+    ]
+  },
+  "notification": {
+    "httpCustom": {
+      "url":     "http://127.0.0.1:'${LISTENER_PORT}'/notify",
+      "payload": "{ %22DT%22: %22${DT}%22 }",
+      "qs":       { "t": "${DT}" },
+      "headers":  {
+        "content-type": "application/json",
+        "x-time": "${DT}"
+      }
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create entity with DT=2022-01-27T13:16:00Z"
+echo "=============================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "DT": {
+    "value": "2022-01-27T13:16:00Z",
+    "type": "DateTime"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. Update entity with DT=2022-01-28T00:00:00Z"
+echo "=============================================="
+payload='{
+  "DT": {
+    "value": "2022-01-28T00:00:00Z",
+    "type": "DateTime"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo "04. Dump accumulator, see 2 notifications with the proper DateTimes"
+echo "==================================================================="
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create custom subscription using DateTime attribute DT in every possible place
+==================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create entity with DT=2022-01-27T13:16:00Z
+==============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update entity with DT=2022-01-28T00:00:00Z
+==============================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Dump accumulator, see 2 notifications with the proper DateTimes
+===================================================================
+POST http://127.0.0.1:REGEX(\d+)/notify?t=2022-01-27T13:16:00.000Z
+Fiware-Servicepath: /
+Content-Length: 36
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+X-Time: 2022-01-27T13:16:00.000Z
+Ngsiv2-Attrsformat: custom
+Host: 127.0.0.1:9997
+Accept: application/json
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "DT": "2022-01-27T13:16:00.000Z"
+}
+=======================================
+POST http://127.0.0.1:REGEX(\d+)/notify?t=2022-01-28T00:00:00.000Z
+Fiware-Servicepath: /
+Content-Length: 36
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+X-Time: 2022-01-28T00:00:00.000Z
+Ngsiv2-Attrsformat: custom
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "DT": "2022-01-28T00:00:00.000Z"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+accumulatorStop


### PR DESCRIPTION
Fix for issue #3894

CC: @Anjali-NEC (for learnability purposes, in the case you want to know of this was finally fixed :)