### PR TITLE
ADD documentation about how to use Orion in Docker on Raspberry Pi OS

### DIFF
--- a/docker/raspberry_pi.jp.md
+++ b/docker/raspberry_pi.jp.md
@@ -5,9 +5,7 @@ Raspberry Pi で Docker を使用すると、Orion Context Broker を非常に�
 [Raspberry Pi](https://www.raspberrypi.org/) は、低価格のクレジット・カード・サイズのコンピュータです。
 ARM ベースのデバイスであり、ARM アーキテクチャ用にコンパイルされたバイナリが必要です。 Orion の Docker
 イメージをビルドして実行するには、ARM architecture 用の 64 ビット Linux と Docker を Raspberry Pi に
-インストールします。Raspberry Pi にインストールされたオペレーティング・システムで Orion を直接ビルド
-して実行する場合は、その方法に関する
-[ドキュメント](../doc/manuals.jp/admin/build_source.md#ubuntu-1804-lts)を参照してください。
+インストールします。
 
 ## 前提条件
 
@@ -15,46 +13,15 @@ ARM ベースのデバイスであり、ARM アーキテクチャ用にコンパ
 
 ターゲット・ハードウェアは、64 ビット ARM アーキテクチャ (aarch64) をサポートする Raspberry Pi 3 および 4 です。
 
-### Linux OS
+### Raspberry Pi OS
 
-現在のところ、Raspberry Pi で64 ビット Linux を使用するオプションは多くありません。Ubuntu 20.04 LTS
-を使用することをお勧めします。[こちら](https://ubuntu.com/download/raspberry-pi)から OS イメージを取得し、
-インストール手順を見つけることができます。
+Raspberry Pi OS Bookworm 12 を使用することをお勧めします。[こちら](https://www.raspberrypi.com/software/)から
+OS イメージを取得し、インストール手順を確認することができます。
 
 ### Docker
 
-次のコマンドに従って、Ubuntu に Docker をインストールできます :
-
-```
-sudo cp -p /etc/apt/sources.list{,.bak}
-sudo apt-get update
-sudo apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg-agent \
-    software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \
-   "deb [arch=arm64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-sudo apt-get install -y docker-ce
-```
-
-Docker のインストールの詳細は[こちら](https://docs.docker.com/install/linux/docker-ce/ubuntu/)です。
-
-### Dokcer compose
-
-aarch64 の Docker Compose のバイナリは提供されていません。ソースコードからビルドする必要があります。
-次のようにコマンドを実行して、Docker Compose のバージョン 1.27.4 をインストールできます :
-
-```
-git clone -b 1.27.4 https://github.com/docker/compose.git
-cd compose/
-sudo ./script/build/linux
-sudo cp dist/docker-compose-Linux-aarch64 /usr/local/bin/docker-compose
-```
+Raspberry Pi OS に Docker と Docker compose plugin をインストールします。Docker
+のインストールの詳細は[こちら](https://docs.docker.com/engine/install/raspberry-pi-os/)です。
 
 ## Orion のビルド方法
 
@@ -87,5 +54,5 @@ services:
     command: --nojournal
 ```
 
-Orion を実行するには、`docker-compose up -d` を実行します。`curl localhost:1026/version` コマンドを実行して、
+Orion を実行するには、`docker compose up -d` を実行します。`curl localhost:1026/version` コマンドを実行して、
 Orion が起動したかどうかを確認します。

--- a/docker/raspberry_pi.md
+++ b/docker/raspberry_pi.md
@@ -5,8 +5,6 @@ You can run Orion Context Broker very easily using docker on Raspberry Pi.
 The [Raspberry Pi](https://www.raspberrypi.org/) is a low cost, credit-card sized computer.
 It is an ARM based device and requires binaries compiled for the ARM architecture. 
 To build and run the docker image of Orion, the 64 bit Linux and docker for the ARM architecture are installed on Raspberry Pi.
-If you want to build and run Orion directly on an operating system installed on a Raspberry Pi, See the
-[documentation](../doc/manuals/admin/build_source.md#ubuntu-1804-lts) on how to do this.
 
 ## Prerequisites
 
@@ -16,44 +14,13 @@ The target devices are Raspberry Pi 3 and 4 which support the 64 bit ARM archite
 
 ### Linux OS
 
-As of now, there are not many options to use the 64 bit Linux on Raspberry Pi. 
-To use Ubuntu 20.04 LTS is better. You can get the OS image and find the install instruction
-[here](https://ubuntu.com/download/raspberry-pi).
+To use Raspberry Pi OS Bookworm 12 is better. You can get the OS image and find the install instruction
+[here](https://www.raspberrypi.com/software/).
 
 ### Docker
 
-You can install Docker on Ubuntu by following the commands as shown:
-
-```
-sudo cp -p /etc/apt/sources.list{,.bak}
-sudo apt-get update
-sudo apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg-agent \
-    software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \
-   "deb [arch=arm64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-sudo apt-get install -y docker-ce
-```
-
-The details to install Docker are [here](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
-
-### Docker compose
-
-The Docker Compose binary for aarch64 is not provided. It is necessary to build it from its source code.
-You can install the docker compose version 1.27.4 by running the commands as shown:
-
-```
-git clone -b 1.27.4 https://github.com/docker/compose.git
-cd compose/
-sudo ./script/build/linux
-sudo cp dist/docker-compose-Linux-aarch64 /usr/local/bin/docker-compose
-```
+You install Docker and Docker compose plugin on Raspberry Pi OS. The details to install Docker are
+[here](https://docs.docker.com/engine/install/raspberry-pi-os/).
 
 ## How to build Orion
 


### PR DESCRIPTION
This PR adds documentation about how to use Orion in Docker on Raspberry Pi OS. 

Currently, The official distribution of Raspberry Pi is Raspberry Pi OS Bookworm 12 (stable). Therefore, this PR switches the distribution from Ubuntu to Raspberry Pi OS for using Orion in Docker on Raspberry Pi.

It would be great if you could review the PR.

Thanks.