### PR TITLE
FIX unintialized variable

### DIFF
--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1589,7 +1589,7 @@ bool entitiesQuery
   unsigned int docs = 0;
 
   orion::BSONObj  r;
-  int             errType;
+  int             errType = ON_NEXT_NO_ERROR;
   std::string     nextErr;
 
   /* Note limit != 0 will cause skipping the while loop in case request didn't actually ask for any result */


### PR DESCRIPTION
Fix a error detected by valgrind (https://github.com/telefonicaid/fiware-orion/runs/6214311708?check_suite_focus=true), introduce by PR #4104 

```
1 test cases show valgrind errors:
  003: pagination_error_in_uri_params shows 2 valgrind errors
```