### PR TITLE
FIX env vars values with unsigned int or long types where not correctly printed at startup time in INFO log level

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,6 +4,7 @@
 - Fix: improve attribute and metadata invalid format dates for DateTime types in logs (#4616)
 - Fix: attrsFormat keyValues and values were not working in custom notifications using ngsi payloads (#4644)
 - Fix: JEXL expressions were not working in attrsFormat simplifiedKeyValues, keyValues or values (#4645)
+- Fix: env vars values with unsigned int or long types where not correctly printed at startup time in INFO log level (#4668)
 - Hardening: upgrade microhttpd dependency from 0.9.76 to 1.0.1
 - Hardening: upgrade libmosquitto dependency from 2.0.15 to 2.0.20
 - Hardening: upgrade libmongoc dependency from 1.24.3 to 1.29.0

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -964,9 +964,17 @@ static void logEnvVars(void)
       {
         LM_I(("env var ORION_%s (%s): %d", aP->envName, aP->option, *((int*) aP->varP)));
       }
+      else if (aP->type == PaUInt)
+      {
+        LM_I(("env var ORION_%s (%s): %u", aP->envName, aP->option, *((unsigned int*) aP->varP)));
+      }      
+      else if (aP->type == PaLong)
+      {
+        LM_I(("env var ORION_%s (%s): %ld", aP->envName, aP->option, *((long*) aP->varP)));
+      }
       else if (aP->type == PaULong)
       {
-        LM_I(("env var ORION_%s (%s): %d", aP->envName, aP->option, *((unsigned long*) aP->varP)));
+        LM_I(("env var ORION_%s (%s): %lu", aP->envName, aP->option, *((unsigned long*) aP->varP)));
       }
       else if (aP->type == PaDouble)
       {


### PR DESCRIPTION
Issue #4668

Tested:

```
$ ORION_CONN_MEMORY=20 ORION_MQTT_MAX_AGE=0 ORION_REQ_TIMEOUT=20 contextBroker -fg -logLevel INFO

time=2025-04-24T07:01:16.000Z | lvl=INFO | corr=N/A | trans=N/A | from=N/A | srv=N/A | subsrv=N/A | comp=Orion | op=contextBroker.cpp[1109]:main | msg=start command line <contextBroker -fg -logLevel INFO>
time=2025-04-24T07:01:16.000Z | lvl=INFO | corr=N/A | trans=N/A | from=N/A | srv=N/A | subsrv=N/A | comp=Orion | op=contextBroker.cpp[973]:logEnvVars | msg=env var ORION_REQ_TIMEOUT (-reqTimeout): 20
time=2025-04-24T07:01:16.000Z | lvl=INFO | corr=N/A | trans=N/A | from=N/A | srv=N/A | subsrv=N/A | comp=Orion | op=contextBroker.cpp[969]:logEnvVars | msg=env var ORION_CONN_MEMORY (-connectionMemory): 20
time=2025-04-24T07:01:16.000Z | lvl=INFO | corr=N/A | trans=N/A | from=N/A | srv=N/A | subsrv=N/A | comp=Orion | op=contextBroker.cpp[965]:logEnvVars | msg=env var ORION_MQTT_MAX_AGE (-mqttMaxAge): 0
...
```