### PR TITLE
FIX valgrind error about unitialized value

### DIFF
--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -502,6 +502,7 @@ ContextAttribute::ContextAttribute
   found                 = _found;
   skip                  = false;
   typeGiven             = false;
+  onlyValue             = false;
   previousValue         = NULL;
   actionType            = "";
   shadowed              = false;
@@ -536,6 +537,7 @@ ContextAttribute::ContextAttribute
   valueType             = orion::ValueTypeObject;  // FIXME P6: Could be ValueTypeVector ...
   skip                  = false;
   typeGiven             = false;
+  onlyValue             = false;
   previousValue         = NULL;
   actionType            = "";
   shadowed              = false;

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -78,7 +78,7 @@ public:
                                                       // ContextAttribute field in the ContextAttribute type declaration)
 
 
-  bool                      onlyValue;                // Used when ony the value is meaningful in v2 updates of value, without regarding metadata
+  bool                      onlyValue;                // Used when only the value is meaningful in v2 updates of value, without regarding metadata
   bool                      shadowed;                 // shadowed true means that the attribute is rendered only if explicitly required
                                                       // in attrs filter (typically for builtin attributes)
 


### PR DESCRIPTION
Solves error detected at valgrind pass (about unitialized value):

```
1 test cases show valgrind errors:
  001: PUT_v1_contextEntities_E1_attributes_A1 shows 1 valgrind errors
```