### PR TITLE
ADD Alpine 3.16.x as distribution with old SSL version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ endif (${CMAKE_BUILD_TYPE} STREQUAL DEBUG)
 
 # Enables some some #ifdef in the code for compiling in old system
 # FIXME: cleanup OLD_SSL_VERSION_FORMAT stuff after consolidating the change to Debian 12+
-IF(${DISTRO} MATCHES "Debian_11.*")
+IF((${DISTRO} MATCHES "Debian_11.*") OR (${DISTRO} MATCHES "Alpine_3.16.*"))
   ADD_DEFINITIONS(-DOLD_SSL_VERSION_FORMAT)
 ENDIF()
 

--- a/scripts/build/osDistro.sh
+++ b/scripts/build/osDistro.sh
@@ -26,6 +26,8 @@ suse_distro=$(cat /etc/SuSE-release 2> /dev/null | grep SUSE | cut -d ' ' -f 1-2
 
 centos_distro=$(cat /etc/redhat-release 2> /dev/null | awk '{print $3}')
 
+alpine_distro=$(cat /etc/alpine-release 2> /dev/null)
+
 # In some cases (e.g. CentOS 7.x) we have found that the /etc/redhat-release content uses the following pattern:
 #
 #  CentOS Linux release 7.2.1511 (Core)
@@ -69,6 +71,9 @@ then
 elif [ "$centos_distro" != "" ]
 then
   distro=CentOS_$centos_distro 
+elif [ "$alpine_distro" != "" ]
+then
+  distro=Alpine_$alpine_distro
 fi
 
 echo -n $distro


### PR DESCRIPTION
This PR adds Alpine 3.16.x as the distribution with old SSL version. It would be great if you could review this PR.

How to build:
```
docker build -t orion.alpine -f Dockerfile.alpine --build-arg GITHUB_ACCOUNT=fisuda --build-arg GIT_NAME=fisuda --build-arg GIT_REV_ORION=hardening/use_old_ssl_version --progress plain . |& tee /tmp/build.log
```

The full log is here: [20230911_PR_#4425_alpine_3_16_x/build.log](https://github.com/fisuda/report/blob/master/orion/20230911_PR_%234425_alpine_3_16_x/build.log)

- ./scripts/build/osDistro.sh

```
$ docker run -it --rm -v /home/fisuda/fiware-orion:/work alpine:3.16.0 sh
/ # /work/scripts/build/osDistro.sh
Alpine_3.16.0/ #
```

Thanks.