### PR TITLE
FIX mkdocs version from 1.2.3 to 1.2.4

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.2.3
+mkdocs==1.2.4
 Pygments==2.15.0
 Markdown==3.3.4
 jinja2==3.1.3


### PR DESCRIPTION
Recent upgrade in jinga2 dependency (PR https://github.com/telefonicaid/fiware-orion/pull/4470) breaks mkdocs. This upgrade supposedly solves the problem (see https://github.com/mkdocs/mkdocs/issues/2799#issuecomment-1079764329) 