### PR TITLE
FIX remove legacyForwarding true in test that does not need it

### DIFF
--- a/test/functionalTest/cases/0501_cors/registration_cors.test
+++ b/test/functionalTest/cases/0501_cors/registration_cors.test
@@ -44,8 +44,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'

--- a/test/functionalTest/cases/1492_limit_zero/limit_zero_regs.test
+++ b/test/functionalTest/cases/1492_limit_zero/limit_zero_regs.test
@@ -62,8 +62,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -88,8 +87,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'

--- a/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create.test
+++ b/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create.test
@@ -58,8 +58,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "inactive"
 }'
@@ -100,7 +99,7 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 311
+Content-Length: 312
 
 {
     "dataProvided": {
@@ -125,7 +124,7 @@ Content-Length: 311
         "http": {
             "url": "http://localhost:REGEX(\d+)/v2"
         },
-        "legacyForwarding": true,
+        "legacyForwarding": false,
         "supportedForwardingMode": "all"
     },
     "status": "inactive"
@@ -138,13 +137,10 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 250
+Content-Length: 206
 
 {
     "counters": {
-        "deprecatedFeatures": {
-            "ngsiv1Forwarding": 2
-        },      
         "jsonRequests": 1,
         "noPayloadRequests": 2,
         "requests": {

--- a/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_errors.test
+++ b/test/functionalTest/cases/3004_v2_reg_create/v2_reg_create_errors.test
@@ -776,8 +776,7 @@ payload='{
   "provider": {
     "http": {
       "url": "http://localhost:'${CP1_PORT}'/v2"
-    },
-    "legacyForwarding": true
+    }
   },
   "status": 4
 }'
@@ -802,8 +801,7 @@ payload='{
   "provider": {
     "http": {
       "url": "http://localhost:'${CP1_PORT}'/v2"
-    },
-    "legacyForwarding": true
+    }
   },
   "status": "green"
 }'
@@ -854,8 +852,7 @@ payload='{
   "provider": {
     "http": {
       "url": "http://localhost:'${CP1_PORT}'/v2"
-    },
-    "legacyForwarding": true
+    }
   }
 }'
 orionCurl --url /v2/registrations --payload "$payload"
@@ -879,8 +876,7 @@ payload='{
   "provider": {
     "http": {
       "url": "http://localhost:'${CP1_PORT}'/v2"
-    },
-    "legacyForwarding": true
+    }
   }
 }'
 orionCurl --url /v2/registrations --payload "$payload"

--- a/test/functionalTest/cases/3005_GET_registrations/get_registrations.test
+++ b/test/functionalTest/cases/3005_GET_registrations/get_registrations.test
@@ -60,8 +60,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -86,8 +85,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -112,8 +110,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -138,8 +135,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -223,7 +219,7 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 1053
+Content-Length: 1057
 
 [
     {
@@ -244,7 +240,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -267,7 +263,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -290,7 +286,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -313,7 +309,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -338,7 +334,7 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 264
+Content-Length: 265
 
 [
     {
@@ -359,7 +355,7 @@ Content-Length: 264
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -373,7 +369,7 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 1053
+Content-Length: 1057
 
 [
     {
@@ -394,7 +390,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -417,7 +413,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -440,7 +436,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -463,7 +459,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"

--- a/test/functionalTest/cases/3005_GET_registrations/get_registrations_with_pagination.test
+++ b/test/functionalTest/cases/3005_GET_registrations/get_registrations_with_pagination.test
@@ -57,8 +57,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -83,8 +82,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -109,8 +107,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -135,8 +132,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -228,7 +224,7 @@ Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Fiware-Total-Count: 4
 Content-Type: application/json
-Content-Length: 1053
+Content-Length: 1057
 
 [
     {
@@ -249,7 +245,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -272,7 +268,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -295,7 +291,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -318,7 +314,7 @@ Content-Length: 1053
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -332,7 +328,7 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 527
+Content-Length: 529
 
 [
     {
@@ -353,7 +349,7 @@ Content-Length: 527
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -376,7 +372,7 @@ Content-Length: 527
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -390,7 +386,7 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 527
+Content-Length: 529
 
 [
     {
@@ -411,7 +407,7 @@ Content-Length: 527
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -434,7 +430,7 @@ Content-Length: 527
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"
@@ -448,7 +444,7 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 264
+Content-Length: 265
 
 [
     {
@@ -469,7 +465,7 @@ Content-Length: 264
             "http": {
                 "url": "http://localhost:REGEX(\d+)/v2"
             },
-            "legacyForwarding": true,
+            "legacyForwarding": false,
             "supportedForwardingMode": "all"
         },
         "status": "active"

--- a/test/functionalTest/cases/3006_delete_registrations/delete_reg_using_v2_created_using_v2.test
+++ b/test/functionalTest/cases/3006_delete_registrations/delete_reg_using_v2_created_using_v2.test
@@ -52,8 +52,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -123,13 +122,10 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 253
+Content-Length: 209
 
 {
     "counters": {
-        "deprecatedFeatures": {
-            "ngsiv1Forwarding": 1
-        },      
         "jsonRequests": 1,
         "noPayloadRequests": 3,
         "requests": {

--- a/test/functionalTest/cases/3008_get_registration/get_reg_using_v2_created_using_v2.test
+++ b/test/functionalTest/cases/3008_get_registration/get_reg_using_v2_created_using_v2.test
@@ -52,8 +52,7 @@ payload='{
    "provider": {
      "http": {
        "url": "http://localhost:'${CP1_PORT}'/v2"
-     },
-     "legacyForwarding": true
+     }
    },
    "status": "active"
 }'
@@ -101,7 +100,7 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 262
+Content-Length: 263
 
 {
     "dataProvided": {
@@ -121,7 +120,7 @@ Content-Length: 262
         "http": {
             "url": "http://localhost:REGEX(\d+)/v2"
         },
-        "legacyForwarding": true,
+        "legacyForwarding": false,
         "supportedForwardingMode": "all"
     },
     "status": "active"
@@ -148,13 +147,10 @@ HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Content-Type: application/json
-Content-Length: 250
+Content-Length: 206
 
 {
     "counters": {
-        "deprecatedFeatures": {
-            "ngsiv1Forwarding": 2
-        },
         "jsonRequests": 1,
         "noPayloadRequests": 3,
         "requests": {

--- a/test/functionalTest/cases/3176_entity_without_attributes_not_listed/entity_without_attributes_not_listed.test
+++ b/test/functionalTest/cases/3176_entity_without_attributes_not_listed/entity_without_attributes_not_listed.test
@@ -55,8 +55,7 @@ payload='{
     "http": {
       "url": "http://contextsource.example.org"
     },
-    "supportedForwardingMode": "all",
-    "legacyForwarding": true
+    "supportedForwardingMode": "all"
   },
   "status": "active"
 }'

--- a/test/functionalTest/cases/3282_compound_not_render_in_not_matching_registration/compound_not_render_in_not_matching_registration.test
+++ b/test/functionalTest/cases/3282_compound_not_render_in_not_matching_registration/compound_not_render_in_not_matching_registration.test
@@ -112,8 +112,7 @@ payload='{
   "provider": {
     "http": {
       "url": "http://localhost':$CP1_PORT'/v1"
-    },
-    "legacyForwarding": true
+    }
   }
 }'
 orionCurl --url /v2/registrations --payload "$payload"

--- a/test/functionalTest/cases/3363_fwd_query_on_fail/fwd_query_on_fail.test
+++ b/test/functionalTest/cases/3363_fwd_query_on_fail/fwd_query_on_fail.test
@@ -86,8 +86,7 @@ payload='{
   "provider": {
     "http": {
       "url": "http://localhost:'${LISTENER_PORT}'/badresponse"
-    },
-    "legacyForwarding": true
+    }
   }
 }'
 orionCurl --url /v2/registrations --payload "$payload"


### PR DESCRIPTION
This PR does a .test simplification, removing legacyForwarding: true (a deprecated feature) in test that don't need it. They are probably old test developed in the times when NGSIv2 forwarding was not fully working.

After this PR the only tree .test that use legacyForwarding: true are he following ones:

* 0000_deprecated_checkings/log_deprecate_warning.test: which checks deprecated features logging as this one
* 3162_context_providers_legacy_non_primitive/blanked_out_attr.test: not sure of the usage of legacyForwarding: true in this case, but this .test seems to be the regression of a particular fixed bug, so I prefer not touching it.
* 3944_legacy_forwarding_rendering/legacy_forwarding_rendering.test: which checks the CRUD of the legacyForwarding field

In addition, note that none of these remaining test is actually implementing a NGSIv1 forwarding case. A .test for that is going to be added in PR https://github.com/telefonicaid/fiware-orion/pull/4603, to test the new parser developed for that.