### PR TITLE
feat: improve notification log #4735

### DIFF
--- a/src/lib/common/logTracing.cpp
+++ b/src/lib/common/logTracing.cpp
@@ -38,8 +38,7 @@
 *
 * NOTE: this function allocated dynamic memory, be careful with memory leaks!
 */
-static char* truncatePayload(const char* payload)
-{
+static char* truncatePayload(const char* payload) {
   // +5 due to "(...)"
   // +1 due to '\0'
   unsigned int truncatedPayloadLengh = logInfoPayloadMaxSize + 5 + 1;
@@ -50,6 +49,54 @@ static char* truncatePayload(const char* payload)
   truncatedPayload[truncatedPayloadLengh - 1] = '\0';
 
   return truncatedPayload;
+}
+
+
+
+static char *get_body(const char *response) {
+  const char *start = strchr(response, '{');
+  if (!start) return NULL;
+
+  const char *end = strrchr(start, '}');
+  if (!end || end < start) return NULL;
+
+  size_t len = (size_t)(end - start + 1);
+
+  char *out = (char*)malloc(len + 1);
+  if (!out) return NULL;
+
+  memcpy(out, start, len);
+  out[len] = '\0';
+
+  return out;
+}
+
+
+
+/* ****************************************************************************
+*
+* logWarnHttpNotification
+*/
+void logWarnHttpNotification
+(
+  const char*  idStringForLogs,
+  long long httpCode,
+  const char*  responseBody
+)
+{
+  if (responseBody == NULL)
+  {
+    responseBody = "";
+  }
+
+  char* effectiveBody = get_body(responseBody);
+  LM_W(("Notification (%s) response NOT OK, http code: %d, response body: %s",
+        idStringForLogs, httpCode, effectiveBody));
+
+  if (effectiveBody)
+  {
+    free(effectiveBody);
+  }
 }
 
 
@@ -296,6 +343,3 @@ void logInfoFwdRequest
   }
 
 }
-
-
-

--- a/src/lib/common/logTracing.h
+++ b/src/lib/common/logTracing.h
@@ -143,6 +143,19 @@ extern void logInfoFwdRequest
 );
 
 
+/* ****************************************************************************
+*
+* logWarnHttpNotification
+*/
+extern void logWarnHttpNotification
+(
+  const char*  idStringForLogs,
+  long long          httpCode,
+  const char*  responseBody
+);
+
+
+
 
 #endif // SRC_LIB_COMMON_LOGTRACING_H_
 

--- a/src/lib/rest/httpRequestSend.cpp
+++ b/src/lib/rest/httpRequestSend.cpp
@@ -48,6 +48,8 @@
 #include "metricsMgr/metricsMgr.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/httpRequestSend.h"
+
+#include "common/logTracing.h"
 #include "rest/HttpHeaders.h"
 #include "rest/rest.h"
 #include "rest/curlSem.h"
@@ -212,15 +214,6 @@ static int contentLenParse(char* s)
 
   return atoi(&contentLenP[offset]);  // ... and get the number
 }
-
-
-std::string get_body(const std::string &raw) {
-  const size_t start = raw.find("{");
-  const size_t end = raw.rfind("}");
-  if (start == std::string::npos || end == std::string::npos) return "";
-  return raw.substr(start, end - start + 1);
-}
-
 
 /* ****************************************************************************
 *
@@ -665,8 +658,7 @@ int httpRequestSend
     }
     else
     {
-  		LM_W(("Notification (%s) response NOT OK, http code: %d, response body: %s",
-			idStringForLogs.c_str(), *statusCodeP, get_body(httpResponse->memory).c_str()));
+  		logWarnHttpNotification(idStringForLogs.c_str(), *statusCodeP, httpResponse->memory);
     }
   }
 


### PR DESCRIPTION
Fix #4735.
Improves notification error logging by including the response body when a notification fails (HTTP response is not OK). This enhancement provides better visibility into notification failures by showing not only the HTTP status code but also the actual error message returned by the endpoint.

### Changes
Modified httpRequestSend.cpp:661-662 to include the response body (outP) in the warning log message when notification responses are NOT OK
The log message now shows: notification ID, HTTP code, and the complete response body
### Benefits
Easier debugging of notification failures by having the full error context in logs
No need to enable debug mode or use external tools to see why a notification failed
Aligns with the information already logged for successful notifications