### PR TITLE
FIX different versions on RPM nightly repo

### DIFF
--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -17,7 +17,7 @@ do
   filename=$(basename $file)
   if [ "$type" == "nightly" ]
   then
-      filename=$(echo $filename | sed 's/[0-9]*.[0-9]*.[0-9]*_next-//g')
+      filename=$(echo $filename | sed 's/[0-9]+.[0-9]+.[0-9]+_next-//g')
   fi
   echo "Uploading $filename"
   curl -v -f -u telefonica-github:$secret --upload-file $file https://nexus.lab.fiware.org/repository/el/8/x86_64/$type/$filename

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -15,6 +15,10 @@ docker run -e BROKER_RELEASE=$type -v $(pwd):/opt/orion --workdir=/opt/orion fiw
 for file in "$(pwd)/rpm/RPMS/x86_64"/*
 do
   filename=$(basename $file)
+  if [ "$type" == "nightly" ]
+  then
+      filename=$(echo $filename | sed 's/[0-9].[0-9].[0-9]_next-//g')
+  fi
   echo "Uploading $filename"
   curl -v -f -u telefonica-github:$secret --upload-file $file https://nexus.lab.fiware.org/repository/el/8/x86_64/$type/$filename
 done

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -17,6 +17,8 @@ do
   filename=$(basename $file)
   if [ "$type" == "nightly" ]
   then
+      # to make the name of the .rpm independent of the version name (i.e. contextBroker-nightly.x86_64.rpm),
+      # avoiding obsolete packages to remain in the yum version when version number steps
       filename=$(echo $filename | sed 's/[0-9]+.[0-9]+.[0-9]+_next-//g')
   fi
   echo "Uploading $filename"

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -19,7 +19,7 @@ do
   then
       # to make the name of the .rpm independent of the version name (i.e. contextBroker-nightly.x86_64.rpm),
       # avoiding obsolete packages to remain in the yum version when version number steps
-      filename=$(echo $filename | sed 's/[0-9]+.[0-9]+.[0-9]+_next-//g')
+      filename=$(echo $filename | sed 's/[0-9]\+.[0-9]\+.[0-9]\+_next-//g')
   fi
   echo "Uploading $filename"
   curl -v -f -u telefonica-github:$secret --upload-file $file https://nexus.lab.fiware.org/repository/el/8/x86_64/$type/$filename

--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -17,7 +17,7 @@ do
   filename=$(basename $file)
   if [ "$type" == "nightly" ]
   then
-      filename=$(echo $filename | sed 's/[0-9].[0-9].[0-9]_next-//g')
+      filename=$(echo $filename | sed 's/[0-9]*.[0-9]*.[0-9]*_next-//g')
   fi
   echo "Uploading $filename"
   curl -v -f -u telefonica-github:$secret --upload-file $file https://nexus.lab.fiware.org/repository/el/8/x86_64/$type/$filename


### PR DESCRIPTION
Added a sed step to CI file stripping the version number in the filename (`X.Y.Z_next`) in case of uploading a nightly build.

This would fix uploading different version names depending of the release version to [here](https://nexus.lab.fiware.org/service/rest/repository/browse/el/8/x86_64/nightly/)