### PR TITLE
Fix: Kafka notification key to use null instead of the subscriptionId

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,4 +2,4 @@
 - Fix: add response payload to INFO traces on error (#4756)
 - Fix: allow PATCH updates on kafkaCustom subscriptions to add headers (#4761)
 - Fix: support authentication parameters in Kafka notifications (#4714)
-- Fix: Kafka notification key to use null instead of the subscriptionId
+- Fix: Kafka notification key to use null instead of the subscriptionId (#4749)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - Fix: add response payload to INFO traces on error (#4756)
 - Fix: allow PATCH updates on kafkaCustom subscriptions to add headers (#4761)
 - Fix: support authentication parameters in Kafka notifications (#4714)
+- Fix: Kafka notification key to use null instead of the subscriptionId

--- a/doc/manuals/user/kafka_notifications.md
+++ b/doc/manuals/user/kafka_notifications.md
@@ -57,7 +57,7 @@ in KAFKA subscriptions work the same as in HTTP subscriptions, taking into accou
 
 ## Structure of a message in Kafka notifications
 
-* `Key`: This is a string/byte value used by Kafka to determine the partition where the message will be stored. In Orion, the key used corresponds to the subscription ID that generated the notification.
+* `Key`: message field used by Kafka for partitioning. In Orion, this field is sent with a null value, so the destination partition is assigned automatically according to the producer configuration.
 * `Headers`: Kafka supports message headers encoded as key-value pairs. Orion includes the following default headers:
 
 - `Fiware-Service`

--- a/src/lib/kafka/KafkaConnectionManager.cpp
+++ b/src/lib/kafka/KafkaConnectionManager.cpp
@@ -624,7 +624,7 @@ bool KafkaConnectionManager::sendKafkaNotification(
   int resultCode = rd_kafka_producev(
             producer,
             RD_KAFKA_V_TOPIC(topic.c_str()),
-            RD_KAFKA_V_KEY((void*)subscriptionId.data(), subscriptionId.size()),
+            RD_KAFKA_V_KEY(NULL, 0),
             RD_KAFKA_V_VALUE(const_cast<char*>(content.data()), content.size()),
             RD_KAFKA_V_HEADERS(headers),
             RD_KAFKA_V_OPAQUE(ctx),  // Opaque user context used later in the Kafka delivery callback

--- a/test/functionalTest/cases/4666_kafka/kafka_basic_subscribe_and_update.test
+++ b/test/functionalTest/cases/4666_kafka/kafka_basic_subscribe_and_update.test
@@ -157,7 +157,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 04. Dump accumulator to see notification
 ========================================
 Kafka message at topic orion
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:

--- a/test/functionalTest/cases/4666_kafka/kafka_basic_subscribe_and_update_multiservice.test
+++ b/test/functionalTest/cases/4666_kafka/kafka_basic_subscribe_and_update_multiservice.test
@@ -157,7 +157,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 04. Dump accumulator to see notification
 ========================================
 Kafka message at topic orion
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /

--- a/test/functionalTest/cases/4666_kafka/kafka_notification.test
+++ b/test/functionalTest/cases/4666_kafka/kafka_notification.test
@@ -250,7 +250,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}; cbnotif=[13])
 }
 =======================================
 REGEX(^Kafka message at topic sub\d+$)
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:
@@ -270,7 +270,7 @@ Payload:
 }
 =======================================
 REGEX(^Kafka message at topic sub\d+$)
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:
@@ -430,7 +430,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}; cbnotif=[13])
 #SORT_START
 =======================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:
@@ -450,7 +450,7 @@ Payload:
 }
 =======================================
 Kafka message at topic sub2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:

--- a/test/functionalTest/cases/4666_kafka/kafka_notification_custom.test
+++ b/test/functionalTest/cases/4666_kafka/kafka_notification_custom.test
@@ -216,7 +216,7 @@ Content-Length: 0
 03. Dump and reset accumulator, see: 1 KAFKA sub_E1 E A:1
 =========================================================
 Kafka message at topic sub_E1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:
@@ -239,7 +239,7 @@ Content-Length: 0
 05. Dump and reset accumulator, see: 1 KAFKA sub_E2 A:2
 =======================================================
 Kafka message at topic sub_E2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:
@@ -260,7 +260,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 07. Dump and reset accumulator, see: 1 KAFKA sub/E1 E A:10
 ==========================================================
 Kafka message at topic sub_E1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:
@@ -281,7 +281,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 09. Dump and reset accumulator, see: 1 KAFKA sub/E2 A:20
 ========================================================
 Kafka message at topic sub_E2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:

--- a/test/functionalTest/cases/4666_kafka/kafka_notification_custom_multiservice.test
+++ b/test/functionalTest/cases/4666_kafka/kafka_notification_custom_multiservice.test
@@ -216,7 +216,7 @@ Content-Length: 0
 03. Dump and reset accumulator, see: 1 KAFKA sub_E1 E A:1
 =========================================================
 Kafka message at topic sub_E1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /
@@ -240,7 +240,7 @@ Content-Length: 0
 05. Dump and reset accumulator, see: 1 KAFKA sub_E2 A:2
 =======================================================
 Kafka message at topic sub_E2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /
@@ -262,7 +262,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 07. Dump and reset accumulator, see: 1 KAFKA sub/E1 E A:10
 ==========================================================
 Kafka message at topic sub_E1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /
@@ -284,7 +284,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 09. Dump and reset accumulator, see: 1 KAFKA sub/E2 A:20
 ========================================================
 Kafka message at topic sub_E2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /

--- a/test/functionalTest/cases/4666_kafka/kafka_notification_multiservice.test
+++ b/test/functionalTest/cases/4666_kafka/kafka_notification_multiservice.test
@@ -251,7 +251,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}; cbnotif=[13])
 }
 =======================================
 REGEX(^Kafka message at topic sub\d+$)
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /
@@ -272,7 +272,7 @@ Payload:
 }
 =======================================
 REGEX(^Kafka message at topic sub\d+$)
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /
@@ -434,7 +434,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36}; cbnotif=[13])
 #SORT_START
 =======================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /
@@ -455,7 +455,7 @@ Payload:
 }
 =======================================
 Kafka message at topic sub2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /

--- a/test/functionalTest/cases/4666_kafka/kafka_subscription_multibroker.test
+++ b/test/functionalTest/cases/4666_kafka/kafka_subscription_multibroker.test
@@ -347,7 +347,7 @@ Kafka connection localhost:9095 too old REGEX(.*)
 ==============================================================================
 #SORT_START
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:
@@ -367,7 +367,7 @@ Payload:
 }
 =======================================
 Kafka message at topic sub2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:
@@ -387,7 +387,7 @@ Payload:
 }
 =======================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:
@@ -407,7 +407,7 @@ Payload:
 }
 =======================================
 Kafka message at topic sub2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:

--- a/test/functionalTest/cases/4666_kafka/kafka_subscription_multibroker_multiservice.test
+++ b/test/functionalTest/cases/4666_kafka/kafka_subscription_multibroker_multiservice.test
@@ -347,7 +347,7 @@ Kafka connection localhost:9095 too old REGEX(.*)
 ==============================================================================
 #SORT_START
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /
@@ -368,7 +368,7 @@ Payload:
 }
 =======================================
 Kafka message at topic sub2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /
@@ -389,7 +389,7 @@ Payload:
 }
 =======================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /
@@ -410,7 +410,7 @@ Payload:
 }
 =======================================
 Kafka message at topic sub2
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /

--- a/test/functionalTest/cases/4714_kafka_auth_integration/kafka_custom_notification_sasl_plain_auth.test
+++ b/test/functionalTest/cases/4714_kafka_auth_integration/kafka_custom_notification_sasl_plain_auth.test
@@ -364,7 +364,7 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
 10. Dump accumulator (expect 1 message at topic sub_auth)
 =========================================================
 Kafka message at topic sub_auth
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
 Payload:

--- a/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/no_special_headers_subscription_modification.test
+++ b/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/no_special_headers_subscription_modification.test
@@ -118,7 +118,7 @@ Content-Length: 0
 03. Check that no special headers were propagated to accumulator
 ================================================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
   x-device-model: Model-1

--- a/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/no_special_headers_subscription_modification_multiservice.test
+++ b/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/no_special_headers_subscription_modification_multiservice.test
@@ -118,7 +118,7 @@ Content-Length: 0
 03. Check that no special headers were propagated to accumulator
 ================================================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /

--- a/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/s_custom_subscription_modification.test
+++ b/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/s_custom_subscription_modification.test
@@ -118,7 +118,7 @@ Content-Length: 0
 03. Check that the Fiware-Service cucu (and not empty) was propagated to accumulator
 ==================================================================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: cucu
   Fiware-Servicepath: /

--- a/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/s_custom_subscription_modification_multiservice.test
+++ b/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/s_custom_subscription_modification_multiservice.test
@@ -118,7 +118,7 @@ Content-Length: 0
 03. Check that the Fiware-Service cucu (and not fgm) was propagated to accumulator
 ==================================================================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: cucu
   Fiware-Servicepath: /

--- a/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/ss_custom_subscription_modification.test
+++ b/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/ss_custom_subscription_modification.test
@@ -116,7 +116,7 @@ Content-Length: 0
 03. Check that the Fiware-ServicePath cucu (and not fgm) was propagated to accumulator
 ======================================================================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /cucu
 Payload:

--- a/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/ss_custom_subscription_modification_multiservice.test
+++ b/test/functionalTest/cases/4726_kafka_notif_override_fiware_service_and_servicepath/ss_custom_subscription_modification_multiservice.test
@@ -116,7 +116,7 @@ Content-Length: 0
 03. Check that the Fiware-ServicePath cucu (and not fgm) was propagated to accumulator
 ======================================================================================
 Kafka message at topic sub1
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /cucu
 Payload:

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_custom_kafka_headers_names.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_custom_kafka_headers_names.test
@@ -111,7 +111,7 @@ Content-Length: 0
 03. Dump accumulator, see 1 notification
 ========================================
 Kafka message at topic orion
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /
   x-myheader: bar

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_custom_kafka_headers_names_multiservice.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_custom_kafka_headers_names_multiservice.test
@@ -111,7 +111,7 @@ Content-Length: 0
 03. Dump accumulator, see 1 notification
 ========================================
 Kafka message at topic orion
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_in_kafka_headers.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_in_kafka_headers.test
@@ -118,7 +118,7 @@ Content-Length: 0
 03. Check the use of macros in headers
 ======================================
 Kafka message at topic orion
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Servicepath: /subservA
   myheader: /subservA/fgm

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_in_kafka_headers_multiservice.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_in_kafka_headers_multiservice.test
@@ -118,7 +118,7 @@ Content-Length: 0
 03. Check the use of macros in headers
 ======================================
 Kafka message at topic orion
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /subservA

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_in_kafka_headers_override.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_in_kafka_headers_override.test
@@ -122,7 +122,7 @@ Content-Length: 0
 03. Check the use of macros in headers
 ======================================
 Kafka message at topic orion
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /subservA

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_in_kafka_headers_override_multiservice.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_in_kafka_headers_override_multiservice.test
@@ -122,7 +122,7 @@ Content-Length: 0
 03. Check the use of macros in headers
 ======================================
 Kafka message at topic orion
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /subservA

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_kafka_json.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_kafka_json.test
@@ -117,7 +117,7 @@ Content-Length: 0
 03. Dump accumulator, see 1 notification
 ========================================
 Kafka message at topic orion_s1_fgm
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /subservA

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_kafka_json_attr_override.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_kafka_json_attr_override.test
@@ -117,7 +117,7 @@ Content-Length: 0
 03. Dump accumulator, see 1 notification
 ========================================
 Kafka message at topic orion_OVERRIDE_fgm
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /subservA

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_kafka_text.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_kafka_text.test
@@ -112,7 +112,7 @@ Content-Length: 0
 03. Dump accumulator, see 1 notification
 ========================================
 Kafka message at topic orion_s1_fgm
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /subservA

--- a/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_kafka_text_attr_override.test
+++ b/test/functionalTest/cases/4732_custom_notif_extra_macros_kafka/custom_notif_extra_macros_kafka_text_attr_override.test
@@ -112,7 +112,7 @@ Content-Length: 0
 03. Dump accumulator, see 1 notification
 ========================================
 Kafka message at topic orion_OVERRIDE_fgm
-Key: REGEX([0-9a-f\-]{24})
+Key: (null)
 Headers:
   Fiware-Service: s1
   Fiware-Servicepath: /subservA


### PR DESCRIPTION
The `subscriptionId` was originally used as the message key to help preserve message ordering and avoid issues in Kafnus when persisting the LastData flow.

According to the Kafnus documentation, messages do not need to arrive in order, as explained here:

`https://github.com/telefonicaid/kafnus/blob/3ac580f85f84d187df1924c8ee14bf04fdc46605/doc/09_scaling.md?plain=1#L88-L89`

For that reason, I suggest using `null` as the default message key. If message ordering is not required for this use case, there is no need to keep using `subscriptionId` as the key. In that case, partition assignment is handled automatically by the producer configuration. According to the librdkafka documentation:

> Consistent-Random partitioner. This is the default partitioner. Uses consistent hashing to map identical keys onto identical partitions, and messages without keys will be assigned via the random partitioner.

References:

* `https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html`
* `https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html`

I also suggest creating a CI image from this PR so Kafnus can test against it. If everything works correctly, we could merge it into `master` without waiting for PR #4774, since the urgent Kafnus use case would already be covered here. This PR only changes the Kafka message key from `subscriptionId` to `null`. PR #4774 goes further by making the key configurable through the subscription, while also proposing `null` as the default instead of `subscriptionId`, which is the current behavior in `master`.
