### PR TITLE
FIX github workflow image

### DIFF
--- a/.github/build-and-push-rpm.sh
+++ b/.github/build-and-push-rpm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# FIXME: rpm no longer supported. To be removed soon
+
 set -e
 
 secret=$1

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-   TEST_IMAGE_NAME: fiware/orion-ci:rpm8
+   TEST_IMAGE_NAME: fiware/orion-ci:deb
 
 jobs:
   functional:

--- a/.github/workflows/publishrpm.yml
+++ b/.github/workflows/publishrpm.yml
@@ -1,5 +1,7 @@
 name: Publish rpm from master
 
+# FIXME: rpm no longer supported. To be removed soon
+
 on:
   schedule:
     # every night at one

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TEST_IMAGE_NAME: fiware/orion-ci:rpm8
+  TEST_IMAGE_NAME: fiware/orion-ci:deb
 
 jobs:
   unit:


### PR DESCRIPTION
Time ago we moved from CentOS 8 to Debian, but it seems some tokens in workflow directory weren't changed.