### PR TITLE
Switch from Docker to Quay

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This project is part of [FIWARE](https://www.fiware.org/). For more information
 check the FIWARE Catalogue entry for
 [Core Context Management](https://github.com/Fiware/catalogue/tree/master/core).
 
-| :books: [Documentation](https://fiware-orion.rtfd.io) | :mortar_board: [Academy](https://fiware-academy.readthedocs.io/en/latest/core/orion) | <img style="height:1em" src="https://quay.io/static/img/quay_favicon.png"/> [quay.io](https://quay.io/repository/fiware/orion) | :dart: [Roadmap](doc/roadmap.md) |
+| :books: [Documentation](https://fiware-orion.rtfd.io) | :mortar_board: [Academy](https://fiware-academy.readthedocs.io/en/latest/core/orion) | <img style="height:1em" src="https://quay.io/static/img/quay_favicon.png"/> [quay.io](https://quay.io/repository/fiware/orion) | :whale: [Docker Hub](https://registry.hub.docker.com/r/telefonicaiot/fiware-orion) | :dart: [Roadmap](doc/roadmap.md) |
 |---|---|---|---|
 
 ## Content

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![FIWARE Core Context Management](https://nexus.lab.fiware.org/repository/raw/public/badges/chapters/core.svg)](https://www.fiware.org/developers/catalogue/)
 [![License badge](https://img.shields.io/github/license/telefonicaid/fiware-orion.svg)](https://opensource.org/licenses/AGPL-3.0)
-[![Docker badge](https://img.shields.io/docker/pulls/fiware/orion.svg)](https://hub.docker.com/r/fiware/orion/)
+[![Docker badge](https://img.shields.io/badge/quay.io-fiware%2Forion-grey?logo=red%20hat&labelColor=EE0000)](https://quay.io/repository/fiware/orion)
 [![Support badge](https://img.shields.io/badge/tag-fiware--orion-orange.svg?logo=stackoverflow)](http://stackoverflow.com/questions/tagged/fiware-orion)
 [![NGSI v2](https://img.shields.io/badge/NGSI-V2-red.svg)](doc/manuals/orion-api.md)
 <br>
@@ -34,7 +34,7 @@ This project is part of [FIWARE](https://www.fiware.org/). For more information
 check the FIWARE Catalogue entry for
 [Core Context Management](https://github.com/Fiware/catalogue/tree/master/core).
 
-| :books: [Documentation](https://fiware-orion.rtfd.io) | :mortar_board: [Academy](https://fiware-academy.readthedocs.io/en/latest/core/orion) | :whale: [Docker Hub](https://hub.docker.com/r/fiware/orion/) | :dart: [Roadmap](doc/roadmap.md) |
+| :books: [Documentation](https://fiware-orion.rtfd.io) | :mortar_board: [Academy](https://fiware-academy.readthedocs.io/en/latest/core/orion) | <img style="height:1em" src="https://quay.io/static/img/quay_favicon.png"/> [quay.io](https://quay.io/repository/fiware/orion) | :dart: [Roadmap](doc/roadmap.md) |
 |---|---|---|---|
 
 ## Content
@@ -263,6 +263,9 @@ version 3](./LICENSE).
 
 © 2023 Telefonica Investigación y Desarrollo, S.A.U
 
+<details>
+<summary><strong>Further information on the use of the AGPL open source license</strong></summary>
+     
 ### Are there any legal issues with AGPL 3.0? Is it safe for me to use?
 
 There is absolutely no problem in using a product licensed under AGPL 3.0. Issues with GPL
@@ -280,3 +283,4 @@ wish to make a clarifying public statement as follows:
 > unmodified version of existing software is not considered a derivative work, and therefore
 > it does not need to be released as under the same license, or even released as open source.
 
+</details>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ check the FIWARE Catalogue entry for
 [Core Context Management](https://github.com/Fiware/catalogue/tree/master/core).
 
 | :books: [Documentation](https://fiware-orion.rtfd.io) | :mortar_board: [Academy](https://fiware-academy.readthedocs.io/en/latest/core/orion) | <img style="height:1em" src="https://quay.io/static/img/quay_favicon.png"/> [quay.io](https://quay.io/repository/fiware/orion) | :whale: [Docker Hub](https://registry.hub.docker.com/r/telefonicaiot/fiware-orion) | :dart: [Roadmap](doc/roadmap.md) |
-|---|---|---|---|
+|---|---|---|---|--|
 
 ## Content
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 [![FIWARE Core Context Management](https://nexus.lab.fiware.org/repository/raw/public/badges/chapters/core.svg)](https://www.fiware.org/developers/catalogue/)
 [![License badge](https://img.shields.io/github/license/telefonicaid/fiware-orion.svg)](https://opensource.org/licenses/AGPL-3.0)
-[![Docker badge](https://img.shields.io/badge/quay.io-fiware%2Forion-grey?logo=red%20hat&labelColor=EE0000)](https://quay.io/repository/fiware/orion)
+[![Quay badge](https://img.shields.io/badge/quay.io-fiware%2Forion-grey?logo=red%20hat&labelColor=EE0000)](https://quay.io/repository/fiware/orion)
+[![Docker badge](https://img.shields.io/badge/docker-telefonicaiot%2Ffiware--orion-blue?logo=docker)](https://registry.hub.docker.com/r/telefonicaiot/fiware-orion)
 [![Support badge](https://img.shields.io/badge/tag-fiware--orion-orange.svg?logo=stackoverflow)](http://stackoverflow.com/questions/tagged/fiware-orion)
 [![NGSI v2](https://img.shields.io/badge/NGSI-V2-red.svg)](doc/manuals/orion-api.md)
 <br>


### PR DESCRIPTION
As discussed within the TSC, badge and links for FIWARE clones of the container image should be switched to quay.io