### PR TITLE
FIX wrong INFO startup log showing ORION_MONGO_TIMEOUT, ORION_IN_REQ_PAYLOAD_MAX_SIZE and ORION_OUT_REQ_MSG_MAX_SIZE env var values

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: wrong INFO startup log showing ORION_MONGO_TIMEOUT, ORION_IN_REQ_PAYLOAD_MAX_SIZE and ORION_OUT_REQ_MSG_MAX_SIZE env var values (#4496)

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -979,13 +979,17 @@ static void logEnvVars(void)
       {
         LM_I(("env var ORION_%s (%s): %d", aP->envName, aP->option, *((int*) aP->varP)));
       }
+      else if (aP->type == PaULong)
+      {
+        LM_I(("env var ORION_%s (%s): %d", aP->envName, aP->option, *((unsigned long*) aP->varP)));
+      }
       else if (aP->type == PaDouble)
       {
         LM_I(("env var ORION_%s (%s): %d", aP->envName, aP->option, *((double*) aP->varP)));
       }
       else
       {
-        LM_I(("env var ORION_%s (%s): %d", aP->envName, aP->option));
+        LM_E(("cannot show env var ORION_%s (%s) due to unrecognized type: %d", aP->envName, aP->option, aP->type));
       }
     }
   }


### PR DESCRIPTION
Solves the problem reported at https://github.com/telefonicaid/fiware-orion/issues/4496#issuecomment-1916898626

Probably there are more times apart from `PaULong` to take into account. The new error trace in the `else` branch would help to detect them in the future.

Some traces:

```
$ ORION_MONGO_URI=mongodb://localhost:27017 ORION_MONGO_TIMEOUT=0 contextBroker -fg -logLevel INFO -logForHumans
INFO@2024-02-06T08:37:58.151Z  contextBroker.cpp[1110]: start command line <contextBroker -fg -logLevel INFO -logForHumans>
INFO@2024-02-06T08:37:58.151Z  contextBroker.cpp[972]: env var ORION_MONGO_URI (-dbURI): mongodb://localhost:27017
INFO@2024-02-06T08:37:58.151Z  contextBroker.cpp[984]: env var ORION_MONGO_TIMEOUT (-dbTimeout): 0
INFO@2024-02-06T08:37:58.151Z  contextBroker.cpp[1184]: Orion Context Broker is running
INFO@2024-02-06T08:37:58.167Z  mongoConnectionPool.cpp[536]: Connected to mongodb://localhost:27017 (dbName: orion, poolsize: 10)
INFO@2024-02-06T08:37:58.168Z  contextBroker.cpp[1324]: Startup completed

$ ORION_MONGO_TIMEOUT=500 contextBroker -fg -logLevel INFO -logForHumans
INFO@2024-02-06T08:38:06.289Z  contextBroker.cpp[1110]: start command line <contextBroker -fg -logLevel INFO -logForHumans>
INFO@2024-02-06T08:38:06.289Z  contextBroker.cpp[984]: env var ORION_MONGO_TIMEOUT (-dbTimeout): 500
INFO@2024-02-06T08:38:06.289Z  contextBroker.cpp[1184]: Orion Context Broker is running
INFO@2024-02-06T08:38:06.306Z  mongoConnectionPool.cpp[536]: Connected to mongodb://localhost/?connectTimeoutMS=500 (dbName: orion, poolsize: 10)
INFO@2024-02-06T08:38:06.307Z  contextBroker.cpp[1324]: Startup completed
```

CC: @goten002