### PR TITLE
FIX memory leak in POST /v2/op/notify operation

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: memory leak in POST /v2/op/notify operation (#4261)

--- a/src/lib/serviceRoutines/postNotifyContext.cpp
+++ b/src/lib/serviceRoutines/postNotifyContext.cpp
@@ -64,5 +64,7 @@ std::string postNotifyContext
                                                        ciP->httpHeaders.ngsiv2AttrsFormat));
   TIMED_RENDER(answer = ncr.toJsonV1());
 
+  parseDataP->ncr.res.release();
+
   return answer;
 }

--- a/test/functionalTest/cases/0000_statistics_operation/statistics_with_counters.test
+++ b/test/functionalTest/cases/0000_statistics_operation/statistics_with_counters.test
@@ -141,9 +141,7 @@ payload='{
     }
   ]
 }'
-# FIXME #4261. Once the issue gets solved, this line should be uncommented
-# The REGEXPECT part would need a little adapation after that
-#orionCurl --url /v2/op/notify -X POST   --payload "$payload"  > /dev/null
+orionCurl --url /v2/op/notify -X POST   --payload "$payload"  > /dev/null
 
 
 payload='{
@@ -218,7 +216,7 @@ Content-Length: REGEX(\d+)
 
 {
     "counters": {
-        "jsonRequests": 11,
+        "jsonRequests": 12,
         "noPayloadRequests": 40,
         "requests": {
             "/admin/log": {
@@ -271,6 +269,9 @@ Content-Length: REGEX(\d+)
                 "PATCH": 1,
                 "POST": 1,
                 "PUT": 1
+            },
+            "/v2/op/notify": {
+                "POST": 1
             },
             "/v2/op/query": {
                 "OPTIONS": 1,


### PR DESCRIPTION
Issue #4261 

Check

```
(p3) fermin@bodoque:~/src/fiware-orion/test/valgrind$ contextBroker --version | head -n 1
4.2.0-next (git version: 319cd1a6b32c8d939eb41d0a8c3399cd1bded1f2) flavours: jexl-expr
(p3) fermin@bodoque:~/src/fiware-orion/test/valgrind$ ./valgrindTestSuite.sh statistics_with_counters.test
lun 12 may 2025 17:31:16 CEST
Run tests 0 to 0
./valgrindTestSuite.sh: línea 243: cd: test/valgrind: No existe el fichero o el directorio
Test 001/1: 0000_statistics_operation/statistics_with_counters ...................................................................................... OK (20.13 seconds)
Total test time: 20.32 seconds (0 minutes)
Great, all valgrind tests ran without any memory leakage
```

(Note the commit above is the same in this PR)