### PR TITLE
FIX simplify init methods in managers

### DIFF
--- a/src/lib/alarmMgr/AlarmManager.cpp
+++ b/src/lib/alarmMgr/AlarmManager.cpp
@@ -79,7 +79,7 @@ AlarmManager::AlarmManager()
 *
 * AlarmManager::init - 
 */
-int AlarmManager::init(bool logAlreadyRaisedAlarms)
+void AlarmManager::init(bool logAlreadyRaisedAlarms)
 {
   notificationErrorLogAlways   = logAlreadyRaisedAlarms;
   badInputLogAlways            = logAlreadyRaisedAlarms;
@@ -87,7 +87,7 @@ int AlarmManager::init(bool logAlreadyRaisedAlarms)
   mqttConnectionErrorLogAlways = logAlreadyRaisedAlarms;
   forwardingErrorLogAlways     = logAlreadyRaisedAlarms;
 
-  return semInit();
+  semInit();
 }
 
 
@@ -96,15 +96,12 @@ int AlarmManager::init(bool logAlreadyRaisedAlarms)
 *
 * AlarmManager::semInit - 
 */
-int AlarmManager::semInit(void)
+void AlarmManager::semInit(void)
 {
   if (sem_init(&sem, 0, 1) == -1)
   {
-    LM_E(("Runtime Error (error initializing 'alarm mgr' semaphore: %s)", strerror(errno)));
-    return -1;
+    LM_X(1, ("Fatal Error (error initializing 'alarm mgr' semaphore: %s)", strerror(errno)));
   }
-
-  return 0;
 }
 
 

--- a/src/lib/alarmMgr/AlarmManager.h
+++ b/src/lib/alarmMgr/AlarmManager.h
@@ -68,7 +68,7 @@ class AlarmManager
  public:
   AlarmManager();
 
-  int  init(bool logAlreadyRaisedAlarms);
+  void  init(bool logAlreadyRaisedAlarms);
 
   void         semTake(void);
   void         semGive(void);
@@ -97,7 +97,7 @@ class AlarmManager
   void mqttConnectionErrorGet(int64_t* active, int64_t* raised, int64_t* released);
 
  private:
-  int  semInit(void);
+  void  semInit(void);
 };
 
 #endif  // SRC_LIB_ALARMMGR_ALARMMANAGER_H_

--- a/src/lib/common/sem.cpp
+++ b/src/lib/common/sem.cpp
@@ -69,37 +69,32 @@ static struct timespec accTimeStatSemTime = { 0, 0 };
 *  -1 on failure
 *
 */
-int semInit(SemOpType _reqPolicy, bool semTimeStat, int shared, int takenInitially)
+void semInit(SemOpType _reqPolicy, bool semTimeStat, int shared, int takenInitially)
 {
   if (sem_init(&reqSem, shared, takenInitially) == -1)
   {
-    LM_E(("Runtime Error (error initializing 'req' semaphore: %s)", strerror(errno)));
-    return -1;
+    LM_X(1, ("Fatal Error (error initializing 'req' semaphore: %s)", strerror(errno)));
   }
 
   if (sem_init(&transSem, shared, takenInitially) == -1)
   {
-    LM_E(("Runtime Error (error initializing 'transactionId' semaphore: %s)", strerror(errno)));
-    return -1;
+    LM_X(1, ("Fatal Error (error initializing 'transactionId' semaphore: %s)", strerror(errno)));
   }
 
   if (sem_init(&cacheSem, shared, takenInitially) == -1)
   {
-    LM_E(("Runtime Error (error initializing 'cache' semaphore: %s)", strerror(errno)));
-    return -1;
+    LM_X(1, ("Fatal Error (error initializing 'cache' semaphore: %s)", strerror(errno)));
   }
 
   if (sem_init(&timeStatSem, shared, takenInitially) == -1)
   {
-    LM_E(("Runtime Error (error initializing 'timeStat' semaphore: %s)", strerror(errno)));
-    return -1;
+    LM_X(1, ("Fatal Error (error initializing 'timeStat' semaphore: %s)", strerror(errno)));
   }
 
   reqPolicy = _reqPolicy;
 
   // Measure accumulated semaphore waiting time?
   semWaitStatistics = semTimeStat;
-  return 0;
 }
 
 

--- a/src/lib/common/sem.h
+++ b/src/lib/common/sem.h
@@ -47,7 +47,7 @@ typedef enum SemOpType
 *
 * semInit -
 */
-extern int semInit
+extern void semInit
 (
   SemOpType  _reqPolicy     = SemReadWriteOp,
   bool       semTimeStat    = false,

--- a/src/lib/metricsMgr/MetricsManager.cpp
+++ b/src/lib/metricsMgr/MetricsManager.cpp
@@ -103,18 +103,15 @@ bool MetricsManager::subServiceValid(const std::string& subsrv)
 *   It's only one sys-call, and this way, the broker is prepared to receive 'on/off'
 *   via REST.
 */
-bool MetricsManager::init(bool _on, bool _semWaitStatistics)
+void MetricsManager::init(bool _on, bool _semWaitStatistics)
 {
   on                 = _on;
   semWaitStatistics  = _semWaitStatistics;
 
   if (sem_init(&sem, 0, 1) == -1)
   {
-    LM_E(("Runtime Error (error initializing 'metrics mgr' semaphore: %s)", strerror(errno)));
-    return false;
+    LM_X(1, ("Fatal Error (error initializing 'metrics mgr' semaphore: %s)", strerror(errno)));
   }
-
-  return true;
 }
 
 

--- a/src/lib/metricsMgr/MetricsManager.h
+++ b/src/lib/metricsMgr/MetricsManager.h
@@ -138,7 +138,7 @@ class MetricsManager
  public:
   MetricsManager();
 
-  bool         init(bool _on, bool _semWaitStatistics);
+  void         init(bool _on, bool _semWaitStatistics);
   void         add(const std::string& srv, const std::string& subServ, const std::string& metric, uint64_t value);
   void         reset(void);
   std::string  toJson(bool doReset);

--- a/src/lib/mqtt/MqttConnectionManager.cpp
+++ b/src/lib/mqtt/MqttConnectionManager.cpp
@@ -105,7 +105,7 @@ MqttConnectionManager::MqttConnectionManager(void)
 *
 * MqttConnectionManager::init -
 */
-int MqttConnectionManager::init(long _timeout)
+void MqttConnectionManager::init(long _timeout)
 {
   LM_T(LmtMqttNotif, ("Initializing MQTT library"));
   mosquitto_lib_init();
@@ -119,7 +119,7 @@ int MqttConnectionManager::init(long _timeout)
     timeout = DEFAULT_TIMEOUT;
   }
 
-  return semInit();
+  semInit();
 }
 
 
@@ -152,15 +152,12 @@ void MqttConnectionManager::teardown(void)
 *
 * MqttConnectionManager::semInit -
 */
-int MqttConnectionManager::semInit(void)
+void MqttConnectionManager::semInit(void)
 {
   if (sem_init(&sem, 0, 1) == -1)
   {
-    LM_E(("Runtime Error (error initializing 'mqtt connection mgr' semaphore: %s)", strerror(errno)));
-    return -1;
+    LM_X(1, ("Fatal Error (error initializing 'mqtt connection mgr' semaphore: %s)", strerror(errno)));
   }
-
-  return 0;
 }
 
 

--- a/src/lib/mqtt/MqttConnectionManager.h
+++ b/src/lib/mqtt/MqttConnectionManager.h
@@ -64,7 +64,7 @@ class MqttConnectionManager
  public:
   MqttConnectionManager();
 
-  int  init(long _timeout);
+  void init(long _timeout);
   void teardown(void);
 
   const char*  semGet(void);
@@ -74,7 +74,7 @@ class MqttConnectionManager
 
  private:
   void disconnect(struct mosquitto*  mosq, const std::string& endpoint);
-  int  semInit(void);
+  void semInit(void);
   void semTake(void);
   void semGive(void);
 

--- a/test/unittests/common/commonSem_test.cpp
+++ b/test/unittests/common/commonSem_test.cpp
@@ -45,8 +45,7 @@ TEST(commonSem, unique)
 {
    int s;
 
-   s = semInit();
-   EXPECT_EQ(0, s);
+   semInit();
 
    s = reqSemGive(__FUNCTION__, "test");
    EXPECT_EQ(0, s);


### PR DESCRIPTION
Simplifications:

* Use LM_X isntead of LM_E if semaphore initialization fails. Semaphore initialization takes place in Orion startup and it's so severe that Orion should refuse to start in that case
* Simplification of the return values in the init methos for existing managers.

This is mainly a minor hardening fix, so I think it doesn't worth to be mentioned in CNR file.