### PR TITLE
FIX Centos 8 repo list 

### DIFF
--- a/ci/rpm8/build-dep.sh
+++ b/ci/rpm8/build-dep.sh
@@ -21,6 +21,11 @@
 #
 # Author: Dmitrii Demin
 
+# FIXME: default yum repositories has been changed to vault due to CentOS 8 EOL on February 1st, 2022
+# This is just a temporal solution so the build doesn't break while we find a new distro to use
+sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+yum upgrade -y
 yum -y install epel-release
 yum -y install \
   bc \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /opt
 
 RUN \
-    #FIXME: Repo fix due to EOL Centos8
+    # FIXME: default yum repositories has been changed to vault due to CentOS 8 EOL on February 1st, 2022
+    # This is just a temporal solution so the build doesn't break while we find a new distro to use
     sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* &&\
     yum upgrade -y && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /opt
 
 RUN \
+    #FIXME: Repo fix due to EOL Centos8
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    yum upgrade -y && \
     adduser --comment "${ORION_USER}" ${ORION_USER} && \
     # Install dependencies
     yum -y install epel-release && \


### PR DESCRIPTION
Due to Centos8 EOL, building the Dockerfile was failing. This PR add a change in the repository base URL in order to keep working it. It changes the URL from `http://mirrorlist.centos.org/?release=$ ... fra=$infra` to `http://vault.centos.org/?release=$relea ... fra=$infra`