### PR TITLE
Fix code scanning alert no. 9: Uncontrolled format string

### DIFF
--- a/src/lib/logMsg/logMsg.cpp
+++ b/src/lib/logMsg/logMsg.cpp
@@ -2378,7 +2378,7 @@ LmStatus lmOut
       }
       else
       {
-        snprintf(line, logLineMaxSize, format, text);
+        snprintf(line, logLineMaxSize, "%s", text);
       }
     }
 


### PR DESCRIPTION
Fixes [https://github.com/telefonicaid/fiware-orion/security/code-scanning/9](https://github.com/telefonicaid/fiware-orion/security/code-scanning/9)

To fix the problem, we need to ensure that the `format` string used in the `snprintf` function is not directly influenced by user input. Instead, we should use a constant format string and pass the user input as an argument to avoid format string vulnerabilities.

The best way to fix this issue without changing existing functionality is to replace the `snprintf` call on line 2381 with a constant format string and pass the `text` variable as an argument. This change should be made in the `src/lib/logMsg/logMsg.cpp` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
