### PR TITLE
FIX upgrade Alpine version from 3.15.0 to 3.16.0 in Dockerfile.alpine

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -19,7 +19,7 @@
 # iot_support at tid dot es
 #
 
-ARG  IMAGE_TAG=3.15.0
+ARG  IMAGE_TAG=3.16.0
 FROM alpine:${IMAGE_TAG}
 
 ARG GITHUB_ACCOUNT=telefonicaid


### PR DESCRIPTION
Alpine 3.16.0 has been released.