### PR TITLE
Removed unnecessary single quote from user documents.

### DIFF
--- a/doc/manuals.jp/user/walkthrough_apiv2.md
+++ b/doc/manuals.jp/user/walkthrough_apiv2.md
@@ -113,7 +113,7 @@ broker にリクエストを発行するには、`curl` コマンド・ライン
 -   POST の場合 :
 
 ```
-curl localhost:1026/<operation_url> -s -S [headers]' -d @- <<EOF
+curl localhost:1026/<operation_url> -s -S [headers] -d @- <<EOF
 [payload]
 EOF
 ```

--- a/doc/manuals/user/walkthrough_apiv2.md
+++ b/doc/manuals/user/walkthrough_apiv2.md
@@ -150,7 +150,7 @@ following:
 -   For POST:
 
 ```
-curl localhost:1026/<operation_url> -s -S [headers]' -d @- <<EOF
+curl localhost:1026/<operation_url> -s -S [headers] -d @- <<EOF
 [payload]
 EOF
 ```


### PR DESCRIPTION
Remove unnecessary single quote from `user/walkthrough_apiv2`.

There were in `manuals` and `manuals.jp`.

ref. https://fiware-orion.readthedocs.io/en/master/user/walkthrough_apiv2.html#issuing-commands-to-the-broker

ref. https://fiware-orion.letsfiware.jp/user/walkthrough_apiv2/#_2