### PR TITLE
FIX ingoreType for Feature and FeatureCollection

### DIFF
--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -43,85 +43,14 @@
 #include "jsonParseV2/utilsParse.h"
 
 
-#if 0
-/* ****************************************************************************
-*
-* checkFeatureGeoJson -
-*
-*/
-static std::string checkFeatureGeoJson(orion::CompoundValueNode* feature)
-{
-  for (unsigned int ix = 0; ix < feature->childV.size(); ++ix)
-  {
-     orion::CompoundValueNode* childP = feature->childV[ix];
-     if (childP->name == "geometry")
-     {
-       if (childP->valueType == orion::ValueTypeObject)
-       {
-         return "OK";
-       }
-       else
-       {
-         return "geometry in Feature is not an object";
-       }
-     }
-  }
-
-  return "geometry in Feature not found";
-}
-
-
-
-
-/* ****************************************************************************
-*
-* checkFeatureCollectionGeoJson -
-*
-*/
-static std::string checkFeatureCollectionGeoJson(orion::CompoundValueNode* featureCollection)
-{
-  for (unsigned int ix = 0; ix < featureCollection->childV.size(); ++ix)
-  {
-     orion::CompoundValueNode* childP = featureCollection->childV[ix];
-     if (childP->name == "features")
-     {
-       if (childP->valueType != orion::ValueTypeVector)
-       {
-         return "features in FeatureCollection is not an array";
-       }
-       else if (childP->childV.size() == 0)
-       {
-         return "features in FeatureCollection has 0 items";
-       }
-       else if (childP->childV.size() > 1)
-       {
-         return "features in FeatureCollection has more than 1 item";
-       }
-       else
-       {
-         return checkFeatureGeoJson(childP->childV[0]);
-       }
-     }
-  }
-
-  return "features field not found in FeatureCollection";
-}
-#endif
-
 
 /* ****************************************************************************
 *
 * checkGeoJson -
 *
-* Do checking that ensure getGeoJson() function in the mongoBackend layer will not
-* break. In particular:
-*
-* - Attribute is null or an object
-* - For Feature, that geometry field exists and it's an object
-* - For FeatureCollection:
-*   * the feature field exists
-*   * the feature field is an array with exactly one item
-*   * the feature field item has a geometry field and it's an object
+* Check that ttribute is null or an object. Other checks for Feature and FeatureCollection
+* are done in location.cpp functions, as they has to be done only when ignoreType:true
+* is not in the entity
 *
 */
 static std::string checkGeoJson(ContextAttribute* caP)
@@ -144,24 +73,6 @@ static std::string checkGeoJson(ContextAttribute* caP)
   {
     return "geo:json needs an object or null as value";
   }
-
-#if 0
-  for (unsigned int ix = 0; ix < caP->compoundValueP->childV.size(); ++ix)
-  {
-     orion::CompoundValueNode* childP = caP->compoundValueP->childV[ix];
-     if ((childP->name == "type") && (childP->valueType == orion::ValueTypeString))
-     {
-       if (childP->stringValue == "Feature")
-       {
-         return checkFeatureGeoJson(caP->compoundValueP);
-       }
-       else if (childP->stringValue == "FeatureCollection")
-       {
-         return checkFeatureCollectionGeoJson(caP->compoundValueP);
-       }
-     }
-  }
-#endif
 
   return "OK";
 }

--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -48,7 +48,7 @@
 *
 * checkGeoJson -
 *
-* Check that ttribute is null or an object. Other checks for Feature and FeatureCollection
+* Check that attribute is null or an object. Other checks for Feature and FeatureCollection
 * are done in location.cpp functions, as they has to be done only when ignoreType:true
 * is not in the entity
 *

--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -43,7 +43,7 @@
 #include "jsonParseV2/utilsParse.h"
 
 
-
+#if 0
 /* ****************************************************************************
 *
 * checkFeatureGeoJson -
@@ -106,7 +106,7 @@ static std::string checkFeatureCollectionGeoJson(orion::CompoundValueNode* featu
 
   return "features field not found in FeatureCollection";
 }
-
+#endif
 
 
 /* ****************************************************************************
@@ -145,6 +145,7 @@ static std::string checkGeoJson(ContextAttribute* caP)
     return "geo:json needs an object or null as value";
   }
 
+#if 0
   for (unsigned int ix = 0; ix < caP->compoundValueP->childV.size(); ++ix)
   {
      orion::CompoundValueNode* childP = caP->compoundValueP->childV[ix];
@@ -160,6 +161,7 @@ static std::string checkGeoJson(ContextAttribute* caP)
        }
      }
   }
+#endif
 
   return "OK";
 }

--- a/src/lib/mongoBackend/location.cpp
+++ b/src/lib/mongoBackend/location.cpp
@@ -178,20 +178,29 @@ orion::CompoundValueNode* getGeometry(orion::CompoundValueNode* compoundValueP)
 * GeoJSON Feature has an especial treatment. The geometry is extracted from
 * "geometry" field at the first level.
 *
-* Preconditions are checked by checkGeoJson() function at parsing layer.
+* Checked:
+* - geometry field exists and it's an object
 */
-static bool isFeatureType(CompoundValueNode* feature, orion::BSONObjBuilder* geoJson, ApiVersion apiVersion)
+static bool isFeatureType(CompoundValueNode* feature, orion::BSONObjBuilder* geoJson, ApiVersion apiVersion, std::string* errP)
 {
   for (unsigned int ix = 0; ix < feature->childV.size(); ++ix)
   {
     CompoundValueNode* childP = feature->childV[ix];
     if (childP->name == "geometry")
     {
+      if (childP->valueType != orion::ValueTypeObject)
+      {
+        *errP = "geometry in Feature is not an object";
+        return true;
+      }
+
       compoundValueBson(childP->childV, *geoJson, apiVersion == V1);
       return true;
     }
   }
-  return false;
+
+  *errP = "geometry in Feature not found";
+  return true;
 }
 
 
@@ -206,20 +215,42 @@ static bool isFeatureType(CompoundValueNode* feature, orion::BSONObjBuilder* geo
 * element in the vector has to be used to set the entity location), but not in this
 * point, but at parsing stage.
 *
-* Preconditions are checked by checkGeoJson() function at parsing layer.
+* Checked:
+*   * the feature field exists
+*   * the feature field is an array with exactly one item
+*   * the feature field item has a geometry field and it's an object
 */
-static bool isFeatureCollectionType(CompoundValueNode* featureCollection, orion::BSONObjBuilder* geoJson, ApiVersion apiVersion)
+static bool isFeatureCollectionType(CompoundValueNode* featureCollection, orion::BSONObjBuilder* geoJson, ApiVersion apiVersion, std::string* errP)
 {
   for (unsigned int ix = 0; ix < featureCollection->childV.size(); ++ix)
   {
     CompoundValueNode* childP = featureCollection->childV[ix];
     if (childP->name == "features")
     {
-      return isFeatureType(featureCollection->childV[ix]->childV[0], geoJson, apiVersion);
+      if (childP->valueType != orion::ValueTypeVector)
+      {
+        *errP = "features in FeatureCollection is not an array";
+        return true;
+      }
+      else if (childP->childV.size() == 0)
+      {
+        *errP = "features in FeatureCollection has 0 items";
+        return true;
+      }
+      else if (childP->childV.size() > 1)
+      {
+        *errP = "features in FeatureCollection has more than 1 item";
+        return true;
+      }
+      else
+      {
+        return isFeatureType(featureCollection->childV[ix]->childV[0], geoJson, apiVersion, errP);
+      }
     }
   }
 
-  return false;
+  *errP = "features field not found in FeatureCollection";
+  return true;
 }
 
 
@@ -228,8 +259,10 @@ static bool isFeatureCollectionType(CompoundValueNode* featureCollection, orion:
 * isSpecialGeoJsonType -
 *
 */
-static bool isSpecialGeoJsonType(const ContextAttribute* caP, orion::BSONObjBuilder* geoJson, ApiVersion apiVersion)
+static bool isSpecialGeoJsonType(const ContextAttribute* caP, orion::BSONObjBuilder* geoJson, ApiVersion apiVersion, std::string* errP)
 {
+  *errP = "";
+
   if (caP->compoundValueP == NULL)
   {
     // This is the case when geo location attribute has null value
@@ -243,11 +276,11 @@ static bool isSpecialGeoJsonType(const ContextAttribute* caP, orion::BSONObjBuil
      {
        if (childP->stringValue == "Feature")
        {
-         return isFeatureType(caP->compoundValueP, geoJson, apiVersion);
+         return isFeatureType(caP->compoundValueP, geoJson, apiVersion, errP);
        }
        if (childP->stringValue == "FeatureCollection")
        {
-         return isFeatureCollectionType(caP->compoundValueP, geoJson, apiVersion);
+         return isFeatureCollectionType(caP->compoundValueP, geoJson, apiVersion, errP);
        }
      }
   }
@@ -342,7 +375,14 @@ static bool getGeoJson
 
     // Feature and FeatureCollection has an special treatment, done insise isSpecialGeoJsonType()
     // For other cases (i.e. when isSpecialGeoJsonType() returns false) do it in the "old way"
-    if (!isSpecialGeoJsonType(caP, geoJson, apiVersion))
+    if (isSpecialGeoJsonType(caP, geoJson, apiVersion, errDetail))
+    {
+      if (!errDetail->empty())
+      {
+        return false;
+      }
+    }
+    else
     {
       // Autocast doesn't make sense in this context, strings2numbers enabled in the case of NGSIv1
       caP->valueBson(std::string(ENT_ATTRS_VALUE), &bo, "", true, apiVersion == V1);
@@ -523,7 +563,7 @@ bool processLocationAtEntityCreation
 
     if (!getGeoJson(caP, geoJson, errDetail, apiVersion))
     {
-      oe->fill(SccBadRequest, *errDetail, ERROR_BAD_REQUEST);
+      oe->fill(SccBadRequest, "error parsing location attribute: " + *errDetail, ERROR_BAD_REQUEST);
       return false;
     }
 

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geobox.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geobox.test
@@ -315,13 +315,13 @@ echo
 01. Create entity with geo:box without vector coordinates -> fail
 =================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 104
+Content-Length: 138
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geo:line, geo:box and geo:polygon needs array of strings as value",
+    "description": "error parsing location attribute: geo:line, geo:box and geo:polygon needs array of strings as value",
     "error": "BadRequest"
 }
 
@@ -343,13 +343,13 @@ Date: REGEX(.*)
 02. Create entity with geo:box with 1 coordinate -> fail
 ========================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 73
+Content-Length: 107
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geo:box uses exactly 2 coordinates",
+    "description": "error parsing location attribute: geo:box uses exactly 2 coordinates",
     "error": "BadRequest"
 }
 
@@ -371,13 +371,13 @@ Date: REGEX(.*)
 03. Create entity with geo:box with 3 coordinates -> fail
 =========================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 73
+Content-Length: 107
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geo:box uses exactly 2 coordinates",
+    "description": "error parsing location attribute: geo:box uses exactly 2 coordinates",
     "error": "BadRequest"
 }
 
@@ -399,13 +399,13 @@ Date: REGEX(.*)
 04. Create entity with geo:box with 2 aligned coordinates -> fail
 =================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 89
+Content-Length: 123
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geo:box coordinates are not defining an actual box",
+    "description": "error parsing location attribute: geo:box coordinates are not defining an actual box",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geoline.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geoline.test
@@ -272,13 +272,13 @@ echo
 01. Create entity with geo:line without vector coordinates -> fail
 ==================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 104
+Content-Length: 138
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geo:line, geo:box and geo:polygon needs array of strings as value",
+    "description": "error parsing location attribute: geo:line, geo:box and geo:polygon needs array of strings as value",
     "error": "BadRequest"
 }
 
@@ -300,13 +300,13 @@ Date: REGEX(.*)
 02. Create entity with geo:line with 1 coordinate -> fail
 =========================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 75
+Content-Length: 109
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geo:line uses at least 2 coordinates",
+    "description": "error parsing location attribute: geo:line uses at least 2 coordinates",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geopolygon.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/errors_geopolygon.test
@@ -293,13 +293,13 @@ echo
 01. Create entity with geo:polygon without vector coordinates -> fail
 =====================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 104
+Content-Length: 138
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geo:line, geo:box and geo:polygon needs array of strings as value",
+    "description": "error parsing location attribute: geo:line, geo:box and geo:polygon needs array of strings as value",
     "error": "BadRequest"
 }
 
@@ -321,13 +321,13 @@ Date: REGEX(.*)
 02. Create entity with geo:polygon with 1 coordinate -> fail
 ============================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 78
+Content-Length: 112
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geo:polygon uses at least 4 coordinates",
+    "description": "error parsing location attribute: geo:polygon uses at least 4 coordinates",
     "error": "BadRequest"
 }
 
@@ -349,13 +349,13 @@ Date: REGEX(.*)
 03. Create entity with geo:polygon with last coordinate not matching the first -> fail
 ======================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 88
+Content-Length: 122
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geo:polygon first and last coordinates must match",
+    "description": "error parsing location attribute: geo:polygon first and last coordinates must match",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/4114_geojson_feature_support/geojson_feature_errors.test
+++ b/test/functionalTest/cases/4114_geojson_feature_support/geojson_feature_errors.test
@@ -46,7 +46,7 @@ brokerStart CB
 # 13. Update entity with location geo:json using FeatureCollection type without features field but invalid, see error
 # 14. Update entity with location geo:json using FeatureCollection with features field but 0 items, see error
 # 15. Update entity with location geo:json using FeatureCollection with features field but more than 1 item, see error
-# 16. Update entity with location geo:json u    sing FeatureCollection with features field, one item but without geometry field, see error
+# 16. Update entity with location geo:json using FeatureCollection with features field, one item but without geometry field, see error
 # 17. Update entity with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid, see error
 #
 # 18. Update attr with location geo:json using Feature type without geometry field, see error
@@ -715,13 +715,13 @@ echo
 01. Create entity with location geo:json using Feature type without geometry field, see error
 =============================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 68
+Content-Length: 102
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature not found",
+    "description": "error parsing location attribute: geometry in Feature not found",
     "error": "BadRequest"
 }
 
@@ -729,13 +729,13 @@ Date: REGEX(.*)
 02. Create entity with location geo:json using Feature type with geometry field but invalid, see error
 ======================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 75
+Content-Length: 109
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature is not an object",
+    "description": "error parsing location attribute: geometry in Feature is not an object",
     "error": "BadRequest"
 }
 
@@ -743,13 +743,13 @@ Date: REGEX(.*)
 03. Create entity with location geo:json using FeatureCollection type without features field, see error
 =======================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 84
+Content-Length: 118
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features field not found in FeatureCollection",
+    "description": "error parsing location attribute: features field not found in FeatureCollection",
     "error": "BadRequest"
 }
 
@@ -757,13 +757,13 @@ Date: REGEX(.*)
 04. Create entity with location geo:json using FeatureCollection type with features field but invalid, see error
 ================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 84
+Content-Length: 118
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features in FeatureCollection is not an array",
+    "description": "error parsing location attribute: features in FeatureCollection is not an array",
     "error": "BadRequest"
 }
 
@@ -771,13 +771,13 @@ Date: REGEX(.*)
 05. Create entity with location geo:json using FeatureCollection with features field but 0 items, see error
 ===========================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 80
+Content-Length: 114
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features in FeatureCollection has 0 items",
+    "description": "error parsing location attribute: features in FeatureCollection has 0 items",
     "error": "BadRequest"
 }
 
@@ -785,13 +785,13 @@ Date: REGEX(.*)
 06. Create entity with location geo:json using FeatureCollection with features field but more than 1 item, see error
 ====================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 89
+Content-Length: 123
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features in FeatureCollection has more than 1 item",
+    "description": "error parsing location attribute: features in FeatureCollection has more than 1 item",
     "error": "BadRequest"
 }
 
@@ -799,13 +799,13 @@ Date: REGEX(.*)
 07. Create entity with location geo:json using FeatureCollection with features field, one item but without geometry field, see error
 ====================================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 68
+Content-Length: 102
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature not found",
+    "description": "error parsing location attribute: geometry in Feature not found",
     "error": "BadRequest"
 }
 
@@ -813,13 +813,13 @@ Date: REGEX(.*)
 08. Create entity with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid, see error
 ============================================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 75
+Content-Length: 109
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature is not an object",
+    "description": "error parsing location attribute: geometry in Feature is not an object",
     "error": "BadRequest"
 }
 
@@ -837,13 +837,13 @@ Date: REGEX(.*)
 10. Update entity with location geo:json using Feature type without geometry field, see error
 =============================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 68
+Content-Length: 102
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature not found",
+    "description": "error parsing location attribute: geometry in Feature not found",
     "error": "BadRequest"
 }
 
@@ -851,13 +851,13 @@ Date: REGEX(.*)
 11. Update entity with location geo:json using Feature type with geometry field but invalid, see error
 ======================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 75
+Content-Length: 109
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature is not an object",
+    "description": "error parsing location attribute: geometry in Feature is not an object",
     "error": "BadRequest"
 }
 
@@ -865,13 +865,13 @@ Date: REGEX(.*)
 12. Update entity with location geo:json using FeatureCollection type without features field, see error
 =======================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 84
+Content-Length: 118
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features field not found in FeatureCollection",
+    "description": "error parsing location attribute: features field not found in FeatureCollection",
     "error": "BadRequest"
 }
 
@@ -879,13 +879,13 @@ Date: REGEX(.*)
 13. Update entity with location geo:json using FeatureCollection type with features field but invalid, see error
 ================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 84
+Content-Length: 118
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features in FeatureCollection is not an array",
+    "description": "error parsing location attribute: features in FeatureCollection is not an array",
     "error": "BadRequest"
 }
 
@@ -893,13 +893,13 @@ Date: REGEX(.*)
 14. Update entity with location geo:json using FeatureCollection with features field but 0 items, see error
 ===========================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 80
+Content-Length: 114
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features in FeatureCollection has 0 items",
+    "description": "error parsing location attribute: features in FeatureCollection has 0 items",
     "error": "BadRequest"
 }
 
@@ -907,13 +907,13 @@ Date: REGEX(.*)
 15. Update entity with location geo:json using FeatureCollection with features field but more than 1 item, see error
 ====================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 89
+Content-Length: 123
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features in FeatureCollection has more than 1 item",
+    "description": "error parsing location attribute: features in FeatureCollection has more than 1 item",
     "error": "BadRequest"
 }
 
@@ -921,13 +921,13 @@ Date: REGEX(.*)
 16. Update entity with location geo:json using FeatureCollection with features field, one item but without geometry field, see error
 ====================================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 68
+Content-Length: 102
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature not found",
+    "description": "error parsing location attribute: geometry in Feature not found",
     "error": "BadRequest"
 }
 
@@ -935,13 +935,13 @@ Date: REGEX(.*)
 17. Update entity with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid, see error
 ============================================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 75
+Content-Length: 109
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature is not an object",
+    "description": "error parsing location attribute: geometry in Feature is not an object",
     "error": "BadRequest"
 }
 
@@ -949,13 +949,13 @@ Date: REGEX(.*)
 18. Update attr with location geo:json using Feature type without geometry field, see error
 ===========================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 68
+Content-Length: 102
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature not found",
+    "description": "error parsing location attribute: geometry in Feature not found",
     "error": "BadRequest"
 }
 
@@ -963,13 +963,13 @@ Date: REGEX(.*)
 19. Update attr with location geo:json using Feature type with geometry field but invalid, see error
 ====================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 75
+Content-Length: 109
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature is not an object",
+    "description": "error parsing location attribute: geometry in Feature is not an object",
     "error": "BadRequest"
 }
 
@@ -977,13 +977,13 @@ Date: REGEX(.*)
 20. Update attr with location geo:json using FeatureCollection type without features field, see error
 =====================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 84
+Content-Length: 118
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features field not found in FeatureCollection",
+    "description": "error parsing location attribute: features field not found in FeatureCollection",
     "error": "BadRequest"
 }
 
@@ -991,13 +991,13 @@ Date: REGEX(.*)
 21. Update attr with location geo:json using FeatureCollection type with features field but invalid, see error
 ==============================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 84
+Content-Length: 118
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features in FeatureCollection is not an array",
+    "description": "error parsing location attribute: features in FeatureCollection is not an array",
     "error": "BadRequest"
 }
 
@@ -1005,13 +1005,13 @@ Date: REGEX(.*)
 22. Update attr with location geo:json using FeatureCollection with features field but 0 items, see error
 =========================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 80
+Content-Length: 114
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features in FeatureCollection has 0 items",
+    "description": "error parsing location attribute: features in FeatureCollection has 0 items",
     "error": "BadRequest"
 }
 
@@ -1019,13 +1019,13 @@ Date: REGEX(.*)
 23. Update attr with location geo:json using FeatureCollection with features field but more than 1 item, see error
 ==================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 89
+Content-Length: 123
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "features in FeatureCollection has more than 1 item",
+    "description": "error parsing location attribute: features in FeatureCollection has more than 1 item",
     "error": "BadRequest"
 }
 
@@ -1033,13 +1033,13 @@ Date: REGEX(.*)
 24. Update attr with location geo:json using FeatureCollection with features field, one item but without geometry field, see error
 ==================================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 68
+Content-Length: 102
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature not found",
+    "description": "error parsing location attribute: geometry in Feature not found",
     "error": "BadRequest"
 }
 
@@ -1047,13 +1047,13 @@ Date: REGEX(.*)
 25. Update attr with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid, see error
 ==========================================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 75
+Content-Length: 109
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "geometry in Feature is not an object",
+    "description": "error parsing location attribute: geometry in Feature is not an object",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/4114_geojson_feature_support/geojson_feature_errors_ignoretype.test
+++ b/test/functionalTest/cases/4114_geojson_feature_support/geojson_feature_errors_ignoretype.test
@@ -1,0 +1,1021 @@
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Error not happending with GeoJSON Feature and FeatureCollection if ignoreType is in use
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity with location geo:json using Feature type without geometry field, with ignoreType
+# 02. Create entity with location geo:json using Feature type with geometry field but invalid, with ignoreType
+# 03. Create entity with location geo:json using FeatureCollection type without features field, with ignoreType
+# 04. Create entity with location geo:json using FeatureCollection type without features field but invalid, with ignoreType
+# 05. Create entity with location geo:json using FeatureCollection with features field but 0 items, with ignoreType
+# 06. Create entity with location geo:json using FeatureCollection with features field but more than 1 item, with ignoreType
+# 07. Create entity with location geo:json using FeatureCollection with features field, one item but without geometry field, with ignoreType
+# 08. Create entity with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid, with ignoreType
+#
+# 09. Create entity with location field, with ignoreType
+# 10. Update entity with location geo:json using Feature type without geometry field
+# 11. Update entity with location geo:json using Feature type with geometry field but invalid
+# 12. Update entity with location geo:json using FeatureCollection type without features field
+# 13. Update entity with location geo:json using FeatureCollection type without features field but invalid
+# 14. Update entity with location geo:json using FeatureCollection with features field but 0 items
+# 15. Update entity with location geo:json using FeatureCollection with features field but more than 1 item
+# 16. Update entity with location geo:json using FeatureCollection with features field, one item but without geometry field
+# 17. Update entity with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid
+#
+# 18. Update attr with location geo:json using Feature type without geometry field
+# 19. Update attr with location geo:json using Feature type with geometry field but invalid
+# 20. Update attr with location geo:json using FeatureCollection type without features field
+# 21. Update attr with location geo:json using FeatureCollection type without features field but invalid
+# 22. Update attr with location geo:json using FeatureCollection with features field but 0 items
+# 23. Update attr with location geo:json using FeatureCollection with features field but more than 1 item
+# 24. Update attr with location geo:json using FeatureCollection with features field, one item but without geometry field
+# 25. Update attr with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid
+#
+# FIXME #4122: currently disabled, given that PUT /v2/entities/E/location/value doesn't work with geo locations (see issue)
+# 26. Update attr value with location geo:json using Feature type without geometry field
+# 27. Update attr value with location geo:json using Feature type with geometry field but invalid
+# 28. Update attr value with location geo:json using FeatureCollection type without features field
+# 29. Update attr value with location geo:json using FeatureCollection type without features field but invalid
+# 30. Update attr value with location geo:json using FeatureCollection with features field but 0 items
+# 31. Update attr value with location geo:json using FeatureCollection with features field but more than 1 item
+# 32. Update attr value with location geo:json using FeatureCollection with features field, one item but without geometry field
+# 33. Update attr value with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid
+#
+
+echo "01. Create entity with location geo:json using Feature type without geometry field, with ignoreType"
+echo "==================================================================================================="
+payload='{
+  "id": "E1",
+  "type": "T",
+  "location": {
+    "value": {
+      "type": "Feature",
+      "properties": {
+        "label": "-3.6127119138731127, 40.53901978067972"
+      }
+    },
+    "type": "geo:json",
+    "metadata": {
+       "ignoreType": {
+         "value": true,
+         "type": "Boolean"
+       }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Create entity with location geo:json using Feature type with geometry field but invalid, with ignoreType"
+echo "============================================================================================================"
+payload='{
+  "id": "E2",
+  "type": "T",
+  "location": {
+    "value": {
+      "type": "Feature",
+      "geometry": "foo",
+      "properties": {
+        "label": "-3.6127119138731127, 40.53901978067972"
+      }
+    },
+    "type": "geo:json",
+    "metadata": {
+       "ignoreType": {
+         "value": true,
+         "type": "Boolean"
+       }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. Create entity with location geo:json using FeatureCollection type without features field, with ignoreType"
+echo "============================================================================================================="
+payload='{
+  "id": "E3",
+  "type": "T",
+  "location": {
+    "value": {
+      "type": "FeatureCollection"
+    },
+    "type": "geo:json",
+    "metadata": {
+       "ignoreType": {
+         "value": true,
+         "type": "Boolean"
+       }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "04. Create entity with location geo:json using FeatureCollection type with features field but invalid, with ignoreType"
+echo "======================================================================================================================"
+payload='{
+  "id": "E4",
+  "type": "T",
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": {}
+    },
+    "type": "geo:json",
+    "metadata": {
+       "ignoreType": {
+         "value": true,
+         "type": "Boolean"
+       }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "05. Create entity with location geo:json using FeatureCollection with features field but 0 items, with ignoreType"
+echo "================================================================================================================="
+payload='{
+  "id": "E5",
+  "type": "T",
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": []
+    },
+    "type": "geo:json",
+    "metadata": {
+       "ignoreType": {
+         "value": true,
+         "type": "Boolean"
+       }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "06. Create entity with location geo:json using FeatureCollection with features field but more than 1 item, with ignoreType"
+echo "=========================================================================================================================="
+payload='{
+  "id": "E6",
+  "type": "T",
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -3.6127119138731127,
+              40.53901978067972
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -3.6127119138731127,
+              40.53901978067972
+            ]
+          }
+        }
+      ]
+    },
+    "type": "geo:json",
+    "metadata": {
+       "ignoreType": {
+         "value": true,
+         "type": "Boolean"
+       }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "07. Create entity with location geo:json using FeatureCollection with features field, one item but without geometry field, with ignoreType"
+echo "=========================================================================================================================================="
+payload='{
+  "id": "E7",
+  "type": "T",
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {}
+        }
+      ]
+    },
+    "type": "geo:json",
+    "metadata": {
+       "ignoreType": {
+         "value": true,
+         "type": "Boolean"
+       }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "08. Create entity with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid, with ignoreType"
+echo "=================================================================================================================================================="
+payload='{
+  "id": "E8",
+  "type": "T",
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": []
+        }
+      ]
+    },
+    "type": "geo:json",
+    "metadata": {
+       "ignoreType": {
+         "value": true,
+         "type": "Boolean"
+       }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "09. Create entity with location field, with ignoreType"
+echo "======================================================"
+payload='{
+  "id": "E",
+  "type": "T",
+  "location": {
+    "value": {
+      "type": "Point",
+      "coordinates": [
+          -3.6127119138731127,
+          40.53901978067972
+      ]
+    },
+    "type": "geo:json",
+    "metadata": {
+       "ignoreType": {
+         "value": true,
+         "type": "Boolean"
+       }
+    }
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "10. Update entity with location geo:json using Feature type without geometry field"
+echo "=================================================================================="
+payload='{
+  "location": {
+    "value": {
+      "type": "Feature",
+      "properties": {
+        "label": "-3.6127119138731127, 40.53901978067972"
+      }
+    },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo "11. Update entity with location geo:json using Feature type with geometry field but invalid"
+echo "==========================================================================================="
+payload='{
+  "location": {
+    "value": {
+      "type": "Feature",
+      "geometry": "foo",
+      "properties": {
+        "label": "-3.6127119138731127, 40.53901978067972"
+      }
+    },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo "12. Update entity with location geo:json using FeatureCollection type without features field"
+echo "============================================================================================"
+payload='{
+  "location": {
+    "value": {
+      "type": "FeatureCollection"
+    },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo "13. Update entity with location geo:json using FeatureCollection type with features field but invalid"
+echo "====================================================================================================="
+payload='{
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": {}
+    },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo "14. Update entity with location geo:json using FeatureCollection with features field but 0 items"
+echo "================================================================================================"
+payload='{
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": []
+    },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo "15. Update entity with location geo:json using FeatureCollection with features field but more than 1 item"
+echo "========================================================================================================="
+payload='{
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -3.6127119138731127,
+              40.53901978067972
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -3.6127119138731127,
+              40.53901978067972
+            ]
+          }
+        }
+      ]
+    },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo "16. Update entity with location geo:json using FeatureCollection with features field, one item but without geometry field"
+echo "========================================================================================================================="
+payload='{
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {}
+        }
+      ]
+    },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo "17. Update entity with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid"
+echo "================================================================================================================================="
+payload='{
+  "location": {
+    "value": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": []
+        }
+      ]
+    },
+    "type": "geo:json"
+  }
+}'
+orionCurl --url /v2/entities/E/attrs --payload "$payload"
+echo
+echo
+
+
+echo "18. Update attr with location geo:json using Feature type without geometry field"
+echo "================================================================================"
+payload='{
+    "value": {
+      "type": "Feature",
+      "properties": {
+        "label": "-3.6127119138731127, 40.53901978067972"
+      }
+    },
+    "type": "geo:json"
+}'
+orionCurl --url /v2/entities/E/attrs/location -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "19. Update attr with location geo:json using Feature type with geometry field but invalid"
+echo "========================================================================================="
+payload='{
+    "value": {
+      "type": "Feature",
+      "geometry": "foo",
+      "properties": {
+        "label": "-3.6127119138731127, 40.53901978067972"
+      }
+    },
+    "type": "geo:json"
+}'
+orionCurl --url /v2/entities/E/attrs/location -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "20. Update attr with location geo:json using FeatureCollection type without features field"
+echo "=========================================================================================="
+payload='{
+    "value": {
+      "type": "FeatureCollection"
+    },
+    "type": "geo:json"
+}'
+orionCurl --url /v2/entities/E/attrs/location -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "21. Update attr with location geo:json using FeatureCollection type with features field but invalid"
+echo "==================================================================================================="
+payload='{
+    "value": {
+      "type": "FeatureCollection",
+      "features": {}
+    },
+    "type": "geo:json"
+}'
+orionCurl --url /v2/entities/E/attrs/location -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "22. Update attr with location geo:json using FeatureCollection with features field but 0 items"
+echo "=============================================================================================="
+payload='{
+    "value": {
+      "type": "FeatureCollection",
+      "features": []
+    },
+    "type": "geo:json"
+}'
+orionCurl --url /v2/entities/E/attrs/location -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "23. Update attr with location geo:json using FeatureCollection with features field but more than 1 item"
+echo "======================================================================================================="
+payload='{
+    "value": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -3.6127119138731127,
+              40.53901978067972
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -3.6127119138731127,
+              40.53901978067972
+            ]
+          }
+        }
+      ]
+    },
+    "type": "geo:json"
+}'
+orionCurl --url /v2/entities/E/attrs/location -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "24. Update attr with location geo:json using FeatureCollection with features field, one item but without geometry field"
+echo "======================================================================================================================="
+payload='{
+    "value": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {}
+        }
+      ]
+    },
+    "type": "geo:json"
+}'
+orionCurl --url /v2/entities/E/attrs/location -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "25. Update attr with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid"
+echo "==============================================================================================================================="
+payload='{
+    "value": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": []
+        }
+      ]
+    },
+    "type": "geo:json"
+}'
+orionCurl --url /v2/entities/E/attrs/location -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "26. Update attr value with location geo:json using Feature type without geometry field"
+echo "======================================================================================"
+payload='{
+      "type": "Feature",
+      "properties": {
+        "label": "-3.6127119138731127, 40.53901978067972"
+      }
+}'
+#orionCurl --url /v2/entities/E/attrs/location/value -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "27. Update attr value with location geo:json using Feature type with geometry field but invalid"
+echo "==============================================================================================="
+payload='{
+      "type": "Feature",
+      "geometry": "foo",
+      "properties": {
+        "label": "-3.6127119138731127, 40.53901978067972"
+      }
+}'
+#orionCurl --url /v2/entities/E/attrs/location/value -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "28. Update attr value with location geo:json using FeatureCollection type without features field"
+echo "================================================================================================"
+payload='{
+      "type": "FeatureCollection"
+}'
+#orionCurl --url /v2/entities/E/attrs/location/value -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "29. Update attr value with location geo:json using FeatureCollection type with features field but invalid"
+echo "========================================================================================================="
+payload='{
+      "type": "FeatureCollection",
+      "features": {}
+}'
+#orionCurl --url /v2/entities/E/attrs/location/value -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "30. Update attr value with location geo:json using FeatureCollection with features field but 0 items"
+echo "===================================================================================================="
+payload='{
+      "type": "FeatureCollection",
+      "features": []
+}'
+#orionCurl --url /v2/entities/E/attrs/location/value -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "31. Update attr value with location geo:json using FeatureCollection with features field but more than 1 item"
+echo "============================================================================================================="
+payload='{
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -3.6127119138731127,
+              40.53901978067972
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -3.6127119138731127,
+              40.53901978067972
+            ]
+          }
+        }
+      ]
+}'
+#orionCurl --url /v2/entities/E/attrs/location/value -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "32. Update attr value with location geo:json using FeatureCollection with features field, one item but without geometry field"
+echo "============================================================================================================================="
+payload='{
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {}
+        }
+      ]
+}'
+#orionCurl --url /v2/entities/E/attrs/location/value -X PUT --payload "$payload"
+echo
+echo
+
+
+echo "33. Update attr value with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid"
+echo "====================================================================================================================================="
+payload='{
+  "type": "Point",
+  "coordinates": [
+    -3.6127119138731127,
+    40.53901978067972
+  ]
+}'
+#orionCurl --url /v2/entities/E/attrs/location/value -X PUT --payload "$payload"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity with location geo:json using Feature type without geometry field, with ignoreType
+===================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create entity with location geo:json using Feature type with geometry field but invalid, with ignoreType
+============================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E2?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Create entity with location geo:json using FeatureCollection type without features field, with ignoreType
+=============================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E3?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Create entity with location geo:json using FeatureCollection type with features field but invalid, with ignoreType
+======================================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E4?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Create entity with location geo:json using FeatureCollection with features field but 0 items, with ignoreType
+=================================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E5?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+06. Create entity with location geo:json using FeatureCollection with features field but more than 1 item, with ignoreType
+==========================================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E6?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+07. Create entity with location geo:json using FeatureCollection with features field, one item but without geometry field, with ignoreType
+==========================================================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E7?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+08. Create entity with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid, with ignoreType
+==================================================================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E8?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+09. Create entity with location field, with ignoreType
+======================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E?type=T
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+10. Update entity with location geo:json using Feature type without geometry field
+==================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+11. Update entity with location geo:json using Feature type with geometry field but invalid
+===========================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+12. Update entity with location geo:json using FeatureCollection type without features field
+============================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+13. Update entity with location geo:json using FeatureCollection type with features field but invalid
+=====================================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+14. Update entity with location geo:json using FeatureCollection with features field but 0 items
+================================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+15. Update entity with location geo:json using FeatureCollection with features field but more than 1 item
+=========================================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+16. Update entity with location geo:json using FeatureCollection with features field, one item but without geometry field
+=========================================================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+17. Update entity with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid
+=================================================================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+18. Update attr with location geo:json using Feature type without geometry field
+================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+19. Update attr with location geo:json using Feature type with geometry field but invalid
+=========================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+20. Update attr with location geo:json using FeatureCollection type without features field
+==========================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+21. Update attr with location geo:json using FeatureCollection type with features field but invalid
+===================================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+22. Update attr with location geo:json using FeatureCollection with features field but 0 items
+==============================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+23. Update attr with location geo:json using FeatureCollection with features field but more than 1 item
+=======================================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+24. Update attr with location geo:json using FeatureCollection with features field, one item but without geometry field
+=======================================================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+25. Update attr with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid
+===============================================================================================================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+26. Update attr value with location geo:json using Feature type without geometry field
+======================================================================================
+
+
+27. Update attr value with location geo:json using Feature type with geometry field but invalid
+===============================================================================================
+
+
+28. Update attr value with location geo:json using FeatureCollection type without features field
+================================================================================================
+
+
+29. Update attr value with location geo:json using FeatureCollection type with features field but invalid
+=========================================================================================================
+
+
+30. Update attr value with location geo:json using FeatureCollection with features field but 0 items
+====================================================================================================
+
+
+31. Update attr value with location geo:json using FeatureCollection with features field but more than 1 item
+=============================================================================================================
+
+
+32. Update attr value with location geo:json using FeatureCollection with features field, one item but without geometry field
+=============================================================================================================================
+
+
+33. Update attr value with location geo:json using FeatureCollection with features field, one item but wit geometry field but invalid
+=====================================================================================================================================
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
The check for Feature and FeatureCollection cannot be done at paring stage, due to it depends on the existence of ignoreType metadata in the entity. This PR fixes that.

In addition, we have done some homogenization in `descriptions` in error responses, including the ""error parsing location attribute: " prefix in all the cases