### PR TITLE
FIX count with geo near is not working

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 - Fix: decimal rounding in some cases was generating wrong JSON in query responses and notifications (#4346)
+- FiX: count option not working when georel=near was in use (500 error was returned)
 - Remove: all NGSIv1 operations (deprecated in Orion 2.0.0) except the following ones
     - PUT /v1/contextEntities/{id}
     - DELETE /v1/contextEntities/{id}

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -2025,8 +2025,9 @@ static unsigned int processSubscriptions
         continue;
       }
 
-      orion::BSONObjBuilder bobQuery;
-      if (!processAreaScopeV2(&geoScope, &bobQuery, true))
+      orion::BSONObjBuilder bobQuery;  // used only to keep processAreaScopeV2() signature
+      orion::BSONObjBuilder bobCountQuery;
+      if (!processAreaScopeV2(&geoScope, &bobQuery, &bobCountQuery))
       {
         // Error in processAreaScopeV2 is interpreted as no-match (conservative approach)
         continue;
@@ -2042,12 +2043,12 @@ static unsigned int processSubscriptions
       std::string  type    = notifyCerP->entity.type;
       std::string  sp      = notifyCerP->entity.servicePath;
 
-      bobQuery.append(keyId, id);
-      bobQuery.append(keyType, type);
-      bobQuery.append(keySp, sp);
+      bobCountQuery.append(keyId, id);
+      bobCountQuery.append(keyType, type);
+      bobCountQuery.append(keySp, sp);
 
       unsigned long long n;
-      if (!orion::collectionCount(composeDatabaseName(tenant), COL_ENTITIES, bobQuery.obj(), &n, &filterErr))
+      if (!orion::collectionCount(composeDatabaseName(tenant), COL_ENTITIES, bobCountQuery.obj(), &n, &filterErr))
       {
         // Error in database access is interpreted as no-match (conservative approach)
         continue;

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -964,7 +964,8 @@ bool processAreaScopeV2(const Scope* scoP, orion::BSONObjBuilder* queryP, bool a
   orion::BSONObjBuilder bobArea;
   if (scoP->georel.type == "near")
   {
-    if (avoidNearUsage)
+    // FIXME PR: clean this, avoidNearUsage no longer needed
+    //if (avoidNearUsage)
     {
       // $near operation is problematic in countDocument()
       // operation (see https://stackoverflow.com/questions/66143435/countdocuments-with-geo-queries-using-mindistance-semantics)
@@ -1042,10 +1043,13 @@ bool processAreaScopeV2(const Scope* scoP, orion::BSONObjBuilder* queryP, bool a
         andArray.append(andToken.obj());
       }
 
-      queryP->append("$and", andArray.arr());
-    }
+      orion::BSONObjBuilder forCount;
+      forCount.append("$and", andArray.arr());
+
+    //  queryP->append("$and", andArray.arr());
+    /*}
     else
-    {
+    {*/
       orion::BSONObjBuilder near;
 
       near.append("$geometry", geometry);
@@ -1061,7 +1065,13 @@ bool processAreaScopeV2(const Scope* scoP, orion::BSONObjBuilder* queryP, bool a
       }
 
       bobArea.append("$near", near.obj());
-      queryP->append(keyLoc, bobArea.obj());
+      //queryP->append(keyLoc, bobArea.obj());
+
+      orion::BSONObjBuilder forQuery;
+      forQuery.append(keyLoc, bobArea.obj());
+
+      queryP->append("__query", forQuery.obj());
+      queryP->append("__count", forCount.obj());
     }
   }
   else if (scoP->georel.type == "coveredBy")

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -214,7 +214,7 @@ extern bool includedAttribute(const std::string& attrName, const StringList& att
 * processAreaScopeV2 -
 *
 */
-extern bool processAreaScopeV2(const Scope* scoP, orion::BSONObjBuilder* queryP, bool avoidNearUsasge = false);
+extern bool processAreaScopeV2(const Scope* scoP, orion::BSONObjBuilder* queryP, orion::BSONObjBuilder* countQueryP);
 
 
 

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -339,6 +339,7 @@ void mongoListSubscriptions
                                     composeDatabaseName(tenant),
                                     COL_CSUBS,
                                     q,
+                                    q,
                                     sortBy.obj(),
                                     limit,
                                     offset,

--- a/src/lib/mongoBackend/mongoRegistrationGet.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationGet.cpp
@@ -363,7 +363,7 @@ void mongoRegistrationsGet
 
   TIME_STAT_MONGO_READ_WAIT_START();
   orion::DBConnection connection = orion::getMongoConnection();
-  if (!orion::collectionRangedQuery(connection, composeDatabaseName(tenant), COL_REGISTRATIONS, q, bSort.obj(), limit, offset, &cursor, countP, &err))
+  if (!orion::collectionRangedQuery(connection, composeDatabaseName(tenant), COL_REGISTRATIONS, q, q, bSort.obj(), limit, offset, &cursor, countP, &err))
   {
     orion::releaseMongoConnection(connection);
     TIME_STAT_MONGO_READ_WAIT_STOP();

--- a/src/lib/mongoDriver/connectionOperations.cpp
+++ b/src/lib/mongoDriver/connectionOperations.cpp
@@ -116,6 +116,11 @@ bool orion::collectionQuery
 * Different from others, this function doesn't use getMongoConnection() and
 * releaseMongoConnection(). It is assumed that the caller will do, as the
 * connection cannot be released before the cursor has been used.
+*
+* Note we have _q (query for search) and _countQuery (query for count) given that
+* in some rare occasions they may be different (in particular, when geo-queries are
+* used, see processAreaScopeV2 function for more detail). However, most of the times
+* this function is called with same value for _q and _countQuery
 */
 bool orion::collectionRangedQuery
 (
@@ -159,7 +164,6 @@ bool orion::collectionRangedQuery
   if (count != NULL)
   {
     bson_error_t error;
-    // FIXME PR: look for other usages of mongoc_collection_count_documents(), do the same
     long long n = mongoc_collection_count_documents(collection, qc, NULL, NULL, NULL, &error);
     if (n >= 0)
     {

--- a/src/lib/mongoDriver/connectionOperations.h
+++ b/src/lib/mongoDriver/connectionOperations.h
@@ -61,6 +61,7 @@ extern bool collectionRangedQuery
   const std::string&   db,
   const std::string&   col,
   const BSONObj&       q,
+  const BSONObj&       countQuery,
   const BSONObj&       sort,
   int                  limit,
   int                  offset,

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/geoquery_circle_geopoint_count.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/geoquery_circle_geopoint_count.test
@@ -1,0 +1,283 @@
+# Copyright 2023 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Geo query (circle) with geo:point (NGSIv2) with count
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+# Same as geoquery_circle_geopoint_count.test but with options=count in every query
+#
+# 01. Create entity corresponding to Madrid
+# 02. Create entity corresponding to Alcobendas
+# 03. Create entity corresponding to Leganes
+# 04. Query inside 13.5 kms radius from Madrid center -> Madrid, Leganes
+# 05. Query inside 15 kms radius from Madrid center  -> Madrid, Alcobendas, Leganes
+# 06. Query in 13.5 kms radius outside Madrid center -> Alcobendas
+# 07. Query minDistance 0 kms to Madrid center -> Madrid, Alcobendas, Leganes
+
+echo "01. Create entity corresponding to Madrid"
+echo "========================================="
+payload='{
+  "id": "Madrid",
+  "type": "City",
+  "location": {
+    "value": "40.418889, -3.691944",
+    "type": "geo:point"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+sleep 1.1
+
+
+echo "02. Create entity corresponding to Alcobendas"
+echo "============================================="
+payload='{
+  "id": "Alcobendas",
+  "type": "City",
+  "location": {
+    "value": "40.533333, -3.633333",
+    "type": "geo:point"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+sleep 1.1
+
+
+echo "03. Create entity corresponding to Leganes"
+echo "=========================================="
+payload='{
+  "id": "Leganes",
+  "type": "City",
+  "location": {
+    "value": "40.316667, -3.75",
+    "type": "geo:point"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "04. Query inside 13.5 kms radius from Madrid center -> Madrid, Leganes"
+echo "======================================================================"
+orionCurl --url '/v2/entities?georel=near;maxDistance:13500&geometry=point&coords=40.418889,-3.691944&options=count'
+echo
+echo
+
+
+echo "05. Query inside 15 kms radius from Madrid center -> Madrid, Alcobendas, Leganes"
+echo "================================================================================"
+orionCurl --url '/v2/entities?georel=near;maxDistance:15000&geometry=point&coords=40.418889,-3.691944&options=count'
+echo
+echo
+
+
+echo "06. Query in 13.5 kms radius outside Madrid center -> Alcobendas"
+echo "================================================================"
+orionCurl --url '/v2/entities?georel=near;minDistance:13500&geometry=point&coords=40.418889,-3.691944&options=count'
+echo
+echo
+
+
+echo "07. Query minDistance 0 kms to Madrid center -> Madrid, Alcobendas, Leganes"
+echo "==========================================================================="
+orionCurl --url '/v2/entities?georel=near;minDistance:0&geometry=point&coords=40.418889,-3.691944&options=count'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity corresponding to Madrid
+=========================================
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/entities/Madrid?type=City
+Content-Length: 0
+
+
+
+02. Create entity corresponding to Alcobendas
+=============================================
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/entities/Alcobendas?type=City
+Content-Length: 0
+
+
+
+03. Create entity corresponding to Leganes
+==========================================
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/entities/Leganes?type=City
+Content-Length: 0
+
+
+
+04. Query inside 13.5 kms radius from Madrid center -> Madrid, Leganes
+======================================================================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Fiware-Total-Count: 2
+Content-Type: application/json
+Content-Length: 212
+
+[
+    {
+        "id": "Madrid",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "40.418889, -3.691944"
+        },
+        "type": "City"
+    },
+    {
+        "id": "Leganes",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "40.316667, -3.75"
+        },
+        "type": "City"
+    }
+]
+
+
+05. Query inside 15 kms radius from Madrid center -> Madrid, Alcobendas, Leganes
+================================================================================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Fiware-Total-Count: 3
+Content-Type: application/json
+Content-Length: 323
+
+[
+    {
+        "id": "Madrid",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "40.418889, -3.691944"
+        },
+        "type": "City"
+    },
+    {
+        "id": "Alcobendas",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "40.533333, -3.633333"
+        },
+        "type": "City"
+    },
+    {
+        "id": "Leganes",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "40.316667, -3.75"
+        },
+        "type": "City"
+    }
+]
+
+
+06. Query in 13.5 kms radius outside Madrid center -> Alcobendas
+================================================================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Fiware-Total-Count: 1
+Content-Type: application/json
+Content-Length: 112
+
+[
+    {
+        "id": "Alcobendas",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "40.533333, -3.633333"
+        },
+        "type": "City"
+    }
+]
+
+
+07. Query minDistance 0 kms to Madrid center -> Madrid, Alcobendas, Leganes
+===========================================================================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Fiware-Total-Count: 3
+Content-Type: application/json
+Content-Length: 323
+
+[
+    {
+        "id": "Madrid",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "40.418889, -3.691944"
+        },
+        "type": "City"
+    },
+    {
+        "id": "Alcobendas",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "40.533333, -3.633333"
+        },
+        "type": "City"
+    },
+    {
+        "id": "Leganes",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "40.316667, -3.75"
+        },
+        "type": "City"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/geoquery_polygon_geopoint_count.test
+++ b/test/functionalTest/cases/1038_ngsiv2_geo_location_entities/geoquery_polygon_geopoint_count.test
@@ -1,0 +1,297 @@
+# Copyright 2023 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Geo query test (polygon) with geo:point (NGSIv2) with count
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+# Same as geoquery_polygon_geopoint_count.test but with options=count in every query
+#
+# 01. Create Point A
+# 02. Create Point B
+# 03. Create Point C
+# 04. Rectangle in: A, B
+# 05. Rectangle in: B, C
+# 06. Triangle in: A
+# 07. Rectangle out: A
+# 08. Triangle out: B, C
+#
+
+echo "01. Create Point A"
+echo "=================="
+payload='{
+  "id": "A",
+  "type": "Point",
+  "location": {
+    "value": "3, 2",
+    "type": "geo:point"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+sleep 1.1
+echo
+echo
+
+
+echo "02. Create Point B"
+echo "=================="
+payload='{
+  "id": "B",
+  "type": "Point",
+  "location": {
+    "value": "5, 5",
+    "type": "geo:point"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+sleep 1.1
+echo
+echo
+
+
+echo "03. Create Point C"
+echo "=================="
+payload='{
+  "id": "C",
+  "type": "Point",
+  "location": {
+    "value": "7, 4",
+    "type": "geo:point"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+sleep 1.1
+echo
+echo
+
+
+echo "04. Rectangle in: A, B"
+echo "======================"
+orionCurl --url '/v2/entities?georel=coveredBy&geometry=polygon&coords=0,0;0,6;6,6;6,0;0,0&options=count'
+echo
+echo
+
+
+echo "05. Rectangle in: B, C"
+echo "======================"
+orionCurl --url '/v2/entities?georel=coveredBy&geometry=polygon&coords=3,3;3,8;11,8;11,3;3,3&options=count'
+echo
+echo
+
+
+echo "06. Triangle in: A"
+echo "=================="
+orionCurl --url '/v2/entities?georel=coveredBy&geometry=polygon&coords=0,0;0,6;6,0;0,0&options=count'
+echo
+echo
+
+
+echo "07. Rectangle out: A"
+echo "===================="
+orionCurl --url '/v2/entities?georel=disjoint&geometry=polygon&coords=3,3;3,8;11,8;11,3;3,3&options=count'
+echo
+echo
+
+
+echo "08. Triangle out: B, C"
+echo "======================"
+orionCurl --url '/v2/entities?georel=disjoint&geometry=polygon&coords=0,0;0,6;6,0;0,0&options=count'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create Point A
+==================
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/entities/A?type=Point
+Content-Length: 0
+
+
+
+02. Create Point B
+==================
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/entities/B?type=Point
+Content-Length: 0
+
+
+
+03. Create Point C
+==================
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/entities/C?type=Point
+Content-Length: 0
+
+
+
+04. Rectangle in: A, B
+======================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Fiware-Total-Count: 2
+Content-Type: application/json
+Content-Length: 175
+
+[
+    {
+        "id": "A",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "3, 2"
+        },
+        "type": "Point"
+    },
+    {
+        "id": "B",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "5, 5"
+        },
+        "type": "Point"
+    }
+]
+
+
+05. Rectangle in: B, C
+======================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Fiware-Total-Count: 2
+Content-Type: application/json
+Content-Length: 175
+
+[
+    {
+        "id": "B",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "5, 5"
+        },
+        "type": "Point"
+    },
+    {
+        "id": "C",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "7, 4"
+        },
+        "type": "Point"
+    }
+]
+
+
+06. Triangle in: A
+==================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Fiware-Total-Count: 1
+Content-Type: application/json
+Content-Length: 88
+
+[
+    {
+        "id": "A",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "3, 2"
+        },
+        "type": "Point"
+    }
+]
+
+
+07. Rectangle out: A
+====================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Fiware-Total-Count: 1
+Content-Type: application/json
+Content-Length: 88
+
+[
+    {
+        "id": "A",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "3, 2"
+        },
+        "type": "Point"
+    }
+]
+
+
+08. Triangle out: B, C
+======================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Fiware-Total-Count: 2
+Content-Type: application/json
+Content-Length: 175
+
+[
+    {
+        "id": "B",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "5, 5"
+        },
+        "type": "Point"
+    },
+    {
+        "id": "C",
+        "location": {
+            "metadata": {},
+            "type": "geo:point",
+            "value": "7, 4"
+        },
+        "type": "Point"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
The first commit in this PR raises the problem, in the form of .test.

As can be seen, the test/functionalTest/cases/1038_ngsiv2_geo_location_entities/geoquery_circle_geopoint_count.test test is not working. A `$geoNear, $near, and $nearSphere are not allowed in this contex` is raised in the collectionRangedQuery() function, in particular when mongoc_collection_count_documents is called

Curiosly, other geo-queries works with problem with count. Note the test/functionalTest/cases/1038_ngsiv2_geo_location_entities/geoquery_polygon_geopoint_count.test test is working.

Related: https://stackoverflow.com/questions/76409607/geonear-near-and-nearsphere-are-not-allowed-in-this-context-error-with-mong

Pending:

- [x] actual fix for the problem
- [x] CNR

