### PR TITLE
ADD ignoreType (for extra locs) metadata feature (3.5 branch) + Bump 3.5.1

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,0 @@
-- Add: ignoreType metadata so Orion ignores attribute type semantic (supported by geo-types at the present moment) (#4032)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Add: ignoreType metadata so Orion ignores attribute type semantic (supported by geo-types at the present moment) (#4032)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Support badge]( https://img.shields.io/badge/support-sof-yellowgreen.svg)](http://stackoverflow.com/questions/tagged/fiware-orion)
 [![NGSI v2](https://img.shields.io/badge/NGSI-V2-red.svg)](http://fiware-ges.github.io/orion/api/v2/stable/)
 <br>
-[![Documentation badge](https://img.shields.io/readthedocs/fiware-orion/3.5.0.svg)](https://fiware-orion.rtfd.io/en/3.5.0/)
+[![Documentation badge](https://img.shields.io/readthedocs/fiware-orion/3.5.1.svg)](https://fiware-orion.rtfd.io/en/3.5.1/)
 ![Compliance Tests](https://github.com/telefonicaid/fiware-orion/workflows/Compliance%20Tests/badge.svg)
 ![Unit Tests](https://github.com/telefonicaid/fiware-orion/workflows/Unit%20Tests/badge.svg)
 ![Functional Tests](https://github.com/telefonicaid/fiware-orion/workflows/Functional%20Tests/badge.svg)

--- a/rpm/SPECS/contextBroker.spec
+++ b/rpm/SPECS/contextBroker.spec
@@ -193,6 +193,9 @@ if [ "$1" == "0" ]; then
 fi
 
 %changelog
+* Fri Feb 04 2022 Fermin Galan <fermin.galanmarquez@telefonica.com> 3.5.1-1
+- Add: ignoreType metadata so Orion ignores attribute type semantic (supported by geo-types at the present moment) (#4032)
+
 * Fri Jan 28 2022 Fermin Galan <fermin.galanmarquez@telefonica.com> 3.5.0-1
 - Fix: avoid duplicated attributes and metadata in arrays in POST /v2/subscriptions and PATCH /v2/subscriptions/{subId} (#2101)
 - Fix: $each usage with $push operator to add several items to array (#744)

--- a/src/app/contextBroker/version.h
+++ b/src/app/contextBroker/version.h
@@ -28,6 +28,6 @@
 
 
 
-#define ORION_VERSION "3.5.0"
+#define ORION_VERSION "3.5.1"
 
 #endif  // SRC_APP_CONTEXTBROKER_VERSION_H_

--- a/src/lib/common/defaultValues.h
+++ b/src/lib/common/defaultValues.h
@@ -41,6 +41,6 @@
 *
 * API Documentation - The link to the the GEri documentation, either in the gh-pages (.github.io/) inside the fiware organization in GitHub or ReadTheDocs manual.
 */
-#define API_DOC                               "https://fiware-orion.rtfd.io/en/3.5.0/"
+#define API_DOC                               "https://fiware-orion.rtfd.io/en/3.5.1/"
 
 #endif  // SRC_LIB_COMMON_DEFAULTVALUES_H_

--- a/src/lib/common/errorMessages.h
+++ b/src/lib/common/errorMessages.h
@@ -99,6 +99,9 @@
 #define ERROR_UNPROCESSABLE                           "Unprocessable"
 #define ERROR_DESC_UNPROCESSABLE_ALREADY_EXISTS       "Already Exists"
 
+#define ERROR_NO_RESOURCES_AVAILABLE                  "NoResourcesAvailable"
+#define ERROR_DESC_NO_RESOURCES_AVAILABLE_GEOLOC      "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations."
+
 #define ERROR_INTERNAL_ERROR                          "InternalError"
 
 #define ERROR_TOO_MANY                                "TooManyResults"

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -3378,7 +3378,7 @@ static unsigned int updateEntity
   std::map<std::string, TriggeredSubscription*> subsToNotify;
 
   /* Is the entity using location? In that case, we fill the locAttr and currentGeoJson attributes with that information, otherwise
-   * we fill an empty locAttrs. Any case, processContextAttributeVector uses that information (and eventually modifies) while it
+   * we fill an empty locAttr. Any case, processContextAttributeVector uses that information (and eventually modifies) while it
    * processes the attributes in the updateContext */
   std::string            locAttr = "";
   orion::BSONObj         currentGeoJson;

--- a/src/lib/mongoBackend/location.cpp
+++ b/src/lib/mongoBackend/location.cpp
@@ -349,9 +349,8 @@ bool processLocationAtEntityCreation
 
     if (!locAttr->empty())
     {
-      *errDetail = "You cannot use more than one geo location attribute "
-                   "when creating an entity [see Orion user manual]";
-      oe->fill(SccRequestEntityTooLarge, *errDetail, "NoResourcesAvailable");
+      *errDetail = ERROR_DESC_NO_RESOURCES_AVAILABLE_GEOLOC;
+      oe->fill(SccRequestEntityTooLarge, *errDetail, ERROR_NO_RESOURCES_AVAILABLE);
       return false;
     }
 
@@ -437,9 +436,7 @@ bool processLocationAtUpdateAttribute
         *errDetail = "attempt to define a geo location attribute [" + targetAttr->name + "]" +
                      " when another one has been previously defined [" + *currentLocAttrName + "]";
 
-        oe->fill(SccRequestEntityTooLarge,
-                 "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
-                 "NoResourcesAvailable");
+        oe->fill(SccRequestEntityTooLarge, ERROR_DESC_NO_RESOURCES_AVAILABLE_GEOLOC, ERROR_NO_RESOURCES_AVAILABLE);
 
         return false;
       }
@@ -538,9 +535,7 @@ bool processLocationAtAppendAttribute
       *errDetail = "attempt to define a geo location attribute [" + targetAttr->name + "]" +
                    " when another one has been previously defined [" + *currentLocAttrName + "]";
 
-      oe->fill(SccRequestEntityTooLarge,
-               "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
-               "NoResourcesAvailable");
+      oe->fill(SccRequestEntityTooLarge, ERROR_DESC_NO_RESOURCES_AVAILABLE_GEOLOC, ERROR_NO_RESOURCES_AVAILABLE);
 
       return false;
     }
@@ -565,9 +560,7 @@ bool processLocationAtAppendAttribute
       *errDetail = "attempt to define a geo location attribute [" + targetAttr->name + "]" +
                    " when another one has been previously defined [" + *currentLocAttrName + "]";
 
-      oe->fill(SccRequestEntityTooLarge,
-               "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
-               "NoResourcesAvailable");
+      oe->fill(SccRequestEntityTooLarge, ERROR_DESC_NO_RESOURCES_AVAILABLE_GEOLOC, ERROR_NO_RESOURCES_AVAILABLE);
 
       return false;
     }

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -576,6 +576,17 @@ std::string ContextAttribute::getLocation(ApiVersion apiVersion) const
     // null value is allowed but inhibits the attribute to be used as location (e.g. in geo-queries)
     if ((valueType != orion::ValueTypeNull) && ((type == GEO_POINT) || (type == GEO_LINE) || (type == GEO_BOX) || (type == GEO_POLYGON) || (type == GEO_JSON)))
     {
+      for (unsigned int ix = 0; ix < metadataVector.size(); ++ix)
+      {
+        // the existence of the ignoreType metadata set to true also inhibits the attribute to be used as location
+        if (metadataVector[ix]->name == NGSI_MD_IGNORE_TYPE)
+        {
+          if ((metadataVector[ix]->valueType == orion::ValueTypeBoolean) && (metadataVector[ix]->boolValue == true))
+          {
+            return "";
+          }
+        }
+      }
       return LOCATION_WGS84;
     }
   }

--- a/src/lib/ngsi/Metadata.h
+++ b/src/lib/ngsi/Metadata.h
@@ -44,7 +44,8 @@
 *
 * Metadata interpreted by Orion Context Broker, i.e. not custom metadata
 */
-#define NGSI_MD_LOCATION           "location"
+#define NGSI_MD_LOCATION           "location"        // Deprecated (NGSIv1)
+#define NGSI_MD_IGNORE_TYPE        "ignoreType"
 #define NGSI_MD_PREVIOUSVALUE      "previousValue"   // Special metadata
 #define NGSI_MD_ACTIONTYPE         "actionType"      // Special metadata
 #define NGSI_MD_DATECREATED        "dateCreated"     // Special metadata

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_general.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_general.test
@@ -227,13 +227,13 @@ echo
 01. Create entity with one geo:point and one geo:line -> fail
 =============================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -314,13 +314,13 @@ Date: REGEX(.*)
 04. Append a new geo:box attribute (attr2) -> fail
 ==================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -461,13 +461,13 @@ Date: REGEX(.*)
 09. Change attr2 type to geo:line again -> fail
 ===============================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geobox.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geobox.test
@@ -427,13 +427,13 @@ Date: REGEX(.*)
 05. Create entity with two geo:box -> fail
 ==========================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -517,13 +517,13 @@ Date: REGEX(.*)
 08. Append a new geo:box attribute (attr2) -> fail
 ==================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -667,13 +667,13 @@ Date: REGEX(.*)
 13. Change attr2 type to geo:box again -> fail
 ==============================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geoline.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geoline.test
@@ -328,13 +328,13 @@ Date: REGEX(.*)
 03. Create entity with two geo:line -> fail
 ============================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -418,13 +418,13 @@ Date: REGEX(.*)
 06. Append a new geo:line attribute (attr2) -> fail
 ===================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -568,13 +568,13 @@ Date: REGEX(.*)
 11. Change attr2 type to geo:line again -> fail
 ===============================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geopoint.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geopoint.test
@@ -227,13 +227,13 @@ echo
 01. Create entity with two geo:point -> fail
 ============================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -311,13 +311,13 @@ Date: REGEX(.*)
 04. Append a new geo:point attribute (attr2) -> fail
 ====================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -452,13 +452,13 @@ Date: REGEX(.*)
 09. Change attr2 type to geo:point again -> fail
 ================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geopolygon.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geopolygon.test
@@ -377,13 +377,13 @@ Date: REGEX(.*)
 04. Create entity with two geo:polygon -> fail
 ==============================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -471,13 +471,13 @@ Date: REGEX(.*)
 07. Append a new geo:polygon attribute (attr2) -> fail
 ======================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -627,13 +627,13 @@ Date: REGEX(.*)
 12. Change attr2 type to geo:polygon again -> fail
 ==================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 

--- a/test/functionalTest/cases/1920_geojson/errors_geojson.test
+++ b/test/functionalTest/cases/1920_geojson/errors_geojson.test
@@ -351,13 +351,13 @@ Date: REGEX(.*)
 03. Create entity with two geo:json -> fail
 ===========================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -469,13 +469,13 @@ Date: REGEX(.*)
 06. Append a new geo:json attribute (attr2) -> fail
 ===================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -640,13 +640,13 @@ Date: REGEX(.*)
 11. Change attr2 type to geo:json again -> fail
 ===============================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 

--- a/test/functionalTest/cases/3533_null_in_datetime_and_geo/null_in_geo_more_than_one.test
+++ b/test/functionalTest/cases/3533_null_in_datetime_and_geo/null_in_geo_more_than_one.test
@@ -172,13 +172,13 @@ Date: REGEX(.*)
 03. Update E1-loc2 to actual location: forbidden as it overpass the limit of one
 ================================================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 
@@ -234,13 +234,13 @@ Date: REGEX(.*)
 07. Update E1-loc1 to actual location: forbidden as it overpass the limit of one
 ================================================================================
 HTTP/1.1 413 Payload Too Large
-Content-Length: 148
+Content-Length: 202
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "You cannot use more than one geo location attribute when creating an entity [see Orion user manual]",
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
     "error": "NoResourcesAvailable"
 }
 

--- a/test/functionalTest/cases/4032_extra_locs/extra_locs.test
+++ b/test/functionalTest/cases/4032_extra_locs/extra_locs.test
@@ -1,0 +1,490 @@
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Extra locations feature
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0-255
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create subscription for entity E
+# 02. Create entity E with actual loc (L1) and 2 extra locs (L2, L3)
+# 03. GET entity E: see actual L1 (actual), L2 (extra), L3 (extra)
+# 04. Dump & reset accumulator: see E with L1 (actual), L2 (extra), L3 (extra)
+# 05. GET geoquery near 1m around L1, to check this is the actual location of the entity
+# 06. Update E to remove ignoreType metadata in L2: see fail
+# 07. Update E to add ignoreType metadata in L1: success
+# 08. GET geoquery near 1m around L1, to check there is no result
+# 09. Update E to remove ignoreType metadata in L2: success
+# 10. GET geoquery near 1m around L2, to check this is the actual location of the entity
+#
+
+echo "01. Create subscription for entity E"
+echo "===================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id" : "E"
+      }
+    ]
+  },
+  "notification": {
+    "http": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create entity E with actual loc (L1) and 2 extra locs (L2, L3)"
+echo "=================================================================="
+payload='{
+  "id": "E",
+  "type": "T",
+  "L1": {
+    "value": { "type":"Point", "coordinates": [10,10] },
+    "type": "geo:json"
+  },
+  "L2": {
+    "value": { "type":"Point", "coordinates": [20,20] },
+    "type": "geo:json",
+    "metadata": {
+      "ignoreType": {
+        "value": true,
+        "type": "Boolean"
+      }
+    }
+  },
+  "L3": {
+    "value": { "type":"Point", "coordinates": [30,30] },
+    "type": "geo:json",
+    "metadata": {
+      "ignoreType": {
+        "value": true,
+        "type": "Boolean"
+      }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "${payload}"
+echo
+echo
+
+
+echo "03. GET entity E: see actual L1 (actual), L2 (extra), L3 (extra)"
+echo "================================================================"
+orionCurl --url /v2/entities/E
+echo
+echo
+
+
+echo "04. Dump & reset accumulator: see E with L1 (actual), L2 (extra), L3 (extra)"
+echo "============================================================================="
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "05. GET geoquery near 1m around L1, to check this is the actual location of the entity"
+echo "======================================================================================"
+orionCurl --url '/v2/entities?georel=near;maxDistance:1&geometry=point&coords=10,10'
+echo
+echo
+
+
+echo "06. Update E to remove ignoreType metadata in L2: see fail"
+echo "=========================================================="
+payload='{
+  "L2": {
+    "value": { "type": "Point", "coordinates": [20,20] },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "${payload}"
+echo
+echo
+
+
+echo "07. Update E to add ignoreType metadata in L1: success"
+echo "======================================================"
+payload='{
+  "L1": {
+    "value": { "type": "Point", "coordinates": [10,10] },
+    "type": "geo:json",
+    "metadata": {
+      "ignoreType": {
+        "value": true,
+        "type": "Boolean"
+      }
+    }
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "${payload}"
+echo
+echo
+
+
+echo "08. GET geoquery near 1m around L1, to check there is no result"
+echo "==============================================================="
+orionCurl --url '/v2/entities?georel=near;maxDistance:1&geometry=point&coords=10,10'
+echo
+echo
+
+
+echo "09. Update E to remove ignoreType metadata in L2: success"
+echo "========================================================="
+payload='{
+  "L2": {
+    "value": { "type": "Point", "coordinates": [20,20] },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "${payload}"
+echo
+echo
+
+
+echo "10. GET geoquery near 1m around L2, to check this is the actual location of the entity"
+echo "======================================================================================"
+orionCurl --url '/v2/entities?georel=near;maxDistance:1&geometry=point&coords=20,20'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create subscription for entity E
+====================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create entity E with actual loc (L1) and 2 extra locs (L2, L3)
+==================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. GET entity E: see actual L1 (actual), L2 (extra), L3 (extra)
+================================================================
+HTTP/1.1 200 OK
+Content-Length: 367
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "L1": {
+        "metadata": {},
+        "type": "geo:json",
+        "value": {
+            "coordinates": [
+                10,
+                10
+            ],
+            "type": "Point"
+        }
+    },
+    "L2": {
+        "metadata": {
+            "ignoreType": {
+                "type": "Boolean",
+                "value": true
+            }
+        },
+        "type": "geo:json",
+        "value": {
+            "coordinates": [
+                20,
+                20
+            ],
+            "type": "Point"
+        }
+    },
+    "L3": {
+        "metadata": {
+            "ignoreType": {
+                "type": "Boolean",
+                "value": true
+            }
+        },
+        "type": "geo:json",
+        "value": {
+            "coordinates": [
+                30,
+                30
+            ],
+            "type": "Point"
+        }
+    },
+    "id": "E",
+    "type": "T"
+}
+
+
+04. Dump & reset accumulator: see E with L1 (actual), L2 (extra), L3 (extra)
+=============================================================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 422
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "L1": {
+                "metadata": {},
+                "type": "geo:json",
+                "value": {
+                    "coordinates": [
+                        10,
+                        10
+                    ],
+                    "type": "Point"
+                }
+            },
+            "L2": {
+                "metadata": {
+                    "ignoreType": {
+                        "type": "Boolean",
+                        "value": true
+                    }
+                },
+                "type": "geo:json",
+                "value": {
+                    "coordinates": [
+                        20,
+                        20
+                    ],
+                    "type": "Point"
+                }
+            },
+            "L3": {
+                "metadata": {
+                    "ignoreType": {
+                        "type": "Boolean",
+                        "value": true
+                    }
+                },
+                "type": "geo:json",
+                "value": {
+                    "coordinates": [
+                        30,
+                        30
+                    ],
+                    "type": "Point"
+                }
+            },
+            "id": "E",
+            "type": "T"
+        }
+    ],
+    "subscriptionId": "REGEX([0-9a-f]{24})"
+}
+=======================================
+
+
+05. GET geoquery near 1m around L1, to check this is the actual location of the entity
+======================================================================================
+HTTP/1.1 200 OK
+Content-Length: 369
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "L1": {
+            "metadata": {},
+            "type": "geo:json",
+            "value": {
+                "coordinates": [
+                    10,
+                    10
+                ],
+                "type": "Point"
+            }
+        },
+        "L2": {
+            "metadata": {
+                "ignoreType": {
+                    "type": "Boolean",
+                    "value": true
+                }
+            },
+            "type": "geo:json",
+            "value": {
+                "coordinates": [
+                    20,
+                    20
+                ],
+                "type": "Point"
+            }
+        },
+        "L3": {
+            "metadata": {
+                "ignoreType": {
+                    "type": "Boolean",
+                    "value": true
+                }
+            },
+            "type": "geo:json",
+            "value": {
+                "coordinates": [
+                    30,
+                    30
+                ],
+                "type": "Point"
+            }
+        },
+        "id": "E",
+        "type": "T"
+    }
+]
+
+
+06. Update E to remove ignoreType metadata in L2: see fail
+==========================================================
+HTTP/1.1 413 Payload Too Large
+Content-Length: 202
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations.",
+    "error": "NoResourcesAvailable"
+}
+
+
+07. Update E to add ignoreType metadata in L1: success
+======================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+08. GET geoquery near 1m around L1, to check there is no result
+===============================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[]
+
+
+09. Update E to remove ignoreType metadata in L2: success
+=========================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+10. GET geoquery near 1m around L2, to check this is the actual location of the entity
+======================================================================================
+HTTP/1.1 200 OK
+Content-Length: 369
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+[
+    {
+        "L1": {
+            "metadata": {
+                "ignoreType": {
+                    "type": "Boolean",
+                    "value": true
+                }
+            },
+            "type": "geo:json",
+            "value": {
+                "coordinates": [
+                    10,
+                    10
+                ],
+                "type": "Point"
+            }
+        },
+        "L2": {
+            "metadata": {},
+            "type": "geo:json",
+            "value": {
+                "coordinates": [
+                    20,
+                    20
+                ],
+                "type": "Point"
+            }
+        },
+        "L3": {
+            "metadata": {
+                "ignoreType": {
+                    "type": "Boolean",
+                    "value": true
+                }
+            },
+            "type": "geo:json",
+            "value": {
+                "coordinates": [
+                    30,
+                    30
+                ],
+                "type": "Point"
+            }
+        },
+        "id": "E",
+        "type": "T"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB


### PR DESCRIPTION
This PR includes:

* First commit (aba0d19db50129810ccbfcff9a0d57b5d36243b5) with a port of PR https://github.com/telefonicaid/fiware-orion/pull/4051 to release/3.5.0 branch. Note the as a kind of checksum, the diff counter (616 additions and 54 deletions) is the same in this commit than in the PR.
* Second commit (~ad9947ab0~ d5a18d5272c0ce1f085e6c2fd68b47553a91b3a3) mimics PR https://github.com/telefonicaid/fiware-orion/pull/4002 and does the step version change from 3.5.0 to 3.5.1

A tag 3.5.1 will be created upon merging of this PR