### PR TITLE
FIX fail in csub cache logic that may make CB to crash in some cases

### DIFF
--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -204,7 +204,6 @@ typedef void (*OrionExitFunction)(int exitCode, const std::string& reason);
 */
 extern char               fwdHost[];
 extern int                fwdPort;
-extern bool               ngsi9Only;
 extern bool               harakiri;
 extern int                startTime;
 extern int                statisticsTime;

--- a/src/lib/mongoBackend/TriggeredSubscription.cpp
+++ b/src/lib/mongoBackend/TriggeredSubscription.cpp
@@ -82,39 +82,6 @@ TriggeredSubscription::TriggeredSubscription
 
 /* ****************************************************************************
 *
-* TriggeredSubscription::TriggeredSubscription -
-*
-* Constructor without throttling (for NGSI9 subscriptions)
-*/
-TriggeredSubscription::TriggeredSubscription
-(
-  RenderFormat             _renderFormat,
-  const ngsiv2::HttpInfo&  _httpInfo,
-  const ngsiv2::MqttInfo&  _mqttInfo,
-  const StringList&        _attrL
-)
-:
-  throttling(-1),
-  maxFailsLimit(-1),
-  failsCounter(-1),
-  lastNotification(-1),
-  renderFormat(_renderFormat),
-  httpInfo(_httpInfo),
-  mqttInfo(_mqttInfo),
-  attrL(_attrL),
-  cacheSubId(""),
-  tenant(""),
-  stringFilterP(NULL),
-  mdStringFilterP(NULL),
-  blacklist(false),
-  covered(false)
-{
-}
-
-
-
-/* ****************************************************************************
-*
 * TriggeredSubscription::~TriggeredSubscription - 
 */
 TriggeredSubscription::~TriggeredSubscription()

--- a/src/lib/mongoBackend/TriggeredSubscription.h
+++ b/src/lib/mongoBackend/TriggeredSubscription.h
@@ -88,11 +88,6 @@ class TriggeredSubscription
                         const char*              _tenant,
                         bool                     _covered);
 
-  TriggeredSubscription(RenderFormat             _renderFormat,
-                        const ngsiv2::HttpInfo&  _httpInfo,
-                        const ngsiv2::MqttInfo&  _mqttInfo,
-                        const StringList&        _attrL);
-
   ~TriggeredSubscription();
 
   // FIXME P5: This method will cease to exist once geo-stuff is implemented the same way StringFilter was implemented (for Issue #1705)

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -419,12 +419,10 @@ int mongoSubCacheItemInsert
   if (sub.hasField(CSUB_MQTTTOPIC))
   {
     cSubP->mqttInfo.fill(sub);
-    //cSubP->httpInfo.json = NULL;
   }
   else
   {
     cSubP->httpInfo.fill(sub);
-    //cSubP->mqttInfo.json = NULL;
   }
 
   //

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -129,8 +129,14 @@ int mongoSubCacheItemInsert(const char* tenant, const orion::BSONObj& sub)
   //
   // Note that the URL of the notification is stored outside the httpInfo object in mongo
   //
-  cSubP->httpInfo.fill(sub);
-  cSubP->mqttInfo.fill(sub);
+  if (sub.hasField(CSUB_MQTTTOPIC))
+  {
+    cSubP->mqttInfo.fill(sub);
+  }
+  else
+  {
+    cSubP->httpInfo.fill(sub);
+  }
 
 
   //
@@ -410,9 +416,16 @@ int mongoSubCacheItemInsert
   //
   // Note that the URL of the notification is stored outside the httpInfo object in mongo
   //
-  cSubP->httpInfo.fill(sub);
-  cSubP->mqttInfo.fill(sub);
-
+  if (sub.hasField(CSUB_MQTTTOPIC))
+  {
+    cSubP->mqttInfo.fill(sub);
+    //cSubP->httpInfo.json = NULL;
+  }
+  else
+  {
+    cSubP->httpInfo.fill(sub);
+    //cSubP->mqttInfo.json = NULL;
+  }
 
   //
   // String Filters

--- a/test/functionalTest/cases/2560_custom_notification_json/custom_notification_http_json_trigger_after_update.test
+++ b/test/functionalTest/cases/2560_custom_notification_json/custom_notification_http_json_trigger_after_update.test
@@ -1,0 +1,201 @@
+# Copyright 2022 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Custom notification HTTP trigger notification after updating subscription
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create entity
+# 02. Create subscriptions without json field
+# 03. Update subscription to add json field
+# 04. Update entity
+# 05. Dump accumulator, see 1 notification
+#
+
+echo "01. Create entity"
+echo "================="
+payload='{
+  "id": "E1",
+  "type": "ET",
+  "A": {
+    "value": "on",
+    "type": "Text"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Create subscriptions without json field"
+echo "==========================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "idPattern": ".*",
+        "type": "ET"
+      }
+    ]
+  },
+  "notification": {
+    "attrs": [
+      "A"
+    ],
+    "httpCustom": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
+      "headers": {
+        "fiware-servicepath": "/sss"
+      }
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+SUB_ID=$(echo "$_responseHeaders" | grep Location | awk -F/ '{ print $4 }' | tr -d "\r\n")
+
+
+echo "03. Update subscription to add json field"
+echo "========================================="
+payload='{
+  "A": "active",
+  "subject": {
+    "entities": [
+      {
+        "idPattern": ".*",
+        "type": "ET"
+      }
+    ]
+  },
+  "notification": {
+    "attrs": [
+      "A"
+    ],
+    "httpCustom": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
+      "headers": {
+        "fiware-servicepath": "/sss"
+      },
+      "json": {
+        "id": "id1",
+        "A": "devel"
+      }
+    }
+  }
+}'
+orionCurl -X PATCH --url /v2/subscriptions/$SUB_ID --payload "$payload"
+echo
+echo
+
+
+
+echo "04. Update entity"
+echo "================="
+payload='{
+  "A": {
+    "value": "off",
+    "type": "Text"
+  }
+}'
+orionCurl --url /v2/entities/E1/attrs --payload "$payload"
+echo
+echo
+
+
+echo "05. Dump accumulator, see 1 notification"
+echo "========================================"
+accumulatorDump
+echo
+echo
+
+
+
+--REGEXPECT--
+01. Create entity
+=================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=ET
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Create subscriptions without json field
+===========================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+03. Update subscription to add json field
+=========================================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+04. Update entity
+=================
+HTTP/1.1 204 No Content
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Dump accumulator, see 1 notification
+========================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Fiware-Servicepath: /sss
+Content-Length: 24
+User-Agent: orion/3.7.0-next libcurl/7.74.0
+Ngsiv2-Attrsformat: custom
+Host: 127.0.0.1:9997
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+
+{
+    "A": "devel",
+    "id": "id1"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+accumulatorStop


### PR DESCRIPTION
Fixes a crash situation (checked by the .test file included in this PR) discovered by @danielvillalbamota 

No need of CHANGES_NEXT_RELEASE entry given that is a fix in a functionality introduced post-3.7.0.

Some minor cleanup in TriggeredSubscriptions and globals.h spotted while working on this.