### PR TITLE
FIX change mongo driver to 1.24.3 in build-dep.sh (ci image)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,3 +4,4 @@
 - Fix: improve error traces (#4387)
 - Add: CLI parameter -dbUri / env var ORION_MONGO_URI (#3794)
 - Fix: improve logs in MongoDB query logic
+- Hardening: upgrade libmongoc dependency from 1.23.1 to 1.24.3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,8 +220,8 @@ SET (BOOST_MT
 
 # See http://mongoc.org/libmongoc/current/tutorial.html#cmake
 # This find_package() command provides the mongo::mongoc_static used in
-# SET for common static libs. We use 1.23.1 as reference version.
-find_package (mongoc-1.0 1.23.1 EXACT)
+# SET for common static libs. We use 1.24.1 as reference version.
+find_package (mongoc-1.0 1.24.1 EXACT)
 
 # Static libs common to contextBroker and unitTest binaries
 SET (COMMON_STATIC_LIBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,8 +220,8 @@ SET (BOOST_MT
 
 # See http://mongoc.org/libmongoc/current/tutorial.html#cmake
 # This find_package() command provides the mongo::mongoc_static used in
-# SET for common static libs. We use 1.24.1 as reference version.
-find_package (mongoc-1.0 1.24.1 EXACT)
+# SET for common static libs. We use 1.24.3 as reference version.
+find_package (mongoc-1.0 1.24.3 EXACT)
 
 # Static libs common to contextBroker and unitTest binaries
 SET (COMMON_STATIC_LIBS

--- a/ci/deb/build-dep.sh
+++ b/ci/deb/build-dep.sh
@@ -69,8 +69,8 @@ echo "INSTALL: python special dependencies" \
 # Recommended setting for DENABLE_AUTOMATIC_INIT_AND_CLEANUP, to be removed in 2.0.0
 # see http://mongoc.org/libmongoc/current/init-cleanup.html#deprecated-feature-automatic-initialization-and-cleanup
 echo "INSTALL: mongodb c driver (required by mongo c++ driver)" \
-&& curl -L https://github.com/mongodb/mongo-c-driver/releases/download/1.23.1/mongo-c-driver-1.23.1.tar.gz | tar xzC /opt/ \
-&& cd /opt/mongo-c-driver-1.23.1 \
+&& curl -L https://github.com/mongodb/mongo-c-driver/releases/download/1.24.3/mongo-c-driver-1.24.3.tar.gz | tar xzC /opt/ \
+&& cd /opt/mongo-c-driver-1.24.3 \
 && mkdir cmake-build \
 && cd cmake-build \
 && cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF .. \
@@ -109,7 +109,7 @@ echo "INSTALL: mosquitto" \
 ldconfig
 
 apt-get -y clean \
-&& rm -Rf /opt/mongo-c-driver-1.23.1 \
+&& rm -Rf /opt/mongo-c-driver-1.24.3 \
 && rm -Rf /opt/rapidjson-1.1.0 \
 && rm -Rf /opt/libmicrohttpd-0.9.76 \
 && rm -Rf /opt/mosquitto-2.0.15 \

--- a/doc/manuals.jp/admin/build_source.md
+++ b/doc/manuals.jp/admin/build_source.md
@@ -12,7 +12,7 @@ Orion Context Broker は、以下のライブラリをビルドの依存関係�
 * openssl: 1.1.1n
 * libuuid: 2.36.1
 * libmosquitto: 2.0.15 (ソースから)
-* Mongo C driver: 1.23.1 (ソースから)
+* Mongo C driver: 1.24.3 (ソースから)
 * rapidjson: 1.1.0 (ソースから)
 * gtest (`make unit_test` ビルディング・ターゲットのみ) : 1.5 (ソースから)
 * gmock (`make unit_test` ビルディング・ターゲットのみ) : 1.5 (ソースから)
@@ -29,9 +29,9 @@ Orion Context Broker は、以下のライブラリをビルドの依存関係�
 
 * ソースから Mongo Driver をインストールします
 
-        wget https://github.com/mongodb/mongo-c-driver/releases/download/1.23.1/mongo-c-driver-1.23.1.tar.gz
-        tar xfvz mongo-c-driver-1.23.1.tar.gz
-        cd mongo-c-driver-1.23.1
+        wget https://github.com/mongodb/mongo-c-driver/releases/download/1.24.3/mongo-c-driver-1.24.3.tar.gz
+        tar xfvz mongo-c-driver-1.24.3.tar.gz
+        cd mongo-c-driver-1.24.3
         mkdir cmake-build
         cd cmake-build
         cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF ..

--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -12,7 +12,7 @@ The Orion Context Broker uses the following libraries as build dependencies:
 * openssl: 1.1.1n
 * libuuid: 2.36.1
 * libmosquitto: 2.0.15 (from source)
-* Mongo C driver: 1.23.1 (from source)
+* Mongo C driver: 1.24.3 (from source)
 * rapidjson: 1.1.0 (from source)
 * gtest (only for `make unit_test` building target): 1.5 (from sources)
 * gmock (only for `make unit_test` building target): 1.5 (from sources)
@@ -30,9 +30,9 @@ commands that require root privilege):
 
 * Install the Mongo Driver from source.
 
-        wget https://github.com/mongodb/mongo-c-driver/releases/download/1.23.1/mongo-c-driver-1.23.1.tar.gz
-        tar xfvz mongo-c-driver-1.23.1.tar.gz
-        cd mongo-c-driver-1.23.1
+        wget https://github.com/mongodb/mongo-c-driver/releases/download/1.24.3/mongo-c-driver-1.24.3.tar.gz
+        tar xfvz mongo-c-driver-1.24.3.tar.gz
+        cd mongo-c-driver-1.24.3
         mkdir cmake-build
         cd cmake-build
         cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF ..

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,9 @@
 # iot_support at tid dot es
 #
 
+# FIXME the change from mongoc driver 1.23.1 to 1.24.1 (PR https://github.com/telefonicaid/fiware-orion/pull/4415)
+# has not been actually tested. Remove this FIXME mark after succesfull test
+
 ARG  IMAGE_TAG=11.6-slim
 FROM debian:${IMAGE_TAG}
 
@@ -80,9 +83,9 @@ RUN \
     ldconfig && \
     # Install mongodb driver from source
     cd /opt && \
-    curl -kOL https://github.com/mongodb/mongo-c-driver/releases/download/1.23.1/mongo-c-driver-1.23.1.tar.gz && \
-    tar xfvz mongo-c-driver-1.23.1.tar.gz && \
-    cd mongo-c-driver-1.23.1 && \
+    curl -kOL https://github.com/mongodb/mongo-c-driver/releases/download/1.24.3/mongo-c-driver-1.24.3.tar.gz && \
+    tar xfvz mongo-c-driver-1.24.3.tar.gz && \
+    cd mongo-c-driver-1.24.3 && \
     mkdir cmake-build && \
     cd cmake-build && \
     # Different from ci/deb/build-dep.sh and build from source documentation, we add here also
@@ -120,8 +123,8 @@ RUN \
            /opt/libmicrohttpd-0.9.76 \
            /opt/mosquitto-2.0.15.tar.gz \
            /opt/mosquitto-2.0.15 \
-           /opt/mongo-c-driver-1.23.1.tar.gz \
-           /opt/mongo-c-driver-1.23.1 \
+           /opt/mongo-c-driver-1.24.3.tar.gz \
+           /opt/mongo-c-driver-1.24.3 \
            /usr/local/include/mongo \
            /usr/local/lib/libmongoclient.a \
            /opt/rapidjson-1.1.0 \

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -82,9 +82,9 @@ RUN \
     #ldconfig && \
     # Install mongodb driver from source
     cd /opt && \
-    curl -kOL https://github.com/mongodb/mongo-c-driver/releases/download/1.23.1/mongo-c-driver-1.23.1.tar.gz && \
-    tar xfvz mongo-c-driver-1.23.1.tar.gz && \
-    cd mongo-c-driver-1.23.1 && \
+    curl -kOL https://github.com/mongodb/mongo-c-driver/releases/download/1.24.3/mongo-c-driver-1.24.3.tar.gz && \
+    tar xfvz mongo-c-driver-1.24.3.tar.gz && \
+    cd mongo-c-driver-1.24.3 && \
     mkdir cmake-build && \
     cd cmake-build && \
     # Different from ci/deb/build-dep.sh and build from source documentation, we add here also
@@ -125,8 +125,8 @@ RUN \
            /opt/libmicrohttpd-0.9.76 \
            /opt/mosquitto-2.0.15.tar.gz \
            /opt/mosquitto-2.0.15 \
-           /opt/mongo-c-driver-1.23.1.tar.gz \
-           /opt/mongo-c-driver-1.23.1 \
+           /opt/mongo-c-driver-1.24.3.tar.gz \
+           /opt/mongo-c-driver-1.24.3 \
            /usr/local/include/mongo \
            /usr/local/lib/libmongoclient.a \
            /opt/rapidjson-1.1.0 \


### PR DESCRIPTION
This PR is to build de ci image so we can regression if Orion will work with the new version of the driver in Debian 11. We will manually launch the CI image build in dockerhub, then re-launch tests in ~master~ this branch (code is the same as in master) branch.