### PR TITLE
(JP) ADD response payload to log info (#4754)

### DIFF
--- a/doc/manuals.jp/admin/logs.md
+++ b/doc/manuals.jp/admin/logs.md
@@ -147,6 +147,16 @@ time=2020-10-22T19:51:03.565Z | lvl=INFO | corr=eabce3e2-149f-11eb-a2e8-000c29df
 
 いくつかの追加の考慮事項:
 
+* クライアントからのリクエストおよび通知において、レスポンス・エラー（2xx 以外のコード）が発生し、かつ実際のレスポンス・ペイロード（レスポンス・ペイロードの長さが 0 ではない）が存在する場合、レスポンス・ペイロードもログ・トレースに含まれます。なお、転送されたリクエストの場合、レスポンス・ペイロードは（エラー・レスポンスかどうかに関わらず）*必ず*含まれます。
+
+```
+time=2026-03-12T13:18:39.461Z | lvl=INFO | corr=fbe7731e-1e15-11f1-9ced-080027207a9f | trans=1773321518-670-00000000003 | from=0.0.0.0 | srv=<none> | subsrv=<none> | comp=Orion | op=logTracing.cpp[283]:logInfoRequestWithPayload | msg=Request received: POST /v2/op/update, request payload (110 bytes): { "actionType": "update", "entities": [ { "type": "T", "id": "E1", "B": { "type": "Number", "value": 2 } } ] }, response code: 422, response payload (68 bytes): {"error":"Unprocessable","description":"do not exist: E1/T - [ B ]"}
+
+...
+
+time=2026-03-12T13:16:09.473Z | lvl=INFO | corr=a280a8ae-1e15-11f1-ae2a-080027207a9f; cbnotif=1 | trans=1773321367-657-00000000004 | from=0.0.0.0 | srv=<none> | subsrv=/ | comp=Orion | op=logTracing.cpp[105]:logInfoHttpNotification | msg=Notif delivered (subId: 69b2bc999bb797a5cd07dc74): POST localhost:9997/giveme400, payload (123 bytes): {"subscriptionId":"69b2bc999bb797a5cd07dc74","data":[{"id":"E1","type":"T","A":{"type":"Number","value":1,"metadata":{}}}]}, response code: 400, response payload (93 bytes): {"error": "FakeError", "description": "this is a forged error response for testing purposes"}
+```
+
 * `-logInfoPayloadMaxSize` CLI 設定 (または、[log admin REST API](management_api.md#log-configs-and-trace-levels)
   の `-logInfoPayloadMaxSize` パラメータ) は、上記のトレース内のペイロードの最大サイズを指定するために使用されます。
   ペイロードがこの制限を超える場合、最初の情報ペイロードの最大サイズのバイトのみが出力されます (そして、`(...)`
@@ -289,21 +299,21 @@ contextBroker -fg -httpTimeout 10000 -logLevel INFO -notificationMode threadpool
 time=2020-10-26T14:48:37.192Z | lvl=INFO | corr=54393a44-179a-11eb-bb87-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000006 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=logTracing.cpp[63]:logInfoHttpNotification | msg=Notif delivered (subId: 5f96e174b14e7532482ac794): POST localhost:1028/accumulate, payload (123 bytes): {"subscriptionId":"5f96e174b14e7532482ac794","data":[{"id":"E","type":"T","A":{"type":"Number","value":42,"metadata":{}}}]}, response code: 200
 ```
 
-400 での通知エンドポイントのレスポンス (WARN トレースがプリントされます) :
+400 での通知エンドポイントのレスポンス (WARN トレースがプリントされます) （*注*：以下の例では、レスポンスにペイロードが含まれていないことを前提としています。ペイロードが含まれている場合は、レスポンスのペイロードも含まれます。）:
 
 ```
 time=2020-10-26T14:49:34.619Z | lvl=WARN | corr=7689f6ba-179a-11eb-ac4c-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000009 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification (subId: 5f96e1fdb14e7532482ac795) response NOT OK, http code: 400
 time=2020-10-26T14:49:34.619Z | lvl=INFO | corr=7689f6ba-179a-11eb-ac4c-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000009 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=logTracing.cpp[63]:logInfoHttpNotification | msg=Notif delivered (subId: 5f96e1fdb14e7532482ac795): POST localhost:1028/giveme400, payload (123 bytes): {"subscriptionId":"5f96e1fdb14e7532482ac795","data":[{"id":"E","type":"T","A":{"type":"Number","value":42,"metadata":{}}}]}, response code: 400
 ```
 
-404 での通知エンドポイントのレスポンス (WARN トレースがプリントされます) :
+404 での通知エンドポイントのレスポンス (WARN トレースがプリントされます) （*注*：以下の例では、レスポンスにペイロードが含まれていないことを前提としています。ペイロードが含まれている場合は、レスポンスのペイロードも含まれます。）:
 
 ```
 time=2020-10-26T14:51:40.764Z | lvl=WARN | corr=c1b8e9c0-179a-11eb-9edc-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000012 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification (subId: 5f96e27cb14e7532482ac796) response NOT OK, http code: 404
 time=2020-10-26T14:51:40.764Z | lvl=INFO | corr=c1b8e9c0-179a-11eb-9edc-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000012 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=logTracing.cpp[63]:logInfoHttpNotification | msg=Notif delivered (subId: 5f96e27cb14e7532482ac796): POST localhost:1028/giveme404, payload (123 bytes): {"subscriptionId":"5f96e27cb14e7532482ac796","data":[{"id":"E","type":"T","A":{"type":"Number","value":42,"metadata":{}}}]}, response code: 404
 ```
 
-500 での通知エンドポイントのレスポンス (WARN トレースがプリントされます) :
+500 での通知エンドポイントのレスポンス (WARN トレースがプリントされます) （*注*：以下の例では、レスポンスにペイロードが含まれていないことを前提としています。ペイロードが含まれている場合は、レスポンスのペイロードも含まれます。）:
 
 ```
 time=2020-10-26T14:53:04.246Z | lvl=WARN | corr=f37b5024-179a-11eb-9ce6-000c29df7908; cbnotif=1 | trans=1603722272-416-00000000015 | from=0.0.0.0 | srv=s1 | subsrv=/A | comp=Orion | op=httpRequestSend.cpp[583]:httpRequestSend | msg=Notification (subId: 5f96e2cfb14e7532482ac797) response NOT OK, http code: 500


### PR DESCRIPTION
This PR adds Japanese documentation in the logs.md file. It would great if you could review the PR.
Thanks.