### PR TITLE
Check valgrind on 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <a name="top"></a>Orion Context Broker
+#  <a name="top"></a>Orion Context Broker
 
 <!-- Documentation badge line is processed by release.sh. Thus, if the structure of the URL changes,
      release.sh needs to be changed also -->


### PR DESCRIPTION
current master seems to be valgrind-fail (see PR https://github.com/telefonicaid/fiware-orion/pull/4709). This PR is to check if 4.2.0 is valgrind-ok.