### PR TITLE
Fix: allow quotes in HTTP and Kafka custom header values for use in JEXL expressions (#4779)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: allow quotes in HTTP and Kafka custom header values for use in JEXL expressions (#4779)

--- a/doc/manuals/orion-api.md
+++ b/doc/manuals/orion-api.md
@@ -452,6 +452,7 @@ There are some exception cases in which the above restrictions do not apply. In 
 * URL parameter `q` allows the special characters needed by the [Simple Query Language](#simple-query-language)
 * URL parameter `mq` allows the special characters needed by the [Simple Query Language](#simple-query-language)
 * URL parameter `georel` and `coords` allow `;`
+* HTTP and Kafka custom header values allow the `'` and `"` quote characters to support quoted string literals in JEXL expressions
 * Within `ngsi` (i.e. `id`, `type` and attribute values) in [NGSI Payload patching](#ngsi-payload-patching) (to support characters used in the [JEXL support in custom notifications](#jexl-support-in-custom-notifications))
 * Whichever attribute value which uses `TextUnrestricted` as attribute type (see [Special Attribute Types](#special-attribute-types) section)
 
@@ -2055,7 +2056,7 @@ a legacy.
 ### Macro substitution
 
 Clients can customize notification messages using a simple template mechanism when
-`notification.httpCustom` or `notification.mqttCustom` are used. Which fields can be templatized
+`notification.httpCustom`, `notification.mqttCustom` or `notification.kafkaCustom` are used. Which fields can be templatized
 depends on the protocol type.
 
 In case of `httpCustom`:
@@ -2072,6 +2073,12 @@ HEAD, OPTIONS, TRACE, and CONNECT.
 
 In case of `mqttCustom`:
 
+* `payload`, `json` and `ngsi` (all them payload related fields)
+* `topic`
+
+In case of `kafkaCustom`:
+
+* `headers` (both header name and value can be templatized).
 * `payload`, `json` and `ngsi` (all them payload related fields)
 * `topic`
 

--- a/src/lib/jsonParseV2/parseSubscription.cpp
+++ b/src/lib/jsonParseV2/parseSubscription.cpp
@@ -73,7 +73,8 @@ static std::string parseNotifyConditionVector(ConnectionInfo* ciP, SubscriptionU
 static std::string parseDictionary(ConnectionInfo*                      ciP,
                                    std::map<std::string, std::string>&  dict,
                                    const Value&                         object,
-                                   const std::string&                   name);
+                                   const std::string&                   name,
+                                   const char*                          valueExceptions = NULL);
 
 
 
@@ -1216,7 +1217,8 @@ static std::string parseNotification(ConnectionInfo* ciP, SubscriptionUpdate* su
       std::string r = parseDictionary(ciP,
                                       subsP->notification.httpInfo.headers,
                                       headers,
-                                      "notification httpCustom headers");
+                                      "notification httpCustom headers",
+                                      "'\"");
 
       if (!r.empty())
       {
@@ -1441,7 +1443,8 @@ static std::string parseNotification(ConnectionInfo* ciP, SubscriptionUpdate* su
       std::string r = parseDictionary(ciP,
                                       subsP->notification.kafkaInfo.headers,
                                       headers,
-                                      "notification kafkaCustom headers");
+                                      "notification kafkaCustom headers",
+                                      "'\"");
 
       if (!r.empty())
       {
@@ -1707,7 +1710,8 @@ static std::string parseDictionary
   ConnectionInfo*                      ciP,
   std::map<std::string, std::string>&  dict,
   const Value&                         object,
-  const std::string&                   name
+  const std::string&                   name,
+  const char*                          valueExceptions
 )
 {
   if (!object.IsObject())
@@ -1725,7 +1729,7 @@ static std::string parseDictionary
     std::string value = iter->value.GetString();
     std::string key   = iter->name.GetString();
 
-    if (forbiddenChars(value.c_str()))
+    if (forbiddenChars(value.c_str(), valueExceptions))
     {
       return badInput(ciP, std::string("forbidden characters in custom ") + name);
     }

--- a/test/functionalTest/cases/4749_custom_header_jexl_quotes/http_custom_header_jexl_quotes.test
+++ b/test/functionalTest/cases/4749_custom_header_jexl_quotes/http_custom_header_jexl_quotes.test
@@ -1,4 +1,4 @@
-# Copyright 2025 Telefonica Investigacion y Desarrollo, S.A.U
+# Copyright 2026 Telefonica Investigacion y Desarrollo, S.A.U
 #
 # This file is part of Orion Context Broker.
 #

--- a/test/functionalTest/cases/4749_custom_header_jexl_quotes/http_custom_header_jexl_quotes.test
+++ b/test/functionalTest/cases/4749_custom_header_jexl_quotes/http_custom_header_jexl_quotes.test
@@ -1,0 +1,140 @@
+# Copyright 2025 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+# JEXL_EXPR_FLAVOUR - to mark the test has to execute only when contextBroker includes jexl-expr flavour
+
+--NAME--
+HTTP Custom Headers With JEXL Quote Default Values
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB 164 IPV4
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create subscription with httpCustom header values using quoted string literals in JEXL expressions
+# 02. Create E/A
+# 03. Check that both evaluated custom headers were propagated
+#
+
+echo "01. Create subscription with httpCustom header values using quoted string literals in JEXL expressions"
+echo "======================================================================================================"
+payload='
+{
+  "subject": {
+    "entities": [
+      {
+        "idPattern": ".*",
+        "type": "T"
+      }
+    ],
+    "condition": {
+      "attrs": []
+    }
+  },
+  "notification": {
+    "httpCustom": {
+      "url": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
+      "payload": "{ %22A%22: %22${A}%22 }",
+      "headers": {
+        "x-single": "${x||'\''one'\''}",
+        "x-double": "${x||\"two\"}"
+      }
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create E/A"
+echo "=============="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+sleep 2s
+
+
+echo "03. Check that both evaluated custom headers were propagated"
+echo "============================================================"
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+--REGEXPECT--
+01. Create subscription with httpCustom header values using quoted string literals in JEXL expressions
+======================================================================================================
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Content-Length: 0
+
+
+
+02. Create E/A
+==============
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/entities/E?type=T
+Content-Length: 0
+
+
+
+03. Check that both evaluated custom headers were propagated
+============================================================
+POST http://127.0.0.1:REGEX(\d+)/notify
+Fiware-Servicepath: /
+Content-Length: 12
+User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
+Ngsiv2-Attrsformat: custom
+Host: 127.0.0.1:REGEX(\d+)
+Accept: application/json
+Content-Type: text/plain; charset=utf-8
+Fiware-Correlator: REGEX([0-9a-f\-]{36}); cbnotif=1
+X-Double: two
+X-Single: one
+
+{
+    "A": "1"
+}
+=======================================
+
+
+--TEARDOWN--
+accumulatorStop
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/4749_custom_header_jexl_quotes/kafka_custom_header_jexl_quotes.test
+++ b/test/functionalTest/cases/4749_custom_header_jexl_quotes/kafka_custom_header_jexl_quotes.test
@@ -1,0 +1,138 @@
+# Copyright 2026 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+# JEXL_EXPR_FLAVOUR - to mark the test has to execute only when contextBroker includes jexl-expr flavour
+
+--NAME--
+KAFKA Custom Headers With JEXL Quote Default Values
+
+--SHELL-INIT--
+dbInit CB
+kafkaCreateTopics "${KAFKA_BOOTSTRAP_A}" orion
+brokerStart CB 164 IPV4
+accumulatorStart --pretty-print --bootstrapServers "${KAFKA_BOOTSTRAP_A}" --kafkaTopic "^orion.*"
+
+--SHELL--
+
+#
+# 01. Create subscription with kafkaCustom header values using quoted string literals in JEXL expressions
+# 02. Create E/A
+# 03. Check that both evaluated custom headers were propagated
+#
+
+echo "01. Create subscription with kafkaCustom header values using quoted string literals in JEXL expressions"
+echo "======================================================================================================="
+payload='
+{
+  "subject": {
+    "entities": [
+      {
+        "idPattern": ".*",
+        "type": "T"
+      }
+    ],
+    "condition": {
+      "attrs": []
+    }
+  },
+  "notification": {
+    "kafkaCustom": {
+      "url": "kafka://'${KAFKA_BOOTSTRAP_A}'",
+      "topic": "orion",
+      "payload": "{ %22A%22: %22${A}%22 }",
+      "headers": {
+        "x-single": "${x||'\''one'\''}",
+        "x-double": "${x||\"two\"}"
+      }
+    }
+  }
+}'
+orionCurl --url /v2/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create E/A"
+echo "=============="
+payload='{
+  "id": "E",
+  "type": "T",
+  "A": {
+    "value": 1,
+    "type": "Number"
+  }
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+sleep 2s
+
+
+echo "03. Check that both evaluated custom headers were propagated"
+echo "============================================================"
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+--REGEXPECT--
+01. Create subscription with kafkaCustom header values using quoted string literals in JEXL expressions
+=======================================================================================================
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/subscriptions/REGEX([0-9a-f]{24})
+Content-Length: 0
+
+
+
+02. Create E/A
+==============
+HTTP/1.1 201 Created
+Date: REGEX(.*)
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Location: /v2/entities/E?type=T
+Content-Length: 0
+
+
+
+03. Check that both evaluated custom headers were propagated
+============================================================
+Kafka message at topic orion
+Key: (null)
+Headers:
+  Fiware-Servicepath: /
+  x-double: two
+  x-single: one
+Payload:
+{
+    "A": "1"
+}
+=======================================
+
+
+--TEARDOWN--
+accumulatorStop
+kafkaDestroyTopics "${KAFKA_BOOTSTRAP_A}" orion
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Issue #4779