### PR TITLE
FIX use warning instead of Runtime Error when adding an object or array in basic expressions mode

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -7,4 +7,5 @@
 - Fix: admin log operations error responses were not following NGSIv2 error response syntax
 - Fix: memory leaks in parse logic in case of parse error (possibly)
 - Fix: csubs and registrations now use isPattern as bool instead of string (legacy from NGSIv1 model), although strings are still supported (#4681)
+- Fix: use warning instead of Runtime Error when adding an object or array in basic expressions mode
 - Hardening: remove a huge amount of NGSIv1 related dead-code (#4681)

--- a/src/lib/expressions/ExprContext.cpp
+++ b/src/lib/expressions/ExprContext.cpp
@@ -164,7 +164,7 @@ void ExprContextObject::add(const std::string &key, ExprContextObject exprContex
 {
   if (basic)
   {
-    LM_E(("Runtime Error (this method must not be invoked in basic mode)"));
+    LM_W(("invoking add for object in basic mode has no effect"));
   }
   else
   {
@@ -184,7 +184,7 @@ void ExprContextObject::add(const std::string &key, ExprContextList exprContextL
 {
   if (basic)
   {
-    LM_E(("Runtime Error (this method must not be invoked in basic mode)"));
+    LM_W(("invoking add for array in basic mode has no effect"));
   }
   else
   {


### PR DESCRIPTION
Comes from https://github.com/telefonicaid/fiware-orion/pull/4700#issuecomment-3270452767