### PR TITLE
FIX memory leak in MQTT getConnetion() logic

### DIFF
--- a/src/lib/mqtt/MqttConnectionManager.cpp
+++ b/src/lib/mqtt/MqttConnectionManager.cpp
@@ -325,6 +325,7 @@ bool MqttConnectionManager::sendMqttNotification(const std::string& host, int po
   if (mosq == NULL)
   {
     // No need of log traces here: the getConnection() method would already print them
+    delete cP;
     semGive();
     return false;
   }


### PR DESCRIPTION
Before this PR:

```
2 tests leaked memory:
   1035: 3001_mqtt_alarms/mqtt_alarms_raise_and_release.test (lost 238 bytes, see mqtt_alarms_raise_and_release.valgrind.out)
   1036: 3001_mqtt_alarms/mqtt_alarms_raise_repeat_and_release.test (lost 238 bytes, see mqtt_alarms_raise_repeat_and_release.valgrind.out)
```

after this PR:

```
Test 001/1: 3001_mqtt_alarms/mqtt_alarms_raise_and_release .......................................................................................... OK (12.41 seconds)
Test 001/1: 3001_mqtt_alarms/mqtt_alarms_raise_repeat_and_release ................................................................................... OK (12.10 seconds)
```