### PR TITLE
FIX CMAKE_MINIMUM_REQUIRED

### DIFF
--- a/src/lib/alarmMgr/CMakeLists.txt
+++ b/src/lib/alarmMgr/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     AlarmManager.cpp

--- a/src/lib/apiTypesV2/CMakeLists.txt
+++ b/src/lib/apiTypesV2/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     Entity.cpp

--- a/src/lib/cache/CMakeLists.txt
+++ b/src/lib/cache/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     subCache.cpp

--- a/src/lib/common/CMakeLists.txt
+++ b/src/lib/common/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     globals.cpp

--- a/src/lib/convenience/CMakeLists.txt
+++ b/src/lib/convenience/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     AppendContextElementRequest.cpp

--- a/src/lib/jsonParse/CMakeLists.txt
+++ b/src/lib/jsonParse/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     jsonRequest.cpp

--- a/src/lib/jsonParseV2/CMakeLists.txt
+++ b/src/lib/jsonParseV2/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     jsonRequestTreat.cpp

--- a/src/lib/logMsg/CMakeLists.txt
+++ b/src/lib/logMsg/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (HEADERS
 	logMsg.h

--- a/src/lib/logSummary/CMakeLists.txt
+++ b/src/lib/logSummary/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     logSummary.cpp

--- a/src/lib/metricsMgr/CMakeLists.txt
+++ b/src/lib/metricsMgr/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     MetricsManager.cpp

--- a/src/lib/mongoBackend/CMakeLists.txt
+++ b/src/lib/mongoBackend/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     MongoGlobal.cpp

--- a/src/lib/mongoDriver/CMakeLists.txt
+++ b/src/lib/mongoDriver/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     BSONTypes.cpp

--- a/src/lib/mqtt/CMakeLists.txt
+++ b/src/lib/mqtt/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     MqttConnectionManager.cpp

--- a/src/lib/ngsi/CMakeLists.txt
+++ b/src/lib/ngsi/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     AttributeExpression.cpp

--- a/src/lib/ngsi10/CMakeLists.txt
+++ b/src/lib/ngsi10/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     NotifyContextRequest.cpp

--- a/src/lib/ngsi9/CMakeLists.txt
+++ b/src/lib/ngsi9/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     RegisterContextRequest.cpp

--- a/src/lib/ngsiNotify/CMakeLists.txt
+++ b/src/lib/ngsiNotify/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     doNotify.cpp

--- a/src/lib/orionTypes/CMakeLists.txt
+++ b/src/lib/orionTypes/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     areas.cpp

--- a/src/lib/parse/CMakeLists.txt
+++ b/src/lib/parse/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     CompoundValueNode.cpp

--- a/src/lib/rest/CMakeLists.txt
+++ b/src/lib/rest/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
     rest.cpp

--- a/src/lib/serviceRoutines/CMakeLists.txt
+++ b/src/lib/serviceRoutines/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
 versionTreat.cpp

--- a/src/lib/serviceRoutinesV2/CMakeLists.txt
+++ b/src/lib/serviceRoutinesV2/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 SET (SOURCES
 getEntities.cpp


### PR DESCRIPTION
Fixed this annoying warning at building time:

```
CMake Deprecation Warning at src/lib/cache/CMakeLists.txt:21 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

Note that in the root CMakeList.txt we already have

```
cmake_minimum_required(VERSION 3.0)
```

so this PR is aligning that in the rest of CMakeList.txt files.