### PR TITLE
[Not to merge] FIX test new implementation with basic expressions

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - task/regression-test-basic-expressions2
   pull_request:
     branches:
       - master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,13 +231,14 @@ SET (BOOST_MT
 find_package (mongoc-1.0 1.24.3 EXACT)
 
 # Is cjexl lib available?
-find_library (HAVE_CJEXL cjexl PATHS /usr/lib /usr/lib64 /usr/local/lib64 /usr/local/lib)
-if (HAVE_CJEXL)
-    message("Using cjexl")
-else (HAVE_CJEXL)
-    message("Not using cjexl")
-    add_definitions(-DEXPR_BASIC)
-endif (HAVE_CJEXL)
+#find_library (HAVE_CJEXL cjexl PATHS /usr/lib /usr/lib64 /usr/local/lib64 /usr/local/lib)
+#if (HAVE_CJEXL)
+#    message("Using cjexl")
+#else (HAVE_CJEXL)
+#    message("Not using cjexl")
+#    add_definitions(-DEXPR_BASIC)
+#endif (HAVE_CJEXL)
+add_definitions(-DEXPR_BASIC)
 
 # Static libs common to contextBroker and unitTest binaries
 SET (COMMON_STATIC_LIBS


### PR DESCRIPTION
Evolved version of PR https://github.com/telefonicaid/fiware-orion/pull/4547

This PR is not for merging, but to check how new implementation behaves with basic expression. To that end, the CMakeList.txt file has been hacked so add_definitions(-DEXPR_BASIC) is always used. GitAction has been also modified to do the pass in this branch (by default only in PRs to be merged to master the pass is done).