### PR TITLE
FIX avoid Runtime Error overloging when no geofilter is actually used

### DIFF
--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1321,7 +1321,10 @@ bool entitiesQuery
   }
 
   /* Part 5: filters */
-  processGeoFilter(&expr.geoFilter, &finalQuery, &finalCountQuery);
+  if (expr.geoFilter.areaType != orion::NoArea)
+  {
+    processGeoFilter(&expr.geoFilter, &finalQuery, &finalCountQuery);
+  }
 
   for (unsigned int ix = 0; ix < expr.stringFilter.mongoFilters.size(); ++ix)
   {


### PR DESCRIPTION
It doesn't happen in 4.2.0, so no entry in CNR is done in this PR.

Probably introduced in PR https://github.com/telefonicaid/fiware-orion/pull/4603 or in the follow up fixes related with https://github.com/telefonicaid/fiware-orion/issues/4681.