### PR TITLE
Include `orion-api.md` into Read the docs documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ google_analytics: ['UA-83236805-1', 'fiware-orion.readthedocs.io']
 pages:
   - Home: index.md
   - 'Getting Started': 'quick_start_guide.md'
+  - 'API': 'orion-api.md'
   - 'User & Programmers Manual':
       - 'Introduction': 'user/index.md'
       - 'API Walkthrough': 'user/walkthrough_apiv2.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,10 +13,10 @@ google_analytics: ['UA-83236805-1', 'fiware-orion.readthedocs.io']
 pages:
   - Home: index.md
   - 'Getting Started': 'quick_start_guide.md'
-  - 'API': 'orion-api.md'
   - 'User & Programmers Manual':
       - 'Introduction': 'user/index.md'
       - 'API Walkthrough': 'user/walkthrough_apiv2.md'
+      - 'API Reference': 'user/orion-api.md'      
       - 'Pagination': 'user/pagination.md'
       - 'CORS': 'user/cors.md'
       - 'Geolocation': 'user/geolocation.md'


### PR DESCRIPTION
This PR adds orion-api.md file to the Read the docs documentation

This PR is part of a bigger series https://github.com/telefonicaid/fiware-orion/pull/4141