### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/scripts/accumulator-server.py
+++ b/scripts/accumulator-server.py
@@ -42,6 +42,7 @@ __author__ = 'fermin'
 # * This script requires at least Flask 2.0.2, which comes with Werkzeug 2.0.2.
 
 from flask import Flask, request, Response
+import logging
 from getopt import getopt, GetoptError
 from datetime import datetime
 from math import trunc
@@ -375,7 +376,8 @@ def record_request(request):
                 s += json.dumps(raw, indent=4, sort_keys=True)
                 s += '\n'
             except ValueError as e:
-                s += str(e)
+                log_error(str(e))  # Log the error details
+                s += "An error occurred while processing the request."
         else:
             s += request.data.decode("utf-8")
 
@@ -389,6 +391,13 @@ def record_request(request):
         print(s)
 
 
+def log_error(error_message):
+    """
+    Log the error message to a file or standard output.
+
+    :param error_message: The error message to log
+    """
+    logging.error(error_message)
 def send_continue(request):
     """
     Inspect request header in order to look if we have to continue or not


### PR DESCRIPTION
Fixes [https://github.com/telefonicaid/fiware-orion/security/code-scanning/1](https://github.com/telefonicaid/fiware-orion/security/code-scanning/1)

To fix the problem, we need to ensure that detailed error messages, including stack traces, are not exposed to the end users. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the `record_request` function to log the exception details and append a generic error message to the response string.

1. Modify the `record_request` function to log the exception details instead of appending them to the response string.
2. Ensure that the `/dump` endpoint returns the accumulated data without exposing sensitive error information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
