### PR TITLE
FIX avoid "-release" in autogenerated release RPMs

### DIFF
--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -5,6 +5,11 @@ set -e
 secret=$1
 type=$2
 
+if [ "$type" == "release" ]
+then
+  type="1"
+fi
+
 docker run -e BROKER_RELEASE=$type -v $(pwd):/opt/orion --workdir=/opt/orion fiware/orion-ci:rpm8 make rpm
 
 for file in "$(pwd)/rpm/RPMS/x86_64"/*


### PR DESCRIPTION
CC: @wistefan 

I think this will be problem we have seen with names like contextBroker-3.5.0-release.x86_64.rpm. Let's check when 3.6.0 gets released ;)