### PR TITLE
FIX logDeprecate not working correctly (release/3.10.0)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: logDeprecate not working correctly (`geo:json` wrongly considered as deprecated)

--- a/src/lib/mongoBackend/location.cpp
+++ b/src/lib/mongoBackend/location.cpp
@@ -348,7 +348,7 @@ static bool getGeoJson
     return true;
   }
 
-  if ((logDeprecate) && ((caP->type == GEO_POINT) || (caP->type == GEO_LINE) || (caP->type == GEO_BOX) || (caP->type != GEO_POLYGON)))
+  if ((logDeprecate) && ((caP->type == GEO_POINT) || (caP->type == GEO_LINE) || (caP->type == GEO_BOX) || (caP->type == GEO_POLYGON)))
   {
     LM_W(("Deprecated usage of %s detected in attribute %s at entity update, please use geo:json instead", caP->type.c_str(), caP->name.c_str()));
   }


### PR DESCRIPTION
Backport of PR https://github.com/telefonicaid/fiware-orion/pull/4371

(Previous attempt PR https://github.com/telefonicaid/fiware-orion/pull/4372 was wrongly using master as base branch)