### PR TITLE
FIX improve documentation about building Orion

### DIFF
--- a/doc/manuals/admin/build_source.md
+++ b/doc/manuals/admin/build_source.md
@@ -2,6 +2,8 @@
 
 Orion Context Broker reference distribution is Debian 12. This doesn't mean that the broker cannot be built in other distributions (actually, it can). This section may include indications on how to build in other distributions, just in the case it may help people that don't use Debian. However, note that the only "officially supported" procedure is the one for Debian 12.
 
+You can also have a look to [3.1 Building in not official distributions](../../../docker/README.md#31-building-in-not-official-distributions) section in the Docker documentation to check how to build Docker containers images in distributions other than the official one.
+
 ## Debian 12 (officially supported)
 
 The Orion Context Broker uses the following libraries as build dependencies:

--- a/docker/README.md
+++ b/docker/README.md
@@ -124,7 +124,7 @@ Check that everything works with
 
 The parameter `-t orion` in the `docker build` command gives the image a name. This name could be anything, or even include an organization like `-t org/fiware-orion`. This name is later used to run the container based on the image.
 
-Two Dockerfiles are provided for step 3 above: the official one (`Dockefile` itself) based in Debian and `Dockefile.alpine`, which is not official but in can be useful as starting point if you want to use Alpine as base distribution.
+Two Dockerfiles are provided for step 3 above: the official one (`Dockefile` itself) based in Debian and `Dockefile.alpine`, which is not official but in can be useful as starting point if you want to use [Alpine](https://www.alpinelinux.org/) as base distribution.
 
 The parameter `--build-arg` in the `docker build` can be set build-time variables. 
 
@@ -136,6 +136,14 @@ The parameter `--build-arg` in the `docker build` can be set build-time variable
 | CLEAN_DEV_TOOLS | Specify whether the development tools clear. It is remained when 0. | --build-arg CLEAN_DEV_TOOLS=0   |
 
 If you want to know more about images and the building process you can find it in [Docker's documentation](https://docs.docker.com/userguide/dockerimages/).
+
+### 3.1 Building in not official distributions
+
+As explained in the [requirements section of the installation documentation](../doc/manuals/admin/install.md#requirements), Debian 12 is the only officially supported
+distribution. However, the following commands have been tested to build Docker containers based in alternative distributions:
+
+* Ubuntu 22.04 TLS: `docker build -t orion-ubuntu22.04 --build-arg IMAGE_NAME=ubuntu --build-arg IMAGE_TAG=22.04 --build-arg CLEAN_DEV_TOOLS=0`
+* Alpine 3.16.0: `docker build -t orion-alpine3.16 -f Dockerfile.alpine`
 
 ## 4. Other info
 


### PR DESCRIPTION
As a complement of recent works (PRs #4422, #4423 and #4425) I think it would be a good idea to provide the `docker build` commands to build Orion in Ubuntu and Alpine in users documentation.

@fisuda what do you think? Please provide feedback on this PR. If you think is ok, it would be great if you could do a PR using hardening/doc-building branch to sync translation in the Japanese documents, please.