### PR TITLE
FIX toJsonV1 wrappers to simplify usage

### DIFF
--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -267,6 +267,28 @@ std::string Entity::toJsonV1
 
 /* ****************************************************************************
 *
+* Entity::toJsonV1 -
+*
+* Wrapper of toJsonV1 with empty attrsFilter and metadataFilter
+*
+*/
+std::string Entity::toJsonV1
+(
+  bool         asJsonObject,
+  RequestType  requestType,
+  bool         blacklist,
+  bool         comma,
+  bool         omitAttributeValues
+)
+{
+  std::vector<std::string> emptyV;
+  return toJsonV1(asJsonObject, requestType, emptyV, blacklist, emptyV, comma, omitAttributeValues);
+}
+
+
+
+/* ****************************************************************************
+*
 * Entity::toJson -
 *
 * The rendering of JSON in APIv2 depends on the URI param 'options'

--- a/src/lib/apiTypesV2/Entity.h
+++ b/src/lib/apiTypesV2/Entity.h
@@ -80,6 +80,12 @@ class Entity
                         bool                             comma,
                         bool                             omitAttributeValues = false);
 
+  std::string  toJsonV1(bool                             asJsonObject,
+                        RequestType                      requestType,
+                        bool                             blacklist,
+                        bool                             comma,
+                        bool                             omitAttributeValues = false);
+
   std::string  toJson(RenderFormat                         renderFormat,
                       const std::vector<std::string>&      attrsFilter,
                       bool                                 blacklist,

--- a/src/lib/apiTypesV2/EntityVector.cpp
+++ b/src/lib/apiTypesV2/EntityVector.cpp
@@ -118,12 +118,9 @@ std::string EntityVector::toJsonV1
 
   out += startTag("contextElements", true);
 
-  // No attribute or metadata filter in this case, an empty vector is used to fulfil method signature
-  std::vector<std::string> emptyV;
-
   for (unsigned int ix = 0; ix < vec.size(); ++ix)
   {
-    out += vec[ix]->toJsonV1(asJsonObject, requestType, emptyV, false, emptyV, ix != vec.size() - 1);
+    out += vec[ix]->toJsonV1(asJsonObject, requestType, false, ix != vec.size() - 1);
   }
 
   out += endTag(comma, true);

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -182,6 +182,33 @@ std::string ContextElementResponse::toJsonV1
 
 /* ****************************************************************************
 *
+* ContextElementResponse::toJsonV1 -
+*
+* Wrapper of toJsonV1 with empty attrsFilter and metadataFilter
+*/
+std::string ContextElementResponse::toJsonV1
+(
+  bool         asJsonObject,
+  RequestType  requestType,
+  bool         blacklist,
+  bool         comma,
+  bool         omitAttributeValues
+)
+{
+  std::string out = "";
+
+  out += startTag();
+  out += entity.toJsonV1(asJsonObject, requestType, blacklist, true, omitAttributeValues);
+  out += statusCode.toJsonV1(false);
+  out += endTag(comma, false);
+
+  return out;
+}
+
+
+
+/* ****************************************************************************
+*
 * ContextElementResponse::toJson - 
 */
 std::string ContextElementResponse::toJson

--- a/src/lib/ngsi/ContextElementResponse.h
+++ b/src/lib/ngsi/ContextElementResponse.h
@@ -74,6 +74,12 @@ typedef struct ContextElementResponse
                         bool                             comma               = false,
                         bool                             omitAttributeValues = false);
 
+  std::string  toJsonV1(bool                             asJsonObject,
+                        RequestType                      requestType,
+                        bool                             blacklist,
+                        bool                             comma               = false,
+                        bool                             omitAttributeValues = false);
+
   std::string  toJson(RenderFormat                         renderFormat,
                       const std::vector<std::string>&      attrsFilter,
                       bool                                 blacklist,

--- a/src/lib/ngsi/ContextElementResponseVector.cpp
+++ b/src/lib/ngsi/ContextElementResponseVector.cpp
@@ -75,6 +75,42 @@ std::string ContextElementResponseVector::toJsonV1
 
 /* ****************************************************************************
 *
+* ContextElementResponseVector::toJsonV1 -
+*
+* Wrapper of toJsonV1 with empty attrsFilter and metadataFilter
+*/
+std::string ContextElementResponseVector::toJsonV1
+(
+  bool         asJsonObject,
+  RequestType  requestType,
+  bool         blacklist,
+  bool         comma,
+  bool         omitAttributeValues
+)
+{
+  std::string out = "";
+
+  if (vec.size() == 0)
+  {
+    return "";
+  }
+
+  out += startTag("contextResponses", true);
+
+  for (unsigned int ix = 0; ix < vec.size(); ++ix)
+  {
+    out += vec[ix]->toJsonV1(asJsonObject, requestType, blacklist, ix < (vec.size() - 1), omitAttributeValues);
+  }
+
+  out += endTag(comma, true);
+
+  return out;
+}
+
+
+
+/* ****************************************************************************
+*
 * ContextElementResponseVector::toJson - 
 */
 std::string ContextElementResponseVector::toJson

--- a/src/lib/ngsi/ContextElementResponseVector.h
+++ b/src/lib/ngsi/ContextElementResponseVector.h
@@ -50,6 +50,12 @@ typedef struct ContextElementResponseVector
                                     bool                             comma               = false,
                                     bool                             omitAttributeValues = false);
 
+  std::string              toJsonV1(bool                             asJsonObject,
+                                    RequestType                      requestType,
+                                    bool                             blacklist,
+                                    bool                             comma               = false,
+                                    bool                             omitAttributeValues = false);
+
   std::string              toJson(RenderFormat                         renderFormat,
                                   const std::vector<std::string>&      attrsFilter,
                                   bool                                 blacklist,

--- a/src/lib/ngsi10/QueryContextResponse.cpp
+++ b/src/lib/ngsi10/QueryContextResponse.cpp
@@ -126,12 +126,9 @@ std::string QueryContextResponse::toJsonV1(bool asJsonObject)
   //
   out += startTag();
 
-  // No attribute or metadata filter in this case, an empty vector is used to fulfil method signature
-  std::vector<std::string> emptyV;
-
   if (contextElementResponseVector.size() > 0)
   {
-    out += contextElementResponseVector.toJsonV1(asJsonObject, QueryContext, emptyV, false, emptyV, errorCodeRendered);
+    out += contextElementResponseVector.toJsonV1(asJsonObject, QueryContext, false, errorCodeRendered);
   }
 
   if (errorCodeRendered == true)

--- a/src/lib/ngsi10/UpdateContextResponse.cpp
+++ b/src/lib/ngsi10/UpdateContextResponse.cpp
@@ -99,10 +99,7 @@ std::string UpdateContextResponse::toJsonV1(bool asJsonObject)
     }
     else
     {      
-      // No attribute or metadata filter in this case, an empty vector is used to fulfil method signature
-      std::vector<std::string> emptyV;
-
-      out += contextElementResponseVector.toJsonV1(asJsonObject, RtUpdateContextResponse, emptyV, false, emptyV, false);
+      out += contextElementResponseVector.toJsonV1(asJsonObject, RtUpdateContextResponse, false, false);
     }
   }
   

--- a/src/lib/serviceRoutines/getAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getAllEntitiesWithTypeAndId.cpp
@@ -135,11 +135,8 @@ std::string getAllEntitiesWithTypeAndId
 
   // 06. Translate QueryContextResponse to ContextElementResponse
 
-  // No attribute or metadata filter in this case, an empty vector is used to fulfil method signature
-  std::vector<std::string> emptyV;
-
   response.fill(&parseDataP->qcrs.res, entityId, entityType);
-  TIMED_RENDER(answer = response.toJsonV1(asJsonObject, RtContextElementResponse, emptyV, false, emptyV));
+  TIMED_RENDER(answer = response.toJsonV1(asJsonObject, RtContextElementResponse, false));
 
   // 07. Cleanup and return result
   parseDataP->qcr.res.release();

--- a/src/lib/serviceRoutines/getIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntity.cpp
@@ -115,11 +115,7 @@ std::string getIndividualContextEntity
 
 
   // 5. Render the ContextElementResponse
-
-  // No attribute or metadata filter in this case, an empty vector is used to fulfil method signature
-  std::vector<std::string> emptyV;
-
-  TIMED_RENDER(answer = response.toJsonV1(asJsonObject, IndividualContextEntity, emptyV, false, emptyV));
+  TIMED_RENDER(answer = response.toJsonV1(asJsonObject, IndividualContextEntity, false));
 
 
   // 6. Cleanup and return result

--- a/test/unittests/apiTypesV2/Entity_test.cpp
+++ b/test/unittests/apiTypesV2/Entity_test.cpp
@@ -114,9 +114,8 @@ TEST(Entity, checkV1)
   // render
   const char*               outfile1 = "ngsi.contextelement.check.middle.json";
   std::string               out;
-  std::vector<std::string>  emptyV;
 
-  out = en2P->toJsonV1(false, UpdateContextElement, emptyV, false, emptyV, false, false);
+  out = en2P->toJsonV1(false, UpdateContextElement, false, false, false);
   EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile1)) << "Error getting test data from '" << outfile1 << "'";
   EXPECT_STREQ(expectedBuf, out.c_str());
 

--- a/test/unittests/ngsi/ContextElementResponseVector_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponseVector_test.cpp
@@ -73,10 +73,8 @@ TEST(ContextElementResponseVector, render)
 
   utInit();
 
-  std::vector<std::string> emptyV;
-
   // FIXME P2: "" is string, function signature says bool..
-  out = cerv.toJsonV1(false, UpdateContextElement, emptyV, false, emptyV, "");
+  out = cerv.toJsonV1(false, UpdateContextElement, false, "");
   EXPECT_STREQ("", out.c_str());
 
   cer.entity.id         = "ID";

--- a/test/unittests/ngsi/ContextElementResponse_test.cpp
+++ b/test/unittests/ngsi/ContextElementResponse_test.cpp
@@ -79,9 +79,7 @@ TEST(ContextElementResponse, render)
 
    cer.statusCode.fill(SccOk, "details");
 
-   std::vector<std::string> emptyV;
-
-   out = cer.toJsonV1(false, UpdateContextElement, emptyV, false, emptyV, false);
+   out = cer.toJsonV1(false, UpdateContextElement, false, false);
    EXPECT_EQ("OK", testDataFromFile(expectedBuf, sizeof(expectedBuf), outfile)) << "Error getting test data from '" << outfile << "'";
    EXPECT_STREQ(expectedBuf, out.c_str());
 


### PR DESCRIPTION
Implement some toJsonV1() wrapper to avoid `emptyV` dirty thing.

(NGSIv1 is deprecate but this code was hurting my eyes :)