### PR TITLE
FIX -dbTimeout conflict with -dbURI (#4496)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- Fix: Changed the default value of `-dbTimeout` to 0 to resolve conflict with `-dbURI` (#4496)
+- Fix: changed the default value of `-dbTimeout` to 0 to resolve conflict with `-dbURI` (#4496) 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: Changed the default value of `-dbTimeout` to 0 to resolve conflict with `-dbURI` (#4496)

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -309,8 +309,8 @@ PaArgument paArgs[] =
   { "-dbDisableRetryWrites",        &dbDisableRetryWrites,  "MONGO_DISABLE_RETRY_WRITES", PaBool, PaOpt, false,                           false, true,                  DBDISABLERETRYWRITES_DESC    },
 
   { "-db",                          dbName,                 "MONGO_DB",                 PaString, PaOpt, _i "orion",                      PaNL,  PaNL,                  DB_DESC                      },
-  { "-dbTimeout",                   &dbTimeout,             "MONGO_TIMEOUT",            PaULong,  PaOpt, 10000,                           0,     UINT_MAX,              DB_TMO_DESC                  },
-  { "-dbPoolSize",                  &dbPoolSize,            "MONGO_POOL_SIZE",          PaInt,    PaOpt, 10,                              1,     10000,                 DBPS_DESC                    },
+  { "-dbTimeout",                   &dbTimeout,             "MONGO_TIMEOUT",            PaULong,  PaOpt, -1,                              -1,    UINT_MAX,              DB_TMO_DESC                  },
+  { "-dbPoolSize",                  &dbPoolSize,            "MONGO_POOL_SIZE",          PaInt,    PaOpt, 10,                               1,    10000,                 DBPS_DESC                    },
 
   { "-ipv4",                        &useOnlyIPv4,           "USEIPV4",                  PaBool,   PaOpt, false,                           false, true,                  USEIPV4_DESC                 },
   { "-ipv6",                        &useOnlyIPv6,           "USEIPV6",                  PaBool,   PaOpt, false,                           false, true,                  USEIPV6_DESC                 },

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -309,8 +309,8 @@ PaArgument paArgs[] =
   { "-dbDisableRetryWrites",        &dbDisableRetryWrites,  "MONGO_DISABLE_RETRY_WRITES", PaBool, PaOpt, false,                           false, true,                  DBDISABLERETRYWRITES_DESC    },
 
   { "-db",                          dbName,                 "MONGO_DB",                 PaString, PaOpt, _i "orion",                      PaNL,  PaNL,                  DB_DESC                      },
-  { "-dbTimeout",                   &dbTimeout,             "MONGO_TIMEOUT",            PaULong,  PaOpt, -1,                              -1,    UINT_MAX,              DB_TMO_DESC                  },
-  { "-dbPoolSize",                  &dbPoolSize,            "MONGO_POOL_SIZE",          PaInt,    PaOpt, 10,                               1,    10000,                 DBPS_DESC                    },
+  { "-dbTimeout",                   &dbTimeout,             "MONGO_TIMEOUT",            PaULong,  PaOpt, 0,                               0,     UINT_MAX,              DB_TMO_DESC                  },
+  { "-dbPoolSize",                  &dbPoolSize,            "MONGO_POOL_SIZE",          PaInt,    PaOpt, 10,                              1,     10000,                 DBPS_DESC                    },
 
   { "-ipv4",                        &useOnlyIPv4,           "USEIPV4",                  PaBool,   PaOpt, false,                           false, true,                  USEIPV4_DESC                 },
   { "-ipv6",                        &useOnlyIPv6,           "USEIPV6",                  PaBool,   PaOpt, false,                           false, true,                  USEIPV6_DESC                 },

--- a/src/lib/mongoDriver/mongoConnectionPool.cpp
+++ b/src/lib/mongoDriver/mongoConnectionPool.cpp
@@ -334,7 +334,7 @@ static std::string composeMongoUri
 
   if (strlen(dbURI) != 0)
   {
-    if (strlen(username) != 0 || strlen(authDb) != 0 || strlen(rplSet) != 0 || strlen(mechanism) != 0 || dbSSL || dbDisableRetryWrites || timeout > 0)
+    if (strlen(username) != 0 || strlen(authDb) != 0 || strlen(rplSet) != 0 || strlen(mechanism) != 0 || dbSSL || dbDisableRetryWrites || timeout > -1)
     {
         LM_X(1, ("Invalid Command Line Options: -dbURI cannot be combined with -dbhost, -rplSet, -dbTimeout, -dbuser, -dbAuthMech, -dbAuthDb, -dbSSL and -dbDisableRetryWrites"));
     }
@@ -399,14 +399,20 @@ static std::string composeMongoUri
       optionPrefix = "&";
     }
 
-    if (timeout > 0)
+    // Check if timeout is not zero (which means it's either unset or explicitly set to a positive value)
+    if (timeout != 0)
     {
-      char buf[STRING_SIZE_FOR_LONG];
-      i2s(timeout, buf, sizeof(buf));
-      uri += optionPrefix + "connectTimeoutMS=" + buf;
-      optionPrefix = "&";
+        // If timeout is negative (e.g., -1 indicating it's unset), set it to the default value of 10000
+        if (timeout < 0)
+        {
+            timeout = 10000;
+        }
+
+        char buf[STRING_SIZE_FOR_LONG];
+        i2s(timeout, buf, sizeof(buf));
+        uri += optionPrefix + "connectTimeoutMS=" + buf;
+        optionPrefix = "&";
     }
-  }
 
   LM_T(LmtMongo, ("MongoDB connection URI: '%s'", offuscatePassword(uri, passwd).c_str()));
 

--- a/src/lib/mongoDriver/mongoConnectionPool.cpp
+++ b/src/lib/mongoDriver/mongoConnectionPool.cpp
@@ -407,6 +407,7 @@ static std::string composeMongoUri
       optionPrefix = "&";
     }
   }
+  
   LM_T(LmtMongo, ("MongoDB connection URI: '%s'", offuscatePassword(uri, passwd).c_str()));
 
   return uri;

--- a/src/lib/mongoDriver/mongoConnectionPool.cpp
+++ b/src/lib/mongoDriver/mongoConnectionPool.cpp
@@ -402,18 +402,20 @@ static std::string composeMongoUri
     // Check if timeout is not zero (which means it's either unset or explicitly set to a positive value)
     if (timeout != 0)
     {
-        // If timeout is negative (e.g., -1 indicating it's unset), set it to the default value of 10000
-        if (timeout < 0)
-        {
-            timeout = 10000;
-        }
-
-        char buf[STRING_SIZE_FOR_LONG];
+      char buf[STRING_SIZE_FOR_LONG];
+      // If timeout is negative (e.g., -1 indicating it's unset), set it to the default value of 10000
+      if (timeout < 0)
+      {
+        i2s(10000, buf, sizeof(buf));
+      }
+      else
+      {
         i2s(timeout, buf, sizeof(buf));
-        uri += optionPrefix + "connectTimeoutMS=" + buf;
-        optionPrefix = "&";
+      }
+      uri += optionPrefix + "connectTimeoutMS=" + buf;
+      optionPrefix = "&";
     }
-
+  }
   LM_T(LmtMongo, ("MongoDB connection URI: '%s'", offuscatePassword(uri, passwd).c_str()));
 
   return uri;

--- a/src/lib/mongoDriver/mongoConnectionPool.cpp
+++ b/src/lib/mongoDriver/mongoConnectionPool.cpp
@@ -334,7 +334,7 @@ static std::string composeMongoUri
 
   if (strlen(dbURI) != 0)
   {
-    if (strlen(username) != 0 || strlen(authDb) != 0 || strlen(rplSet) != 0 || strlen(mechanism) != 0 || dbSSL || dbDisableRetryWrites || timeout > -1)
+    if (strlen(username) != 0 || strlen(authDb) != 0 || strlen(rplSet) != 0 || strlen(mechanism) != 0 || dbSSL || dbDisableRetryWrites || timeout > 0)
     {
         LM_X(1, ("Invalid Command Line Options: -dbURI cannot be combined with -dbhost, -rplSet, -dbTimeout, -dbuser, -dbAuthMech, -dbAuthDb, -dbSSL and -dbDisableRetryWrites"));
     }
@@ -399,19 +399,10 @@ static std::string composeMongoUri
       optionPrefix = "&";
     }
 
-    // Check if timeout is not zero (which means it's either unset or explicitly set to a positive value)
-    if (timeout != 0)
+    if (timeout > 0)
     {
       char buf[STRING_SIZE_FOR_LONG];
-      // If timeout is negative (e.g., -1 indicating it's unset), set it to the default value of 10000
-      if (timeout < 0)
-      {
-        i2s(10000, buf, sizeof(buf));
-      }
-      else
-      {
-        i2s(timeout, buf, sizeof(buf));
-      }
+      i2s(timeout, buf, sizeof(buf));
       uri += optionPrefix + "connectTimeoutMS=" + buf;
       optionPrefix = "&";
     }

--- a/test/functionalTest/cases/3658_env_vars/env_vars.test
+++ b/test/functionalTest/cases/3658_env_vars/env_vars.test
@@ -95,7 +95,7 @@ Extended Usage: contextBroker  [option '-U' (extended usage)]                   
                                [option '-dbSSL' (enable SSL connection to DB)]                                     ORION_MONGO_SSL                    FALSE /FALSE/
                                [option '-dbDisableRetryWrites' (set retryWrite parameter to false in DB connect]   ORION_MONGO_DISABLE_RETRY_WRITES   FALSE /FALSE/
                                [option '-db' <database name>]                                                      ORION_MONGO_DB                     'orion' /'orion'/
-                               [option '-dbTimeout' <timeout in milliseconds for connections to the replica set]   ORION_MONGO_TIMEOUT                0 <= 10000 /10000/ <= 4294967295
+                               [option '-dbTimeout' <timeout in milliseconds for connections to the replica set]   ORION_MONGO_TIMEOUT                0 <= 0 /0/ <= 4294967295
                                [option '-dbPoolSize' <database connection pool size>]                              ORION_MONGO_POOL_SIZE              1 <= 10 /10/ <= 10000
                                [option '-ipv4' (use ip v4 only)]                                                   ORION_USEIPV4                      FALSE /FALSE/
                                [option '-ipv6' (use ip v6 only)]                                                   ORION_USEIPV6                      FALSE /FALSE/


### PR DESCRIPTION
This pull request resolves the configuration conflict identified in issue [#4496](https://github.com/telefonicaid/fiware-orion/issues/4496), where using the -dbURI parameter along with the default dbTimeout value caused startup failures in Orion.

**Key Changes**
- Modified the composeMongoUri function to handle a default dbTimeout value of -1, enabling it to work seamlessly with the -dbURI parameter.
- Implemented a condition to set dbTimeout to 10000 if it is at its default value of -1. This maintains the standard behavior when -dbURI is not being used, thus ensuring backward compatibility.
- Adjusted the error validation logic in composeMongoUri to prevent false triggering of configuration conflicts when dbTimeout is in its default state.

These changes improve the usability of the Orion Context Broker, particularly for configurations utilizing the -dbURI parameter. It addresses the issue where users transitioning to -dbURI faced unnecessary hurdles due to the pre-existing default dbTimeout settings.