### PR TITLE
FIX Dockerfile to make them work after mongoc-1.23.1 upgrade

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,7 +85,9 @@ RUN \
     cd mongo-c-driver-1.23.1 && \
     mkdir cmake-build && \
     cd cmake-build && \
-    cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF ..   && \
+    # Different from ci/deb/build-dep.sh and build from source documentation, we add here also
+    # the MONGOC_TEST_USE_CRYPT_SHARED=FALSE. It needs Python and in this tiny image we don't have it
+    cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DMONGOC_TEST_USE_CRYPT_SHARED=FALSE ..   && \
     make && \
     make install && \
     # Install rapidjson from source

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -87,7 +87,9 @@ RUN \
     cd mongo-c-driver-1.23.1 && \
     mkdir cmake-build && \
     cd cmake-build && \
-    cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF ..   && \
+    # Different from ci/deb/build-dep.sh and build from source documentation, we add here also
+    # the MONGOC_TEST_USE_CRYPT_SHARED=FALSE. It needs Python and in this tiny image we don't have it
+    cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DMONGOC_TEST_USE_CRYPT_SHARED=FALSE ..   && \
     make && \
     make install && \
     # Install rapidjson from source


### PR DESCRIPTION
After upgrading to mongoc 1.23.1 in PR https://github.com/telefonicaid/fiware-orion/pull/4259 we get this error when building Dockerfile:

```
2023-01-11T10:03:52Z [91mAdding -fPIC to compilation of mongoc_static components
2023-01-11T10:03:52Z [0m[91mCMake Error at src/libmongoc/CMakeLists.txt:868 (message):
2023-01-11T10:03:52Z MONGOC_TEST_USE_CRYPT_SHARED is enabled, but we were unable to find a
2023-01-11T10:03:52Z Python 3 interpreter to use mongodl.py. Install a Python 3 or set
2023-01-11T10:03:52Z MONGOC_TEST_USE_CRYPT_SHARED to FALSE
```

This PR should fix it.