### PR TITLE
use HTTPS for downloads

### DIFF
--- a/ci/deb/build-dep.sh
+++ b/ci/deb/build-dep.sh
@@ -81,7 +81,7 @@ echo "INSTALL: rapidjson" \
 && mv /opt/rapidjson-1.1.0/include/rapidjson/ /usr/local/include
 
 echo "INSTALL: libmicrohttpd" \
-&& curl -L http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz | tar xzC /opt/ \
+&& curl -L https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz | tar xzC /opt/ \
 && cd /opt/libmicrohttpd-0.9.70  \
 && ./configure --disable-messages --disable-postprocessor --disable-dauth  \
 && make \
@@ -97,7 +97,7 @@ echo "INSTALL: gmock" \
 && make install
 
 echo "INSTALL: mosquitto" \
-&& curl -kL http://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz | tar xzC /opt/ \
+&& curl -kL https://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz | tar xzC /opt/ \
 && cd /opt/mosquitto-2.0.12 \
 && sed -i 's/WITH_CJSON:=yes/WITH_CJSON:=no/g' config.mk \
 && sed -i 's/WITH_STATIC_LIBRARIES:=no/WITH_STATIC_LIBRARIES:=yes/g' config.mk \

--- a/doc/manuals.jp/admin/build_source.md
+++ b/doc/manuals.jp/admin/build_source.md
@@ -46,7 +46,7 @@ Orion Context Broker は、以下のライブラリをビルドの依存関係�
 
 * ソースから libmicrohttpd をインストールします (`./configure` 下のコマンドはライブラリの最小限のフットプリントを得るための推奨ビルド設定を示していますが、上級ユーザの方は好きなように設定できます)
 
-        wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz
+        wget https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz
         tar xvf libmicrohttpd-0.9.70.tar.gz
         cd libmicrohttpd-0.9.70
         ./configure --disable-messages --disable-postprocessor --disable-dauth
@@ -56,7 +56,7 @@ Orion Context Broker は、以下のライブラリをビルドの依存関係�
 
 * ソースから mosquitto をインストールします (WITH_CJSON, WITH_STATIC_LIBRARIES, WITH_SHARED_LIBRARIES の設定を変更することで、mosquitto-2.0.12/ の下の config.mk ファイルを変更してビルドを微調整できます)
 
-        wget http://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz
+        wget https://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz
         tar xvf mosquitto-2.0.12.tar.gz
         cd mosquitto-2.0.12
         sed -i 's/WITH_CJSON:=yes/WITH_CJSON:=no/g' config.mk
@@ -195,7 +195,7 @@ aarch64 アーキテクチャの場合、apt-get を使用して libxslt をイ�
 * ソースから libmicrohttpd をインストールします (`./configure` 下のコマンドはライブラリの最小限のフットプリントを
 得るための推奨ビルド設定を示していますが、上級ユーザの方は好きなように設定できます)
 
-        wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz
+        wget https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz
         tar xvf libmicrohttpd-0.9.70.tar.gz
         cd libmicrohttpd-0.9.70
         ./configure --disable-messages --disable-postprocessor --disable-dauth
@@ -205,7 +205,7 @@ aarch64 アーキテクチャの場合、apt-get を使用して libxslt をイ�
 
 * ソースから mosquitto をインストールします (WITH_CJSON, WITH_STATIC_LIBRARIES, WITH_SHARED_LIBRARIES の設定を変更することで、mosquitto-2.0.12/ の下の config.mk ファイルを変更してビルドを微調整できます)
 
-        wget http://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz
+        wget https://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz
         tar xvf mosquitto-2.0.12.tar.gz
         cd mosquitto-2.0.12
         sed -i 's/WITH_CJSON:=yes/WITH_CJSON:=no/g' config.mk

--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -47,7 +47,7 @@ commands that require root privilege):
 
 * Install libmicrohttpd from sources (the `./configure` command below shows the recommended build configuration to get minimum library footprint, but if you are an advanced user, you can configure as you prefer)
 
-        wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz
+        wget https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz
         tar xvf libmicrohttpd-0.9.70.tar.gz
         cd libmicrohttpd-0.9.70
         ./configure --disable-messages --disable-postprocessor --disable-dauth
@@ -57,7 +57,7 @@ commands that require root privilege):
 
 * Install mosquitto from sources (appart from changing WITH_CJSON, WITH_STATIC_LIBRARIES and WITH_SHARED_LIBRARIES settings, config.mk file under mosquitto-2.0.12/ can be modified to fine tune the build)
 
-        wget http://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz
+        wget https://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz
         tar xvf mosquitto-2.0.12.tar.gz
         cd mosquitto-2.0.12
         sed -i 's/WITH_CJSON:=yes/WITH_CJSON:=no/g' config.mk
@@ -194,7 +194,7 @@ commands that require root privilege):
 
 * Install libmicrohttpd from sources (the `./configure` command below shows the recommended build configuration to get minimum library footprint, but if you are an advanced user, you can configure as you prefer)
 
-        wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz
+        wget https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz
         tar xvf libmicrohttpd-0.9.70.tar.gz
         cd libmicrohttpd-0.9.70
         ./configure --disable-messages --disable-postprocessor --disable-dauth
@@ -204,7 +204,7 @@ commands that require root privilege):
 
 * Install mosquitto from sources (appart from changing WITH_CJSON, WITH_STATIC_LIBRARIES and WITH_SHARED_LIBRARIES settings, config.mk file under mosquitto-2.0.12/ can be modified to fine tune the build)
 
-        wget http://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz
+        wget https://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz
         tar xvf mosquitto-2.0.12.tar.gz
         cd mosquitto-2.0.12
         sed -i 's/WITH_CJSON:=yes/WITH_CJSON:=no/g' config.mk

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,7 +60,7 @@ RUN \
       libgcrypt-dev && \
     # Install libmicrohttpd from source
     cd /opt && \
-    curl -kOL http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz && \
+    curl -kOL https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz && \
     tar xvf libmicrohttpd-0.9.70.tar.gz && \
     cd libmicrohttpd-0.9.70 && \
     ./configure --disable-messages --disable-postprocessor --disable-dauth && \
@@ -69,7 +69,7 @@ RUN \
     ldconfig && \
     # Install mosquitto from source
     cd /opt && \
-    curl -kOL http://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz && \
+    curl -kOL https://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz && \
     tar xvf mosquitto-2.0.12.tar.gz && \
     cd mosquitto-2.0.12 && \
     sed -i 's/WITH_CJSON:=yes/WITH_CJSON:=no/g' config.mk && \

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -58,7 +58,7 @@ RUN \
     # Install libmicrohttpd from source
     echo =====================MARK1 && \
     cd /opt && \
-    curl -kOL http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz && \
+    curl -kOL https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.70.tar.gz && \
     tar xvf libmicrohttpd-0.9.70.tar.gz && \
     cd libmicrohttpd-0.9.70 && \
     ./configure --disable-messages --disable-postprocessor --disable-dauth && \
@@ -70,7 +70,7 @@ RUN \
     echo =====================MARK3 && \
     # Install mosquitto from source
     cd /opt && \
-    curl -kOL http://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz && \
+    curl -kOL https://mosquitto.org/files/source/mosquitto-2.0.12.tar.gz && \
     tar xvf mosquitto-2.0.12.tar.gz && \
     cd mosquitto-2.0.12 && \
     sed -i 's/WITH_CJSON:=yes/WITH_CJSON:=no/g' config.mk && \


### PR DESCRIPTION
use HTTPS for downloading *libmicrohttpd* and *Mosquitto*.

both web servers (i.e. `gnu.org` and `mosquitto.org`) are not configured to redirect to HTTPS.