### PR TITLE
REMOVE deprecated mongo CLI in compose files

### DIFF
--- a/docker/README.jp.md
+++ b/docker/README.jp.md
@@ -37,11 +37,8 @@ Orion Context Broker を試してみたいし、データベースについて�
 
 		  mongo:
 		    image: mongo:8.0
-		    command: --nojournal
 
 3. コマンドラインを使用して作成したディレクトリで、`sudo docker-compose up` を実行します
-
-> `--nojournal` に関しては、それはプロダクション利用では推奨されていませんが、Orion コンテナが高速で、DB が見つからず準備ができていない場合に、mongo コンテナの起動を高速化し、いくつかの競合状態の問題を回避します。
 
 数秒後、Context Broker が実行され、ポート 1026 をリッスンします。
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,11 +39,8 @@ Follow these steps:
 		
 		  mongo:
 		    image: mongo:8.0
-		    command: --nojournal
 
 3. Using the command-line and within the directory you created type: `sudo docker-compose up`.
-
-> Regarding --nojournal it is not recommened for production, but it speeds up mongo container start up and avoids some race conditions problems if Orion container is faster and doesn't find the DB up and ready.
 
 After a few seconds you should have your Context Broker running and listening on port `1026`.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,5 +11,4 @@ services:
 
   mongo:
     image: mongo:8.0
-    command: --nojournal
 

--- a/docker/raspberry_pi.jp.md
+++ b/docker/raspberry_pi.jp.md
@@ -51,7 +51,6 @@ services:
 
   mongo:
     image: mongo:8.0
-    command: --nojournal
 ```
 
 Orion を実行するには、`docker compose up -d` を実行します。`curl localhost:1026/version` コマンドを実行して、

--- a/docker/raspberry_pi.md
+++ b/docker/raspberry_pi.md
@@ -50,7 +50,6 @@ services:
 
   mongo:
     image: mongo:8.0
-    command: --nojournal
 ```
 
 To start up Orion, you run `docker-compose up -d`. Run the `curl localhost:1026/version` command


### PR DESCRIPTION
As explained in MongoDB documentation (https://www.mongodb.com/docs/manual/core/journaling/)

> NOTE
> Starting in MongoDB 6.1, journaling is always enabled. As a result, MongoDB removes the `storage.journal.enabled` option and the corresponding `--journal` and `--nojournal` command-line options.

