### PR TITLE
ADD documentation regarding new attrsFormat values and notifyOnMetadataChange

### DIFF
--- a/doc/manuals/orion-api.md
+++ b/doc/manuals/orion-api.md
@@ -1958,7 +1958,7 @@ Notifications include two fields:
 If `attrsFormat` is `normalized` (or if `attrsFormat` is omitted) then default entity representation
 is used:
 
-```
+```json
 {
   "subscriptionId": "12345",
   "data": [
@@ -1980,6 +1980,26 @@ is used:
 }
 ```
 
+If `attrsFormat` is `simplifiedNormalized` then a simplified variant of `normalized` (ommiting `subscriptionId`
+and the `data` holder) is used:
+
+```json
+{
+  "id": "Room1",
+  "type": "Room",
+  "temperature": {
+    "value": 23,
+    "type": "Number",
+    "metadata": {}
+  },
+  "humidity": {
+    "value": 70,
+    "type": "percentage",
+    "metadata": {}
+  }
+}
+```
+
 If `attrsFormat` is `keyValues` then keyValues partial entity representation mode is used:
 
 ```json
@@ -1996,6 +2016,18 @@ If `attrsFormat` is `keyValues` then keyValues partial entity representation mod
 }
 ```
 
+If `attrsFormat` is `simplifiedKeyValues` then a simplified variant of `keyValues` (ommiting `subscriptionId`
+and the `data` holder) is used:
+
+
+```json
+{
+  "id": "Room1",
+  "type": "Room",
+  "temperature": 23,
+  "humidity": 70
+}
+```
 
 If `attrsFormat` is `values` then values partial entity representation mode is used:
 
@@ -2042,6 +2074,11 @@ Note that NGSIv1 is deprecated. Thus, we don't recommend to use `legacy` notific
 Notifications must include the `Ngsiv2-AttrsFormat` (expect when `attrsFormat` is `legacy`)
 HTTP header with the value of the format of the associated subscription, so that notification receivers
 are aware of the format without needing to process the notification payload.
+
+**NOTE:** note that noficiations always include exactly one entity so you may ask why the `data` array
+is really needed. In the past we have multi-entity notifications (in particular, the so called "initial
+notification" that was deprecated in Orion 3.1.0 and removed in Orion 3.2.0) and the `data` array remains as
+a legacy.
 
 ## Custom Notifications
 
@@ -3660,6 +3697,7 @@ A `condition` contains the following subfields:
 | `attrs`      | ✓        | array | Array of attribute names that will trigger the notification. Empty list is not allowed.                                       |
 | `expression` | ✓        | object| An expression composed of `q`, `mq`, `georel`, `geometry` and `coords` (see [List Entities](#list-entities-get-v2entities) operation above about this field). `expression` and sub elements (i.e. `q`) must have content, i.e. `{}` or `""` is not allowed |
 | `alterationTypes` | ✓   | array | Specify under which alterations (entity creation, entity modification, etc.) the subscription is triggered (see section [Subscriptions based in alteration type](#subscriptions-based-in-alteration-type)) |
+| `notifyOnMetadataChange` | ✓   | boolean | If `true` then metadata is considered part of the value of the attribute in the context of notification, so if the value doesn't change but the metadata changes, then a notification is triggered. If `false` then the metadata is not considered part of the value of the attribute in the context of notification, so if the value doesn't change but the metadata changes, then a notification is not triggered. Default value is `true`. |
 
 Notification triggering (i.e. when a notification is triggered based on entity updates)
 is described in [this specific section](#notification-triggering).
@@ -3672,7 +3710,7 @@ A `notification` object contains the following subfields:
 |--------------------|-------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `attrs` or `exceptAttrs` |          | array | Both cannot be used at the same time. <ul><li><code>attrs</code>: List of attributes to be included in notification messages. It also defines the order in which attributes must appear in notifications when <code>attrsFormat</code> <code>value</code> is used (see [Notification Messages](#notification-messages) section). An empty list means that all attributes are to be included in notifications. See [Filtering out attributes and metadata](#filtering-out-attributes-and-metadata) section for more detail.</li><li><code>exceptAttrs</code>: List of attributes to be excluded from the notification message, i.e. a notification message includes all entity attributes except the ones listed in this field. It must be a non-empty list.</li><li>If neither <code>attrs</code> nor <code>exceptAttrs</code> is specified, all attributes are included in notifications.</li></ul>|
 | [`http`](#subscriptionnotificationhttp), [`httpCustom`](#subscriptionnotificationhttpcustom), [`mqtt`](#subscriptionnotificationmqtt) or [`mqttCustom`](#subscriptionnotificationmqttcustom)| ✓                 | object | One of them must be present, but not more than one at the same time. It is used to convey parameters for notifications delivered through the transport protocol. |
-| `attrsFormat`          | ✓                 | string | Specifies how the entities are represented in notifications. Accepted values are `normalized` (default), `keyValues`, `values` or `legacy`.<br> If `attrsFormat` takes any value different than those, an error is raised. See detail in [Notification Messages](#notification-messages) section. |
+| `attrsFormat`          | ✓                 | string | Specifies how the entities are represented in notifications. Accepted values are `normalized` (default), `simplifiedNormalized`, `keyValues`, `simplifiedKeyValues`, `values` or `legacy`.<br> If `attrsFormat` takes any value different than those, an error is raised. See detail in [Notification Messages](#notification-messages) section. |
 | `metadata`         | ✓                 | string  | List of metadata to be included in notification messages. See [Filtering out attributes and metadata](#filtering-out-attributes-and-metadata) section for more detail.            |
 | `onlyChangedAttrs` | ✓                 | boolean | If `true` then notifications will include only attributes that changed in the triggering update request, in combination with the `attrs` or `exceptAttrs` field. (default is `false` if the field is omitted)) |
 | `covered`          | ✓                 | boolean | If `true` then notifications will include all the attributes defined in `attrs` field, even if they are not present in the entity (in this, case, with `null` value). (default value is false). For further information see [Covered subscriptions](#covered-subscriptions) section |


### PR DESCRIPTION
Complementary documentation for PRs https://github.com/telefonicaid/fiware-orion/pull/4298 and https://github.com/telefonicaid/fiware-orion/pull/3000

CC: @chetan-NEC @Anjali-NEC

To be merged at the same time that #4298 and #4300 (i.e. a "triple" LGTM is required to merge them all at the same time)

In the meanwhile, @fisuda maybe you could do PR using hardening/doc-for-3727-and-4286 as base branch in order to incorporate Japanese translation modification, please?