### PR TITLE
FIX OrionError field names refactor

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -11,6 +11,7 @@
 - Fix: provide more informative error description in some error responses in update/delete operations
 - Fix: proper use of "PartialUpdate" (instead of "Unprocessed") in responses in the case of partial updates/deletions (#3499)
 - Fix: response 404 Not Found "NotFound" errors instead of 422 Unprocessable Content "Unprocessed" in the case of missing attribute in existing entity in attribute update operations
+- Fix: "Internal Server Error" changed to "InternalServerError" in error responses
 - Add: CLI parameter -dbUri / env var ORION_MONGO_URI (#3794)
 - Fix: improve logs in MongoDB query logic
 - Fix: false positive in log deprecation logic when entity name (or other literal) includes the token "v1" (#4454)

--- a/doc/manuals/admin/diagnosis.md
+++ b/doc/manuals/admin/diagnosis.md
@@ -271,45 +271,20 @@ The symptoms of a database connection problem are the following:
 -   At startup time. The broker doesn't start and the following message
     appears in the log file:
 
-` X@08:04:45 main[313]: MongoDB error`
+```
+... msg=Database Startup Error (cannot connect to mongo - doing 100 retries with a 1000 millisecond interval)
+... msg=Fatal Error (MongoDB error)
+
+```
 
 -   During broker operation. Error message like the following ones
     appear in the responses sent by the broker.
 
 ```
-
-    ...
-    "errorCode": {
-        "code": "500",
-        "reasonPhrase": "Database Error",
-        "details": "collection: ... - exception: Null cursor"
-    }
-    ...
-
-    ...
-    "errorCode": {
-        "code": "500",
-        "reasonPhrase": "Database Error",
-        "details": "collection: ... - exception: socket exception [CONNECT_ERROR] for localhost:27017"
-    }
-    ...
-
-    ...
-    "errorCode": {
-        "code": "500",
-        "reasonPhrase": "Database Error",
-        "details": "collection: ... - exception: socket exception [FAILED_STATE] for localhost:27017"
-    }
-    ...
-
-    ...
-    "errorCode": {
-        "code": "500",
-        "reasonPhrase": "Database Error",
-        "details": "collection: ... - exception: DBClientBase::findN: transport error: localhost:27017 ns: orion.$cmd query: { .. }"
-    }
-    ...
-
+{
+    "error": "InternalServerError",
+    "description": "Database Error ..."
+}
 ```
 
 In both cases, check that the connection to MonogDB is correctly

--- a/doc/manuals/orion-api.md
+++ b/doc/manuals/orion-api.md
@@ -458,6 +458,7 @@ The `error` reporting is as follows:
   + HTTP 411 Length Required corresponds to `ContentLengthRequired` (`411`)
   + HTTP 413 Request Entity Too Large corresponds to `RequestEntityTooLarge` (`413`)
   + HTTP 415 Unsupported Media Type corresponds to `UnsupportedMediaType` (`415`)
++ Internal errors use `InternalServerError` (`500`)
 
 ## Multi tenancy
 

--- a/doc/manuals/user/known_limitations.md
+++ b/doc/manuals/user/known_limitations.md
@@ -7,11 +7,8 @@ this limitation into account, you will get messages such the following ones:
 
 ```
 {
-  "errorCode" : {
-    "code" : "413",
-    "reasonPhrase" : "Request Entity Too Large",
-    "details" : "payload size: 1500000, max size supported: 1048576"
-  }
+    "error": "RequestEntityTooLarge"
+    "description": "payload size: 1500000, max size supported: 1048576",
 }
 ```
 

--- a/src/lib/jsonParseV2/parseNotification.cpp
+++ b/src/lib/jsonParseV2/parseNotification.cpp
@@ -212,7 +212,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
 
       if (parseNotificationData(ciP, iter, ncrP, oeP) == false)
       {
-        alarmMgr.badInput(clientIp, oeP->details);
+        alarmMgr.badInput(clientIp, oeP->description);
         ciP->httpStatusCode = SccBadRequest;
 
         return false;

--- a/src/lib/jsonParseV2/parseRegistration.cpp
+++ b/src/lib/jsonParseV2/parseRegistration.cpp
@@ -58,8 +58,8 @@ static bool dataProvidedParse
   {
     ciP->httpStatusCode = SccBadRequest;
     oeP->code           = SccBadRequest;
-    oeP->reasonPhrase   = ERROR_BAD_REQUEST;
-    oeP->details        = "/dataProvided/ must be a JSON object";
+    oeP->error   = ERROR_BAD_REQUEST;
+    oeP->description        = "/dataProvided/ must be a JSON object";
 
     return false;
   }
@@ -68,20 +68,20 @@ static bool dataProvidedParse
   {
     ciP->httpStatusCode = SccBadRequest;
     oeP->code           = SccBadRequest;
-    oeP->reasonPhrase   = ERROR_BAD_REQUEST;
-    oeP->details        = "/dataProvided/ is empty";
+    oeP->error   = ERROR_BAD_REQUEST;
+    oeP->description        = "/dataProvided/ is empty";
 
     return false;
   }
 
   if (dataProvided.HasMember("entities"))
   {
-    bool b = parseEntitiesVector(ciP, &dataProvidedP->entities, dataProvided["entities"], &oeP->details);
+    bool b = parseEntitiesVector(ciP, &dataProvidedP->entities, dataProvided["entities"], &oeP->description);
     if (b == false)
     {
       ciP->httpStatusCode = SccBadRequest;
       oeP->code           = SccBadRequest;
-      oeP->reasonPhrase   = ERROR_BAD_REQUEST;
+      oeP->error   = ERROR_BAD_REQUEST;
 
       return false;
     }
@@ -99,8 +99,8 @@ static bool dataProvidedParse
     {
       ciP->httpStatusCode = SccNotImplemented;
       oeP->code           = SccNotImplemented;
-      oeP->reasonPhrase   = ERROR_NOTIMPLEMENTED;
-      oeP->details        = ERROR_DESC_IDPATTERN_NOTSUPPORTED;
+      oeP->error   = ERROR_NOTIMPLEMENTED;
+      oeP->description        = ERROR_DESC_IDPATTERN_NOTSUPPORTED;
 
       return false;
     }
@@ -109,8 +109,8 @@ static bool dataProvidedParse
     {
       ciP->httpStatusCode = SccNotImplemented;
       oeP->code           = SccNotImplemented;
-      oeP->reasonPhrase   = ERROR_NOTIMPLEMENTED;
-      oeP->details        = ERROR_DESC_TYPEPATTERN_NOTIMPLEMENTED;
+      oeP->error   = ERROR_NOTIMPLEMENTED;
+      oeP->description        = ERROR_DESC_TYPEPATTERN_NOTIMPLEMENTED;
 
       return false;
     }
@@ -118,11 +118,11 @@ static bool dataProvidedParse
 
   if (dataProvided.HasMember("attrs"))
   {
-    if (!parseStringVector(&dataProvidedP->attributes, dataProvided["attrs"], "attrs", true, true, &oeP->details))
+    if (!parseStringVector(&dataProvidedP->attributes, dataProvided["attrs"], "attrs", true, true, &oeP->description))
     {
       ciP->httpStatusCode = SccBadRequest;
       oeP->code           = SccBadRequest;
-      oeP->reasonPhrase   = ERROR_BAD_REQUEST;
+      oeP->error   = ERROR_BAD_REQUEST;
 
       return false;
     }

--- a/src/lib/jsonParseV2/parseRegistration.cpp
+++ b/src/lib/jsonParseV2/parseRegistration.cpp
@@ -58,8 +58,8 @@ static bool dataProvidedParse
   {
     ciP->httpStatusCode = SccBadRequest;
     oeP->code           = SccBadRequest;
-    oeP->error   = ERROR_BAD_REQUEST;
-    oeP->description        = "/dataProvided/ must be a JSON object";
+    oeP->error          = ERROR_BAD_REQUEST;
+    oeP->description    = "/dataProvided/ must be a JSON object";
 
     return false;
   }
@@ -68,8 +68,8 @@ static bool dataProvidedParse
   {
     ciP->httpStatusCode = SccBadRequest;
     oeP->code           = SccBadRequest;
-    oeP->error   = ERROR_BAD_REQUEST;
-    oeP->description        = "/dataProvided/ is empty";
+    oeP->error          = ERROR_BAD_REQUEST;
+    oeP->description    = "/dataProvided/ is empty";
 
     return false;
   }
@@ -81,7 +81,7 @@ static bool dataProvidedParse
     {
       ciP->httpStatusCode = SccBadRequest;
       oeP->code           = SccBadRequest;
-      oeP->error   = ERROR_BAD_REQUEST;
+      oeP->error          = ERROR_BAD_REQUEST;
 
       return false;
     }
@@ -99,8 +99,8 @@ static bool dataProvidedParse
     {
       ciP->httpStatusCode = SccNotImplemented;
       oeP->code           = SccNotImplemented;
-      oeP->error   = ERROR_NOTIMPLEMENTED;
-      oeP->description        = ERROR_DESC_IDPATTERN_NOTSUPPORTED;
+      oeP->error          = ERROR_NOTIMPLEMENTED;
+      oeP->description    = ERROR_DESC_IDPATTERN_NOTSUPPORTED;
 
       return false;
     }
@@ -109,8 +109,8 @@ static bool dataProvidedParse
     {
       ciP->httpStatusCode = SccNotImplemented;
       oeP->code           = SccNotImplemented;
-      oeP->error   = ERROR_NOTIMPLEMENTED;
-      oeP->description        = ERROR_DESC_TYPEPATTERN_NOTIMPLEMENTED;
+      oeP->error          = ERROR_NOTIMPLEMENTED;
+      oeP->description    = ERROR_DESC_TYPEPATTERN_NOTIMPLEMENTED;
 
       return false;
     }
@@ -122,7 +122,7 @@ static bool dataProvidedParse
     {
       ciP->httpStatusCode = SccBadRequest;
       oeP->code           = SccBadRequest;
-      oeP->error   = ERROR_BAD_REQUEST;
+      oeP->error          = ERROR_BAD_REQUEST;
 
       return false;
     }

--- a/src/lib/mongoBackend/mongoSubscribeContext.cpp
+++ b/src/lib/mongoBackend/mongoSubscribeContext.cpp
@@ -70,7 +70,7 @@ HttpStatusCode mongoSubscribeContext
   else
   {
     // Check OrionError
-    responseP->subscribeError.errorCode.fill(oe.code, oe.details);
+    responseP->subscribeError.errorCode.fill(oe.code, oe.description);
   }
 
   // free sub memory associated to subscription

--- a/src/lib/mongoBackend/mongoUpdateContext.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContext.cpp
@@ -222,7 +222,7 @@ HttpStatusCode mongoUpdateContext
     if (updateCoverage == UC_PARTIAL)
     {
       responseP->oe.code         = SccInvalidModification;
-      responseP->oe.reasonPhrase = ERROR_PARTIAL_UPDATE;
+      responseP->oe.error = ERROR_PARTIAL_UPDATE;
     }
 
     LM_T(LmtNotifier, ("total notifications sent during update: %d", notifSent));

--- a/src/lib/mongoBackend/mongoUpdateContext.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContext.cpp
@@ -221,7 +221,7 @@ HttpStatusCode mongoUpdateContext
     // Other cases follow the usual response processing flow (whatever it is :)
     if (updateCoverage == UC_PARTIAL)
     {
-      responseP->oe.code         = SccInvalidModification;
+      responseP->oe.code  = SccInvalidModification;
       responseP->oe.error = ERROR_PARTIAL_UPDATE;
     }
 

--- a/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextSubscription.cpp
@@ -83,7 +83,7 @@ HttpStatusCode mongoUpdateContextSubscription
     }
     else
     {
-      responseP->subscribeError.errorCode.fill(oe.code, oe.details);
+      responseP->subscribeError.errorCode.fill(oe.code, oe.description);
     }
   }
 

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -39,10 +39,10 @@
 */
 OrionError::OrionError()
 {
-  code         = SccNone;
-  error = "";
-  description      = "";
-  filled       = false;
+  code        = SccNone;
+  error       = "";
+  description = "";
+  filled      = false;
 }
 
 
@@ -194,13 +194,13 @@ std::string OrionError::toJsonV1(void)
   //
   // OrionError is NEVER part of any other payload, so the JSON start/end braces must be added here
   //
-  out += startTag("orionError", false);
-  out += valueTag("code",          code, true);
-  out += valueTag("reasonPhrase",  error, !description.empty());
+  out += startTag("orionError",   false);
+  out += valueTag("code",         code, true);
+  out += valueTag("reasonPhrase", error, !description.empty());
 
   if (!description.empty())
   {
-    out += valueTag("details",       description);
+    out += valueTag("details",    description);
   }
 
   out += endTag();

--- a/src/lib/rest/OrionError.h
+++ b/src/lib/rest/OrionError.h
@@ -42,25 +42,25 @@ typedef struct OrionError
 {
 public:
   HttpStatusCode  code;
-  std::string     reasonPhrase;
-  std::string     details;
+  std::string     error;
+  std::string     description;
   bool            filled;
 
   OrionError();
   OrionError(StatusCode& statusCode);
-  OrionError(HttpStatusCode _code, const std::string& _details = "", const std::string& _reasonPhrase = "");
+  OrionError(HttpStatusCode _code, const std::string& _description = "", const std::string& _error = "");
 
   std::string  smartRender(ApiVersion apiVersion);
   std::string  setStatusCodeAndSmartRender(ApiVersion apiVersion, HttpStatusCode* scP);
   std::string  toJson(void);
   std::string  toJsonV1(void);
-  void         fill(HttpStatusCode _code, const std::string& _details,  const std::string& _reasonPhrase = "");
+  void         fill(HttpStatusCode _code, const std::string& _description,  const std::string& _error = "");
   void         fill(const StatusCode& sc);
-  void         fillOrAppend(HttpStatusCode _code, const std::string& fullDetails, const std::string& appendDetail, const std::string& _reasonPhrase);
+  void         fillOrAppend(HttpStatusCode _code, const std::string& fullDetails, const std::string& appendDetail, const std::string& _error);
 
 
 private:
-  void         shrinkReasonPhrase(void);
+  void         shrinkError(void);
 
 } OrionError;
 

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -556,7 +556,7 @@ static std::string restService(ConnectionInfo* ciP, RestService* serviceV)
 
     if (compErrorDetect(ciP->apiVersion, components, compV, &oe))
     {
-      alarmMgr.badInput(clientIp, oe.details);
+      alarmMgr.badInput(clientIp, oe.description);
       ciP->httpStatusCode = SccBadRequest;
       restReply(ciP, oe.smartRender(ciP->apiVersion));
       return "URL PATH component error";

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1555,15 +1555,15 @@ static MHD_Result connectionTreat
 
     if (textAccepted)
     {
-      oe.details = "acceptable MIME types: application/json, text/plain";
+      oe.description = "acceptable MIME types: application/json, text/plain";
     }
     else
     {
-      oe.details = "acceptable MIME types: application/json";
+      oe.description = "acceptable MIME types: application/json";
     }
 
     ciP->httpStatusCode = oe.code;
-    alarmMgr.badInput(clientIp, oe.details);
+    alarmMgr.badInput(clientIp, oe.description);
     restReply(ciP, oe.smartRender(ciP->apiVersion));
     return MHD_YES;
   }
@@ -1581,15 +1581,15 @@ static MHD_Result connectionTreat
 
     if (textAccepted)
     {
-      oe.details = "acceptable MIME types: application/json, text/plain";
+      oe.description = "acceptable MIME types: application/json, text/plain";
     }
     else
     {
-      oe.details = "acceptable MIME types: application/json";
+      oe.description = "acceptable MIME types: application/json";
     }
 
     ciP->httpStatusCode = oe.code;
-    alarmMgr.badInput(clientIp, oe.details);
+    alarmMgr.badInput(clientIp, oe.description);
     restReply(ciP, oe.smartRender(ciP->apiVersion));
     return MHD_YES;
   }

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -424,7 +424,7 @@ static bool queryForward
 
     if (b == false)
     {
-      alarmMgr.forwardingError(url, "error parsing reply from context provider: " + oe.details);
+      alarmMgr.forwardingError(url, "error parsing reply from context provider: " + oe.description);
       parseData.qcr.res.release();
       parseData.qcrs.res.release();
       return false;

--- a/src/lib/serviceRoutinesV2/getEntities.cpp
+++ b/src/lib/serviceRoutinesV2/getEntities.cpp
@@ -315,7 +315,7 @@ std::string getEntities
   {
     OrionError oe;
     entities.fill(parseDataP->qcrs.res, &oe);
-    TIMED_RENDER(answer = oe.toJson());
+    TIMED_RENDER(answer = oe.smartRender(V2));
     ciP->httpStatusCode = oe.code;
   }
   // 04. Render Entities response

--- a/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
@@ -105,11 +105,11 @@ std::string getEntityAttribute
     TIMED_RENDER(answer = oe.toJson());
   }
 
-  if (oe.reasonPhrase == ERROR_TOO_MANY)
+  if (oe.error == ERROR_TOO_MANY)
   {
     ciP->httpStatusCode = SccConflict;
   }
-  else if (oe.reasonPhrase == ERROR_NOT_FOUND)
+  else if (oe.error == ERROR_NOT_FOUND)
   {
     ciP->httpStatusCode = SccContextElementNotFound;  // Attribute to be precise!
   }

--- a/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
@@ -93,7 +93,7 @@ std::string putEntityAttribute
   if (parseDataP->upcrs.res.oe.code != SccNone )
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
-    alarmMgr.badInput(clientIp, parseDataP->upcrs.res.oe.details);
+    alarmMgr.badInput(clientIp, parseDataP->upcrs.res.oe.description);
     ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else

--- a/src/lib/serviceRoutinesV2/serviceRoutinesCommon.cpp
+++ b/src/lib/serviceRoutinesV2/serviceRoutinesCommon.cpp
@@ -135,16 +135,16 @@ RenderFormat getRenderFormat(std::map<std::string, bool>&  uriParamOptions)
 */
 void adaptErrorCodeForSingleEntityOperation(OrionError* oeP, bool singleAttributeCheck)
 {
-  if ((oeP->code == SccContextElementNotFound) & (oeP->reasonPhrase == ERROR_NOT_FOUND))
+  if ((oeP->code == SccContextElementNotFound) & (oeP->error == ERROR_NOT_FOUND))
   {
     // In single entity attribute operations (e.g. DELETE /v2/entities/E/attrs/A) when the entity doesn't exist
-    oeP->details = ERROR_DESC_NOT_FOUND_ENTITY;
+    oeP->description = ERROR_DESC_NOT_FOUND_ENTITY;
   }
-  else if (singleAttributeCheck && (oeP->code == SccInvalidModification) & (oeP->reasonPhrase == ERROR_UNPROCESSABLE))
+  else if (singleAttributeCheck && (oeP->code == SccInvalidModification) & (oeP->error == ERROR_UNPROCESSABLE))
   {
     // In single entity attribute operations (e.g. DELETE /v2/entities/E/attrs/A) when the entity exists but the attribute doesn't
     oeP->code = SccContextElementNotFound;
-    oeP->reasonPhrase = ERROR_NOT_FOUND;
-    oeP->details = ERROR_DESC_NOT_FOUND_ATTRIBUTE;
+    oeP->error = ERROR_NOT_FOUND;
+    oeP->description = ERROR_DESC_NOT_FOUND_ATTRIBUTE;
   }
 }

--- a/test/unittests/mongoBackend/mongoCreateSubscription_test.cpp
+++ b/test/unittests/mongoBackend/mongoCreateSubscription_test.cpp
@@ -96,8 +96,8 @@ TEST(mongoCreateSubscriptions, createSubscriptionNotCustomOK)
 
   /* Check response is as expected */
   EXPECT_EQ(SccNone, oe.code);
-  EXPECT_EQ("", oe.reasonPhrase);
-  EXPECT_EQ("", oe.details);
+  EXPECT_EQ("", oe.error);
+  EXPECT_EQ("", oe.description);
 
   DBClientBase* connection = getMongoConnection();
 
@@ -193,8 +193,8 @@ TEST(mongoCreateSubscriptions, createSubscriptionCustomOK)
 
   /* Check response is as expected */
   EXPECT_EQ(SccNone, oe.code);
-  EXPECT_EQ("", oe.reasonPhrase);
-  EXPECT_EQ("", oe.details);
+  EXPECT_EQ("", oe.error);
+  EXPECT_EQ("", oe.description);
 
   DBClientBase* connection = getMongoConnection();
 

--- a/test/unittests/mongoBackend/mongoGetSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoGetSubscriptions_test.cpp
@@ -140,8 +140,8 @@ TEST(mongoListSubscriptions, getAllSubscriptionsV1Info)
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, oe.code);
-  EXPECT_EQ("OK", oe.reasonPhrase);
-  EXPECT_EQ("", oe.details);
+  EXPECT_EQ("OK", oe.error);
+  EXPECT_EQ("", oe.description);
 
   ASSERT_EQ(3, subs.size());
   Subscription             s;
@@ -244,8 +244,8 @@ TEST(mongoGetSubscription, getSubscription)
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, oe.code);
-  EXPECT_EQ("OK", oe.reasonPhrase);
-  EXPECT_EQ("", oe.details);
+  EXPECT_EQ("OK", oe.error);
+  EXPECT_EQ("", oe.description);
 
   std::vector<EntID>       ents;
   std::vector<std::string> attrs;

--- a/test/unittests/rest/OrionError_test.cpp
+++ b/test/unittests/rest/OrionError_test.cpp
@@ -53,20 +53,20 @@ TEST(OrionError, all)
   ci.outMimeType = JSON;
 
   EXPECT_EQ(SccNone, e0.code);
-  EXPECT_EQ("",      e0.reasonPhrase);
-  EXPECT_EQ("",      e0.details);
+  EXPECT_EQ("",      e0.error);
+  EXPECT_EQ("",      e0.description);
 
   EXPECT_EQ(SccOk,          e1.code);
-  EXPECT_EQ("OK",           e1.reasonPhrase);
-  EXPECT_EQ("no details 3", e1.details);
+  EXPECT_EQ("OK",           e1.error);
+  EXPECT_EQ("no details 3", e1.description);
 
   EXPECT_EQ(sc.code,         e3.code);
-  EXPECT_EQ(sc.reasonPhrase, e3.reasonPhrase);
-  EXPECT_EQ(sc.details,      e3.details);
+  EXPECT_EQ(sc.reasonPhrase, e3.error);
+  EXPECT_EQ(sc.details,      e3.description);
 
   EXPECT_EQ(SccOk,          e4.code);
-  EXPECT_EQ("OK",           e4.reasonPhrase);
-  EXPECT_EQ("Good Request", e4.details);
+  EXPECT_EQ("OK",           e4.error);
+  EXPECT_EQ("Good Request", e4.description);
 
   ci.outMimeType = JSON;
 


### PR DESCRIPTION
Change OrionError fields to use proper names aligned with NGSIv2 terminology. In particular:

* reasonPhrase -> error
* details -> description