### PR TITLE
ADD cases/1492_limit_zero/limit_zero_simple_cases.test

### DIFF
--- a/test/functionalTest/cases/1492_limit_zero/limit_zero_simple_cases.test
+++ b/test/functionalTest/cases/1492_limit_zero/limit_zero_simple_cases.test
@@ -1,0 +1,127 @@
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Limit zero simple cases
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. GET /v2/entities with limit = 0 and see error
+# 02. GET /v2/types with limit = 0 and see error
+# 03. GET /v2/subscriptions with limit = 0 and see error
+# 04. GET /v2/registrations with limit = 0 and see error
+#
+#
+
+echo "01. GET /v2/entities with limit = 0 and see error"
+echo "================================================="
+orionCurl --url "/v2/entities?limit=0"
+echo
+echo
+
+
+echo "02. GET /v2/types with limit = 0 and see error"
+echo "=============================================="
+orionCurl --url "/v2/types?limit=0"
+echo
+echo
+
+
+echo "03. GET /v2/subscriptions with limit = 0 and see error"
+echo "======================================================"
+orionCurl --url "/v2/subscriptions?limit=0"
+echo
+echo
+
+
+echo "04. GET /v2/registrations with limit = 0 and see error"
+echo "======================================================"
+orionCurl --url "/v2/registrations?limit=0"
+echo
+echo
+
+
+--REGEXPECT--
+01. GET /v2/entities with limit = 0 and see error
+=================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 98
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Bad pagination limit: /0/ [a value of ZERO is unacceptable]",
+    "error": "BadRequest"
+}
+
+
+02. GET /v2/types with limit = 0 and see error
+==============================================
+HTTP/1.1 400 Bad Request
+Content-Length: 98
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Bad pagination limit: /0/ [a value of ZERO is unacceptable]",
+    "error": "BadRequest"
+}
+
+
+03. GET /v2/subscriptions with limit = 0 and see error
+======================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 98
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Bad pagination limit: /0/ [a value of ZERO is unacceptable]",
+    "error": "BadRequest"
+}
+
+
+04. GET /v2/registrations with limit = 0 and see error
+======================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 98
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "Bad pagination limit: /0/ [a value of ZERO is unacceptable]",
+    "error": "BadRequest"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
limit zero errors are not currently covered in NGSIv2. The .test added in this PR is a NGSIv2 equivalent of case 3 in https://github.com/telefonicaid/fiware-orion/blob/master/test/functionalTest/cases/0000_bad_requests/pagination_error_in_uri_params.test

I have realized of this while working on PR #4104. Once this PR gets merged into master, PR #4104 will be upgrade and limit_zero_simple_cases.test changed to valid `[]` responses.