### PR TITLE
FIX preamble and NGSIv2 spec links

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Reference sections below in order to know more details about the API
 
 ## API
 
--   Orion API FIWARE NGSIv2 Walkthrough FIWARE NGSI v2 [(en)](doc/manuals/user/walkthrough_apiv2.md)
+-   FIWARE NGSIv2 Orion API Walkthrough FIWARE NGSI v2 [(en)](doc/manuals/user/walkthrough_apiv2.md)
     [(jp)](doc/manuals.jp/user/walkthrough_apiv2.md) (Markdown)
 
 [Top](#top)
@@ -186,7 +186,7 @@ Reference sections below in order to know more details about the API
 
 API Reference Documentation:
 
--   Orion API FIWARE NGSI v2
+-   FIWARE NGSIv2 Orion API
     [(en)](doc/manuals/orion-api.md)
     [(jp)](doc/manuals.jp/orion-api.md) (Markdown)
 

--- a/doc/manuals/orion-api.md
+++ b/doc/manuals/orion-api.md
@@ -1,4 +1,4 @@
-# FIWARE-NGSI v2 (release 2.1) Specification
+# FIWARE NGSIv2 Orion API Specification
  
 <!-- TOC -->
 
@@ -146,9 +146,13 @@
 <!-- /TOC -->
 
 # Preface
- 
-This is the release 2.1 of the [NGSIv2 specification](http://telefonicaid.github.io/fiware-orion/api/v2/stable),
-fully backward compatible with the original NGSIv2 released at September 15th, 2018.
+
+This document describes the FIWARE NSGISv2 Orion API specification. The Orion API is 
+built upon [the original NGSIv2 specification](http://telefonicaid.github.io/fiware-orion/archive/api/v2/stable)],
+adding a huge number of improvements and enhancements.
+
+The Orion API is fully compatible with the original NGSIv2 specification although some differences
+are described in [an annex]((#differences-regarding-the-original-ngsiv2-spec)) at the end of this document.
 
 # Specification
 
@@ -4508,7 +4512,7 @@ _**Response code**_
 # Differences regarding the original NGSIv2 spec
 
 This section contains the topics that, due to implementation decision, differs from the described in [the 
-original NGSIv2 specification](http://telefonicaid.github.io/fiware-orion/api/v2/stable/). These differences come after years of experience with NGSIv2, in two senses:
+original NGSIv2 specification](http://telefonicaid.github.io/fiware-orion/archive/api/v2/stable/). These differences come after years of experience with NGSIv2, in two senses:
 
 * Some functionally originally included in NGSIv2 has resulted not to be really useful or needed in real world scenarios. Thus, Orion doesn't implement it. For instance, update registrations operation
 * NGSIv2 has some flaws not detected at specification time. For instance, the way in which `failed` subscription status was designed.

--- a/doc/manuals/orion-api.md
+++ b/doc/manuals/orion-api.md
@@ -151,7 +151,7 @@ This document describes the FIWARE NSGISv2 Orion API specification. The Orion AP
 built upon [the original NGSIv2 specification](http://telefonicaid.github.io/fiware-orion/archive/api/v2/stable)],
 adding a huge number of improvements and enhancements.
 
-The Orion API is fully compatible with the original NGSIv2 specification although some differences
+The Orion API is fully compatible with the original NGSIv2 specification although some minor differences
 are described in [an annex]((#differences-regarding-the-original-ngsiv2-spec)) at the end of this document.
 
 # Specification
@@ -4512,7 +4512,7 @@ _**Response code**_
 # Differences regarding the original NGSIv2 spec
 
 This section contains the topics that, due to implementation decision, differs from the described in [the 
-original NGSIv2 specification](http://telefonicaid.github.io/fiware-orion/archive/api/v2/stable/). These differences come after years of experience with NGSIv2, in two senses:
+original NGSIv2 specification](http://telefonicaid.github.io/fiware-orion/archive/api/v2/stable/). These differences come after years of experience integrating and operating vertical solutions with NGSIv2, in two senses:
 
 * Some functionally originally included in NGSIv2 has resulted not to be really useful or needed in real world scenarios. Thus, Orion doesn't implement it. For instance, update registrations operation
 * NGSIv2 has some flaws not detected at specification time. For instance, the way in which `failed` subscription status was designed.

--- a/scripts/apib_renders/contextbroker-build-docgen.sh
+++ b/scripts/apib_renders/contextbroker-build-docgen.sh
@@ -25,6 +25,8 @@
 # - It is assumed that required commands (e.g. rvm, apiary, etc.) are already installed in the system where this scripts runs; otherwise it is going to fail
 # - It is assumed that required env vars (e.g. WORKSPACE) are already set; otherwise it is going to fail
 
+# FIXME: after the changes in the location of the NGSIv2 documents (from api/v2 to archive/api/v2) I'm not
+# sure if this script is longer working. It should checked if it is needed at some moment
 
 # Preparing specifications repo clone
 cd /tmp

--- a/scripts/apib_renders/ngsiv2-upload-stable-cookbook.sh
+++ b/scripts/apib_renders/ngsiv2-upload-stable-cookbook.sh
@@ -25,6 +25,9 @@
 # - It is assumed that required commands (e.g. rvm, apiary, etc.) are already installed in the system where this scripts runs; otherwise it is going to fail
 # - It is assumed that required env vars (e.g. WORKSPACE) are already set; otherwise it is going to fail
 
+# FIXME: after the changes in the location of the NGSIv2 documents (from api/v2 to archive/api/v2) I'm not
+# sure if this script is longer working. It should checked if it is needed at some moment
+
 # Preparing specifications repo clone
 cd /tmp
 rm -rf specifications  # to avoid problems if this job previously failed without reaching end of script

--- a/scripts/apib_renders/ngsiv2-upload-stable-spec.sh
+++ b/scripts/apib_renders/ngsiv2-upload-stable-spec.sh
@@ -25,6 +25,9 @@
 # - It is assumed that required commands (e.g. rvm, apiary, etc.) are already installed in the system where this scripts runs; otherwise it is going to fail
 # - It is assumed that required env vars (e.g. WORKSPACE) are already set; otherwise it is going to fail
 
+# FIXME: after the changes in the location of the NGSIv2 documents (from api/v2 to archive/api/v2) I'm not
+# sure if this script is longer working. It should checked if it is needed at some moment
+
 # Preparing specifications repo clone
 cd /tmp
 rm -rf specifications  # to avoid problems if this job previously failed without reaching end of script


### PR DESCRIPTION
This is part of a bigger series https://github.com/telefonicaid/fiware-orion/pull/4141

Fix preamble wording and links to old NGSIv2 spec