### PR TITLE
FIX sort keys in JSON used in test

### DIFF
--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_full_replacement_attribute_compound.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_full_replacement_attribute_compound.test
@@ -133,7 +133,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_full_replacement_attribute_simple.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_full_replacement_attribute_simple.test
@@ -137,7 +137,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_partial_replacement_attribute_compound.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_partial_replacement_attribute_compound.test
@@ -133,7 +133,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {
@@ -304,13 +304,13 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
                 "metadata": {},
                 "type": "StructuredValue",
                 "value": [
-                    "{\"z\":10,\"w\":\"ttt\"} thing",
+                    "{\"w\":\"ttt\",\"z\":10} thing",
                     {
                         "one": [
                             "foo [4,null,{\"r\":2}] bar",
                             "this is: null"
                         ],
-                        "two": "some other{\"z\":10,\"w\":\"ttt\"}"
+                        "two": "some other{\"w\":\"ttt\",\"z\":10}"
                     }
                 ]
             },

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_partial_replacement_attribute_simple.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_partial_replacement_attribute_simple.test
@@ -129,7 +129,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {
@@ -287,7 +287,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
             "A3": {
                 "metadata": {},
                 "type": "Boolean",
-                "value": "this is an stringfied object: {\"z\":10,\"w\":\"ttt\"}"
+                "value": "this is an stringfied object: {\"w\":\"ttt\",\"z\":10}"
             },
             "A4": {
                 "metadata": {},

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_with_filtering.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_with_filtering.test
@@ -138,7 +138,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_with_filtering_in_compounds.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_with_filtering_in_compounds.test
@@ -134,7 +134,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_without_any_source_attribute.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_without_any_source_attribute.test
@@ -138,7 +138,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10},
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_without_some_source_attributes.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_adding_without_some_source_attributes.test
@@ -138,7 +138,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_mapping_partial_replacement_attribute_simple.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_mapping_partial_replacement_attribute_simple.test
@@ -137,7 +137,7 @@ payload='{
     "type": "irrelevant"
   },
   "A4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10},
     "type": "irrelevant"
   },
   "A5": {
@@ -273,7 +273,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
             "A4": {
                 "metadata": {},
                 "type": "Text",
-                "value": "this is A4: {\"z\":10,\"w\":\"ttt\"}"
+                "value": "this is A4: {\"w\":\"ttt\",\"z\":10}"
             },
             "A5": {
                 "metadata": {},

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_mapping_with_filtering.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_http_ngsi_mapping_with_filtering.test
@@ -138,7 +138,7 @@ payload='{
     "type": "irrelevant"
   },
   "A4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "A5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_full_replacement_attribute_compound.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_full_replacement_attribute_compound.test
@@ -134,7 +134,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_full_replacement_attribute_simple.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_full_replacement_attribute_simple.test
@@ -138,7 +138,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10},
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_partial_replacement_attribute_compound.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_partial_replacement_attribute_compound.test
@@ -134,7 +134,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {
@@ -296,13 +296,13 @@ MQTT message at topic topic1:
                 "metadata": {},
                 "type": "StructuredValue",
                 "value": [
-                    "{\"z\":10,\"w\":\"ttt\"} thing",
+                    "{\"w\":\"ttt\",\"z\":10} thing",
                     {
                         "one": [
                             "foo [4,null,{\"r\":2}] bar",
                             "this is: null"
                         ],
-                        "two": "some other{\"z\":10,\"w\":\"ttt\"}"
+                        "two": "some other{\"w\":\"ttt\",\"z\":10}"
                     }
                 ]
             },

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_partial_replacement_attribute_simple.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_partial_replacement_attribute_simple.test
@@ -130,7 +130,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {
@@ -279,7 +279,7 @@ MQTT message at topic topic1:
             "A3": {
                 "metadata": {},
                 "type": "Boolean",
-                "value": "this is an stringfied object: {\"z\":10,\"w\":\"ttt\"}"
+                "value": "this is an stringfied object: {\"w\":\"ttt\",\"z\":10}"
             },
             "A4": {
                 "metadata": {},

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_with_filtering.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_with_filtering.test
@@ -139,7 +139,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_with_filtering_in_compounds.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_with_filtering_in_compounds.test
@@ -135,7 +135,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_without_any_source_attribute.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_without_any_source_attribute.test
@@ -139,7 +139,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_without_some_source_attributes.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_adding_without_some_source_attributes.test
@@ -139,7 +139,7 @@ payload='{
     "type": "irrelevant"
   },
   "B4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "B5": {

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_mapping_partial_replacement_attribute_simple.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_mapping_partial_replacement_attribute_simple.test
@@ -138,7 +138,7 @@ payload='{
     "type": "irrelevant"
   },
   "A4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10 },
     "type": "irrelevant"
   },
   "A5": {
@@ -265,7 +265,7 @@ MQTT message at topic topic1:
             "A4": {
                 "metadata": {},
                 "type": "Text",
-                "value": "this is A4: {\"z\":10,\"w\":\"ttt\"}"
+                "value": "this is A4: {\"w\":\"ttt\",\"z\":10}"
             },
             "A5": {
                 "metadata": {},

--- a/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_mapping_with_filtering.test
+++ b/test/functionalTest/cases/4085_custom_notifications_ngsi_payload/custom_notification_mqtt_ngsi_mapping_with_filtering.test
@@ -139,7 +139,7 @@ payload='{
     "type": "irrelevant"
   },
   "A4": {
-    "value": { "z": 10, "w": "ttt"},
+    "value": { "w": "ttt", "z": 10},
     "type": "irrelevant"
   },
   "A5": {


### PR DESCRIPTION
This change in keys ordering has no functional impact in ftest.

We are doing it in preparation of PR https://github.com/telefonicaid/fiware-orion/pull/4511, where the cjexl implementation does a key sorting.