### PR TITLE
ADD libVersions option for GET /version

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Add: GET /version?options=noLibVersions to simplify the response avoding the "libversions" field
 - Fix: lighter operation to get databases list from MongoDB (#4517)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- Add: GET /version?options=noLibVersions to simplify the response avoding the "libversions" field
+- Fix: simplified GET /version operation, without including "libversions" field (add ?options=libVersions to get it)
 - Fix: lighter operation to get databases list from MongoDB (#4517)

--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -128,6 +128,7 @@
 #define OPT_OVERRIDEMETADATA            "overrideMetadata"
 #define OPT_SKIPFORWARDING              "skipForwarding"
 #define OPT_FULL_COUNTERS               "fullCounters"
+#define OPT_NO_LIB_VERSIONS             "noLibVersions"  // used in GET /version operation
 
 
 /* ****************************************************************************

--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -128,7 +128,7 @@
 #define OPT_OVERRIDEMETADATA            "overrideMetadata"
 #define OPT_SKIPFORWARDING              "skipForwarding"
 #define OPT_FULL_COUNTERS               "fullCounters"
-#define OPT_NO_LIB_VERSIONS             "noLibVersions"  // used in GET /version operation
+#define OPT_LIB_VERSIONS                "libVersions"  // used in GET /version operation
 
 
 /* ****************************************************************************

--- a/src/lib/rest/ConnectionInfo.cpp
+++ b/src/lib/rest/ConnectionInfo.cpp
@@ -54,7 +54,7 @@ static const char* validOptions[] =
   OPT_FLOW_CONTROL,
   OPT_SKIPFORWARDING,
   OPT_FULL_COUNTERS,
-  OPT_NO_LIB_VERSIONS,
+  OPT_LIB_VERSIONS,
 
   // FIXME P3: initial notification feature was removed in CB 3.2.0, but we leave this
   // here for a while, so existing clients using options=skipInitialNotification don't break

--- a/src/lib/rest/ConnectionInfo.cpp
+++ b/src/lib/rest/ConnectionInfo.cpp
@@ -54,6 +54,7 @@ static const char* validOptions[] =
   OPT_FLOW_CONTROL,
   OPT_SKIPFORWARDING,
   OPT_FULL_COUNTERS,
+  OPT_NO_LIB_VERSIONS,
 
   // FIXME P3: initial notification feature was removed in CB 3.2.0, but we leave this
   // here for a while, so existing clients using options=skipInitialNotification don't break

--- a/src/lib/serviceRoutines/versionTreat.cpp
+++ b/src/lib/serviceRoutines/versionTreat.cpp
@@ -132,6 +132,8 @@ std::string versionTreat
   ParseData*                 parseDataP
 )
 {
+  bool noLibVersions = ciP->uriParamOptions[OPT_NO_LIB_VERSIONS];
+
   if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
     ciP->httpHeader.push_back(HTTP_ACCESS_CONTROL_ALLOW_ORIGIN);
@@ -168,8 +170,15 @@ std::string versionTreat
   out += "  \"compiled_in\" : \"" + std::string(COMPILED_IN) + "\",\n";
   out += "  \"release_date\" : \"" + std::string(RELEASE_DATE) + "\",\n";
   out += "  \"machine\" : \"" + std::string(MACHINE_ARCH) + "\",\n";
-  out += "  \"doc\" : \"" + std::string(API_DOC) + "\"," "\n" + "  " + libVersions();
-  out += "  }\n";
+  if (noLibVersions)
+  {
+    out += "  \"doc\" : \"" + std::string(API_DOC) + "\"\n";
+  }
+  else
+  {
+    out += "  \"doc\" : \"" + std::string(API_DOC) + "\"," "\n" + "  " + libVersions();
+    out += "  }\n";
+  }  
   out += "}\n";
   out += "}\n";
 

--- a/src/lib/serviceRoutines/versionTreat.cpp
+++ b/src/lib/serviceRoutines/versionTreat.cpp
@@ -132,7 +132,7 @@ std::string versionTreat
   ParseData*                 parseDataP
 )
 {
-  bool noLibVersions = ciP->uriParamOptions[OPT_NO_LIB_VERSIONS];
+  bool showLibVersions = ciP->uriParamOptions[OPT_LIB_VERSIONS];
 
   if (isOriginAllowedForCORS(ciP->httpHeaders.origin))
   {
@@ -170,14 +170,14 @@ std::string versionTreat
   out += "  \"compiled_in\" : \"" + std::string(COMPILED_IN) + "\",\n";
   out += "  \"release_date\" : \"" + std::string(RELEASE_DATE) + "\",\n";
   out += "  \"machine\" : \"" + std::string(MACHINE_ARCH) + "\",\n";
-  if (noLibVersions)
-  {
-    out += "  \"doc\" : \"" + std::string(API_DOC) + "\"\n";
-  }
-  else
+  if (showLibVersions)
   {
     out += "  \"doc\" : \"" + std::string(API_DOC) + "\"," "\n" + "  " + libVersions();
     out += "  }\n";
+  }
+  else
+  {
+    out += "  \"doc\" : \"" + std::string(API_DOC) + "\"\n";
   }  
   out += "}\n";
   out += "}\n";

--- a/test/functionalTest/cases/0000_version_operation/version_via_rest.test
+++ b/test/functionalTest/cases/0000_version_operation/version_via_rest.test
@@ -34,7 +34,7 @@ brokerStart CB
 #
 echo "01. Getting version via REST"
 echo "============================"
-orionCurl --url "/version" --noPayloadCheck
+orionCurl --url "/version?options=noLibVersions" --noPayloadCheck
 echo
 echo
 
@@ -58,17 +58,7 @@ Content-Length: REGEX(\d+)
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
   "machine" : "REGEX(.*)",
-  "doc" : "REGEX(.*)",
-  "libversions": {
-     "boost": "REGEX(.*)",
-     "libcurl": "REGEX(.*)",
-     "libmosquitto": "REGEX(.*)",
-     "libmicrohttpd": "REGEX(.*)",
-     "openssl": "REGEX(.*)",
-     "rapidjson": "REGEX(.*)",
-     "mongoc": "REGEX(.*)",
-     "bson": "REGEX(.*)"
-  }
+  "doc" : "REGEX(.*)"
 }
 }
 

--- a/test/functionalTest/cases/0000_version_operation/version_via_rest.test
+++ b/test/functionalTest/cases/0000_version_operation/version_via_rest.test
@@ -34,7 +34,7 @@ brokerStart CB
 #
 echo "01. Getting version via REST"
 echo "============================"
-orionCurl --url "/version?options=noLibVersions" --noPayloadCheck
+orionCurl --url "/version" --noPayloadCheck
 echo
 echo
 

--- a/test/functionalTest/cases/0501_cors/version_request.test
+++ b/test/functionalTest/cases/0501_cors/version_request.test
@@ -35,19 +35,19 @@ brokerStart CB 0-255 IPV4 -corsOrigin arrakis
 --SHELL--
 echo "01. GET Version (Access-Control-Allow-Origin header not included)"
 echo "================================================================="
-orionCurl --url /version --noPayloadCheck
+orionCurl --url /version?options=noLibVersions --noPayloadCheck
 echo
 echo
 
 echo "02. GET Version with arrakis origin (Access-Control-Allow-Origin header included)"
 echo "================================================================================="
-orionCurl --url /version -X GET --origin arrakis --noPayloadCheck
+orionCurl --url /version?options=noLibVersions -X GET --origin arrakis --noPayloadCheck
 echo
 echo
 
 echo "03. GET Version with caladan origin (Access-Control-Allow-Origin header not included)"
 echo "====================================================================================="
-orionCurl --url /version -X GET --origin caladan --noPayloadCheck
+orionCurl --url /version?options=noLibVersions -X GET --origin caladan --noPayloadCheck
 echo
 echo
 
@@ -88,17 +88,7 @@ Content-Length: REGEX(\d+)
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
   "machine" : "REGEX(.*)",
-  "doc" : "REGEX(.*)",
-  "libversions": {
-     "boost": "REGEX(.*)",
-     "libcurl": "REGEX(.*)",
-     "libmosquitto": "REGEX(.*)",
-     "libmicrohttpd": "REGEX(.*)",
-     "openssl": "REGEX(.*)",
-     "rapidjson": "REGEX(.*)",
-     "mongoc": "REGEX(.*)",
-     "bson": "REGEX(.*)"
-  }
+  "doc" : "REGEX(.*)"
 }
 }
 
@@ -124,17 +114,7 @@ Content-Length: REGEX(\d+)
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
   "machine" : "REGEX(.*)",
-  "doc" : "REGEX(.*)",
-  "libversions": {
-     "boost": "REGEX(.*)",
-     "libcurl": "REGEX(.*)",
-     "libmosquitto": "REGEX(.*)",
-     "libmicrohttpd": "REGEX(.*)",
-     "openssl": "REGEX(.*)",
-     "rapidjson": "REGEX(.*)",
-     "mongoc": "REGEX(.*)",
-     "bson": "REGEX(.*)"
-  }
+  "doc" : "REGEX(.*)"
 }
 }
 
@@ -158,17 +138,7 @@ Content-Length: REGEX(\d+)
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
   "machine" : "REGEX(.*)",
-  "doc" : "REGEX(.*)",
-  "libversions": {
-     "boost": "REGEX(.*)",
-     "libcurl": "REGEX(.*)",
-     "libmosquitto": "REGEX(.*)",
-     "libmicrohttpd": "REGEX(.*)",
-     "openssl": "REGEX(.*)",
-     "rapidjson": "REGEX(.*)",
-     "mongoc": "REGEX(.*)",
-     "bson": "REGEX(.*)"
-  }
+  "doc" : "REGEX(.*)"
 }
 }
 

--- a/test/functionalTest/cases/0501_cors/version_request.test
+++ b/test/functionalTest/cases/0501_cors/version_request.test
@@ -35,19 +35,19 @@ brokerStart CB 0-255 IPV4 -corsOrigin arrakis
 --SHELL--
 echo "01. GET Version (Access-Control-Allow-Origin header not included)"
 echo "================================================================="
-orionCurl --url /version?options=noLibVersions --noPayloadCheck
+orionCurl --url /version --noPayloadCheck
 echo
 echo
 
 echo "02. GET Version with arrakis origin (Access-Control-Allow-Origin header included)"
 echo "================================================================================="
-orionCurl --url /version?options=noLibVersions -X GET --origin arrakis --noPayloadCheck
+orionCurl --url /version -X GET --origin arrakis --noPayloadCheck
 echo
 echo
 
 echo "03. GET Version with caladan origin (Access-Control-Allow-Origin header not included)"
 echo "====================================================================================="
-orionCurl --url /version?options=noLibVersions -X GET --origin caladan --noPayloadCheck
+orionCurl --url /version -X GET --origin caladan --noPayloadCheck
 echo
 echo
 

--- a/test/functionalTest/cases/1916_fiware_correlator/fiware_correlator.test
+++ b/test/functionalTest/cases/1916_fiware_correlator/fiware_correlator.test
@@ -36,14 +36,14 @@ brokerStart CB 0
 
 echo "01. version request without correlator, see new correlator in response"
 echo "======================================================================"
-orionCurl --url /version?options=noLibVersions --noPayloadCheck
+orionCurl --url /version --noPayloadCheck
 echo
 echo
 
 
 echo "02. version request with correlator, see same correlator in response"
 echo "===================================================================="
-orionCurl --url /version?options=noLibVersions --noPayloadCheck --header "Fiware-Correlator: OLD_CORRELATOR"
+orionCurl --url /version --noPayloadCheck --header "Fiware-Correlator: OLD_CORRELATOR"
 echo
 echo
 

--- a/test/functionalTest/cases/1916_fiware_correlator/fiware_correlator.test
+++ b/test/functionalTest/cases/1916_fiware_correlator/fiware_correlator.test
@@ -36,14 +36,14 @@ brokerStart CB 0
 
 echo "01. version request without correlator, see new correlator in response"
 echo "======================================================================"
-orionCurl --url /version --noPayloadCheck
+orionCurl --url /version?options=noLibVersions --noPayloadCheck
 echo
 echo
 
 
 echo "02. version request with correlator, see same correlator in response"
 echo "===================================================================="
-orionCurl --url /version --noPayloadCheck --header "Fiware-Correlator: OLD_CORRELATOR"
+orionCurl --url /version?options=noLibVersions --noPayloadCheck --header "Fiware-Correlator: OLD_CORRELATOR"
 echo
 echo
 
@@ -67,17 +67,7 @@ Content-Length: REGEX(\d+)
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
   "machine" : "REGEX(.*)",
-  "doc" : "REGEX(.*)",
-  "libversions": {
-     "boost": "REGEX(.*)",
-     "libcurl": "REGEX(.*)",
-     "libmosquitto": "REGEX(.*)",
-     "libmicrohttpd": "REGEX(.*)",
-     "openssl": "REGEX(.*)",
-     "rapidjson": "REGEX(.*)",
-     "mongoc": "REGEX(.*)",
-     "bson": "REGEX(.*)"
-  }
+  "doc" : "REGEX(.*)"
 }
 }
 
@@ -101,17 +91,7 @@ Content-Length: REGEX(\d+)
   "compiled_in" : "REGEX(.*)",
   "release_date" : "REGEX(.*)",
   "machine" : "REGEX(.*)",
-  "doc" : "REGEX(.*)",
-  "libversions": {
-     "boost": "REGEX(.*)",
-     "libcurl": "REGEX(.*)",
-     "libmosquitto": "REGEX(.*)",
-     "libmicrohttpd": "REGEX(.*)",
-     "openssl": "REGEX(.*)",
-     "rapidjson": "REGEX(.*)",
-     "mongoc": "REGEX(.*)",
-     "bson": "REGEX(.*)"
-  }
+  "doc" : "REGEX(.*)"
 }
 }
 

--- a/test/unittests/serviceRoutines/versionTreat_test.cpp
+++ b/test/unittests/serviceRoutines/versionTreat_test.cpp
@@ -73,7 +73,6 @@ TEST(versionTreat, ok)
   // "  \"compiled_in\" : \".*\"\n"
   // "  \"machine\" : \".*\"\n"
   // "  \"doc\" : \".*\"\n"
-  // "  \"libversions\" : (drill down) "\n"
   // "}\n"
   // "}\n";
   // bool            match;
@@ -89,15 +88,6 @@ TEST(versionTreat, ok)
   EXPECT_TRUE(strstr(out.c_str(), "release_date") != NULL);
   EXPECT_TRUE(strstr(out.c_str(), "machine") != NULL);
   EXPECT_TRUE(strstr(out.c_str(), "doc") != NULL);
-  EXPECT_TRUE(strstr(out.c_str(), "libversions") != NULL);
-
-  EXPECT_TRUE(strstr(out.c_str(), "boost") != NULL);
-  EXPECT_TRUE(strstr(out.c_str(), "libcurl") != NULL);
-  EXPECT_TRUE(strstr(out.c_str(), "libmicrohttpd") != NULL);
-  EXPECT_TRUE(strstr(out.c_str(), "openssl") != NULL);
-  EXPECT_TRUE(strstr(out.c_str(), "rapidjson") != NULL);
-  EXPECT_TRUE(strstr(out.c_str(), "mongoc") != NULL);
-  EXPECT_TRUE(strstr(out.c_str(), "bson") != NULL);
 
   extern const char*  orionUnitTestVersion;
   std::string         expected = std::string("\"version\" : \"") + orionUnitTestVersion + "\"";


### PR DESCRIPTION
The new flag allows to simplify the output of GET /version in some tests.

This is motivated by the work done in PR https://github.com/telefonicaid/fiware-orion/pull/4511, to allow having a same set of tests no matter if basic-expr or jexl-expr flavours.