### PR TITLE
FIX log fwd update

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,5 +3,6 @@
 - Fix: allow limit=0 in all paginated operations in the NGSIv2 API (entities, entity types, subscriptions and registrations) (#1492)
 - Add: conditions.alterationTypes subscription fuctionality (#1494)
 - Add: alterationType built-in atrribute in notifications (#1494)
+- Fix: wrong log traces in update forwarding cases
 - Fix: covered notifications in subscriptions (#3693)
 - Reference distribution changed RHEL/CentOS 8 to Debian 11

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -3599,7 +3599,6 @@ static unsigned int updateEntity
     {
       if (!attrs.hasField (eP->attributeVector[ix]->name))
       {
-        alarmMgr.badInput(clientIp, "attribute not exists");
         *attributeNotExistingError = true;
 
         // Add to the list of non existing attributes - for the error response

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -676,71 +676,61 @@ std::string postUpdateContext
   {
     ContextElementResponse* cerP  = upcrsP->contextElementResponseVector[cerIx];
 
-    if (cerP->entity.attributeVector.size() == 0)
+    for (unsigned int aIx = 0; aIx < cerP->entity.attributeVector.size(); ++aIx)
     {
+      ContextAttribute* aP = cerP->entity.attributeVector[aIx];
+
       //
-      // If we find a contextElement without attributes here, then something is wrong
+      // 0. If the attribute is 'not-found' - just add the attribute to the outgoing response
       //
-      LM_E(("Runtime Error (empty contextAttributeVector for ContextElementResponse %d)", cerIx));
-    }
-    else
-    {
-      for (unsigned int aIx = 0; aIx < cerP->entity.attributeVector.size(); ++aIx)
+      if (aP->found == false)
       {
-        ContextAttribute* aP = cerP->entity.attributeVector[aIx];
-
-        //
-        // 0. If the attribute is 'not-found' - just add the attribute to the outgoing response
-        //
-        if (aP->found == false)
-        {
-          ContextAttribute ca(aP);
-          response.notFoundPush(&cerP->entity, &ca, NULL);
-          continue;
-        }
-
-
-        //
-        // 1. If the attribute is found locally - just add the attribute to the outgoing response
-        //
-        if (aP->providingApplication.get().empty())
-        {
-          ContextAttribute ca(aP);
-          response.foundPush(&cerP->entity, &ca);
-          continue;
-        }
-
-
-        //
-        // 2. Lookup UpdateContextRequest in requestV according to providingApplication.
-        //    If not found, add one.
-        UpdateContextRequest*  reqP = requestV.lookup(aP->providingApplication.get());
-        if (reqP == NULL)
-        {
-          reqP = new UpdateContextRequest(aP->providingApplication.get(), aP->providingApplication.providerFormat, &cerP->entity);
-          reqP->updateActionType = ActionTypeUpdate;
-          requestV.push_back(reqP);
-          regIdsV.push_back(aP->providingApplication.getRegId());
-        }
-
-        //
-        // 3. Lookup ContextElement in UpdateContextRequest according to EntityId.
-        //    If not found, add one (to the EntityVector of the UpdateContextRequest).
-        //
-        Entity* eP = reqP->entityVector.lookup(cerP->entity.id, cerP->entity.type);
-        if (eP == NULL)
-        {
-          eP = new Entity();
-          eP->fill(cerP->entity.id, cerP->entity.type, cerP->entity.isPattern);
-          reqP->entityVector.push_back(eP);
-        }
-
-
-        //
-        // 4. Add ContextAttribute to the correct ContextElement in the correct UpdateContextRequest
-        //
-        eP->attributeVector.push_back(new ContextAttribute(aP));
+        ContextAttribute ca(aP);
+        response.notFoundPush(&cerP->entity, &ca, NULL);
+        continue;
       }
+
+
+      //
+      // 1. If the attribute is found locally - just add the attribute to the outgoing response
+      //
+      if (aP->providingApplication.get().empty())
+      {
+        ContextAttribute ca(aP);
+        response.foundPush(&cerP->entity, &ca);
+        continue;
+      }
+
+
+      //
+      // 2. Lookup UpdateContextRequest in requestV according to providingApplication.
+      //    If not found, add one.
+      UpdateContextRequest*  reqP = requestV.lookup(aP->providingApplication.get());
+      if (reqP == NULL)
+      {
+        reqP = new UpdateContextRequest(aP->providingApplication.get(), aP->providingApplication.providerFormat, &cerP->entity);
+        reqP->updateActionType = ActionTypeUpdate;
+        requestV.push_back(reqP);
+        regIdsV.push_back(aP->providingApplication.getRegId());
+      }
+
+      //
+      // 3. Lookup ContextElement in UpdateContextRequest according to EntityId.
+      //    If not found, add one (to the EntityVector of the UpdateContextRequest).
+      //
+      Entity* eP = reqP->entityVector.lookup(cerP->entity.id, cerP->entity.type);
+      if (eP == NULL)
+      {
+        eP = new Entity();
+        eP->fill(cerP->entity.id, cerP->entity.type, cerP->entity.isPattern);
+        reqP->entityVector.push_back(eP);
+      }
+
+
+      //
+      // 4. Add ContextAttribute to the correct ContextElement in the correct UpdateContextRequest
+      //
+      eP->attributeVector.push_back(new ContextAttribute(aP));
     }
   }
 

--- a/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
@@ -36,6 +36,7 @@
 #include "serviceRoutinesV2/putEntityAttribute.h"
 #include "rest/OrionError.h"
 #include "parse/forbiddenChars.h"
+#include "alarmMgr/alarmMgr.h"
 
 
 
@@ -88,6 +89,7 @@ std::string putEntityAttribute
   if (parseDataP->upcrs.res.oe.code != SccNone )
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
+    alarmMgr.badInput(clientIp, parseDataP->upcrs.res.oe.details);
     ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else


### PR DESCRIPTION
This PR solves two minor issues in logs in update forwarding cases:

* Removes a wrong "Runtime Error" (probably still there because in the past, before the forwarding logic, it makes sense)
* Fixes bad input alarm. Previous to this PR, if the attribute doesn't exist locally but exists in the Context Provider an alarm was being wrongly raised

**Hint:** use "hide whitespace" when reviewing this (a big block of code has changed indent and could be "noisy" in the review)