### PR TITLE
FIX memory leak in parseSubscription logic

### DIFF
--- a/src/lib/jsonParseV2/parseSubscription.cpp
+++ b/src/lib/jsonParseV2/parseSubscription.cpp
@@ -317,6 +317,7 @@ std::string parseCustomJson
 )
 {
   // this new memory is freed in in HttpInfo::release()/MqttInfo::release()()
+  // or before returning in this function in the case of error
   *json = new orion::CompoundValueNode();
 
   if (holder.IsArray())
@@ -364,6 +365,8 @@ std::string parseCustomJson
         std::string r = parseCompoundValue(iter, cvnP, 0);
         if (r != "OK")
         {
+          // Early return
+          delete *json;
           return r;
         }
       }
@@ -416,6 +419,7 @@ std::string parseCustomJson
         if (r != "OK")
         {
           // Early return
+          delete *json;
           return r;
         }
       }
@@ -423,6 +427,7 @@ std::string parseCustomJson
   }
   else
   {
+    delete *json;
     return "json fields in httpCustom or mqttCustom must be object or array";
   }
 


### PR DESCRIPTION
Detected in https://github.com/telefonicaid/fiware-orion/actions/runs/3706314217/jobs/6281370472

```
2 tests leaked memory:
   915: 2560_custom_notification_json/custom_notification_http_json_errors.test (lost 112 bytes, see custom_notification_http_json_errors.valgrind.out)
   924: 2560_custom_notification_json/custom_notification_mqtt_json_errors.test (lost 112 bytes, see custom_notification_mqtt_json_errors.valgrind.out)
```