### PR TITLE
[WIP] FIX hasField calls wrongly using char* instead of std::string

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -840,7 +840,7 @@ static bool updateAttribute
   }
   else
   {
-    if (!attrs.hasField(effectiveName.c_str()))
+    if (!attrs.hasField(effectiveName))
     {
       return false;
     }
@@ -889,7 +889,7 @@ static bool appendAttribute
   const std::string composedName = std::string(ENT_ATTRS) + "." + effectiveName;
 
   /* APPEND with existing attribute equals to UPDATE */
-  if (attrs.hasField(effectiveName.c_str()))
+  if (attrs.hasField(effectiveName))
   {
     updateAttribute(attrs, toSet, toUnset, attrNamesAdd, caP, actualUpdate, false, forcedUpdate, apiVersion);
     return false;
@@ -964,7 +964,7 @@ static bool deleteAttribute
 {
   std::string effectiveName = dbEncode(caP->name);
 
-  if (!attrs.hasField(effectiveName.c_str()))
+  if (!attrs.hasField(effectiveName))
   {
     return false;
   }


### PR DESCRIPTION
Note orion::BSONObj hasField() signature is:

```
  bool hasField(const std::string& field) const;
```

Thus I understand that although compiler doesn't complaint about it, hasField() on a char* is always evaluated to `false`.

What I wonder is how this has worked without problem until now... need to be analysed with a little of care

[ ] CNR ?
