### PR TITLE
POST /v2/op/notify must not response in NGSIv1 format

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 - Fix: memory leak in POST /v2/op/notify operation (#4261)
-- Fix: POST /v2/op/notify proper response (formarly it was using NSGIv1 format payload) (#4681)
+- Fix: POST /v2/op/notify proper response (formerly it was using NSGIv1 format payload) (#4681)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: memory leak in POST /v2/op/notify operation (#4261)
+- Fix: POST /v2/op/notify proper response (formarly it was using NSGIv1 format payload) (#4681)

--- a/src/lib/jsonParseV2/parseNotification.cpp
+++ b/src/lib/jsonParseV2/parseNotification.cpp
@@ -271,5 +271,5 @@ std::string parseNotification(ConnectionInfo* ciP, NotifyContextRequest* ncrP)
     return "OK";  // FIXME #3151: parseNotification should return bool and have an input param "OrionError* oeP"
   }
 
-  return oe.toJson();
+  return oe.smartRender(V2);
 }

--- a/src/lib/mongoBackend/mongoNotifyContext.cpp
+++ b/src/lib/mongoBackend/mongoNotifyContext.cpp
@@ -71,7 +71,7 @@ HttpStatusCode mongoNotifyContext
   }
 
   reqSemGive(__FUNCTION__, "ngsi10 notification", reqSemTaken);
-  responseP->responseCode.fill(SccOk);
+  responseP->oe.fill(SccOk, "");
 
   return SccOk;
 }

--- a/src/lib/ngsi10/NotifyContextRequest.cpp
+++ b/src/lib/ngsi10/NotifyContextRequest.cpp
@@ -141,20 +141,20 @@ std::string NotifyContextRequest::check(ApiVersion apiVersion, const std::string
 
   if (!predetectedError.empty())
   {
-    response.responseCode.fill(SccBadRequest, predetectedError);
+    response.oe.fill(SccBadRequest, predetectedError);
   }
   else if (((res = subscriptionId.check())                    != "OK") ||
            ((res = originator.check())                        != "OK") ||
            ((res = contextElementResponseVector.check(apiVersion, QueryContext, predetectedError, 0)) != "OK"))
   {
-    response.responseCode.fill(SccBadRequest, res);
+    response.oe.fill(SccBadRequest, res);
   }
   else
   {
     return "OK";
   }
 
-  return response.toJsonV1();
+  return response.oe.toJson();
 }
 
 

--- a/src/lib/ngsi10/NotifyContextResponse.cpp
+++ b/src/lib/ngsi10/NotifyContextResponse.cpp
@@ -42,7 +42,7 @@
 */
 NotifyContextResponse::NotifyContextResponse()
 {
-  responseCode.fill(SccOk);
+  oe.fill(SccOk, "");
 }
 
 
@@ -53,35 +53,5 @@ NotifyContextResponse::NotifyContextResponse()
 */
 NotifyContextResponse::NotifyContextResponse(StatusCode& sc)
 {
-   responseCode.fill(&sc);
-}
-
-
-
-/* ****************************************************************************
-*
-* NotifyContextResponse::toJsonV1 -
-*/
-std::string NotifyContextResponse::toJsonV1(void)
-{
-  std::string out = "";
-
-  responseCode.keyNameSet("responseCode");
-
-  out += startTag();
-  out += responseCode.toJsonV1(false);
-  out += endTag();
-
-  return out;
-}
-
-
-
-/* ****************************************************************************
-*
-* NotifyContextResponse::release - 
-*/
-void NotifyContextResponse::release(void)
-{
-  responseCode.release();
+   oe.fill(sc);
 }

--- a/src/lib/ngsi10/NotifyContextResponse.h
+++ b/src/lib/ngsi10/NotifyContextResponse.h
@@ -31,6 +31,8 @@
 #include "ngsi/Request.h"
 #include "ngsi/StatusCode.h"
 
+#include "rest/OrionError.h"
+
 
 
 /* ****************************************************************************
@@ -39,13 +41,11 @@
 */
 typedef struct NotifyContextResponse
 {
-  StatusCode    responseCode;              // Mandatory
+  OrionError    oe;              // Mandatory
 
   NotifyContextResponse();
   NotifyContextResponse(StatusCode& sc);
 
-  std::string   toJsonV1(void);
-  void          release(void);
 } NotifyContextResponse;
 
 #endif  // SRC_LIB_NGSI10_NOTIFYCONTEXTRESPONSE_H_

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -207,7 +207,7 @@ void restErrorReplyGet(ConnectionInfo* ciP, HttpStatusCode code, const std::stri
   else if (ciP->restServiceP->request == NotifyContext)
   {
     NotifyContextResponse ncr(errorCode);
-    *outStringP = ncr.toJsonV1();
+    *outStringP = ncr.oe.toJson();
   }
   else
   {

--- a/src/lib/serviceRoutines/postNotifyContext.cpp
+++ b/src/lib/serviceRoutines/postNotifyContext.cpp
@@ -1,27 +1,27 @@
 /*
-*
-* Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
-*
-* This file is part of Orion Context Broker.
-*
-* Orion Context Broker is free software: you can redistribute it and/or
-* modify it under the terms of the GNU Affero General Public License as
-* published by the Free Software Foundation, either version 3 of the
-* License, or (at your option) any later version.
-*
-* Orion Context Broker is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
-* General Public License for more details.
-*
-* You should have received a copy of the GNU Affero General Public License
-* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
-*
-* For those usages not covered by this license please contact with
-* iot_support at tid dot es
-*
-* Author: Ken Zangelin
-*/
+ *
+ * Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
+ *
+ * This file is part of Orion Context Broker.
+ *
+ * Orion Context Broker is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Orion Context Broker is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by this license please contact with
+ * iot_support at tid dot es
+ *
+ * Author: Ken Zangelin
+ */
 #include <string>
 #include <vector>
 
@@ -38,22 +38,18 @@
 #include "rest/ConnectionInfo.h"
 #include "serviceRoutines/postNotifyContext.h"
 
-
-
 /* ****************************************************************************
-*
-* postNotifyContext -
-*/
-std::string postNotifyContext
-(
-  ConnectionInfo*            ciP,
-  int                        components,
-  std::vector<std::string>&  compV,
-  ParseData*                 parseDataP
-)
+ *
+ * postNotifyContext -
+ */
+std::string postNotifyContext(
+    ConnectionInfo *ciP,
+    int components,
+    std::vector<std::string> &compV,
+    ParseData *parseDataP)
 {
-  NotifyContextResponse  ncr;
-  std::string            answer;
+  NotifyContextResponse ncr;
+  std::string answer;
 
   TIMED_MONGO(ciP->httpStatusCode = mongoNotifyContext(&parseDataP->ncr.res,
                                                        &ncr,
@@ -62,7 +58,17 @@ std::string postNotifyContext
                                                        ciP->servicePathV,
                                                        ciP->httpHeaders.correlator,
                                                        ciP->httpHeaders.ngsiv2AttrsFormat));
-  TIMED_RENDER(answer = ncr.toJsonV1());
+
+  // Check potential error
+  if (ncr.oe.code != SccOk)
+  {
+    TIMED_RENDER(answer = ncr.oe.toJson());
+    ciP->httpStatusCode = ncr.oe.code;
+  }
+  else
+  {
+    ciP->httpStatusCode = SccOk;
+  }
 
   parseDataP->ncr.res.release();
 

--- a/src/lib/serviceRoutines/postNotifyContext.cpp
+++ b/src/lib/serviceRoutines/postNotifyContext.cpp
@@ -1,27 +1,27 @@
 /*
- *
- * Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
- *
- * This file is part of Orion Context Broker.
- *
- * Orion Context Broker is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * Orion Context Broker is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
- * General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
- *
- * For those usages not covered by this license please contact with
- * iot_support at tid dot es
- *
- * Author: Ken Zangelin
- */
+*
+* Copyright 2013 Telefonica Investigacion y Desarrollo, S.A.U
+*
+* This file is part of Orion Context Broker.
+*
+* Orion Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* iot_support at tid dot es
+*
+* Author: Ken Zangelin
+*/
 #include <string>
 #include <vector>
 

--- a/src/lib/serviceRoutines/postNotifyContext.cpp
+++ b/src/lib/serviceRoutines/postNotifyContext.cpp
@@ -39,17 +39,19 @@
 #include "serviceRoutines/postNotifyContext.h"
 
 /* ****************************************************************************
- *
- * postNotifyContext -
- */
-std::string postNotifyContext(
-    ConnectionInfo *ciP,
-    int components,
-    std::vector<std::string> &compV,
-    ParseData *parseDataP)
+*
+* postNotifyContext -
+*/
+std::string postNotifyContext
+(
+  ConnectionInfo*            ciP,
+  int                        components,
+  std::vector<std::string>&  compV,
+  ParseData*                 parseDataP
+)
 {
-  NotifyContextResponse ncr;
-  std::string answer;
+  NotifyContextResponse  ncr;
+  std::string            answer;
 
   TIMED_MONGO(ciP->httpStatusCode = mongoNotifyContext(&parseDataP->ncr.res,
                                                        &ncr,

--- a/src/lib/serviceRoutines/postNotifyContext.cpp
+++ b/src/lib/serviceRoutines/postNotifyContext.cpp
@@ -64,7 +64,7 @@ std::string postNotifyContext
   // Check potential error
   if (ncr.oe.code != SccOk)
   {
-    TIMED_RENDER(answer = ncr.oe.toJson());
+    TIMED_RENDER(answer = ncr.oe.smartRender(V2));
     ciP->httpStatusCode = ncr.oe.code;
   }
   else

--- a/test/functionalTest/cases/4681_notify_op/notify_op.test
+++ b/test/functionalTest/cases/4681_notify_op/notify_op.test
@@ -34,6 +34,9 @@ brokerStart CB
 # (https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#notify-post-v2opnotify)
 # it is a good idea to have a .test covering it
 #
+# 01. POST /v2/op/notify
+# 02. GET /v2/entities
+#
 
 echo "01. POST /v2/op/notify"
 echo "======================"

--- a/test/functionalTest/cases/4681_notify_op/notify_op.test
+++ b/test/functionalTest/cases/4681_notify_op/notify_op.test
@@ -36,6 +36,7 @@ brokerStart CB
 #
 # 01. POST /v2/op/notify
 # 02. GET /v2/entities
+# 03. POST /v2/op/notify with error
 #
 
 echo "01. POST /v2/op/notify"
@@ -58,6 +59,23 @@ echo
 echo "02. GET /v2/entities"
 echo "===================="
 orionCurl --url /v2/entities
+echo
+echo
+
+
+echo "03. POST /v2/op/notify with error"
+echo "================================="
+payload='{
+  "subscriptionId": "1231",
+  "data": [
+    {
+      "id": "E",
+      "type": "T",
+      "A": {"value": "(forbiden chars)", "type": "Number"}
+    }
+  ]
+}'
+orionCurl --url /v2/op/notify -X POST  --payload "$payload"
 echo
 echo
 
@@ -91,6 +109,20 @@ Content-Length: 69
         "type": "T"
     }
 ]
+
+
+03. POST /v2/op/notify with error
+=================================
+HTTP/1.1 400 Bad Request
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Content-Type: application/json
+Content-Length: 76
+
+{
+    "description": "Invalid characters in attribute value",
+    "error": "BadRequest"
+}
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/4681_notify_op/notify_op.test
+++ b/test/functionalTest/cases/4681_notify_op/notify_op.test
@@ -25,7 +25,7 @@ POST /v2/op/notify
 
 --SHELL-INIT--
 dbInit CB
-brokerStart CB 0 IPv4 -statCounters
+brokerStart CB
 
 --SHELL--
 
@@ -65,15 +65,8 @@ echo
 HTTP/1.1 200 OK
 Date: REGEX(.*)
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
-Content-Type: application/json
-Content-Length: 51
+Content-Length: 0
 
-{
-    "responseCode": {
-        "code": "200",
-        "reasonPhrase": "OK"
-    }
-}
 
 
 02. GET /v2/entities

--- a/test/functionalTest/cases/4681_notify_op/notify_op.test
+++ b/test/functionalTest/cases/4681_notify_op/notify_op.test
@@ -1,0 +1,102 @@
+# Copyright 2025 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+POST /v2/op/notify
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 0 IPv4 -statCounters
+
+--SHELL--
+
+#
+# This is not an operation commonly used, but as long it is part of the NGISv2 API
+# (https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#notify-post-v2opnotify)
+# it is a good idea to have a .test covering it
+#
+
+echo "01. POST /v2/op/notify"
+echo "======================"
+payload='{
+  "subscriptionId": "1231",
+  "data": [
+    {
+      "id": "E",
+      "type": "T",
+      "A": {"value": 1, "type": "Number"}
+    }
+  ]
+}'
+orionCurl --url /v2/op/notify -X POST  --payload "$payload" 
+echo
+echo
+
+
+echo "02. GET /v2/entities"
+echo "===================="
+orionCurl --url /v2/entities
+echo
+echo
+
+
+--REGEXPECT--
+01. POST /v2/op/notify
+======================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Content-Type: application/json
+Content-Length: 51
+
+{
+    "responseCode": {
+        "code": "200",
+        "reasonPhrase": "OK"
+    }
+}
+
+
+02. GET /v2/entities
+====================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Content-Type: application/json
+Content-Length: 69
+
+[
+    {
+        "A": {
+            "metadata": {},
+            "type": "Number",
+            "value": 1
+        },
+        "id": "E",
+        "type": "T"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/simplyTestHarness.sh
+++ b/test/functionalTest/simplyTestHarness.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2025 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+CB_MAX_TRIES=1 CB_DIFF_TOOL=meld ./testHarness.sh $@

--- a/test/unittests/ngsi10/NotifyContextRequest_test.cpp
+++ b/test/unittests/ngsi10/NotifyContextRequest_test.cpp
@@ -116,12 +116,11 @@ TEST(NotifyContextResponse, Constructor)
 
   utInit();
 
-  EXPECT_EQ(SccOk, ncr.responseCode.code);
-  ncr.release();
+  EXPECT_EQ(SccOk, ncr.oe.code);
 
   StatusCode ec(SccOk, "4");
   NotifyContextResponse ncr2(ec);
-  EXPECT_EQ(SccOk, ncr2.responseCode.code);
+  EXPECT_EQ(SccOk, ncr2.oe.code);
 
   utExit();
 }

--- a/test/unittests/testData/ngsi10.notifyContextResponse.badIsPattern.valid.json
+++ b/test/unittests/testData/ngsi10.notifyContextResponse.badIsPattern.valid.json
@@ -1,1 +1,1 @@
-{"responseCode":{"code":"400","reasonPhrase":"Bad Request","details":"invalid isPattern value for entity: /phalse/"}}
+{"error":"Bad Request","description":"invalid isPattern value for entity: /phalse/"}


### PR DESCRIPTION
The first commit in this PR (81a4eeb5dff7ae95d66ab76c676630fa7f985319) shows how this **must not** work.

It is not very important (as this operations is not very used and, even in this case, the response use to be ignored) but we should fix to adhere to our API (https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#notify-post-v2opnotify).

- [x] fix it an align .test
- [x] CNR

Bonus-track: simplyTestHarness.sh script a a wrapper of testHarness.sh with the env var configurations, useful to debug