### PR TITLE
FIX validation data for oriondb consistency script

### DIFF
--- a/scripts/oriondb_consistency/validation_data.js
+++ b/scripts/oriondb_consistency/validation_data.js
@@ -4454,23 +4454,15 @@ db.getSiblingDB("orion-validation").entities.insertMany([
 
 db.getSiblingDB("orion-validation").csubs.insertMany([
     {
-      "expiration": {
-        "$numberLong": "9223372036854775807"
-      },
+      "expiration": 9223372036854775807,
       "reference": "http://notify-receptor:5055/notify",
       "custom": true,
-      "timeout": {
-        "$numberLong": "0"
-      },
+      "timeout": 0,
       "headers": {
         "fiware-servicepath": "/SS1"
       },
-      "throttling": {
-        "$numberLong": "0"
-      },
-      "maxFailsLimit": {
-        "$numberLong": "-1"
-      },
+      "throttling": 0,
+      "maxFailsLimit": -1,
       "servicePath": "/SS2",
       "status": "active",
       "statusLastChange": 1682640509.6958137,

--- a/scripts/oriondb_consistency/validation_data.js
+++ b/scripts/oriondb_consistency/validation_data.js
@@ -4454,15 +4454,15 @@ db.getSiblingDB("orion-validation").entities.insertMany([
 
 db.getSiblingDB("orion-validation").csubs.insertMany([
     {
-      "expiration": 9223372036854775807,
+      "expiration": NumberLong("9223372036854775807"),
       "reference": "http://notify-receptor:5055/notify",
       "custom": true,
-      "timeout": 0,
+      "timeout": NumberLong("0"),
       "headers": {
         "fiware-servicepath": "/SS1"
       },
-      "throttling": 0,
-      "maxFailsLimit": -1,
+      "throttling": NumberLong("0"),
+      "maxFailsLimit": NumberLong("-1"),
       "servicePath": "/SS2",
       "status": "active",
       "statusLastChange": 1682640509.6958137,


### PR DESCRIPTION
It was causing ERROR traces like this:

> time=2024-09-20T07:09:56.259Z | lvl=ERROR | corr=N/A | trans=N/A | from=N/A | srv=N/A | subsrv=N/A | comp=Orion | op=safeMongo.cpp[63]:logKeyNotFound | msg=Runtime Error (field 'timeout' was supposed to be a long but the type is 'Object' (type as integer: 3) in BSONObj <{ "_id" : { "$oid" : "661674497716995c9d05299d" }, "expiration" : { "$numberLong" : "9223372036854775807" }, "reference" : "http://notify-receptor:5055/notify", "custom" : true, "timeout" : { "$numberLong" : "0" }, "headers" : { "fiware-servicepath" : "/SS1" }, "throttling" : { "$numberLong" : "0" }, "maxFailsLimit" : { "$numberLong" : "-1" }, "servicePath" : "/SS2", "status" : "active", "statusLastChange" : 1682640509.6958136559, "entities" : [ { "id" : ".*", "isPattern" : "true", "type" : "T", "isTypePattern" : false } ], "attrs" : [ "temperature" ], "metadata" : [  ], "blacklist" : false, "onlyChanged" : false, "covered" : false, "description" : "Foobar", "conditions" : [ "TimeInstant" ], "expression" : { "q" : "", "mq" : "", "geometry" : "", "coords" : "", "georel" : "" }, "altTypes" : [  ], "format" : "normalized" }> from caller fill:123)