### PR TITLE
FIX right type for variable

### DIFF
--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -188,7 +188,7 @@ unsigned long   logInfoPayloadMaxSize;
 bool            disableMetrics;
 bool            disableNgsiv1;
 bool            disableFileLog;
-int             reqTimeout;
+long            reqTimeout;       // FIXME PR: missmatch in paArgs[] (where PaLong is used for this)
 bool            insecureNotif;
 bool            ngsiv1Autocast;
 

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -188,7 +188,7 @@ unsigned long   logInfoPayloadMaxSize;
 bool            disableMetrics;
 bool            disableNgsiv1;
 bool            disableFileLog;
-long            reqTimeout;       // FIXME PR: missmatch in paArgs[] (where PaLong is used for this)
+long            reqTimeout;
 bool            insecureNotif;
 bool            ngsiv1Autocast;
 

--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -340,8 +340,8 @@ PaArgument paArgs[] =
 
   { "-disableFileLog",              &disableFileLog,        "DISABLE_FILE_LOG",         PaBool,   PaOpt, false,                           false, true,                  DISABLE_FILE_LOG             },
   { "-logForHumans",                &logForHumans,          "LOG_FOR_HUMANS",           PaBool,   PaOpt, false,                           false, true,                  LOG_FOR_HUMANS_DESC          },
-  { "-logLineMaxSize",              &logLineMaxSize,        "LOG_LINE_MAX_SIZE",        PaLong,   PaOpt, (32 * 1024),                     100,   PaNL,                  LOG_LINE_MAX_SIZE_DESC       },
-  { "-logInfoPayloadMaxSize",       &logInfoPayloadMaxSize, "LOG_INFO_PAYLOAD_MAX_SIZE",PaLong,   PaOpt, (5 * 1024),                      0,     PaNL,                  LOG_INFO_PAYLOAD_MAX_SIZE_DESC  },
+  { "-logLineMaxSize",              &logLineMaxSize,        "LOG_LINE_MAX_SIZE",        PaULong,  PaOpt, (32 * 1024),                     100,   PaNL,                  LOG_LINE_MAX_SIZE_DESC       },
+  { "-logInfoPayloadMaxSize",       &logInfoPayloadMaxSize, "LOG_INFO_PAYLOAD_MAX_SIZE",PaULong,  PaOpt, (5 * 1024),                      0,     PaNL,                  LOG_INFO_PAYLOAD_MAX_SIZE_DESC  },
 
   { "-disableMetrics",              &disableMetrics,        "DISABLE_METRICS",          PaBool,   PaOpt, false,                           false, true,                  DISABLE_METRICS_DESC         },
   { "-disableNgsiv1",               &disableNgsiv1,         "DISABLE_NGSIV1",           PaBool,   PaOpt, false,                           false, true,                  DISABLE_NGSIV1_DESC          },


### PR DESCRIPTION
Related with issue https://github.com/telefonicaid/fiware-orion/issues/4668, somehow continuation of PR https://github.com/telefonicaid/fiware-orion/pull/4670

- [x] review the type of each global variable in `paArgs[]` mathes with the type specified in the row of that table (`PaLong`, `PaInt`, etc.) - https://github.com/telefonicaid/fiware-orion/commit/993d9e3b37f7543bb184cb1c213647e91835d63c
- [x] Remove testing image from dockerhub `telefonicaiot/fiware-orion:test`
- [x] Remove testing branch hardening/4668-debug
- [x] CNR? (unsure) - very minor change, not needed
