### PR TITLE
FIX compile using C++14

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: lighter operation to get databases list from MongoDB (#4517)
+- Hardening: compile code using C++14 standard

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,3 @@
-- Fix: lighter operation to get databases list from MongoDB (#4517)
 - Add: JEXL expression support in custom notification macro replacement (using cjexl 0.2.0) (#4004)
 - Add: expression context build and evaluation counters in timing section in GET /statistics (#4004)
 - Fix: use null for non existing attributes in custom covered notifications macro substitution (instead of empty string) to make behaviour more consistent (#4004)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ PROJECT(contextBroker)
 # find_package() for mongo driver doesn't work with cmake 2
 cmake_minimum_required(VERSION 3.0)
 
+# set C++14 standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 #
 # DEBUG or RELEASE build ?
 #


### PR DESCRIPTION
Example compilation in file, before the change in CMakeList.txt:

> cd /home/fermin/src/fiware-orion/BUILD_DEBUG/src/lib/rest && /usr/bin/c++ -DDEBUG -DDEBUG_fermin -DLINUX -DLM_ON -I/usr/local/include/libmongoc-1.0 -I/usr/local/include/libbson-1.0 -I/home/fermin/src/fiware-orion/src/lib -Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -fno-var-tracking-assignments -Wno-format-truncation -Wno-stringop-truncation -DLINUX -g   -fPIC -DDEBUG_SER  -fstack-protector -MD -MT src/lib/rest/CMakeFiles/rest.dir/rest.cpp.o -MF CMakeFiles/rest.dir/rest.cpp.o.d -o CMakeFiles/rest.dir/rest.cpp.o -c /home/fermin/src/fiware-orion/src/lib/rest/rest.cpp
> /usr/bin/ar qc librest.a CMakeFiles/rest.dir/rest.cpp.o CMakeFiles/rest.dir/restReply.cpp.o CMakeFiles/rest.dir/RestService.cpp.o CMakeFiles/rest.dir/Verb.cpp.o CMakeFiles/rest.dir/curlSem.cpp.o CMakeFiles/rest.dir/httpRequestSend.cpp.o CMakeFiles/rest.dir/orionLogReply.cpp.o CMakeFiles/rest.dir/OrionError.cpp.o CMakeFiles/rest.dir/HttpStatusCode.cpp.o CMakeFiles/rest.dir/ConnectionInfo.cpp.o CMakeFiles/rest.dir/StringFilter.cpp.o CMakeFiles/rest.dir/HttpHeaders.cpp.o CMakeFiles/rest.dir/restServiceLookup.cpp.o

After the change in CMakeList.txt:

> cd /home/fermin/src/fiware-orion/BUILD_DEBUG/src/lib/rest && /usr/bin/c++ -DDEBUG -DDEBUG_fermin -DLINUX -DLM_ON -I/usr/local/include/libmongoc-1.0 -I/usr/local/include/libbson-1.0 -I/home/fermin/src/fiware-orion/src/lib -Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -fno-var-tracking-assignments -Wno-format-truncation -Wno-stringop-truncation -DLINUX -g   -fPIC -DDEBUG_SER  -fstack-protector -std=gnu++14 -MD -MT src/lib/rest/CMakeFiles/rest.dir/rest.cpp.o -MF CMakeFiles/rest.dir/rest.cpp.o.d -o CMakeFiles/rest.dir/rest.cpp.o -c /home/fermin/src/fiware-orion/src/lib/rest/rest.cpp
/usr/bin/ar qc librest.a CMakeFiles/rest.dir/rest.cpp.o CMakeFiles/rest.dir/restReply.cpp.o CMakeFiles/rest.dir/RestService.cpp.o CMakeFiles/rest.dir/Verb.cpp.o CMakeFiles/rest.dir/curlSem.cpp.o CMakeFiles/rest.dir/httpRequestSend.cpp.o CMakeFiles/rest.dir/orionLogReply.cpp.o CMakeFiles/rest.dir/OrionError.cpp.o CMakeFiles/rest.dir/HttpStatusCode.cpp.o CMakeFiles/rest.dir/ConnectionInfo.cpp.o CMakeFiles/rest.dir/StringFilter.cpp.o CMakeFiles/rest.dir/HttpHeaders.cpp.o CMakeFiles/rest.dir/restServiceLookup.cpp.o


This is the exact difference:

![imagen](https://github.com/telefonicaid/fiware-orion/assets/1534240/88c3b1e2-eadf-4146-98ba-90babd048ad2)
