### PR TITLE
ADD custom notification json field additional tests

### DIFF
--- a/doc/manuals/orion-api.md
+++ b/doc/manuals/orion-api.md
@@ -2248,13 +2248,13 @@ Some notes to take into account when using `json`:
 * The [macro replacement logic](#macro-substitution) works as expected, with the following
   considerations:
   * It cannot be used in the key part of JSON objects, i.e. `"${key}": 10` will not work
-  * The value of the JSON object or JSON array item in which the macro is used has to match
-    exactly with the macro expression. Thus, `"t": "${temperature}"` works, but
-    `"t": "the temperature is ${temperature}"` or `"h": "humidity ranges from ${humidityMin} to ${humidityMax}"`
-    will not work
-  * It takes into account the nature of the attribute value to be replaced. For instance,
-    `"t": "${temperature}"` resolves to `"t": 10` if temperature attribute is a number or to
-    `"t": "10"` if `temperature` attribute is a string.
+  * If the macro *covers completely the string where is used*, then the JSON nature of the attribute value
+    is taken into account. For instance, `"t": "${temperature}"` resolves to `"t": 10`
+    if temperature attribute is a number or to `"t": "10"` if `temperature` attribute is a string.
+  * If the macro *is only part of string where is used*, then the attribute value is always casted
+    to string. For instance, `"t": "Temperature is: ${temperature}"` resolves to 
+    `"t": "Temperature is 10"` even if temperature attribute is a number. Note that if the
+    attribute value is a JSON array or object, it is stringfied in this case.  
   * If the attribute doesn't exist in the entity, then `null` value is used
 * `Content-Type` header is set to `application/json`, except if overwritten by `headers` field
 

--- a/test/functionalTest/cases/2560_custom_notification_json/custom_notification_http_json_errors.test
+++ b/test/functionalTest/cases/2560_custom_notification_json/custom_notification_http_json_errors.test
@@ -31,6 +31,7 @@ brokerStart CB
 
 #
 # 01. Create custom subscription with payload and json field, see error
+# 02. Create custom subscription with json field as string, see error
 #
 
 echo "01. Create custom subscription with payload and json field, see error"
@@ -59,6 +60,28 @@ echo
 echo
 
 
+echo "02. Create custom subscription with json field as string, see error"
+echo "==================================================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id" : "E1",
+        "type": "T"
+      }
+    ]
+  },
+  "notification": {
+    "httpCustom": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
+      "json": "only objects and arrays are accepted"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
 
 --REGEXPECT--
 01. Create custom subscription with payload and json field, see error
@@ -71,6 +94,20 @@ Date: REGEX(.*)
 
 {
     "description": "only one of payload, json or ngsi fields accepted at the same time in httpCustom or mqttCustom",
+    "error": "BadRequest"
+}
+
+
+02. Create custom subscription with json field as string, see error
+===================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 102
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "json fields in httpCustom or mqttCustom must be object or array",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/2560_custom_notification_json/custom_notification_http_json_replacements_inside.test
+++ b/test/functionalTest/cases/2560_custom_notification_json/custom_notification_http_json_replacements_inside.test
@@ -21,12 +21,12 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Custom notification MQTT with JSON with replacements
+Custom notification HTTP with JSON with replacements inside value
 
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart --pretty-print --mqttHost ${MQTT_HOST} --mqttPort ${MQTT_PORT} --mqttTopic "#"
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -50,16 +50,15 @@ payload='{
     ]
   },
   "notification": {
-    "mqttCustom": {
-      "topic": "topic1",
-      "url": "mqtt://localhost:1883",
+    "httpCustom": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
       "json": {
-        "text": "${text}",
-        "number": "${number}",
-        "bool": "${bool}",
-        "null": "${null}",
-        "array": "${array}",
-        "object": "${object}"
+        "A": "ns:${text}",
+        "B": "ns:${number}",
+        "C": "ns:${bool}",
+        "D": "ns:${null}",
+        "E": "ns:${array}",
+        "F": "ns:${object}"
       }
     }
   }
@@ -81,16 +80,15 @@ payload='{
     ]
   },
   "notification": {
-    "mqttCustom": {
-      "topic": "topic1",
-      "url": "mqtt://localhost:1883",
+    "httpCustom": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
       "json": [
-        "${text}",
-        "${number}",
-        "${bool}",
-        "${null}",
-        "${array}",
-        "${object}"
+        "ns:${text}",
+        "ns:${number}",
+        "ns:${bool}",
+        "ns:${null}",
+        "ns:${array}",
+        "ns:${object}"
       ]
     }
   }
@@ -155,10 +153,6 @@ echo
 echo
 
 
-# Sometimes the accumulator needs some time to get the MQTT notification
-sleep 0.5s
-
-
 echo "05. Dump accumulator, see 2 notifications"
 echo "========================================="
 accumulatorDump
@@ -190,7 +184,7 @@ Date: REGEX(.*)
 03. GET /v2/subscriptions and see both subscriptions
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 778
+Content-Length: 755
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -202,18 +196,16 @@ Date: REGEX(.*)
             "attrs": [],
             "attrsFormat": "normalized",
             "covered": false,
-            "mqttCustom": {
+            "httpCustom": {
                 "json": {
-                    "array": "${array}",
-                    "bool": "${bool}",
-                    "null": "${null}",
-                    "number": "${number}",
-                    "object": "${object}",
-                    "text": "${text}"
+                    "A": "ns:${text}",
+                    "B": "ns:${number}",
+                    "C": "ns:${bool}",
+                    "D": "ns:${null}",
+                    "E": "ns:${array}",
+                    "F": "ns:${object}"
                 },
-                "qos": 0,
-                "topic": "topic1",
-                "url": "mqtt://localhost:1883"
+                "url": "http://127.0.0.1:9997/notify"
             },
             "onlyChangedAttrs": false
         },
@@ -236,18 +228,16 @@ Date: REGEX(.*)
             "attrs": [],
             "attrsFormat": "normalized",
             "covered": false,
-            "mqttCustom": {
+            "httpCustom": {
                 "json": [
-                    "${text}",
-                    "${number}",
-                    "${bool}",
-                    "${null}",
-                    "${array}",
-                    "${object}"
+                    "ns:${text}",
+                    "ns:${number}",
+                    "ns:${bool}",
+                    "ns:${null}",
+                    "ns:${array}",
+                    "ns:${object}"
                 ],
-                "qos": 0,
-                "topic": "topic1",
-                "url": "mqtt://localhost:1883"
+                "url": "http://127.0.0.1:9997/notify"
             },
             "onlyChangedAttrs": false
         },
@@ -280,68 +270,42 @@ Date: REGEX(.*)
 #SORT_START
 05. Dump accumulator, see 2 notifications
 =========================================
-MQTT message at topic topic1:
+POST http://127.0.0.1:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 187
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: custom
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}; cbnotif=[12])
+
 {
-    "array": [
-        "22",
-        {
-            "x": [
-                "x1",
-                "x2"
-            ],
-            "y": 3
-        },
-        [
-            "z1",
-            "z2"
-        ]
-    ],
-    "bool": true,
-    "null": null,
-    "number": 10,
-    "object": {
-        "x": {
-            "x1": "a",
-            "x2": "b"
-        },
-        "y": [
-            "y1",
-            "y2"
-        ]
-    },
-    "text": "foo"
+    "A": "ns:foo",
+    "B": "ns:10",
+    "C": "ns:true",
+    "D": "ns:null",
+    "E": "ns:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]",
+    "F": "ns:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}"
 }
 =======================================
-MQTT message at topic topic1:
+POST http://127.0.0.1:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 163
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: custom
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}; cbnotif=[12])
+
 [
-    "foo",
-    10,
-    true,
-    null,
-    [
-        "22",
-        {
-            "x": [
-                "x1",
-                "x2"
-            ],
-            "y": 3
-        },
-        [
-            "z1",
-            "z2"
-        ]
-    ],
-    {
-        "x": {
-            "x1": "a",
-            "x2": "b"
-        },
-        "y": [
-            "y1",
-            "y2"
-        ]
-    }
+    "ns:foo",
+    "ns:10",
+    "ns:true",
+    "ns:null",
+    "ns:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]",
+    "ns:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}"
 ]
 =======================================
 #SORT_END

--- a/test/functionalTest/cases/2560_custom_notification_json/custom_notification_http_json_replacements_inside_multi.test
+++ b/test/functionalTest/cases/2560_custom_notification_json/custom_notification_http_json_replacements_inside_multi.test
@@ -21,12 +21,12 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Custom notification MQTT with JSON with replacements
+Custom notification HTTP with JSON with replacements inside value multiple occurrences
 
 --SHELL-INIT--
 dbInit CB
 brokerStart CB
-accumulatorStart --pretty-print --mqttHost ${MQTT_HOST} --mqttPort ${MQTT_PORT} --mqttTopic "#"
+accumulatorStart --pretty-print
 
 --SHELL--
 
@@ -50,16 +50,15 @@ payload='{
     ]
   },
   "notification": {
-    "mqttCustom": {
-      "topic": "topic1",
-      "url": "mqtt://localhost:1883",
+    "httpCustom": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
       "json": {
-        "text": "${text}",
-        "number": "${number}",
-        "bool": "${bool}",
-        "null": "${null}",
-        "array": "${array}",
-        "object": "${object}"
+        "A": "ns:${text}:${object}",
+        "B": "ns:${number}:${array}",
+        "C": "ns:${bool}:${null}",
+        "D": "ns:${null}:${bool}",
+        "E": "ns:${array}:${number}",
+        "F": "ns:${object}:${text}"
       }
     }
   }
@@ -81,16 +80,15 @@ payload='{
     ]
   },
   "notification": {
-    "mqttCustom": {
-      "topic": "topic1",
-      "url": "mqtt://localhost:1883",
+    "httpCustom": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
       "json": [
-        "${text}",
-        "${number}",
-        "${bool}",
-        "${null}",
-        "${array}",
-        "${object}"
+        "ns:${text}:${object}",
+        "ns:${number}:${array}",
+        "ns:${bool}:${null}",
+        "ns:${null}:${bool}",
+        "ns:${array}:${number}",
+        "ns:${object}:${text}"
       ]
     }
   }
@@ -155,10 +153,6 @@ echo
 echo
 
 
-# Sometimes the accumulator needs some time to get the MQTT notification
-sleep 0.5s
-
-
 echo "05. Dump accumulator, see 2 notifications"
 echo "========================================="
 accumulatorDump
@@ -190,7 +184,7 @@ Date: REGEX(.*)
 03. GET /v2/subscriptions and see both subscriptions
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 778
+Content-Length: 861
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -202,18 +196,16 @@ Date: REGEX(.*)
             "attrs": [],
             "attrsFormat": "normalized",
             "covered": false,
-            "mqttCustom": {
+            "httpCustom": {
                 "json": {
-                    "array": "${array}",
-                    "bool": "${bool}",
-                    "null": "${null}",
-                    "number": "${number}",
-                    "object": "${object}",
-                    "text": "${text}"
+                    "A": "ns:${text}:${object}",
+                    "B": "ns:${number}:${array}",
+                    "C": "ns:${bool}:${null}",
+                    "D": "ns:${null}:${bool}",
+                    "E": "ns:${array}:${number}",
+                    "F": "ns:${object}:${text}"
                 },
-                "qos": 0,
-                "topic": "topic1",
-                "url": "mqtt://localhost:1883"
+                "url": "http://127.0.0.1:9997/notify"
             },
             "onlyChangedAttrs": false
         },
@@ -236,18 +228,16 @@ Date: REGEX(.*)
             "attrs": [],
             "attrsFormat": "normalized",
             "covered": false,
-            "mqttCustom": {
+            "httpCustom": {
                 "json": [
-                    "${text}",
-                    "${number}",
-                    "${bool}",
-                    "${null}",
-                    "${array}",
-                    "${object}"
+                    "ns:${text}:${object}",
+                    "ns:${number}:${array}",
+                    "ns:${bool}:${null}",
+                    "ns:${null}:${bool}",
+                    "ns:${array}:${number}",
+                    "ns:${object}:${text}"
                 ],
-                "qos": 0,
-                "topic": "topic1",
-                "url": "mqtt://localhost:1883"
+                "url": "http://127.0.0.1:9997/notify"
             },
             "onlyChangedAttrs": false
         },
@@ -280,68 +270,42 @@ Date: REGEX(.*)
 #SORT_START
 05. Dump accumulator, see 2 notifications
 =========================================
-MQTT message at topic topic1:
+POST http://127.0.0.1:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 319
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: custom
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}; cbnotif=[12])
+
 {
-    "array": [
-        "22",
-        {
-            "x": [
-                "x1",
-                "x2"
-            ],
-            "y": 3
-        },
-        [
-            "z1",
-            "z2"
-        ]
-    ],
-    "bool": true,
-    "null": null,
-    "number": 10,
-    "object": {
-        "x": {
-            "x1": "a",
-            "x2": "b"
-        },
-        "y": [
-            "y1",
-            "y2"
-        ]
-    },
-    "text": "foo"
+    "A": "ns:foo:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}",
+    "B": "ns:10:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]",
+    "C": "ns:true:null",
+    "D": "ns:null:true",
+    "E": "ns:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]:10",
+    "F": "ns:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}:foo"
 }
 =======================================
-MQTT message at topic topic1:
+POST http://127.0.0.1:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 295
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: custom
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/json
+Content-Type: application/json; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}; cbnotif=[12])
+
 [
-    "foo",
-    10,
-    true,
-    null,
-    [
-        "22",
-        {
-            "x": [
-                "x1",
-                "x2"
-            ],
-            "y": 3
-        },
-        [
-            "z1",
-            "z2"
-        ]
-    ],
-    {
-        "x": {
-            "x1": "a",
-            "x2": "b"
-        },
-        "y": [
-            "y1",
-            "y2"
-        ]
-    }
+    "ns:foo:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}",
+    "ns:10:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]",
+    "ns:true:null",
+    "ns:null:true",
+    "ns:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]:10",
+    "ns:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}:foo"
 ]
 =======================================
 #SORT_END

--- a/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_constants.test
+++ b/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_constants.test
@@ -148,6 +148,10 @@ echo
 echo
 
 
+# Sometimes the accumulator needs some time to get the MQTT notification
+sleep 0.5s
+
+
 echo "05. Dump accumulator, see 2 notifications"
 echo "========================================="
 accumulatorDump

--- a/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_errors.test
+++ b/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_errors.test
@@ -31,6 +31,7 @@ brokerStart CB
 
 #
 # 01. Create custom subscription with payload and json field, see error
+# 02. Create custom subscription with json field as string, see error
 #
 
 echo "01. Create custom subscription with payload and json field, see error"
@@ -60,6 +61,28 @@ echo
 echo
 
 
+echo "02. Create custom subscription with json field as string, see error"
+echo "==================================================================="
+payload='{
+  "subject": {
+    "entities": [
+      {
+        "id" : "E1",
+        "type": "T"
+      }
+    ]
+  },
+  "notification": {
+    "httpCustom": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
+      "json": "only objects and arrays are accepted"
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
 
 --REGEXPECT--
 01. Create custom subscription with payload and json field, see error
@@ -72,6 +95,20 @@ Date: REGEX(.*)
 
 {
     "description": "only one of payload, json or ngsi fields accepted at the same time in httpCustom or mqttCustom",
+    "error": "BadRequest"
+}
+
+
+02. Create custom subscription with json field as string, see error
+===================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 102
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "description": "json fields in httpCustom or mqttCustom must be object or array",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_replacements_inside.test
+++ b/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_replacements_inside.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Custom notification MQTT with JSON with replacements
+Custom notification MQTT with JSON with replacements inside value
 
 --SHELL-INIT--
 dbInit CB
@@ -54,12 +54,12 @@ payload='{
       "topic": "topic1",
       "url": "mqtt://localhost:1883",
       "json": {
-        "text": "${text}",
-        "number": "${number}",
-        "bool": "${bool}",
-        "null": "${null}",
-        "array": "${array}",
-        "object": "${object}"
+        "A": "ns:${text}",
+        "B": "ns:${number}",
+        "C": "ns:${bool}",
+        "D": "ns:${null}",
+        "E": "ns:${array}",
+        "F": "ns:${object}"
       }
     }
   }
@@ -85,12 +85,12 @@ payload='{
       "topic": "topic1",
       "url": "mqtt://localhost:1883",
       "json": [
-        "${text}",
-        "${number}",
-        "${bool}",
-        "${null}",
-        "${array}",
-        "${object}"
+        "ns:${text}",
+        "ns:${number}",
+        "ns:${bool}",
+        "ns:${null}",
+        "ns:${array}",
+        "ns:${object}"
       ]
     }
   }
@@ -154,7 +154,6 @@ orionCurl --url /v2/entities --payload "$payload"
 echo
 echo
 
-
 # Sometimes the accumulator needs some time to get the MQTT notification
 sleep 0.5s
 
@@ -190,7 +189,7 @@ Date: REGEX(.*)
 03. GET /v2/subscriptions and see both subscriptions
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 778
+Content-Length: 791
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -204,12 +203,12 @@ Date: REGEX(.*)
             "covered": false,
             "mqttCustom": {
                 "json": {
-                    "array": "${array}",
-                    "bool": "${bool}",
-                    "null": "${null}",
-                    "number": "${number}",
-                    "object": "${object}",
-                    "text": "${text}"
+                    "A": "ns:${text}",
+                    "B": "ns:${number}",
+                    "C": "ns:${bool}",
+                    "D": "ns:${null}",
+                    "E": "ns:${array}",
+                    "F": "ns:${object}"
                 },
                 "qos": 0,
                 "topic": "topic1",
@@ -238,12 +237,12 @@ Date: REGEX(.*)
             "covered": false,
             "mqttCustom": {
                 "json": [
-                    "${text}",
-                    "${number}",
-                    "${bool}",
-                    "${null}",
-                    "${array}",
-                    "${object}"
+                    "ns:${text}",
+                    "ns:${number}",
+                    "ns:${bool}",
+                    "ns:${null}",
+                    "ns:${array}",
+                    "ns:${object}"
                 ],
                 "qos": 0,
                 "topic": "topic1",
@@ -282,66 +281,22 @@ Date: REGEX(.*)
 =========================================
 MQTT message at topic topic1:
 {
-    "array": [
-        "22",
-        {
-            "x": [
-                "x1",
-                "x2"
-            ],
-            "y": 3
-        },
-        [
-            "z1",
-            "z2"
-        ]
-    ],
-    "bool": true,
-    "null": null,
-    "number": 10,
-    "object": {
-        "x": {
-            "x1": "a",
-            "x2": "b"
-        },
-        "y": [
-            "y1",
-            "y2"
-        ]
-    },
-    "text": "foo"
+    "A": "ns:foo",
+    "B": "ns:10",
+    "C": "ns:true",
+    "D": "ns:null",
+    "E": "ns:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]",
+    "F": "ns:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}"
 }
 =======================================
 MQTT message at topic topic1:
 [
-    "foo",
-    10,
-    true,
-    null,
-    [
-        "22",
-        {
-            "x": [
-                "x1",
-                "x2"
-            ],
-            "y": 3
-        },
-        [
-            "z1",
-            "z2"
-        ]
-    ],
-    {
-        "x": {
-            "x1": "a",
-            "x2": "b"
-        },
-        "y": [
-            "y1",
-            "y2"
-        ]
-    }
+    "ns:foo",
+    "ns:10",
+    "ns:true",
+    "ns:null",
+    "ns:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]",
+    "ns:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}"
 ]
 =======================================
 #SORT_END

--- a/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_replacements_inside_multi.test
+++ b/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_replacements_inside_multi.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Custom notification MQTT with JSON with replacements
+Custom notification MQTT with JSON with replacements inside value multiple occurrences
 
 --SHELL-INIT--
 dbInit CB
@@ -54,12 +54,12 @@ payload='{
       "topic": "topic1",
       "url": "mqtt://localhost:1883",
       "json": {
-        "text": "${text}",
-        "number": "${number}",
-        "bool": "${bool}",
-        "null": "${null}",
-        "array": "${array}",
-        "object": "${object}"
+        "A": "ns:${text}:${object}",
+        "B": "ns:${number}:${array}",
+        "C": "ns:${bool}:${null}",
+        "D": "ns:${null}:${bool}",
+        "E": "ns:${array}:${number}",
+        "F": "ns:${object}:${text}"
       }
     }
   }
@@ -85,12 +85,12 @@ payload='{
       "topic": "topic1",
       "url": "mqtt://localhost:1883",
       "json": [
-        "${text}",
-        "${number}",
-        "${bool}",
-        "${null}",
-        "${array}",
-        "${object}"
+        "ns:${text}:${object}",
+        "ns:${number}:${array}",
+        "ns:${bool}:${null}",
+        "ns:${null}:${bool}",
+        "ns:${array}:${number}",
+        "ns:${object}:${text}"
       ]
     }
   }
@@ -190,7 +190,7 @@ Date: REGEX(.*)
 03. GET /v2/subscriptions and see both subscriptions
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 778
+Content-Length: 897
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -204,12 +204,12 @@ Date: REGEX(.*)
             "covered": false,
             "mqttCustom": {
                 "json": {
-                    "array": "${array}",
-                    "bool": "${bool}",
-                    "null": "${null}",
-                    "number": "${number}",
-                    "object": "${object}",
-                    "text": "${text}"
+                    "A": "ns:${text}:${object}",
+                    "B": "ns:${number}:${array}",
+                    "C": "ns:${bool}:${null}",
+                    "D": "ns:${null}:${bool}",
+                    "E": "ns:${array}:${number}",
+                    "F": "ns:${object}:${text}"
                 },
                 "qos": 0,
                 "topic": "topic1",
@@ -238,12 +238,12 @@ Date: REGEX(.*)
             "covered": false,
             "mqttCustom": {
                 "json": [
-                    "${text}",
-                    "${number}",
-                    "${bool}",
-                    "${null}",
-                    "${array}",
-                    "${object}"
+                    "ns:${text}:${object}",
+                    "ns:${number}:${array}",
+                    "ns:${bool}:${null}",
+                    "ns:${null}:${bool}",
+                    "ns:${array}:${number}",
+                    "ns:${object}:${text}"
                 ],
                 "qos": 0,
                 "topic": "topic1",
@@ -282,66 +282,22 @@ Date: REGEX(.*)
 =========================================
 MQTT message at topic topic1:
 {
-    "array": [
-        "22",
-        {
-            "x": [
-                "x1",
-                "x2"
-            ],
-            "y": 3
-        },
-        [
-            "z1",
-            "z2"
-        ]
-    ],
-    "bool": true,
-    "null": null,
-    "number": 10,
-    "object": {
-        "x": {
-            "x1": "a",
-            "x2": "b"
-        },
-        "y": [
-            "y1",
-            "y2"
-        ]
-    },
-    "text": "foo"
+    "A": "ns:foo:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}",
+    "B": "ns:10:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]",
+    "C": "ns:true:null",
+    "D": "ns:null:true",
+    "E": "ns:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]:10",
+    "F": "ns:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}:foo"
 }
 =======================================
 MQTT message at topic topic1:
 [
-    "foo",
-    10,
-    true,
-    null,
-    [
-        "22",
-        {
-            "x": [
-                "x1",
-                "x2"
-            ],
-            "y": 3
-        },
-        [
-            "z1",
-            "z2"
-        ]
-    ],
-    {
-        "x": {
-            "x1": "a",
-            "x2": "b"
-        },
-        "y": [
-            "y1",
-            "y2"
-        ]
-    }
+    "ns:foo:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}",
+    "ns:10:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]",
+    "ns:true:null",
+    "ns:null:true",
+    "ns:[\"22\",{\"x\":[\"x1\",\"x2\"],\"y\":3},[\"z1\",\"z2\"]]:10",
+    "ns:{\"x\":{\"x1\":\"a\",\"x2\":\"b\"},\"y\":[\"y1\",\"y2\"]}:foo"
 ]
 =======================================
 #SORT_END

--- a/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_replacements_intermediate.test
+++ b/test/functionalTest/cases/2560_custom_notification_json/custom_notification_mqtt_json_replacements_intermediate.test
@@ -125,6 +125,10 @@ echo
 echo
 
 
+# Sometimes the accumulator needs some time to get the MQTT notification
+sleep 0.5s
+
+
 echo "05. Dump accumulator, see 2 notifications"
 echo "========================================="
 accumulatorDump


### PR DESCRIPTION
Additional tests for #2560 along with documentation improvements.

No CNR entry needed. This is already covered by current entry:

```
- Add: json field in httpCustom and mqttCustom subscriptions to implement JSON-based payloads in notifications (#2560)
```