### PR TITLE
ADD IMAGE_NAME arg to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,8 +19,9 @@
 # iot_support at tid dot es
 #
 
+ARG  IMAGE_NAME=debian
 ARG  IMAGE_TAG=12.1-slim
-FROM debian:${IMAGE_TAG}
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
 
 ARG GITHUB_ACCOUNT=telefonicaid
 ARG GITHUB_REPOSITORY=fiware-orion

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -22,8 +22,9 @@
 # FIXME the change from mongoc driver 1.23.1 to 1.24.1 (PR https://github.com/telefonicaid/fiware-orion/pull/4415)
 # has not been actually tested. Remove this FIXME mark after succesfull test
 
+ARG  IMAGE_NAME=alpine
 ARG  IMAGE_TAG=3.16.0
-FROM alpine:${IMAGE_TAG}
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
 
 ARG GITHUB_ACCOUNT=telefonicaid
 ARG GITHUB_REPOSITORY=fiware-orion

--- a/docker/README.jp.md
+++ b/docker/README.jp.md
@@ -128,7 +128,8 @@ Orion Context Broker を試してみたいし、データベースについて�
 
 | ARG             | 説明                                                           | 例                              |
 | --------------- | -------------------------------------------------------------- | ------------------------------- |
-| IMAGE_TAG       | ベース・イメージのタグを指定します                             | --build-arg IMAGE_TAG=centos7   |
+| IMAGE_NAME      | ベース・イメージの名前を指定します                             | --build-arg IMAGE_NAME=ubuntu   |
+| IMAGE_TAG       | ベース・イメージのタグを指定します                             | --build-arg IMAGE_TAG=22.04     |
 | GIT_NAME        | GitHub リポジトリのユーザ名を指定します                        | --build-arg GIT_NAME=fiware-ges |
 | GIT_REV_ORION   | ビルドする Orion バージョンを指定します                        | --build-arg GIT_REV_ORION=2.3.0 |
 | CLEAN_DEV_TOOLS | 開発ツールをクリアするかどうかを指定します。0 の場合は残ります | --build-arg CLEAN_DEV_TOOLS=0   |

--- a/docker/README.md
+++ b/docker/README.md
@@ -130,7 +130,8 @@ The parameter `--build-arg` in the `docker build` can be set build-time variable
 
 | ARG             | Description                                                         | Example                         |
 | --------------- | ------------------------------------------------------------------- | ------------------------------- |
-| IMAGE_TAG       | Specify a tag of the base image.                                    | --build-arg IMAGE_TAG=centos7   |
+| IMAGE_NAME      | Specify a name of the base image.                                   | --build-arg IMAGE_TAG=ubuntu    |
+| IMAGE_TAG       | Specify a tag of the base image.                                    | --build-arg IMAGE_TAG=22.04     |
 | GIT_NAME        | Specify a username of GitHub repository.                            | --build-arg GIT_NAME=fiware-ges |
 | GIT_REV_ORION   | Specify the Orion version you want to build.                        | --build-arg GIT_REV_ORION=2.3.0 |
 | CLEAN_DEV_TOOLS | Specify whether the development tools clear. It is remained when 0. | --build-arg CLEAN_DEV_TOOLS=0   |


### PR DESCRIPTION
This PR adds the `IMAGE_NAME` argument to Dockerfile. For example, Orion with Ubuntu 22.04 as a base image can be build as shown:

```
docker build -t orion-ubuntu22.04 --build-arg IMAGE_NAME=ubuntu --build-arg IMAGE_TAG=22.04 --build-arg CLEAN_DEV_TOOLS=0
```

The build logs:

 - [build_on_ubuntu_22_04_x86_64.log](https://github.com/fisuda/report/blob/master/orion/20230910_ubuntu22.04_in_docker/build_on_ubuntu_22_04_x86_64.log)
 - [build_on_ubuntu_22_04_arrch64.log](https://github.com/fisuda/report/blob/master/orion/20230910_ubuntu22.04_in_docker/build_on_ubuntu_22_04_arrch64.log)

Result:

- Orion on Ubuntu 22.04 (x86_64)

```
$ curl http://localhost:1026/version
{
"orion" : {
  "version" : "3.10.0-next",
  "uptime" : "0 d, 0 h, 0 m, 13 s",
  "git_hash" : "7b6275bb053701af043ed05536ce8facc46f0efc",
  "compile_time" : "Sun Sep 10 02:01:01 UTC 2023",
  "compiled_by" : "root",
  "compiled_in" : "buildkitsandbox",
  "release_date" : "Sun Sep 10 02:01:01 UTC 2023",
  "machine" : "x86_64",
  "doc" : "https://fiware-orion.rtfd.io/",
  "libversions": {
     "boost": "1_74",
     "libcurl": "libcurl/7.81.0 OpenSSL/3.0.2 zlib/1.2.13 brotli/1.0.9 zstd/1.4.8 libidn2/2.3.2 libpsl/0.21.0 (+libidn2/2.3.2) libssh/0.9.6/openssl/zlib nghttp2/1.43.0 librtmp/2.3 OpenLDAP/2.5.16",
     "libmosquitto": "2.0.15",
     "libmicrohttpd": "0.9.76",
     "openssl": "3.0.2",
     "rapidjson": "1.1.0",
     "mongoc": "1.24.3",
     "bson": "1.24.3"
  }
}
}
```

- Orion on Ubuntu 22.04 (aarch64)

```
{
"orion" : {
  "version" : "3.10.0-next",
  "uptime" : "0 d, 0 h, 0 m, 10 s",
  "git_hash" : "7b6275bb053701af043ed05536ce8facc46f0efc",
  "compile_time" : "Sun Sep 10 02:17:40 UTC 2023",
  "compiled_by" : "root",
  "compiled_in" : "buildkitsandbox",
  "release_date" : "Sun Sep 10 02:17:40 UTC 2023",
  "machine" : "aarch64",
  "doc" : "https://fiware-orion.rtfd.io/",
  "libversions": {
     "boost": "1_74",
     "libcurl": "libcurl/7.81.0 OpenSSL/3.0.2 zlib/1.2.13 brotli/1.0.9 zstd/1.4.8 libidn2/2.3.2 libpsl/0.21.0 (+libidn2/2.3.2) libssh/0.9.6/openssl/zlib nghttp2/1.43.0 librtmp/2.3 OpenLDAP/2.5.16",
     "libmosquitto": "2.0.15",
     "libmicrohttpd": "0.9.76",
     "openssl": "3.0.2",
     "rapidjson": "1.1.0",
     "mongoc": "1.24.3",
     "bson": "1.24.3"
  }
}
}
```

It would be great if you could review this PR.

Thanks.