### PR TITLE
ADD example lanuch.json file for VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ tag `fiware-orion`
 
 [Top](#top)
 
+## Useful stuff
+
+If you use [VSCode](https://code.visualstudio.com/) you may find useful this [launch configuration](launch.json). Have a look to the
+comments in the file itself.
+
+[Top](#top)
+
 ---
 
 ## License

--- a/launch.json
+++ b/launch.json
@@ -1,0 +1,44 @@
+{
+    // Put this file in .vscode/launch.json in your project folder to use it for debugging.
+    // The example "args" are the usual ones for running ORion Context for functional tests,
+    // change them as you need.    
+
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Context Broker (gdb)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/BUILD_DEBUG/src/app/contextBroker/contextBroker",
+            "args": [
+                "-fg",
+                "-harakiri",
+                "-port", "9999",
+                "-pidpath", "/tmp/orion_9999.pid",
+                "-dbURI", "mongodb://localhost:27017",
+                "-db", "ftest",
+                "-dbPoolSize", "10",
+                "-t 0-255",
+                "-logLevel", "DEBUG",    
+                "-notificationMode", "threadpool:200:20",
+                "-noCache"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+
+    ]
+}

--- a/scripts/check_files_compliance.py
+++ b/scripts/check_files_compliance.py
@@ -138,7 +138,7 @@ def ignore(root, file):
                    'ContributionPolicy.txt', 'CHANGES_NEXT_RELEASE', 'Changelog', 'compileInfo.h',
                    'unittests_that_fail_sporadically.txt', 'Vagrantfile', 'contextBroker.ubuntu',
                    'mkdocs.yml', 'fiware-ngsiv2-reference.errata', 'ServiceRoutines.txt', '.readthedocs.yml', 'uncrustify.cfg',
-                   'requirements.txt', 'mosquitto_passwd' ]
+                   'requirements.txt', 'mosquitto_passwd', 'launch.json' ]
     if file in files_names:
         return True
     if 'scripts' in root and (file == 'cpplint.py' or file == 'pdi-pep8.py' or file == 'uncrustify.cfg' \


### PR DESCRIPTION
Repository should be IDE-neutral (thus I'm not creating this file directly in `.vscode/launch.json` path :) but I think it can be an useful help to people using VSCode to develop Orion code.