### PR TITLE
Fix entityDelete

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1264,22 +1264,14 @@ static void fill_idPtypeNP
   const std::string&  typePatternQ
 )
 {
-  std::string typeCheck;
-
-  // Sometimes (for instance, when we reach this point during a entity deletion operation)
-  // we don't know the type of the entity, in which case the check for type shouldn't be included
-  if (!entityType.empty())
-  {
-    typeCheck = std::string("(this.")+CSUB_ENTITIES+"[i]."+CSUB_ENTITY_TYPE+" == \""+entityType+"\" || " +
-        "this."+CSUB_ENTITIES+"[i]."+CSUB_ENTITY_TYPE+" == \"\" || " +
-        "!(\""+CSUB_ENTITY_TYPE+"\" in this."+CSUB_ENTITIES+"[i])) && ";
-  }
-
   bgP->functionIdPtypeNP = std::string("function()") +
          "{" +
             "for (var i=0; i < this."+CSUB_ENTITIES+".length; i++) {" +
                 "if (this."+CSUB_ENTITIES+"[i]."+CSUB_ENTITY_ISPATTERN+" == \"true\" && " +
-                    "!this."+CSUB_ENTITIES+"[i]."+CSUB_ENTITY_ISTYPEPATTERN+" && " + typeCheck +
+                    "!this."+CSUB_ENTITIES+"[i]."+CSUB_ENTITY_ISTYPEPATTERN+" && " +
+                    "(this."+CSUB_ENTITIES+"[i]."+CSUB_ENTITY_TYPE+" == \""+entityType+"\" || " +
+                        "this."+CSUB_ENTITIES+"[i]."+CSUB_ENTITY_TYPE+" == \"\" || " +
+                        "!(\""+CSUB_ENTITY_TYPE+"\" in this."+CSUB_ENTITIES+"[i])) && " +
                     "\""+entityId+"\".match(this."+CSUB_ENTITIES+"[i]."+CSUB_ENTITY_ID+")) {" +
                     "return true; " +
                 "}" +
@@ -3474,8 +3466,11 @@ static unsigned int updateEntity
     {
       attrNames.push_back(eP->attributeVector[ix]->name);
     }
-    if (!addTriggeredSubscriptions(eP->id,
-                                   eP->type,
+
+    // Note we cannot usse eP->type for the type, as it may be blank in the request
+    // (that would break the cases/1494_subscription_alteration_types/sub_alteration_type_entity_delete2.test case)
+    if (!addTriggeredSubscriptions(notifyCerP->entity.id,
+                                   notifyCerP->entity.type,
                                    attrNames,
                                    attrNames,
                                    subsToNotify,

--- a/test/functionalTest/cases/1494_subscription_alteration_types/sub_alteration_type_entity_delete2.test
+++ b/test/functionalTest/cases/1494_subscription_alteration_types/sub_alteration_type_entity_delete2.test
@@ -1,0 +1,196 @@
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Subscription alterationType entityDelete
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0-255
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create subscription for .*-T1 with entityDelete
+# 02. Create entity E1-T1
+# 03. Create entity E2-T2
+# 04. Delete entity E1-T1
+# 05. Delete entity E2-T2
+# 06. Dump accumulator: see only notification corresponding to E1-T1
+#
+
+echo "01. Create subscription for .*-T1 with entityDelete"
+echo "==================================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "idPattern" : ".*",
+        "type": "T1"
+      }
+    ],
+    "condition": {
+      "alterationTypes": [ "entityDelete" ]
+    }
+  },
+  "notification": {
+    "http": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create entity E1-T1"
+echo "======================="
+payload='{
+  "id": "E1",
+  "type": "T1",
+  "A": {
+    "value": 1,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "${payload}"
+echo
+echo
+
+
+echo "02. Create entity E2-T2"
+echo "======================="
+payload='{
+  "id": "E2",
+  "type": "T2",
+  "A": {
+    "value": 2,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "${payload}"
+echo
+echo
+
+
+echo "04. Delete entity E1-T1"
+echo "======================="
+orionCurl --url /v2/entities/E1 -X DELETE
+echo
+echo
+
+
+echo "05. Delete entity E2-T2"
+echo "======================="
+orionCurl --url /v2/entities/E2 -X DELETE
+echo
+echo
+
+
+echo "06. Dump accumulator: see only notification corresponding to E1-T1"
+echo "=================================================================="
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create subscription for .*-T1 with entityDelete
+===================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create entity E1-T1
+=======================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=T1
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create entity E2-T2
+=======================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E2?type=T2
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Delete entity E1-T1
+=======================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Delete entity E2-T2
+=======================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. Dump accumulator: see only notification corresponding to E1-T1
+==================================================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 124
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: normalized
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "data": [
+        {
+            "A": {
+                "metadata": {},
+                "type": "Number",
+                "value": 1
+            },
+            "id": "E1",
+            "type": "T1"
+        }
+    ],
+    "subscriptionId": "623b211e2fd85429d906b8cb"
+}
+
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB

--- a/test/functionalTest/cases/1494_subscription_alteration_types/sub_alteration_type_entity_delete2.test
+++ b/test/functionalTest/cases/1494_subscription_alteration_types/sub_alteration_type_entity_delete2.test
@@ -21,7 +21,8 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Subscription alterationType entityDelete
+Subscription alterationType entityDelete (extra case)
+
 --SHELL-INIT--
 dbInit CB
 brokerStart CB 0-255
@@ -185,9 +186,9 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
             "type": "T1"
         }
     ],
-    "subscriptionId": "623b211e2fd85429d906b8cb"
+    "subscriptionId": "REGEX([0-9a-f]{24})"
 }
-
+=======================================
 
 
 --TEARDOWN--


### PR DESCRIPTION
The .test included in the first commit of this PR shows that the implementation done in https://github.com/telefonicaid/fiware-orion/pull/4084 has a flaw regarding entityDelete notifications.

Two comments:

* We need the an actual type when calling addTriggeredSubscription() in the delete logic (eP->type with "" causes this problem. Maybe a findAndModify() with removal semantics should be used? Maybe we already has this information in notifyCerP?
* The changes done in addTriggeredSubscription_noCache logic to skip type in some case should be rolled-back.