### PR TITLE
[Not to merge] FIX test new implementation with basic expressions

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -6,6 +6,7 @@ on:
       - master
   pull_request:
     branches:
+      - task/regression-test-basic-expressions
       - master
       - '!checkvalgrind**'
 

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
       - task/regression-test-basic-expressions
+  pull_request:
+    branches:      
       - master
       - '!checkvalgrind**'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,13 +231,14 @@ SET (BOOST_MT
 find_package (mongoc-1.0 1.24.3 EXACT)
 
 # Is cjexl lib available?
-find_library (HAVE_CJEXL cjexl PATHS /usr/lib /usr/lib64 /usr/local/lib64 /usr/local/lib)
-if (HAVE_CJEXL)
-    message("Using cjexl")
-else (HAVE_CJEXL)
-    message("Not using cjexl")
-    add_definitions(-DEXPR_BASIC)
-endif (HAVE_CJEXL)
+#find_library (HAVE_CJEXL cjexl PATHS /usr/lib /usr/lib64 /usr/local/lib64 /usr/local/lib)
+#if (HAVE_CJEXL)
+#    message("Using cjexl")
+#else (HAVE_CJEXL)
+#    message("Not using cjexl")
+#    add_definitions(-DEXPR_BASIC)
+#endif (HAVE_CJEXL)
+add_definitions(-DEXPR_BASIC)
 
 # Static libs common to contextBroker and unitTest binaries
 SET (COMMON_STATIC_LIBS


### PR DESCRIPTION
This PR is not for merging, but to check how new implementation behaves with basic expression. To that end, the CMakeList.txt file has been hacked so add_definitions(-DEXPR_BASIC) is always used. GitAction has been also modified to do the pass in this branch (by default only in PRs to be merged to master the pass is done).